### PR TITLE
Restore MonthTable.cbl from embedded HTML rendering

### DIFF
--- a/examples/Tables/MonthTable.cbl
+++ b/examples/Tables/MonthTable.cbl
@@ -1,0 +1,75 @@
+      $ SET SOURCEFORMAT"FREE"
+IDENTIFICATION DIVISION.
+PROGRAM-ID.  MonthTable.
+AUTHOR.  Michael Coughlan.
+* This program counts the number of students born in each month and
+* displays the result.
+
+ENVIRONMENT DIVISION.
+INPUT-OUTPUT SECTION.
+FILE-CONTROL.
+    SELECT StudentFile ASSIGN TO "STUDENTS.DAT"
+		ORGANIZATION IS LINE SEQUENTIAL.
+
+DATA DIVISION.
+FILE SECTION.
+FD StudentFile.
+01 StudentDetails.
+   88  EndOfStudentFile  VALUE HIGH-VALUES.
+   02  StudentId       PIC 9(7).
+   02  StudentName.
+       03 Surname      PIC X(8).
+       03 Initials     PIC XX.
+   02  DateOfBirth.
+       03 YOBirth      PIC 9(4).
+       03 MOBirth      PIC 9(2).
+       03 DOBirth      PIC 9(2).
+   02  CourseCode      PIC X(4).
+   02  Gender          PIC X.
+
+WORKING-STORAGE SECTION.
+01 MonthTable.
+   02 TableValues.
+      03 FILLER       PIC X(18) VALUE "January  February".
+      03 FILLER       PIC X(18) VALUE "March    April".
+      03 FILLER       PIC X(18) VALUE "May      June".
+      03 FILLER       PIC X(18) VALUE "July     August".
+      03 FILLER       PIC X(18) VALUE "SeptemberOctober".
+      03 FILLER       PIC X(18) VALUE "November December".
+   02 FILLER REDEFINES TableValues.
+      03 Month OCCURS 12 TIMES PIC X(9).
+
+01 MonthCount OCCURS 12 TIMES PIC 999 VALUE ZEROS.
+
+01 MonthIdx           PIC 999.
+
+01 HeadingLine          PIC X(19) VALUE " Month    StudCount".
+
+01 DisplayLine.
+   02 PrnMonth          PIC X(9).
+   02 FILLER            PIC X(4) VALUE SPACES.
+   02 PrnStudentCount   PIC ZZ9.
+
+
+PROCEDURE DIVISION.
+Begin.
+   OPEN INPUT StudentFile
+   READ StudentFile
+      AT END SET EndOfStudentFile TO TRUE
+   END-READ
+   PERFORM UNTIL EndOfStudentFile
+      ADD 1 TO MonthCount(MOBirth)
+      READ StudentFile
+         AT END SET EndOfStudentFile TO TRUE
+      END-READ
+   END-PERFORM
+
+   DISPLAY HeadingLine
+   PERFORM VARYING MonthIdx FROM 1 BY 1 UNTIL MonthIdx > 12
+      MOVE Month(MonthIdx) TO PrnMonth
+      MOVE MonthCount(MonthIdx) TO PrnStudentCount
+      DISPLAY DisplayLine
+   END-PERFORM.
+
+   CLOSE StudentFile
+   STOP RUN.

--- a/exercises/MonthTable.html
+++ b/exercises/MonthTable.html
@@ -253,7 +253,7 @@ number as a direct index into the month table.</p>
 <h2>
 Sample Solution</h2>
 <p>When you have written your program and have compiled it and have it working 
-  correctly you may wish to compare it with this <a href="ftp://www.csis.ul.ie/cobol/exercises/MonthTable.cbl">sample
+  correctly you may wish to compare it with this <a href="../examples/Tables/MonthTable.cbl">sample
   solution</a>. </p>
 <p align="center"><b><u><font color="#FF0000">WARNING</font></u></b> </p>
 <p align="left">As always please do not look at the solution until you have finished 


### PR DESCRIPTION
## Summary

Closes #8. Restores `examples/Tables/MonthTable.cbl`, which was lost when the `csis.ul.ie` FTP server went away.

The full source turned out to already be in the repo, embedded in the `<pre>` block of [examples/Tables/MonthTable.html](examples/Tables/MonthTable.html) (a non-source HTML rendering of the original program). Extracted that into a real `.cbl` and re-pointed the broken FTP `<a href>` in [exercises/MonthTable.html](exercises/MonthTable.html) at the local copy, mirroring the pattern from #11.

## Changes

- **New** `examples/Tables/MonthTable.cbl` — extracted from the embedded `<pre>` in `examples/Tables/MonthTable.html`. Two transcription fixes vs. the raw HTML:
  - Decoded `&gt;` → `>` on the `PERFORM VARYING MonthIdx ... UNTIL MonthIdx > 12` line.
  - Corrected `02 FILLERh REDEFINES TableValues.` → `02 FILLER REDEFINES TableValues.`. The trailing "h" is clearly a render artifact (not valid COBOL); `02 FILLER REDEFINES TableValues.` is the canonical spelling used elsewhere in the corpus (e.g. `examples/SubProg/DateValid/ValiDate.cbl:11`, `examples/ReportWriter/RepWriteA.cbl:34`).
  - CRLF line endings to match the rest of the `.cbl` files in the repo.
- **Edit** `exercises/MonthTable.html` — rewrote the broken `ftp://www.csis.ul.ie/cobol/exercises/MonthTable.cbl` href to `../examples/Tables/MonthTable.cbl`.

## Sanity check vs. exercise spec

Cross-checked the restored .cbl against the exercise prose and field table in `exercises/MonthTable.html`:

- Record layout (`StudentId 9(7)`, `Surname X(8)`, `Initials XX`, `YOBirth 9(4)`, `MOBirth 9(2)`, `DOBirth 9(2)`, `CourseCode X(4)`, `Gender X`) matches the exercise's "Student File Description" table exactly.
- Algorithm matches the suggested approach: read sequentially, use `MOBirth` as a direct 1–12 index into `MonthCount`, then walk a parallel `Month` redefine to print results in calendar order.
- Output formatting (`PIC X(9) + 4 spaces + PIC ZZ9`) reproduces the example run shown in the exercise, and the `ZZ9` zero-suppression satisfies the explicit "use Edited picture clauses and the zero suppression symbol" requirement.
- Six 18-char `FILLER` literals × 12 nine-char slots line up correctly across the `REDEFINES`.

## Test plan

- [ ] Run `python -m http.server` at the repo root, open `exercises/MonthTable.html`, and confirm the "sample solution" link downloads `examples/Tables/MonthTable.cbl`.
- [ ] Optionally compile `examples/Tables/MonthTable.cbl` with GnuCOBOL against `examples/SeqRead/STUDENTS.DAT` and confirm the per-month counts display in January–December order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)