### PR TITLE
Make COBOLIntro.html responsive and clean up legacy markup

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -1,7 +1,48 @@
 <html>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+   <meta name="viewport" content="width=device-width, initial-scale=1">
    <meta name="GENERATOR" content="Mozilla/4.0 [en] (WinNT; I) [Netscape]">
    <title>Introduction to COBOL</title>
+<style type="text/css">
+  img { max-width: 100%; height: auto; }
+  table { max-width: 100%; }
+  td[width="175"] h4 {
+    font-family: Arial, Helvetica, sans-serif;
+    color: #800000;
+    font-weight: bold;
+    font-size: 1.17em;
+    line-height: 1.2;
+  }
+  td[width="175"] h4 font { color: inherit; font-family: inherit; }
+  td[width="175"] h4 b { font-weight: inherit; }
+  ul.construct-list {
+    list-style-image: url(Resources/pics/BallRedG.gif);
+    font-family: Arial, Helvetica, sans-serif;
+    font-weight: bold;
+    color: #000099;
+    font-size: 1.5em;
+    padding-left: 4em;
+  }
+  ul.construct-list li { padding-left: 0.5em; }
+  @media (max-width: 600px) {
+    body { margin: 0; }
+    table[width="715"], table[width="710"],
+    table[width="715"] > tbody, table[width="710"] > tbody,
+    table[width="715"] > tbody > tr, table[width="710"] > tbody > tr,
+    table[width="715"] > tbody > tr > td, table[width="710"] > tbody > tr > td {
+      display: block;
+      width: auto;
+    }
+    table[width] { width: 100%; }
+    td[width="175"], td[width="525"] { display: block; width: auto; padding: 8px 12px; }
+    td[width="525"] { word-wrap: break-word; overflow-wrap: break-word; }
+    td[width="175"] h4 { margin: 0; }
+    blockquote { margin-left: 12px; margin-right: 12px; }
+    pre { overflow-x: auto; }
+    table[background] { table-layout: fixed; }
+    h2 { font-size: 1.4em; }
+  }
+</style>
 </head>
 <body text="#000000" bgcolor="#FFFFFF" link="#0000FF" vlink="#FF0000" alink="#009B00">
 <table border="1" width="715" cellspacing="0">
@@ -128,7 +169,6 @@
           </td>
           <td width="525" valign="top"> 
             <p>None. This is the first unit in the course.</p>
-            <p>&nbsp;</p>
           </td>
         </tr>
         <tr> 
@@ -148,7 +188,7 @@
         </tr>
         <tr> 
           <td valign="TOP" align="LEFT" width="175" bgcolor="#FFFFCC"> 
-            <h4><font face="Arial, Helvetica, sans-serif" color="#800000"><b>Introduction</b></font></h4>
+            <h4><font face="Arial, Helvetica, sans-serif" color="#800000">Introduction</font></h4>
           </td>
           <td width="525" valign="top"> 
             <p>COBOL is a high-level programming language first developed by the 
@@ -170,8 +210,8 @@
         </tr>
         <tr> 
           <td valign="TOP" align="LEFT" width="175" bgcolor="#FFFFCC"> 
-            <h4><font color="#800000"><b><font face="Arial, Helvetica, sans-serif">How 
-              widely used is COBOL? </font></b></font></h4>
+            <h4><font color="#800000" face="Arial, Helvetica, sans-serif">How
+              widely used is COBOL?</font></h4>
           </td>
           <td width="525" valign="top"> 
             <p>For over four decades COBOL has been the dominant programming language 
@@ -202,8 +242,10 @@
           </td>
         </tr>
         <tr> 
-          <td valign="TOP" align="LEFT" width="175" bgcolor="#FFFFCC"><font face="Arial, Helvetica, sans-serif" color="#800000"><b>Surprised 
-            by COBOL's success?</b></font></td>
+          <td valign="TOP" align="LEFT" width="175" bgcolor="#FFFFCC">
+            <h4><font face="Arial, Helvetica, sans-serif" color="#800000">Surprised
+              by COBOL's success?</font></h4>
+          </td>
           <td width="525" valign="top"> 
             <p>People are often surprised when presented with the evidence for 
               COBOL's dominance in the market place. The hype that surrounds some 
@@ -222,7 +264,7 @@
               spare and repair parts and equipment items with an inventory value 
               of $28 billion. The system runs on Amdahl mainframes at multiple 
               locations throughout the U.S. and contains over 4,000,000 lines 
-              of COBOL code.&quot; [<font size="-1">http://www.uppermohawkinc.com/corporate_capabilities.htm</font>] 
+              of COBOL code.&quot; [<font size="-1"><a href="#uppermohawk">Upper Mohawk</a></font>]
             </p>
             <p>In the horizontal software market, applications may still cost 
               millions of dollars to produce but thousands, and in some cases 
@@ -256,16 +298,15 @@
         </tr>
         <tr> 
           <td valign="TOP" align="LEFT" width="175" bgcolor="#FFFFCC"> 
-            <p><font face="Arial, Helvetica, sans-serif" color="#800000"><b>Some 
-              characteristics of COBOL applications</b></font></p>
-            <p>&nbsp;</p>
+            <h4><font face="Arial, Helvetica, sans-serif" color="#800000">Some
+              characteristics of COBOL applications</font></h4>
           </td>
           <td width="525" valign="top"> 
             <p>As exemplified by the DoD MRP II example above, COBOL applications 
-              are often very large.Many COBOL applications consist of more than 
+              are often very large. Many COBOL applications consist of more than 
               1,000,000 lines of code - with 6,000,000+ line applications not 
               considered unusually large in many shops.</p>
-            <p>COBOL applications are also very long-lived.The huge investment 
+            <p>COBOL applications are also very long-lived. The huge investment 
               in creating a software application consisting of some millions of 
               lines of COBOL code means that the application cannot simply be 
               discarded when some new programming language or technology appears. 
@@ -277,19 +318,21 @@
               these applications they just didn't anticipate that they would last 
               into this millennium.</p>
             <p>COBOL applications often run in critical areas of business. For 
-              instance, over 95% of finance&#150;insurance data is processed with 
-              COBOL [<font size="-1"><a href="#arranga">In Cobol&#146;s Defense</a>].</font> 
+              instance, over 95% of finance&#8211;insurance data is processed with 
+              COBOL [<font size="-1"><a href="#arranga">In Cobol&#8217;s Defense</a>].</font> 
               The serious financial and legal consequences that can result from 
               an application failure is one reason for the near panic over the 
               year 2000 problem.</p>
-            <p>COBOL applications often deal with enormous volumes of data.Single 
+            <p>COBOL applications often deal with enormous volumes of data. Single 
               production files and databases measured in terabytes are not uncommon.</p>
             <hr width="100%" align="center" size="1">
           </td>
         </tr>
         <tr> 
-          <td valign="TOP" align="LEFT" width="175" bgcolor="#FFFFCC"><font face="Arial, Helvetica, sans-serif" color="#800000"><b>Some 
-            characteristics that contribute to COBOL's success</b></font></td>
+          <td valign="TOP" align="LEFT" width="175" bgcolor="#FFFFCC">
+            <h4><font face="Arial, Helvetica, sans-serif" color="#800000">Some
+              characteristics that contribute to COBOL's success</font></h4>
+          </td>
           <td width="525" valign="top"> 
             <p><b>COBOL is self-documenting</b><br>
               One of the design goals for COBOL was to make it possible for non-programmers 
@@ -342,19 +385,15 @@
               of OO-COBOL has changed all that. OO-COBOL retains all the advantages 
               of previous versions but now includes -</p>
             <ul>
-              <ul>
-                <ul>
-                  <li>User Defined Functions </li>
-                  <li>Object Orientation</li>
-                  <li>National Characters - Unicode </li>
-                  <li>Multiple Currency Symbols </li>
-                  <li>Cultural Adaptability (Locales) </li>
-                  <li>Dynamic Memory Allocation (pointers)</li>
-                  <li>Data Validation Using New VALIDATE Verb </li>
-                  <li>Binary and Floating Point Data Types </li>
-                  <li>User Defined Data Types </li>
-                </ul>
-              </ul>
+              <li>User Defined Functions </li>
+              <li>Object Orientation</li>
+              <li>National Characters - Unicode </li>
+              <li>Multiple Currency Symbols </li>
+              <li>Cultural Adaptability (Locales) </li>
+              <li>Dynamic Memory Allocation (pointers)</li>
+              <li>Data Validation Using New VALIDATE Verb </li>
+              <li>Binary and Floating Point Data Types </li>
+              <li>User Defined Data Types </li>
             </ul>
             <p><b>COBOL is non-proprietary (portable)</b><br>
               The COBOL standard does not belong to any particular vendor. The 
@@ -365,7 +404,7 @@
               DG, VM, and MVS.</p>
             <p><br>
               <b>COBOL is Maintainable<br>
-              </b>COBOL has a 30 year proven track record for application maintenance, 
+              </b> COBOL has a 30 year proven track record for application maintenance, 
               enhancement and production support at the enterprise level. Early 
               indications from the year 2000 problem are that COBOL applications 
               were actually cheaper to fix than applications written in more recent 
@@ -438,9 +477,9 @@
               Programming Legacy - MicroFocus Ltd.</p>
             <p>Silverberg, Fred, COBOL and the Business Programming Paradigm (1996)</p>
             <p>Sneed, Harry M.- The Evolution of COBOL - COBOLReport.com</p>
-            <p>Wilkinson,Stephanie - From the Dustbin, Cobol Rises (May, 2001)- 
+            <p><a name="uppermohawk"></a><a href="https://web.archive.org/web/20030206082345/http://www.uppermohawkinc.com/corporate_capabilities.htm">Upper Mohawk, Inc. - Corporate Capabilities - uppermohawkinc.com</a></p>
+            <p>Wilkinson,Stephanie - From the Dustbin, Cobol Rises (May, 2001)-
               eWeek</p>
-            <p>&nbsp;</p>
             </td>
         </tr>
         <tr> 
@@ -474,8 +513,9 @@
           </td>
         </tr>
         <tr> 
-          <td valign="TOP" align="LEFT" width="175" bgcolor="#FFFFCC"><font color="#800000" face="Arial, Helvetica, sans-serif"><b> 
-            Let's write a program</b></font></td>
+          <td valign="TOP" align="LEFT" width="175" bgcolor="#FFFFCC">
+            <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Let's write a program</font></h4>
+          </td>
           <td width="525" valign="top"> 
             <p align="left">A program is a collection of statements written in 
               a language the computer understands.<br>
@@ -485,14 +525,11 @@
               statement in the program alters the order of execution.</p>
             <p align="left">Computer Scientists have shown that any program can 
               be written using the three main programming constructs;</p>
-            <table width="100%" border="0" cellspacing="1" cellpadding="1">
-              <tr> 
-                <td width="125">&nbsp;</td>
-                <td><font size="+2" face="Arial, Helvetica, sans-serif"><b><font size="+1" color="#000099"><img src="Resources/pics/BallRedG.gif" width="13" height="13" hspace="10">Sequence</font></b></font><font size="+1" color="#000099" face="Arial, Helvetica, sans-serif"><b><br>
-                  <font size="+2"><b><img src="Resources/pics/BallRedG.gif" width="13" height="13" hspace="10"></b></font>Selection<br>
-                  <font size="+2"><b><img src="Resources/pics/BallRedG.gif" width="13" height="13" hspace="10"></b></font>Iteration</b></font></td>
-              </tr>
-            </table>
+            <ul class="construct-list">
+              <li>Sequence</li>
+              <li>Selection</li>
+              <li>Iteration</li>
+            </ul>
             <p align="left">This section introduces COBOL programming by writing 
               some simple COBOL programs using these constructs.</p>
             <hr size="1" width="100%">
@@ -500,9 +537,8 @@
         </tr>
         <tr> 
           <td valign="TOP" align="LEFT" width="175" bgcolor="#FFFFCC"> 
-            <h4><font color="#800000" face="Arial, Helvetica, sans-serif"><b>Sequence 
-              Program Specification</b></font></h4>
-            <h4>&nbsp;</h4>
+            <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Sequence
+              Program Specification</font></h4>
             <h4 align="center"><font size="-1"> </font></h4>
           </td>
           <td width="525" valign="top"> 
@@ -557,8 +593,10 @@
           </td>
         </tr>
         <tr> 
-          <td valign="TOP" align="LEFT" width="175" bgcolor="#FFFFCC"><b><font color="#800000" face="Arial, Helvetica, sans-serif">Getting 
-            the Algorithm right</font></b></td>
+          <td valign="TOP" align="LEFT" width="175" bgcolor="#FFFFCC">
+            <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Getting
+              the Algorithm right</font></h4>
+          </td>
           <td width="525" valign="top"> 
             <p>Now all we need to do to have a working program is to declare the 
               items needed to store the data and to place the statements shown 
@@ -566,8 +604,7 @@
             <p>Click on these animations to see our attempts to write a program 
               that produces the correct answer. These attempts illustrate importance 
               of arranging the statements in a program so that they are executed 
-              in the correct order. 
-            <p>&nbsp; 
+              in the correct order.
             <table width="80%" border="1" cellspacing="1" cellpadding="1" align="center">
               <tr> 
                 <td> 
@@ -597,8 +634,8 @@
         </tr>
         <tr> 
           <td valign="TOP" align="LEFT" width="175" bgcolor="#FFFFCC"> 
-            <h4><font color="#800000" face="Arial, Helvetica, sans-serif"><b>An 
-              annotated look at the COBOL program</b></font></h4>
+            <h4><font color="#800000" face="Arial, Helvetica, sans-serif">An
+              annotated look at the COBOL program</font></h4>
           </td>
           <td width="525" valign="top"> 
             <p>Click on the animation below for an annotated version of the program. 
@@ -636,7 +673,6 @@
           <td valign="TOP" align="LEFT" width="175" bgcolor="#FFFFCC"> 
             <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Iteration 
               Program Specification</font></h4>
-            <p align="center">&nbsp;</p>
           </td>
           <td width="525" valign="top"> 
             <p>Write a program that accepts two numbers and an operator from the 
@@ -648,7 +684,6 @@
             <p align="center">Iteration Program<br>
               <a href="Resources/ppz/TC-CobIntro6.html"><img src="Resources/pics/i-Animation.gif" width="62" height="62" align="middle" border="0"></a> 
             </p>
-            <p>&nbsp;</p>
           </td>
         </tr>
         <tr> 
@@ -669,7 +704,6 @@
         <tr> 
           <td valign="TOP" align="LEFT" width="175" bgcolor="#FFFFCC"> 
             <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font></h4>
-            <h4>&nbsp;</h4>
           </td>
           <td width="525" valign="top"> 
             <p>This section presents the fundamentals of constructing COBOL programs. 
@@ -682,8 +716,8 @@
         </tr>
         <tr> 
           <td valign="TOP" align="LEFT" width="175" bgcolor="#FFFFCC"> 
-            <h4 align="left"><b><font color="#800000" face="Arial, Helvetica, sans-serif">COBOL 
-              idiosyncrasies</font> </b></h4>
+            <h4 align="left"><font color="#800000" face="Arial, Helvetica, sans-serif">COBOL
+              idiosyncrasies</font></h4>
           </td>
           <td width="525" valign="top"> 
             <p>COBOL is one of the oldest programming languages in use. As a result 
@@ -739,7 +773,6 @@
           <td valign="TOP" align="LEFT" width="175" bgcolor="#FFFFCC"> 
             <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Some 
               notes on syntax diagrams</font></h4>
-            <h4>&nbsp;</h4>
           </td>
           <td width="525" valign="top"> 
             <p>To simplify the syntax diagrams and reduce the number of rules 
@@ -776,28 +809,17 @@
                     or an alphanumeric data-item</font></td>
                 </tr>
               </table>
-              <p>&nbsp;</p>
-            </blockquote>
+              </blockquote>
           </td>
         </tr>
         <tr> 
           <td valign="TOP" align="LEFT" width="175" bgcolor="#FFFFCC"> 
             <h4><font color="#800000" face="Arial, Helvetica, sans-serif">An example 
               syntax diagram</font></h4>
-            <h4>&nbsp;</h4>
-            <h4>&nbsp;</h4>
-            <h4>&nbsp; </h4>
-            <h4>&nbsp;</h4>
-            <h4>&nbsp;</h4>
-            <h4>&nbsp;</h4>
-            <h4>&nbsp;</h4>
-            <h4>&nbsp;</h4>
             <div align="center"><img src="Resources/pics/i-Detail.gif" width="30" height="37"><br>
               <font size="-1">Note that for clarity data items may be separated 
               from one another by means of an optional comma. <br>
               This has been done in the COMPUTE statement opposite</font></div>
-            <h4>&nbsp;</h4>
-            <h4 align="center">&nbsp;</h4>
           </td>
           <td width="525" valign="top"> 
             <p>In COBOL, evaluating an arithmetic expression and assigning the 
@@ -833,8 +855,8 @@
         </tr>
         <tr> 
           <td valign="TOP" align="LEFT" width="175" bgcolor="#FFFFCC"> 
-            <h4><font color="#800000" face="Arial, Helvetica, sans-serif"><b>COBOL 
-              coding rules</b></font></h4>
+            <h4><font color="#800000" face="Arial, Helvetica, sans-serif">COBOL
+              coding rules</font></h4>
           </td>
           <td width="525" valign="top"> 
             <p>Traditionally, COBOL programs were written on coding forms and 
@@ -864,8 +886,8 @@
         </tr>
         <tr> 
           <td valign="TOP" align="LEFT" width="175" bgcolor="#FFFFCC"> 
-            <h4><b><font color="#800000" face="Arial, Helvetica, sans-serif">Name 
-              construction</font></b></h4>
+            <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Name
+              construction</font></h4>
           </td>
           <td width="525" valign="top"> 
             <p>All user-defined names, such as data names, paragraph names, section 
@@ -890,11 +912,6 @@
           <td valign="TOP" align="LEFT" width="175" bgcolor="#FFFFCC"> 
             <h4><font face="Arial, Helvetica, sans-serif" color="#800000">The 
               structure of COBOL programs</font></h4>
-            <h4 align="center">&nbsp;</h4>
-            <h4 align="center">&nbsp;</h4>
-            <h4 align="center">&nbsp;</h4>
-            <h4 align="center">&nbsp;</h4>
-            <h4 align="center">&nbsp;</h4>
           </td>
           <td width="525" valign="top"> 
             <p>COBOL programs are hierarchical in structure. Each element of the 
@@ -906,10 +923,8 @@
               or more Statements. </p>
             <p>We can represent the COBOL hierarchy using the COBOL metalanguage 
               as follows;</p>
-            <p>&nbsp;</p>
             <p align="center"> <img src="Resources/pics/CobolStructure.gif" width="467" height="203"><br>
             </p>
-            <p align="center">&nbsp;</p>
             <p align="left"><b><font face="Arial, Helvetica, sans-serif">Divisions</font></b><br>
               A division is a block of code, usually containing one or more sections, 
               that starts where the division name is encountered and ends with 
@@ -928,8 +943,7 @@
               <p> <b><font face="Courier New, Courier, mono">SelectUnpaidBills 
                 SECTION.<br>
                 </font></b><font face="Courier New, Courier, mono"><b>FILE SECTION.</b></font></p>
-              <p>&nbsp;</p>
-            </blockquote>
+              </blockquote>
             <p><font face="Arial, Helvetica, sans-serif"><b>Paragraphs</b></font><br>
               A paragraph is a block of code made up of one or more sentences. 
               A paragraph begins with the paragraph name and ends with the next 
@@ -941,7 +955,6 @@
               <p><font face="Courier New, Courier, mono"><b>PrintFinalTotals.<br>
                 </b></font><font face="Courier New, Courier, mono"><b>PROGRAM-ID.</b></font><br>
               </p>
-              <p>&nbsp; </p>
             </blockquote>
             <p><font face="Arial, Helvetica, sans-serif"><b>Sentences and statements</b></font><br>
               A sentence consists of one or more statements and is terminated 
@@ -961,7 +974,6 @@
                 GrossPay GIVING NetPay</font></b><br>
               </p>
             </blockquote>
-            <p align="left">&nbsp; </p>
           </td>
         </tr>
         <tr> 
@@ -988,27 +1000,22 @@
               divide the program into distinct structural elements. Although some 
               of the divisions may be omitted, the sequence in which they are 
               specified is fixed, and must follow the order below.</p>
-            <blockquote> 
-              <blockquote> 
-                <blockquote> 
-                  <p align="center"><br>
-                    <b><font face="Arial, Helvetica, sans-serif" size="+1">IDENTIFICATION 
-                    DIVISION.</font></b><br>
-                    Contains program information</p>
-                  <p align="center"><font face="Arial, Helvetica, sans-serif"><b><font size="+1">ENVIRONMENT 
-                    DIVISION.</font></b></font><br>
-                    Contains environment information</p>
-                  <p align="center"><font face="Arial, Helvetica, sans-serif"><b><font size="+1">DATA 
-                    DIVISION.</font></b></font><br>
-                    Contains data descriptions</p>
-                  <p align="center"><b><font face="Arial, Helvetica, sans-serif" size="+1">PROCEDURE 
-                    DIVISION.</font></b><br>
-                    Contains the program algorithms<br>
-                  </p>
-                </blockquote>
-              </blockquote>
+            <blockquote>
+              <p align="center"><br>
+                <b><font face="Arial, Helvetica, sans-serif" size="+1">IDENTIFICATION
+                DIVISION.</font></b><br>
+                Contains program information</p>
+              <p align="center"><font face="Arial, Helvetica, sans-serif"><b><font size="+1">ENVIRONMENT
+                DIVISION.</font></b></font><br>
+                Contains environment information</p>
+              <p align="center"><font face="Arial, Helvetica, sans-serif"><b><font size="+1">DATA
+                DIVISION.</font></b></font><br>
+                Contains data descriptions</p>
+              <p align="center"><b><font face="Arial, Helvetica, sans-serif" size="+1">PROCEDURE
+                DIVISION.</font></b><br>
+                Contains the program algorithms<br>
+              </p>
             </blockquote>
-            <div align="center"></div>
             <hr width="100%" size="1">
           </td>
         </tr>
@@ -1051,15 +1058,13 @@
                 </td>
               </tr>
             </table>
-            <p>&nbsp;</p>
             <hr size="1" width="100%">
           </td>
         </tr>
         <tr> 
           <td valign="TOP" align="LEFT" width="175" bgcolor="#FFFFCC"> 
-            <h4 align="left"><font color="#800000"><b><font face="Arial, Helvetica, sans-serif">The 
-              ENVIRONMENT DIVISION</font></b></font></h4>
-            <h4>&nbsp;</h4>
+            <h4 align="left"><font color="#800000" face="Arial, Helvetica, sans-serif">The
+              ENVIRONMENT DIVISION</font></h4>
           </td>
           <td width="525" valign="top"> 
             <p>The <font size="-1">ENVIRONMENT DIVISION</font> is used to describe 
@@ -1079,8 +1084,8 @@
         </tr>
         <tr> 
           <td valign="TOP" align="LEFT" width="175" bgcolor="#FFFFCC"> 
-            <div align="left"><font color="#800000"><b><font face="Arial, Helvetica, sans-serif">The 
-              DATA DIVISION</font></b></font></div>
+            <h4 align="left"><font color="#800000" face="Arial, Helvetica, sans-serif">The
+              DATA DIVISION</font></h4>
           </td>
           <td width="525" valign="top"> 
             <p>As the name suggests, the <font size="-1">DATA DIVISION</font> 
@@ -1112,7 +1117,6 @@
                 </td>
               </tr>
             </table>
-            <p>&nbsp;</p>
             <hr size="1" width="100%">
           </td>
         </tr>
@@ -1120,7 +1124,6 @@
           <td valign="TOP" align="LEFT" width="175" bgcolor="#FFFFCC"> 
             <h4 align="left"><font color="#800000" face="Arial, Helvetica, sans-serif">The 
               PROCEDURE DIVISION</font></h4>
-            <h4>&nbsp;</h4>
           </td>
           <td width="525" valign="top"> 
             <p>The <font size="-1">PROCEDURE DIVISION</font> contains the code 
@@ -1159,7 +1162,6 @@ CalculateResult.
                 </td>
               </tr>
             </table>
-            <p>&nbsp;</p>
             <p>Some COBOL compilers require that all the divisions be present 
               in a program while others only require the <font size="-1">IDENTIFICATION 
               DIVISION</font> and the <font size="-1">PROCEDURE DIVISION</font>. 
@@ -1178,8 +1180,6 @@ DisplayGreeting.
                 </td>
               </tr>
             </table>
-            <p>&nbsp;</p>
-            <p align="left">&nbsp; </p>
           </td>
         </tr>
         <tr> 


### PR DESCRIPTION
## Summary

The COBOL Introduction page was authored for a fixed 715px desktop layout with no viewport meta tag, so mobile browsers rendered it at desktop-width zoom and the two-column sidebar/content tables overflowed off-screen. This PR makes the page render cleanly on phones while preserving the desktop two-column design, and incidentally cleans up some legacy markup quirks (cp1252 entities, vertical-tab control characters, triple-nested `<ul>`/`<blockquote>` indentation hacks, a hand-built `<table>` standing in for a bullet list, and an inline URL that should have been a citation).

## What changed

**Responsive (`course/COBOLIntro.html`)**
- Add `<meta name=viewport>`.
- Add a small `<style>` block: caps images and tables at 100% width; under 600px stacks the layout-table cells, allows long URLs to break, scopes blockquote indentation, makes `<pre>` blocks scroll horizontally, and forces `table-layout: fixed` on the code-fragment tables so they honor 100% width instead of expanding to the longest source line.

**Sidebar headings**
- Wrap the six sidebar titles that were bare `<font>` / `<p>` / `<div>` in `<h4>` so all sidebar headings share the same tag.
- Strip redundant inner `<b>` from the existing `<h4>` sidebar titles (some browsers were rendering nested `<b>` as extra-bold).
- CSS now styles only `td[width=\"175\"] h4`, so non-heading sidebar content like the "Detail" notes renders normally.

**Markup cleanup**
- Delete empty `<h4>&nbsp;</h4>` / `<p>&nbsp;</p>` desktop spacers that produced large blank yellow blocks once rows stacked.
- Collapse triple-nested `<ul><ul><ul>` around the OO-COBOL features list and triple-nested `<blockquote>` around the four-divisions list to single elements.
- Convert the Sequence/Selection/Iteration construct list from a hand-built `<table>` with inline `<img>` bullets and `<br>`s into a real `<ul>` that uses `BallRedG.gif` as `list-style-image`.
- Replace four vertical-tab control characters (U+000B) that were rendering as empty boxes with regular spaces.
- Replace cp1252 numeric character references `&#150;` / `&#146;` with the standard Unicode entities `&#8211;` (en-dash) / `&#8217;` (right single quote).
- Replace the inline `uppermohawkinc.com` URL with an in-page `[Upper Mohawk]` anchor link (matching the existing `[Brown]` / `[Capers Jones]` / `[Kappleman]` citation pattern), and add a "Upper Mohawk, Inc. - Corporate Capabilities - uppermohawkinc.com" entry to the References section linking to the web.archive.org snapshot.

The desktop two-column sidebar/content layout, color palette, and typography are preserved.

## Test plan

- [ ] Open `course/COBOLIntro.html` at desktop width — two-column layout intact, all sidebar headings render at the same bold maroon Arial weight, "Detail" notes still small.
- [ ] Open at mobile width (~375px) — no horizontal scroll, sidebar headings sit above their content rather than next to it, code blocks scroll horizontally inside their card.
- [ ] Click `[Upper Mohawk]` in the "What is COBOL?" section — jumps to the new entry in References; clicking the entry opens the web.archive.org page.
- [ ] Spot-check rendering of "very large. Many", "long-lived. The", "data. Single", "finance–insurance", and "Cobol's Defense" — no empty boxes.