### PR TITLE
Add README with deployed site and Internet Archive links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Limerick COBOL
+
+Michael Coughlan's University of Limerick COBOL tutorial, recovered from the Internet Archive.
+
+**Deployed site:** https://bushidocodes.github.io/limerick-cobol/
+
+## Rationale
+
+A few years back, Michael Coughlan's well-known University of Limerick COBOL tutorial bit-rotted off the web. It's the course I originally used to learn COBOL way back when. I pulled it out of the Internet Archive and cleaned up the PowerPoint browser-plugin scaffolding so the slides render cleanly as embedded PDFs.
+
+If anyone happens to have Michael Coughlan's contact info, please reach out — I'd like to get in touch about licensing this under Creative Commons.
+
+## Internet Archive snapshots
+
+The original course lived at `http://www.csis.ul.ie/cobol/`. Snapshots used as the source for this restoration:
+
+- All Wayback captures: https://web.archive.org/web/*/http://www.csis.ul.ie/cobol/*
+- Course index calendar: https://web.archive.org/web/*/http://www.csis.ul.ie/cobol/
+- Late capture (2014): https://web.archive.org/web/2014*/http://www.csis.ul.ie/cobol/

--- a/README.md
+++ b/README.md
@@ -10,10 +10,8 @@ A few years back, Michael Coughlan's well-known University of Limerick COBOL tut
 
 If anyone happens to have Michael Coughlan's contact info, please reach out — I'd like to get in touch about licensing this under Creative Commons.
 
-## Internet Archive snapshots
+## Internet Archive snapshot
 
-The original course lived at `http://www.csis.ul.ie/cobol/`. Snapshots used as the source for this restoration:
+The original course lived at `http://www.csis.ul.ie/cobol/`. Source snapshot used for this restoration:
 
-- All Wayback captures: https://web.archive.org/web/*/http://www.csis.ul.ie/cobol/*
-- Course index calendar: https://web.archive.org/web/*/http://www.csis.ul.ie/cobol/
-- Late capture (2014): https://web.archive.org/web/2014*/http://www.csis.ul.ie/cobol/
+- https://web.archive.org/web/20140226022647/http://www.csis.ul.ie/cobol/


### PR DESCRIPTION
## Summary
- Adds a README explaining the project: a restoration of Michael Coughlan's University of Limerick COBOL tutorial pulled from the Internet Archive
- Links to the GitHub Pages deployment at https://bushidocodes.github.io/limerick-cobol/
- Links to the Wayback Machine snapshots of the original `csis.ul.ie/cobol` site used as the source

## Test plan
- [ ] Confirm README renders correctly on the GitHub repo landing page
- [ ] Verify deployed-site link resolves
- [ ] Verify Wayback Machine links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)