### PR TITLE
Use i-pagetop.gif image for "back to top" link on six course pages

### DIFF
--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -165,7 +165,7 @@
 <tr>
 <td>
 <hr/>
-<p align="CENTER"><a href="#top">To top of page</a></p>
+<p align="CENTER"><a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a></p>
 
 </td>
 </tr>
@@ -388,7 +388,7 @@ VIDEO STATUS :- 23</pre>
 <tr>
 <td>
 <hr/>
-<p align="CENTER"><a href="#top">To top of page</a></p>
+<p align="CENTER"><a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a></p>
 
 </td>
 </tr>
@@ -501,7 +501,7 @@ VIDEO STATUS :- 23</pre>
 <tr>
 <td>
 <hr/>
-<p align="CENTER"><a href="#top">To top of page</a></p>
+<p align="CENTER"><a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a></p>
 
 </td>
 </tr>
@@ -577,7 +577,7 @@ VIDEO STATUS :- 23</pre>
 <tr>
 <td>
 <hr/>
-<p align="CENTER"><a href="#top">To top of page</a></p>
+<p align="CENTER"><a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a></p>
 
 </td>
 </tr>
@@ -785,7 +785,7 @@ VIDEO STATUS :- 23</pre>
 <tr>
 <td>
 <hr/>
-<p align="CENTER"><a href="#top">To top of page</a></p>
+<p align="CENTER"><a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a></p>
 
 </td>
 </tr>
@@ -1190,7 +1190,7 @@ ProcessOneBook.
 <tr>
 <td>
 <hr/>
-<p align="CENTER"><a href="#top">To top of page</a></p>
+<p align="CENTER"><a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a></p>
 
 </td>
 </tr>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -206,7 +206,7 @@
 <tr>
 <td>
 <hr/>
-<p align="CENTER"><a href="#top">To top of page</a></p>
+<p align="CENTER"><a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a></p>
 
 </td>
 </tr>
@@ -345,7 +345,7 @@ Begin.
 <tr>
 <td>
 <hr/>
-<p align="CENTER"><a href="#top">To top of page</a></p>
+<p align="CENTER"><a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a></p>
 
 </td>
 </tr>
@@ -395,7 +395,7 @@ INSPECT SourceLine TALLYING ECount
 <tr>
 <td>
 <hr/>
-<p align="CENTER"><a href="#top">To top of page</a></p>
+<p align="CENTER"><a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a></p>
 
 </td>
 </tr>
@@ -509,7 +509,7 @@ END-PERFORM</pre>
 <tr>
 <td>
 <hr/>
-<p align="CENTER"><a href="#top">To top of page</a></p>
+<p align="CENTER"><a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a></p>
 
 </td>
 </tr>
@@ -535,7 +535,7 @@ END-PERFORM</pre>
 <tr>
 <td>
 <hr/>
-<p align="CENTER"><a href="#top">To top of page</a></p>
+<p align="CENTER"><a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a></p>
 
 </td>
 </tr>
@@ -673,7 +673,7 @@ END-PERFORM</pre>
 <tr>
 <td>
 <hr/>
-<p align="CENTER"><a href="#top">To top of page</a></p>
+<p align="CENTER"><a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a></p>
 
 </td>
 </tr>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -162,7 +162,7 @@
 <tr>
 <td>
 <hr/>
-<p align="CENTER"><a href="#top">To top of page</a></p>
+<p align="CENTER"><a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a></p>
 
 </td>
 </tr>
@@ -319,7 +319,7 @@
 <tr>
 <td>
 <hr/>
-<p align="CENTER"><a href="#top">To top of page</a></p>
+<p align="CENTER"><a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a></p>
 
 </td>
 </tr>
@@ -453,7 +453,7 @@
 <tr>
 <td>
 <hr/>
-<p align="CENTER"><a href="#top">To top of page</a></p>
+<p align="CENTER"><a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a></p>
 
 </td>
 </tr>
@@ -564,7 +564,7 @@
 <tr>
 <td>
 <hr/>
-<p align="CENTER"><a href="#top">To top of page</a></p>
+<p align="CENTER"><a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a></p>
 
 </td>
 </tr>
@@ -943,7 +943,7 @@
 <tr>
 <td>
 <hr/>
-<p align="CENTER"><a href="#top">To top of page</a></p>
+<p align="CENTER"><a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a></p>
 
 </td>
 </tr>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -176,7 +176,7 @@
 <tr>
 <td>
 <hr/>
-<p align="CENTER"><a href="#top">To top of page</a></p>
+<p align="CENTER"><a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a></p>
 
 </td>
 </tr>
@@ -290,7 +290,7 @@ Enter supplier key (2 digits)-&gt; 05
 <tr>
 <td>
 <hr/>
-<p align="CENTER"><a href="#top">To top of page</a></p>
+<p align="CENTER"><a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a></p>
 
 </td>
 </tr>
@@ -423,7 +423,7 @@ Enter supplier key (2 digits)-&gt; 05
 <tr>
 <td>
 <hr/>
-<p align="CENTER"><a href="#top">To top of page</a></p>
+<p align="CENTER"><a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a></p>
 
 </td>
 </tr>
@@ -711,7 +711,7 @@ Enter supplier key (2 digits)-&gt; 05
 <tr>
 <td>
 <hr/>
-<p align="CENTER"><a href="#top">To top of page</a></p>
+<p align="CENTER"><a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a></p>
 
 </td>
 </tr>
@@ -849,7 +849,7 @@ Begin.</pre>
 <tr>
 <td>
 <hr/>
-<p align="CENTER"><a href="#top">To top of page</a></p>
+<p align="CENTER"><a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a></p>
 
 </td>
 </tr>

--- a/course/String.html
+++ b/course/String.html
@@ -155,7 +155,7 @@
 <tr>
 <td>
 <hr/>
-<p align="CENTER"><a href="#top">To top of page</a></p>
+<p align="CENTER"><a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a></p>
 
 </td>
 </tr>
@@ -332,7 +332,7 @@ END-STRING.</pre>
 <tr>
 <td>
 <hr/>
-<p align="CENTER"><a href="#top">To top of page</a></p>
+<p align="CENTER"><a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a></p>
 
 </td>
 </tr>
@@ -476,7 +476,7 @@ END-STRING.</pre>
 <tr>
 <td>
 <hr/>
-<p align="CENTER"><a href="#top">To top of page</a></p>
+<p align="CENTER"><a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a></p>
 
 </td>
 </tr>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -158,7 +158,7 @@
 <tr>
 <td>
 <hr/>
-<p align="CENTER"><a href="#top">To top of page</a></p>
+<p align="CENTER"><a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a></p>
 
 </td>
 </tr>
@@ -395,7 +395,7 @@ END-UNSTRING.</pre>
 <tr>
 <td>
 <hr/>
-<p align="CENTER"><a href="#top">To top of page</a></p>
+<p align="CENTER"><a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a></p>
 
 </td>
 </tr>
@@ -568,7 +568,7 @@ Begin.
 <tr>
 <td>
 <hr/>
-<p align="CENTER"><a href="#top">To top of page</a></p>
+<p align="CENTER"><a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a></p>
 
 </td>
 </tr>
@@ -635,7 +635,7 @@ Begin.
 <tr>
 <td>
 <hr/>
-<p align="CENTER"><a href="#top">To top of page</a></p>
+<p align="CENTER"><a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a></p>
 
 </td>
 </tr>


### PR DESCRIPTION
## Summary
- Six course pages (Unstring, String, Inspect, IndexedFiles, RelativeFiles, Intro2DirectAccess) had a plain text `To top of page` hyperlink at the bottom of each section while the other 19 course pages used the `Resources/pics/i-pagetop.gif` image link.
- Replaced the inner link content on those six pages so the bottom-of-section nav matches the rest of the course visually.
- Surrounding markup (`<tr><td><hr/><p align="CENTER">...</p></td></tr>`) is unchanged — only the anchor body went from `To top of page` text to the same `<img ... src="Resources/pics/i-pagetop.gif" ...>` already used elsewhere.

## Test plan
- [ ] Open each affected page in a browser and scroll to the bottom of any section — the "back to top" element should now render as the image button instead of an unstyled text link.
- [ ] Click the image link and confirm it still jumps to `#top`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)