### PR TITLE
Link Resources citations in COBOLIntro

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -446,23 +446,23 @@
               dynamic and links are all to easily broken I won't give the URL's 
               here. You will have to search for them.</p>
             <h3 align="center">Resources</h3>
-            <p>Ankrum,T. Scott - COBOL -- A Best Practice (Sept, 2001)- COBOLReport.com</p>
-            <p>Arranga,Edmund C. - The Viagrazation of COBOL - COBOLwebler.com</p>
-            <p>Arranga, Edmund C. &amp; Price, Wilson - Fresh from Y2K, What's 
-              next for COBOL? (March/April 2000) - IEEE Software</p>
-            <p><a name="arranga"></a>Arranga et al - In COBOL's Defense : Roundtable 
-              Discussion (March/April 2000) - IEEE Software</p>
+            <p><a href="https://web.archive.org/web/20020126202926/http://cobolreport.com/pp/">Ankrum,T. Scott - COBOL -- A Best Practice (Sept, 2001)- COBOLReport.com</a></p>
+            <p><a href="https://web.archive.org/web/20020326093554/http://www.cobolwebler.com/new_cobol.htm">Arranga,Edmund C. - The Viagrazation of COBOL - COBOLwebler.com</a></p>
+            <p><a href="https://ieeexplore.ieee.org/document/841599">Arranga, Edmund C. &amp; Price, Wilson - Fresh from Y2K, What's
+              next for COBOL? (March/April 2000) - IEEE Software</a></p>
+            <p><a name="arranga"></a><a href="https://www.computer.org/csdl/magazine/so/2000/02/s2070/13rRUxBrGey">Arranga et al - In COBOL's Defense : Roundtable
+              Discussion (March/April 2000) - IEEE Software</a></p>
             <p>Badower, Justin - COBOL: Foundation of the future - COBOLwebler.com</p>
             <p><a name="brown"></a>Brown, Gary DeWard - COBOL: The failure that 
               wasn't - COBOLReport.com</p>
             <p>Burger,Thomas Wolfgang - COBOL in an open source future (May 2000) 
               - IBM developerWorks : Linux : Linux articles</p>
-            <p>Carr, Donald &amp; Kizior, Ronald J. - The Case for Continued COBOL 
-              Education (March/April 2000) - IEEE Software</p>
+            <p><a href="https://ieeexplore.ieee.org/abstract/document/841603">Carr, Donald &amp; Kizior, Ronald J. - The Case for Continued COBOL
+              Education (March/April 2000) - IEEE Software</a></p>
             <p>Feiman, J. - The Gartner Programming Language Survey (October 2001) 
               - Gartner Advisory</p>
-            <p>Glass, Robert L. - Cobol - A Contradiction and an Enigma - COMMUNICATIONS 
-              OF THE ACM September 1997/Vol. 40, No. 9</p>
+            <p><a href="https://dl.acm.org/doi/10.1145/260750.260752">Glass, Robert L. - Cobol - A Contradiction and an Enigma - COMMUNICATIONS
+              OF THE ACM September 1997/Vol. 40, No. 9</a></p>
             <p><a name="capers"></a>Jones, Capers - The global economic impact 
               of the year 2000 software problem (Jan, 1997) </p>
             <p><a name="kapple"></a>Kappelman, Leon A. - Some Strategic Y2K Blessings 


### PR DESCRIPTION
## Summary
- Convert six entries in the **References and further reading** list of `course/COBOLIntro.html` into hyperlinks, wrapping the whole citation in the anchor to match the existing Upper Mohawk entry's style.
- Defunct sites (COBOLReport.com, COBOLwebler.com) point at stable archive.org snapshots; journal articles point at publisher canonical URLs (IEEE Xplore, ACM DL, IEEE Computer Society).
- Preserves the existing `<a name="arranga">` named anchor on the In COBOL's Defense paragraph.

Newly linked citations:
- Ankrum, T. Scott - COBOL -- A Best Practice
- Arranga, Edmund C. - The Viagrazation of COBOL
- Arranga & Price - Fresh from Y2K, What's next for COBOL?
- Arranga et al - In COBOL's Defense: Roundtable Discussion
- Carr & Kizior - The Case for Continued COBOL Education
- Glass, Robert L. - Cobol - A Contradiction and an Enigma

## Test plan
- [ ] Open `course/COBOLIntro.html` and scroll to the Resources section; confirm each new link renders and points at the expected URL.
- [ ] Verify the `#arranga` fragment still scrolls to the In COBOL's Defense paragraph.