### PR TITLE
Make outer borders consistent across course pages

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -47,7 +47,7 @@
 </style>
 </head>
 <body text="#000000" bgcolor="#FFFFFF" link="#0000FF" vlink="#FF0000" alink="#009B00">
-<table border="1" width="715" cellspacing="0">
+<table border="1" width="715">
   <tr>
     <td> 
       <table width="710" cellpadding="4" cellspacing="0" border="0">

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -67,7 +67,7 @@
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
-<table border="1" cellspacing="0" height="100%" width="715">
+<table border="1" height="100%" width="715">
 <tr>
 <td>
 <table border="0" cellpadding="4" cellspacing="0" width="710">

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -68,7 +68,7 @@
     }
   }
 </style>
-<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000"><table border="1" width="715"><tbody><tr><td>
 <center>
 </center>
 <center>
@@ -1211,7 +1211,7 @@ ProcessOneBook.
 </td>
 </tr>
 </table>
-</body>
+</td></tr></tbody></table></body>
 </html>
 &lt;!--
 &lt;!--

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -68,7 +68,7 @@
     }
   }
 </style>
-<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000"><table border="1" width="715"><tbody><tr><td>
 <center>
 </center>
 <center>
@@ -694,7 +694,7 @@ END-PERFORM</pre>
 </td>
 </tr>
 </table>
-</body>
+</td></tr></tbody></table></body>
 </html>
 &lt;!--
 &lt;!--

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -68,7 +68,7 @@
     }
   }
 </style>
-<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000"><center>
+<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000"><table border="1" width="715"><tbody><tr><td><center>
 <div align="LEFT">
 <table border="0" width="710">
 <tr>
@@ -979,7 +979,7 @@
 </table>
 </div>
 
-</body>
+</td></tr></tbody></table></body>
 </html>
 &lt;!--
 &lt;!--

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -68,7 +68,7 @@
     }
   }
 </style>
-<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000"><table border="1" width="715"><tbody><tr><td>
 <center>
 <h2> </h2>
 </center>
@@ -870,7 +870,7 @@ Begin.</pre>
 </td>
 </tr>
 </table>
-</body>
+</td></tr></tbody></table></body>
 </html>
 &lt;!--
 &lt;!--

--- a/course/Search.html
+++ b/course/Search.html
@@ -67,7 +67,7 @@
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
-<table border="1" cellspacing="0" width="715">
+<table border="1" width="715">
 <tr>
 <td>
 <table border="0" cellpadding="4" cellspacing="0" width="710">

--- a/course/String.html
+++ b/course/String.html
@@ -68,7 +68,7 @@
     }
   }
 </style>
-<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000"><table border="1" width="715"><tbody><tr><td>
 <center>
 </center>
 <center>
@@ -497,7 +497,7 @@ END-STRING.</pre>
 </td>
 </tr>
 </table>
-</body>
+</td></tr></tbody></table></body>
 </html>
 &lt;!--
 &lt;!--

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -67,7 +67,7 @@
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
-<table border="1" cellspacing="0" width="715">
+<table border="1" width="715">
 <tr>
 <td>
 <table border="0" cellpadding="4" cellspacing="0" width="710">

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -67,7 +67,7 @@
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
-<table border="1" cellspacing="0" width="715">
+<table border="1" width="715">
 <tr>
 <td>
 <table border="0" cellpadding="4" cellspacing="0" width="710">

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -67,7 +67,7 @@
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
-<table border="1" cellspacing="0" width="715">
+<table border="1" width="715">
 <tr>
 <td>
 <table border="0" cellpadding="4" cellspacing="0" width="710">

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -68,7 +68,7 @@
     }
   }
 </style>
-<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000"><table border="1" width="715"><tbody><tr><td>
 <center>
 </center>
 <center>
@@ -656,7 +656,7 @@ Begin.
 </td>
 </tr>
 </table>
-</body>
+</td></tr></tbody></table></body>
 </html>
 &lt;!--
 &lt;!--

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -67,7 +67,7 @@
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
-<table border="1" cellspacing="0" height="100%" width="715">
+<table border="1" height="100%" width="715">
 <tr>
 <td>
 <table border="0" cellpadding="4" cellspacing="0" width="710">


### PR DESCRIPTION
## Summary
- Course pages had three different outer-border treatments: a true double border (most pages), a single line (`cellspacing=\"0\"` collapsed table+cell borders), and no border at all (no outer wrapper).
- Removed `cellspacing=\"0\"` from the outer `<table border=\"1\">` on the single-line pages so the browser's default cellspacing reinstates the two-line look.
- Wrapped the borderless pages in `<table border=\"1\" width=\"715\"><tbody><tr><td>…</td></tr></tbody></table>` so they get the same frame.

Pages affected:
- Single → double: COBOLIntro, Copy, Search, Subprograms, Tables1, Tables2, Usage
- None → double: Inspect, String, Unstring, IndexedFiles, Intro2DirectAccess, RelativeFiles

## Test plan
- [ ] Visit each modified page on desktop and confirm a double-line border around the page content
- [ ] Visit a previously-correct page (e.g. Iteration.html) and confirm it is unchanged
- [ ] Spot-check mobile rendering — the existing `@media (max-width: 600px)` rules should still apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)