### PR TITLE
Remove stale "(new may 2002)" annotations from course index

### DIFF
--- a/course/index.html
+++ b/course/index.html
@@ -69,9 +69,8 @@
             <table width="100%" border="0" cellspacing="0" cellpadding="0">
               <tr>
                 <td width="5%"><img src="Resources/pics/i-Tut.gif" width="22" height="21" vspace="4" hspace="5" alt="COBOL tutorial"></td>
-                <td width="95%"><a href="COBOLIntro.html">The structure 
-                  of COBOL programs</a> <font color="#FF0000" size="-1">(new 
-                  may 2002)</font></td>
+                <td width="95%"><a href="COBOLIntro.html">The structure
+                  of COBOL programs</a></td>
               </tr>
               <tr>
                 <td width="5%"><img src="Resources/pics/i-Tut.gif" width="22" height="21" vspace="4" hspace="5" alt="COBOL tutorial"></td>
@@ -183,8 +182,8 @@
               </tr>
               <tr> 
                 <td width="5%"><img src="Resources/pics/i-Tut.gif" width="22" height="21" vspace="4" hspace="4" alt="COBOL tutorial"></td>
-                <td width="95%"><a href="Usage.html">The USAGE 
-                  clause</a> <font color="#FF0000" size="-1">(new may 2002)</font></td>
+                <td width="95%"><a href="Usage.html">The USAGE
+                  clause</a></td>
               </tr>
               <tr> 
                 <td width="5%"><img src="Resources/pics/i-exercise.gif" width="21" height="21" vspace="4" hspace="4"></td>
@@ -307,15 +306,13 @@
             <table width="100%" border="0" cellspacing="0" cellpadding="0">
               <tr> 
                 <td width="5%"><img src="Resources/pics/i-Tut.gif" width="22" height="21" vspace="4" hspace="4" alt="COBOL tutorial"></td>
-                <td width="95%"><a href="Subprograms.html">Contained 
-                  and external sub-programs</a> <font color="#FF0000" size="-1">(new 
-                  may 2002)</font></td>
+                <td width="95%"><a href="Subprograms.html">Contained
+                  and external sub-programs</a></td>
               </tr>
               <tr> 
                 <td width="5%"><img src="Resources/pics/i-Tut.gif" width="22" height="21" vspace="4" hspace="4" alt="COBOL tutorial"></td>
-                <td width="95%"><a href="Copy.html">The 
-                  COPY verb</a> <font color="#FF0000" size="-1">(new may 
-                  2002)</font></td>
+                <td width="95%"><a href="Copy.html">The
+                  COPY verb</a></td>
               </tr>
             </table>
             


### PR DESCRIPTION
## Summary
- Removed four red `(new may 2002)` badges from `course/index.html` (next to *The structure of COBOL programs*, *The USAGE clause*, *Contained and external sub-programs*, and *The COPY verb*)
- These tags were added 24 years ago to flag newly added tutorials and no longer convey useful information

## Test plan
- [ ] Open `course/index.html` in a browser and confirm the four entries render cleanly with no leftover red text or stray whitespace