### PR TITLE
Restore itercalc.cbl starter for CountDown exercise

### DIFF
--- a/examples/Conditn/itercalc.cbl
+++ b/examples/Conditn/itercalc.cbl
@@ -1,0 +1,35 @@
+      $ SET SOURCEFORMAT"FREE"
+IDENTIFICATION DIVISION.
+PROGRAM-ID.  Iteration-Calculator.
+AUTHOR.  Michael Coughlan.
+* This program accepts two numbers and an operator from the user and
+* depending on the type of the operator either adds the numbers or
+* multiplys them together and displays the result.  It does this three times.
+* No error checking is done.
+
+
+DATA DIVISION.
+WORKING-STORAGE SECTION.
+01  Num1           PIC 9  VALUE ZEROS.
+01  Num2           PIC 9  VALUE ZEROS.
+01  Result         PIC 99 VALUE ZEROS.
+01  Operator       PIC X  VALUE SPACE.
+
+PROCEDURE DIVISION.
+Calculator.
+    PERFORM 3 TIMES
+       DISPLAY "Enter First Number      : " WITH NO ADVANCING
+       ACCEPT Num1
+       DISPLAY "Enter Second Number     : " WITH NO ADVANCING
+       ACCEPT Num2
+       DISPLAY "Enter operator (+ or *) : " WITH NO ADVANCING
+       ACCEPT Operator
+       IF Operator = "+" THEN
+          COMPUTE Result = Num1 + Num2
+       END-IF
+       IF Operator = "*" THEN
+          COMPUTE Result = Num1 * Num2
+       END-IF
+       DISPLAY "Result is = ", Result
+    END-PERFORM.
+    STOP RUN.

--- a/exercises/CountDown.html
+++ b/exercises/CountDown.html
@@ -27,7 +27,7 @@ is a version of the example iteration program shown in the <a href="../lectures/
 COBOL lecture</a>.&nbsp;&nbsp; Note - use your browsers back button to
 get back to this page.
 
-<p>Download the <a href="ftp://www.csis.ul.ie/cobol/exercises/itercalc.cbl">IterCalc.Cbl</a>
+<p>Download the <a href="../examples/Conditn/itercalc.cbl">IterCalc.Cbl</a>
   program and save it to the \WorkArea directory on drive D:.
 <p>Load the program into the NetExpress environment. <br>
   &nbsp;


### PR DESCRIPTION
## Summary
- Restores `examples/Conditn/itercalc.cbl` (the iteration calculator starter referenced by the Calculator/Countdown exercise) from the JMU CS 430 student-project mirror of Michael Coughlan's COBOL tutorial.
- Rewrites the dead `ftp://www.csis.ul.ie/cobol/exercises/itercalc.cbl` link in `exercises/CountDown.html` to point at the local copy.

Closes #5.

## Test plan
- [ ] Open `exercises/CountDown.html` in a browser and confirm the IterCalc.Cbl link resolves to the new file.
- [ ] Compile `examples/Conditn/itercalc.cbl` with a free-format COBOL compiler (e.g. GnuCOBOL) and run it through three iterations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)