### PR TITLE
Make course/index.html responsive on mobile

### DIFF
--- a/course/index.html
+++ b/course/index.html
@@ -1,5 +1,6 @@
 <html>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>COBOL Programming Course</title>
 <meta name="resource-type" content="document">
 <meta name="description" content="" on-line cobol programming course - includes tutorials, example programs and exercises.">
@@ -11,6 +12,16 @@
 <meta name="generator" content="Mozilla/4.0 [en] (WinNT; I) [Netscape]">
 <meta name="robots" content="All">
 <meta name="rating" content="General">
+<style type="text/css">
+  table { max-width: 100%; }
+  h1 img { max-width: 100%; height: auto; }
+  hr { max-width: 100%; }
+  @media (max-width: 600px) {
+    body { margin: 8px; padding-bottom: 65px; }
+    h1 font { font-size: medium; }
+    table[width], td[width], th[width] { width: auto !important; }
+  }
+</style>
 </head>
 <body text="#000000" bgcolor="#FFFFFF" link="#0000FF" vlink="#FF0000" alink="#009B00">
 <table width="605" border="0" cellspacing="0" cellpadding="0">
@@ -30,11 +41,11 @@
           </td>
         </tr>
         <tr> 
-          <td width="14%" height="15"><img src="Resources/pics/i-Tuts.gif" width="17" height="16" vspace="1" hspace="2"></td>
+          <td width="14%" height="15"><img src="Resources/pics/i-Tuts.gif" width="22" height="21" vspace="1" hspace="2"></td>
           <td width="86%" height="15"> <font size="-1">COBOL tutorial</font></td>
         </tr>
-        <tr> 
-          <td width="14%"><img src="Resources/pics/i-exercises.gif" width="16" height="16" hspace="2" vspace="1"></td>
+        <tr>
+          <td width="14%"><img src="Resources/pics/i-exercises.gif" width="21" height="21" hspace="2" vspace="1"></td>
           <td width="86%"><font size="-1">COBOL programming exercise</font></td>
         </tr>
         <tr valign="middle"> 


### PR DESCRIPTION
## Summary
- Add viewport meta tag and a small style block to [course/index.html](course/index.html) so mobile browsers reflow the page instead of rendering at desktop-width zoom.
- Below 600px, override the inline `width="..."` attributes on tables/cells so the fixed-pixel layout shrinks to fit narrow screens; cap the H1 dept image and large tables at 100%.
- Bump the legend's tutorial/exercise icons from 17x16/16x16 to 22x21/21x21 to match the icons used in the body section tables.
- Add 65px of bottom padding on mobile so the last row clears the browser's hide-on-scroll bottom toolbar (and the preview pane's bottom overlay).

Mirrors the minimal-CSS approach used for the landing page in #23 (`a350c48`). Desktop layout (>=600px) is unchanged — original 605/600px table widths still apply.

## Test plan
- [ ] Verify `course/index.html` fits a 375px-wide viewport with no horizontal scroll
- [ ] Verify the same at 320px
- [ ] Verify the page is unchanged at 1024px desktop
- [ ] Confirm the legend icons render at the larger size and match the body icons
- [ ] Confirm the last row ("The COBOL Report Writer") is reachable without being hidden under the browser's bottom toolbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)