### PR TITLE
Clean up content errors and encoding artifacts in course pages

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -217,7 +217,7 @@
           </td>
           <td width="525" valign="top"> 
             <p>For over four decades COBOL has been the dominant programming language 
-              in the business computing domain. In that time it it has seen off 
+              in the business computing domain. In that time it has seen off
               the challenges of a number of other languages such as PL1, Algol68, 
               Pascal, Modula, Ada, C, C++. All these languages have found a niche 
               but none has yet displaced COBOL. Two recent challengers though, 
@@ -237,7 +237,7 @@
                 deployed applications will include extensions to existing legacy 
                 (usually COBOL) programs. </p>
               <p>Gartner estimates for 2002 are that there are about two million 
-                COBOL programmers world-wide compared to about about one million 
+                COBOL programmers world-wide compared to about one million
                 Java programmers and one million C++ programmers.</p>
             </blockquote>
             <hr width="100%" align="center" size="1">
@@ -874,9 +874,8 @@
             <p>When a COBOL compiler recognizes the two areas, all division names, 
               section names, paragraph names, FD entries and 01 level numbers 
               must start in Area A. All other sentences must start in Area B.</p>
-            <p>In our example programs we use the compiler directive (available 
-              with the NetExpress COBOL compiler) - <font size="-1">$ SET SOURCEFORMAT&quot;FREE&quot;</font> 
-              - to free us from these formatting restrictions.<br>
+            <p>In our example programs we use the compiler directive <font size="-1">&gt;&gt;SOURCE FORMAT FREE</font>
+              to free us from these formatting restrictions.<br>
             </p>
             <p align="center"><b>Ancient COBOL coding form</b><img src="Resources/pics/CodingForm.jpg" width="498" height="415" border="1"></p>
             <hr width="100%" size="1">

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -225,7 +225,7 @@
               must be selected<br/>
 </font><font size="-1">[ ] brackets mean that the item is optional<br/>
 </font><font size="-1">ellipses (...) mean that the item may be 
-              repeated at the programmers discretion.</font></p>
+              repeated at the programmer's discretion.</font></p>
 <p align="left"><font size="-1">The symbols used in the syntax diagram 
               identifiers have the following significance:-</font><br/>
 <font size="-1"><b>$</b> signifies a string item,<br/>
@@ -321,19 +321,19 @@ DISPLAY PrinterSetupCodes UPON PrinterPort1.
 <div align="left">
 <pre>
 01 CurrentDate         PIC 9(6).
-* CurrentDate is the date in YYMMDD format
+*&gt; CurrentDate is the date in YYMMDD format
 
 
 01 DayOfYear           PIC 9(5).
-* DayOfYear is current day in YYDDD format
+*&gt; DayOfYear is current day in YYDDD format
 
 
-01 Day0fWeek           PIC 9.
-* DAY-OF-WEEK is a single digit where 1=Monday
+01 DayOfWeek           PIC 9.
+*&gt; DAY-OF-WEEK is a single digit where 1=Monday
 
 
 01 CurrentTime         PIC 9(8).
-* CurrentTime is the time in HHMMSSss format where s = S/100
+*&gt; CurrentTime is the time in HHMMSSss format where s = S/100
 </pre>
 </div>
 </div>
@@ -366,9 +366,9 @@ DISPLAY PrinterSetupCodes UPON PrinterPort1.
               must be defined as; </p>
 <blockquote>
 <pre>01 Y2KDate PIC 9(8).
-* Y2KDate is the date in YYYYMMDD format </pre>
+*&gt; Y2KDate is the date in YYYYMMDD format </pre>
 <pre>01 Y2KDayOfYear PIC 9(7).
-* Y2KDayOfYear is current day in YYYYDDD format </pre>
+*&gt; Y2KDayOfYear is current day in YYYYDDD format </pre>
 </blockquote>
 <hr width="50%"/>
 </td>
@@ -393,65 +393,65 @@ DISPLAY PrinterSetupCodes UPON PrinterPort1.
 <tr>
 <td height="333">
 <div align="left">
-<pre>      $ SET SOURCEFORMAT"FREE"
+<pre>       >>SOURCE FORMAT FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  AcceptAndDisplay.
 AUTHOR.  Michael Coughlan.
-* Uses the ACCEPT and DISPLAY verbs to accept a student record 
-* from the user and display some of the fields.  Also shows how
-* the ACCEPT may be used to get the system date and time.
+*&gt; Uses the ACCEPT and DISPLAY verbs to accept a student record
+*&gt; from the user and display some of the fields.  Also shows how
+*&gt; the ACCEPT may be used to get the system date and time.
 
-* The YYYYMMDD in "ACCEPT  CurrentDate FROM DATE YYYYMMDD." 
-* is a format command that ensures that the date contains a 
-* 4 digit year.  If not used, the year supplied by the system
-* will only contain two digits which may cause a problem 
-* in the year 2000.
+*&gt; The YYYYMMDD in "ACCEPT  CurrentDate FROM DATE YYYYMMDD."
+*&gt; is a format command that ensures that the date contains a
+*&gt; 4 digit year.  If not used, the year supplied by the system
+*&gt; will only contain two digits which may cause a problem
+*&gt; in the year 2000.
 
 DATA DIVISION.
 WORKING-STORAGE SECTION.
 01 StudentDetails.
-   02  StudentId       PIC 9(7).
-   02  StudentName.
-       03 Surname      PIC X(8).
-       03 Initials     PIC XX.
-   02  CourseCode      PIC X(4).
-   02  Gender          PIC X.
+    02  StudentId       PIC 9(7).
+    02  StudentName.
+        03 Surname      PIC X(8).
+        03 Initials     PIC XX.
+    02  CourseCode      PIC X(4).
+    02  Gender          PIC X.
 
-* YYMMDD
+*&gt; YYMMDD
 01 CurrentDate.
-   02  CurrentYear     PIC 9(4).
-   02  CurrentMonth    PIC 99.
-   02  CurrentDay      PIC 99.
+    02  CurrentYear     PIC 9(4).
+    02  CurrentMonth    PIC 99.
+    02  CurrentDay      PIC 99.
 
-* YYDDD
+*&gt; YYDDD
 01 DayOfYear.
-   02  FILLER          PIC 9(4).
-   02  YearDay         PIC 9(3).
+    02  FILLER          PIC 9(4).
+    02  YearDay         PIC 9(3).
 
 
-* HHMMSSss   s = S/100
+*&gt; HHMMSSss   s = S/100
 01 CurrentTime.
-   02  CurrentHour     PIC 99.
-   02  CurrentMinute   PIC 99.
-   02  FILLER          PIC 9(4).
+    02  CurrentHour     PIC 99.
+    02  CurrentMinute   PIC 99.
+    02  FILLER          PIC 9(4).
 
 
 PROCEDURE DIVISION.
 Begin.
-   DISPLAY "Enter student details using template below".
-   DISPLAY "Enter - ID,Surname,Initials,CourseCode,Gender"
-   DISPLAY "SSSSSSSNNNNNNNNIICCCCG".
-   ACCEPT  StudentDetails.
-   ACCEPT  CurrentDate FROM DATE YYYYMMDD.
-   ACCEPT  DayOfYear FROM DAY YYYYDDD.
-   ACCEPT  CurrentTime FROM TIME.
-   DISPLAY "Name is ", Initials SPACE Surname.
-   DISPLAY "Date is " CurrentDay SPACE CurrentMonth 
-           SPACE CurrentYear.
-   DISPLAY "Today is day " YearDay " of the year".
-   DISPLAY "The time is " CurrentHour ":" CurrentMinute.
-   STOP RUN.
-                                                   </pre>
+    DISPLAY "Enter student details using template below".
+    DISPLAY "Enter - ID,Surname,Initials,CourseCode,Gender"
+    DISPLAY "SSSSSSSNNNNNNNNIICCCCG".
+    ACCEPT  StudentDetails.
+    ACCEPT  CurrentDate FROM DATE YYYYMMDD.
+    ACCEPT  DayOfYear FROM DAY YYYYDDD.
+    ACCEPT  CurrentTime FROM TIME.
+    DISPLAY "Name is ", Initials SPACE Surname.
+    DISPLAY "Date is " CurrentDay SPACE CurrentMonth
+            SPACE CurrentYear.
+    DISPLAY "Today is day " YearDay " of the year".
+    DISPLAY "The time is " CurrentHour ":" CurrentMinute.
+    STOP RUN.
+</pre>
 </div>
 </td>
 </tr>
@@ -496,10 +496,10 @@ The time is 14:41
 <h4 align="left"><font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font></h4>
 </td>
 <td height="355" valign="top" width="540">
-<p>In Âstrongly typedÂ languages like Modula-2, Pascal or ADA the 
+<p>In "strongly typed" languages like Modula-2, Pascal or ADA the 
               assignment operation is simple because assignment is only allowed 
               between data items with compatible types. The simplicity of assignment 
-              in these languages, is achieved at the ÂcostÂ of having a large 
+              in these languages, is achieved at the "cost" of having a large 
               number of data types. </p>
 <p>In COBOL there are basically only three data types;</p>
 <ul>
@@ -584,11 +584,6 @@ The time is 14:41
 </tr>
 <tr>
 <td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
-<div align="center"> </div>
-</td>
-</tr>
-<tr>
-<td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
 <div align="center">
 <hr/>
 <p><a href="#top"> <img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"/></a>
@@ -659,7 +654,7 @@ The time is 14:41
 <p align="left">If the <font size="-1">GIVING</font> phrase is not 
                 used, the data-item(s) after the word <font size="-1">TO</font>, 
                 <font size="-1">FROM</font>, <font size="-1">BY</font> or <font size="-1">INTO 
-                </font>both contribute to the result and are receiving field for 
+                </font>both contribute to the result and are receiving fields for
                 it. </p>
 <p align="left">The maximum size of each operand is 18 digits. </p>
 
@@ -924,11 +919,11 @@ The time is 14:41
               other does not.</p>
 <p><b>Format1</b></p>
 <p><img height="101" src="Resources/pics/Div1.gif" width="525"/></p>
-<p>In the <font size="-1">GIVING</font> phrase is used, the Value#il 
-              to the left of <font size="-1">BY</font> or <font size="-1">INTO</font> 
-              is divided by or into the Value#il to the right of <font size="-1">BY</font> 
-              or <font size="-1">INTO</font> and the result of the calculation 
-              in moved into <b>each</b> of the Result#i items in turn.</p>
+<p>If the <font size="-1">GIVING</font> phrase is used, the Value#il
+              to the left of <font size="-1">BY</font> or <font size="-1">INTO</font>
+              is divided by or into the Value#il to the right of <font size="-1">BY</font>
+              or <font size="-1">INTO</font> and the result of the calculation
+              is moved into <b>each</b> of the Result#i items in turn.</p>
 <p>If the <font size="-1">GIVING</font> phrase is not used, the item 
               to the left of the word <font size="-1">INTO</font> is divided into 
               each of the ValueResult#i items in turn. The result of each calculation 

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -137,7 +137,7 @@
 <h4><font color="#993300" face="Arial, Helvetica, sans-serif">Aims</font></h4>
 </td>
 <td width="540">
-<p>The aim of this unit is give you an understanding of the different 
+<p>The aim of this unit is to give you an understanding of the different
               categories of data used in a COBOL program and to demonstrate how 
               items of each category may be created and used.</p>
 <hr width="50%"/>
@@ -215,11 +215,9 @@
 <p>There are three categories of data item used in COBOL programs: 
             </p>
 <ul>
-<ul>
 <li>Variables.</li>
 <li>Literals.</li>
 <li>Figurative Constants. </li>
-</ul>
 </ul>
 <hr width="50%"/>
 </td>
@@ -285,7 +283,7 @@
 <p>COBOL programmers must make sure that non-numeric data is never 
               assigned to numeric items intended for use in calculations. Programmers 
               who use strongly typed languages don't need this level of discipline 
-              because the compiler ensures that a variable of a particular types 
+              because the compiler ensures that a variable of a particular type
               can only be assigned appropriate values.</p>
 <hr width="50%"/>
 </td>
@@ -394,7 +392,7 @@
 <tr>
 <td valign="TOP" width="47%"> <font size="-1"><b>ALL</b></font> 
                   literal</td>
-<td valign="TOP" width="53%"> Allows a ordinary literal to act 
+<td valign="TOP" width="53%"> Allows an ordinary literal to act
                   as Figurative Constant</td>
 </tr>
 </table>
@@ -408,7 +406,7 @@
                 Constants. The same applies to <font size="-1">SPACE</font> and 
                 <font size="-1">SPACES</font>, <font size="-1">QUOTE</font> and 
                 <font size="-1">QUOTES</font>, <font size="-1">HIGH-VALUE</font> 
-                and <font size="-1">HIGH-VALUES</font>, <font size="-1">LOW-VALUES</font> 
+                and <font size="-1">HIGH-VALUES</font>, <font size="-1">LOW-VALUE</font>
                 and <font size="-1">LOW-VALUES</font>. </li>
 </ul>
 <hr width="50%"/>
@@ -416,9 +414,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#FFFFCC" valign="TOP" width="175">
-<h4 align="left"><font color="#800000" face="Arial, Helvetica, sans-serif">Using 
-              COBOLdata<br/>
-              ------ examples ------</font></h4>
+<h4 align="left"><font color="#800000" face="Arial, Helvetica, sans-serif">Using COBOL data &mdash; examples</font></h4>
 </td>
 <td valign="top" width="525">
 <p><font color="#800000" face="Arial, Helvetica, sans-serif"><a name="data1"></a></font>The 
@@ -785,14 +781,8 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </pre>
 <td valign="top" width="8%"><b>Q4.</b></td>
 <td width="92%"> 
                     What is the data type of DateOfBirth? Is 
-                      it numeric, alphabetic or alphanumeric.
+                      it numeric, alphabetic or alphanumeric?
                   </td>
-</tr>
-<tr>
-<td valign="top" width="8%"> </td>
-<td width="92%">
-
-</td>
 </tr>
 <tr>
 <td valign="top" width="8%"><b>A1.</b></td>
@@ -861,7 +851,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </pre>
 </td>
 <td valign="top" width="525">
 <p>In the animation below we show how level numbers can be used to 
-              define a record structure as hierarchy of data-items.</p>
+              define a record structure as a hierarchy of data-items.</p>
 <div align="center">
 
 <p><a href="Resources/ppz/TC-Data2.html"><img alt="Click to view the animation" border="0" height="62" src="Resources/pics/i-Animation.gif" width="62"/></a></p>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -1052,14 +1052,14 @@ OutOfLineEG.
 <td height="188" valign="top" width="525">
 <p>Processing a stream of data items of undetermined length, is a 
               common operation in COBOL, because sequential files fall into this 
-              category. A useful strategy known as the Âread aheadÂ has been developed 
+              category. A useful strategy known as the "read ahead" has been developed 
               for processing sequential files.</p>
 <p>The central idea of the "read ahead" is that, because 
               the end of the file cannot be detected until an attempt is made 
               to read a record, the Read must be positioned as the last statement 
               in the record processing loop. </p>
 <p>You can see how this works in the processing template below. With 
-              the Âread aheadÂ strategy we always try to stay one data item ahead 
+              the "read ahead" strategy we always try to stay one data item ahead 
               of the processing. So the Read outside the loop, reads the first 
               record and this record is processed inside the loop. The Read inside 
               the loop, reads the next, and all the succeeding records. When the 

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -895,7 +895,7 @@ END-IF
 <blockquote>
 <div align="left">
 <pre align="left">e.g. 02 DeptCode          PIC X. 
-        88 ProductionDept VALUE ÂIÂ,ÂLÂ,ÂTÂ. </pre>
+        88 ProductionDept VALUE "I","L","T". </pre>
 </div>
 </blockquote>
 <p align="left">To specify a range, use the keyword <font size="-1">THRU</font>, 

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -239,7 +239,7 @@
 <div align="center">
 <p align="left">COBOL is generally used in situations where the 
                 volume of data to be processed is large. These systems are sometimes 
-                referred to as Âdata intensiveÂ systems. Generally, large volumes 
+                referred to as "data intensive" systems. Generally, large volumes 
                 arise not because the data is inherently voluminous but because 
                 the same items of information have been recorded about a great 
                 many instances of the same object. Record-based files are used 
@@ -366,7 +366,7 @@
               read the record into the input record buffer, transfer it to the 
               output record buffer and then write the data to the output file 
               from the output record buffer. This type of data transfer between 
-              ÂbuffersÂ is quite common in COBOL programs. </p>
+              'buffers' is quite common in COBOL programs. </p>
 
 </td>
 </tr>
@@ -558,7 +558,7 @@ FD StudentFile.
 INPUT-OUTPUT SECTION.
 FILE-CONTROL.
    SELECT StudentFile 
-          ASSIGN TO ÂSTUDENTS.DATÂ.
+          ASSIGN TO "STUDENTS.DAT".
 DATA DIVISION.
 FILE SECTION.
 FD StudentFile.

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -399,8 +399,8 @@
 <p>While it is easy to add records to an unordered Sequential file 
               it is not really feasible to delete or update records in an unordered 
               Sequential file.</p>
-<p>Records in a Sequential file can not be deleted or updated Âin 
-              situÂ. The only way to <b>delete</b> records from a Sequential file, 
+<p>Records in a Sequential file can not be deleted or updated "in 
+              situ". The only way to <b>delete</b> records from a Sequential file, 
               is to create a new file which does not contain them; and the only 
               way to <b>update</b> records in a Sequential file, is to create 
               a new file which contains the updated records. Because both these 

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -287,7 +287,7 @@
 INPUT-OUTPUT SECTION.
 FILE-CONTROL.
    SELECT TransFile 
-          ASSIGN TO ÂTRANS.DATÂ
+          ASSIGN TO "TRANS.DAT"
           ORGANIZATION IS LINE SEQUENTIAL.
 DATA DIVISION.
 FILE SECTION.
@@ -317,8 +317,8 @@ FD TransFile.
 </tr>
 </table>
 <p>What is not obvious from this description is that COBOL still continues 
-              to create just a single Ârecord bufferÂ for the file! And this Ârecord 
-              bufferÂ is only able to store a single record at a time!</p>
+              to create just a single 'record buffer' for the file! And this 'record 
+              buffer' is only able to store a single record at a time!</p>
 <hr align="center" width="50%"/>
 
 </td>
@@ -343,7 +343,7 @@ FD TransFile.
                 for each type of record.</p>
 <p align="left">Even though there are different types of record 
                 in the file, and there are separate record declarations for each 
-                record type, only a single Ârecord bufferÂ is created for the 
+                record type, only a single 'record buffer' is created for the 
                 file.</p>
 <p align="left">All the record declarations map on to this area 
                 of storage, which is the size of the largest record, and all the 
@@ -443,7 +443,7 @@ FD TransFile.
 INPUT-OUTPUT SECTION.
 FILE-CONTROL.
    SELECT TransFile 
-          ASSIGN TO ÂTRANS.DATÂ
+          ASSIGN TO "TRANS.DAT"
           ORGANIZATION IS LINE SEQUENTIAL.
 DATA DIVISION.
 FILE SECTION.
@@ -533,7 +533,7 @@ FD TransFile.
 INPUT-OUTPUT SECTION.
 FILE-CONTROL.
    SELECT TransFile 
-          ASSIGN TO ÂTRANS.DATÂ
+          ASSIGN TO "TRANS.DAT"
           ORGANIZATION IS LINE SEQUENTIAL.
 
 DATA DIVISION.

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -388,7 +388,7 @@ DISPLAY "County 3 total is ", County3TaxTotal
 <p>Tables have the following attributes</p>
 <ul>
 <li> a single name is used to identify all the elements </li>
-<li>individual elements can be identified using an ÂindexÂ or ÂsubscriptÂ 
+<li>individual elements can be identified using an "index" or "subscript" 
               </li>
 <li>all elements have the same type or structure </li>
 <li>COBOL arrays/tables, always start at element 1 (not 0) and go 

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -263,7 +263,7 @@
 <p>Tables have the following attributes</p>
 <ul>
 <li> a single name is used to identify all the elements </li>
-<li>individual elements can be identified using an ÂindexÂ or ÂsubscriptÂ 
+<li>individual elements can be identified using an "index" or "subscript" 
               </li>
 <li>all elements have the same type or structure </li>
 <li>COBOL arrays/tables, always start at element 1 (not 0) and go 
@@ -1217,14 +1217,14 @@ ADD 56 TO PopTotal(12,3,2)</pre>
 <blockquote>
 <pre align="left">EVALUATE TRUE
     WHEN DateIsSort
-           DISPLAY ÂSortDate format is yyyy-mm-dd Â
-           DISPLAY  SortYear Â-Â SortMonth Â-Â SortYear
+           DISPLAY "SortDate format is yyyy-mm-dd "
+           DISPLAY  SortYear "-" SortMonth "-" SortYear
     WHEN DateIsEuro
-           DISPLAY ÂEuroDate format is dd-mm-yyyy Â
-           DISPLAY  EuroDay Â-Â EuroMonth Â-Â EuroYear
+           DISPLAY "EuroDate format is dd-mm-yyyy "
+           DISPLAY  EuroDay "-" EuroMonth "-" EuroYear
     WHEN DateIsUS 
-           DISPLAY ÂUSDate format is mm-dd-yyyy Â
-           DISPLAY  USMonth Â-Â USDay Â-Â USYear
+           DISPLAY "USDate format is mm-dd-yyyy "
+           DISPLAY  USMonth "-" USDay "-" USYear
 END-EVALUATE </pre>
 </blockquote>
 <p>- and still get the correct values displayed.</p>

--- a/examples/default.html
+++ b/examples/default.html
@@ -822,7 +822,7 @@
 </td>
 <td align="left" height="159" width="298"><font size="-1">Exam paper model 
       answer. Each time a book is borrowed, the Pascal Memorial Library pays the 
-      author a small sum of money as royalty.Â  Royalties are paid to authors through 
+      author a small sum of money as royalty.  Royalties are paid to authors through 
       their agents. A report is required which processes the Authors file and 
       the Books File to produce a report which shows the amount to be sent to 
       each agent, shows the breakdown of the agent payment into author payments, 

--- a/exercises/index.html
+++ b/exercises/index.html
@@ -273,7 +273,7 @@
 <td height="110" valign="top" width="27%"><img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13"/><a href="Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html">LibraryRoyaltiesRpt</a></td>
 <td height="110" valign="top" width="73%">
 <p><font size="-1">Each time a book is borrowed, the Pascal Memorial Library 
-          pays the author a small sum of money as royalty.Â  Royalties are paid 
+          pays the author a small sum of money as royalty.  Royalties are paid 
           to authors through their agents. A report is required which processes 
           the Authors file and the Books File to produce a report which shows 
           the amount to be sent to each agent, shows the breakdown of the agent 


### PR DESCRIPTION
## Summary

- Strip double-UTF-8-encoded Windows-1252 mojibake (smart quotes, NBSP) across 10 HTML files — same systematic pattern as the prior `strip-encoded-comment-markers` cleanup. Affected: `course/COBOLcommands.html`, `course/Iteration.html`, `course/Selection.html`, `course/SequentialFiles{1,2,3}.html`, `course/Tables{1,2}.html`, `examples/default.html`, `exercises/index.html`.
- Modernize the AcceptAndDisplay example to free-format COBOL: `>>SOURCE FORMAT FREE` and `*>` inline comments; matching tutorial fragment snippets in `COBOLcommands.html` updated for consistency; narrative reference in `COBOLIntro.html` updated.
- Typos / grammar across `COBOLIntro.html`, `DataDeclaration.html`, and `COBOLcommands.html` (duplicate words, missing apostrophes, wrong articles, `In` vs `If`, `in` vs `is`, `Day0fWeek` zero-vs-O, missing `?`, etc.).
- Drop a redundant nested `<ul>` wrapper that double-indented the Variables/Literals/Figurative Constants list.
- Remove two empty `<tr>` spacer rows that produced unwanted vertical gaps.
- Tidy a section header from `Using COBOLdata / ------ examples ------` to `Using COBOL data — examples`.

## Test plan

- [ ] Spot-check `course/COBOLcommands.html`, `course/COBOLIntro.html`, `course/DataDeclaration.html` rendering — text reads cleanly, no `Â` artifacts.
- [ ] Verify the AcceptAndDisplay code block renders with `>>SOURCE FORMAT FREE` (column 8, 7 leading spaces) and `*>` comment markers.
- [ ] Confirm the Variables/Literals/Figurative Constants list is single-indent on the Categories of COBOL data section.
- [ ] Confirm Q4 → A1 in DataDeclaration flows without an extra blank gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)