### PR TITLE
Fix Iteration page rendering wider than other course pages

### DIFF
--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -1148,7 +1148,7 @@ END-PERFORM</pre>
 </td>
 </tr>
 <tr>
-<td align="LEFT" bgcolor="#FFFFCC" height="355" nowrap="" valign="top" width="175">
+<td align="LEFT" bgcolor="#FFFFCC" height="355" valign="top" width="175">
 <h4 align="left"><font color="#800000" face="Arial, Helvetica, sans-serif">PERFORM..VARYING 
               syntax </font></h4>
 </td>
@@ -1189,7 +1189,7 @@ END-PERFORM</pre>
 </td>
 </tr>
 <tr>
-<td align="LEFT" bgcolor="#FFFFCC" nowrap="" valign="top" width="175">
+<td align="LEFT" bgcolor="#FFFFCC" valign="top" width="175">
 <h4 align="left"><font color="#800000" face="Arial, Helvetica, sans-serif">PERFORM..VARYING 
               using one counter </font><font color="#800000" face="Arial, Helvetica, sans-serif">Example</font></h4>
 
@@ -1228,7 +1228,7 @@ END-PERFORM</pre>
 </td>
 </tr>
 <tr>
-<td align="LEFT" bgcolor="#FFFFCC" nowrap="" valign="top" width="175">
+<td align="LEFT" bgcolor="#FFFFCC" valign="top" width="175">
 <h4 align="left"><font color="#800000" face="Arial, Helvetica, sans-serif">PERFORM..VARYING 
               </font><font color="#800000" face="Arial, Helvetica, sans-serif">Example 
               Program</font></h4>


### PR DESCRIPTION
## Summary

- Removed `nowrap=""` from three `<td>` elements in [course/Iteration.html](course/Iteration.html) so their long PERFORM..VARYING headings can wrap.
- The Iteration page now renders at the standard 715px width matching every other course page (was rendering at ~875px).

## Root cause

Three left-column header cells had `nowrap=""`. Their headings (e.g. "PERFORM..VARYING using one counter Example") couldn't break across lines, forcing the column declared as `width="175"` to render at ~380px. That cascaded up and stretched the whole page table to ~875px, making the "Aims" column and everything else visibly wider than on sibling pages like Selection.html.

## Test plan

- [x] Loaded `course/Iteration.html` in the preview server — outer table renders at 718px (declared 715), Aims column at 178px (declared 175), matching other course pages.
- [ ] Spot-check the PERFORM..VARYING sections — the three affected headings now wrap normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)