### PR TITLE
Align Students.Dat spec tables with fixture (drop Grant, fix Year size)

### DIFF
--- a/exercises/SeqInsert.html
+++ b/exercises/SeqInsert.html
@@ -153,11 +153,11 @@ all have the same description.
 </td>
 
 <td width="84">
-<center>2</center>
+<center>4</center>
 </td>
 
 <td width="127">
-<center>00-99</center>
+<center>0000-9999</center>
 </td>
 </tr>
 
@@ -206,22 +206,6 @@ all have the same description.
 
 <td width="127">
 <center>-</center>
-</td>
-</tr>
-
-<tr>
-<td width="144">Grant</td>
-
-<td width="67">
-<center>9</center>
-</td>
-
-<td width="84">
-<center>4</center>
-</td>
-
-<td width="127">
-<center>0000-9999</center>
 </td>
 </tr>
 

--- a/exercises/SeqReadIf.html
+++ b/exercises/SeqReadIf.html
@@ -146,11 +146,11 @@ displays these counts on the computer screen.
 </td>
 
 <td width="84">
-<center>2</center>
+<center>4</center>
 </td>
 
 <td width="127">
-<center>00-99</center>
+<center>0000-9999</center>
 </td>
 </tr>
 
@@ -199,22 +199,6 @@ displays these counts on the computer screen.
 
 <td width="127">
 <center>-</center>
-</td>
-</tr>
-
-<tr>
-<td width="144">Grant</td>
-
-<td width="67">
-<center>9</center>
-</td>
-
-<td width="84">
-<center>4</center>
-</td>
-
-<td width="127">
-<center>0000-9999</center>
 </td>
 </tr>
 

--- a/exercises/SeqUpdate.html
+++ b/exercises/SeqUpdate.html
@@ -228,11 +228,11 @@ description;
 </td>
 
 <td width="78">
-<center>2</center>
+<center>4</center>
 </td>
 
 <td width="133">
-<center>00-99</center>
+<center>0000-9999</center>
 </td>
 </tr>
 
@@ -281,22 +281,6 @@ description;
 
 <td width="133">
 <center>-</center>
-</td>
-</tr>
-
-<tr>
-<td width="144">Grant</td>
-
-<td width="67">
-<center>9</center>
-</td>
-
-<td width="78">
-<center>4</center>
-</td>
-
-<td width="133">
-<center>0000-9999</center>
 </td>
 </tr>
 

--- a/exercises/SortIP.html
+++ b/exercises/SortIP.html
@@ -127,11 +127,11 @@ order.
 </td>
 
 <td width="78">
-<center>2</center>
+<center>4</center>
 </td>
 
 <td width="133">
-<center>00-99</center>
+<center>0000-9999</center>
 </td>
 </tr>
 
@@ -180,22 +180,6 @@ order.
 
 <td width="133">
 <center>-</center>
-</td>
-</tr>
-
-<tr>
-<td width="144">Grant</td>
-
-<td width="67">
-<center>9</center>
-</td>
-
-<td width="78">
-<center>4</center>
-</td>
-
-<td width="133">
-<center>0000-9999</center>
 </td>
 </tr>
 


### PR DESCRIPTION
## Summary
- Spec tables on four exercise pages described a 32-byte `Students.Dat` record (Year `9(2)`, plus a `Grant 9(4)` field), but the actual fixture and every working sample program use a 30-byte layout (Year `9(4)`, no Grant).
- Updated the record-description tables on `SeqReadIf.html`, `SeqInsert.html`, `SeqUpdate.html`, and `SortIP.html`: Year length `2 → 4`, range `00-99 → 0000-9999`, and removed the `Grant` row.
- No exercise reads, writes, compares, or computes `Grant` or does date arithmetic, so no learning objective is lost.

Closes #20

## Test plan
- [ ] Open each of the four exercise pages and confirm the record table now shows `Year 9 / 4 / 0000-9999` and no `Grant` row.
- [ ] Confirm the layout (StudentId 7 + Surname 8 + Initials 2 + Year 4 + Month 2 + Day 2 + CourseCode 4 + Gender 1 = 30) matches `examples/SeqRead/STUDENTS.DAT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)