### PR TITLE
Add viewport meta and minimal responsive CSS to landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <html>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="google-site-verification" content="g9Kb5_0qV7EdRel40vEW48IAmR1DCIYL7oBqiuPNTr8"/> 
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="google-site-verification" content="g9Kb5_0qV7EdRel40vEW48IAmR1DCIYL7oBqiuPNTr8"/>
 <title>COBOL programming - tutorials, lectures, exercises, examples</title>
 <meta name="resource-type" content="document">
 <meta name="description" content="COBOL programming site with a full COBOL course as well as lectures, tutorials, programming exercises, and over 50 example COBOL programs.">
@@ -12,6 +13,14 @@
 <meta name="generator" content="Mozilla/4.0 [en] (WinNT; I) [Netscape]">
 <meta name="robots" content="All">
 <meta name="rating" content="General">
+<style type="text/css">
+  h1 img { max-width: 100%; height: auto; }
+  table { max-width: 100%; }
+  @media (max-width: 600px) {
+    blockquote { margin-left: 12px; margin-right: 12px; }
+    h1 font { font-size: medium; }
+  }
+</style>
 </head>
 <body text="#000000" bgcolor="#FFFFFF" link="#0000FF" vlink="#FF0000" alink="#009B00">
 <div align="left"> 


### PR DESCRIPTION
The landing page had no viewport meta tag, so mobile browsers rendered it at desktop-width zoom. Add the viewport tag plus a small style block that constrains only the oversized header image, scopes blockquote margin and subtitle font size below 600px, and leaves all other layout and visual styling untouched.