### PR TITLE
Add COBOL syntax highlighting to course pages

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -4,6 +4,9 @@
    <meta name="viewport" content="width=device-width, initial-scale=1">
    <meta name="GENERATOR" content="Mozilla/4.0 [en] (WinNT; I) [Netscape]">
    <title>Introduction to COBOL</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" rel="stylesheet"/>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cobol.min.js"></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -569,23 +572,23 @@
             <p align="left">What COBOL program statements will we need to do the 
               job specified above and what data items will we need to access?<br>
             </p>
-            <blockquote> 
+            <blockquote>
               <p>We will need a statement to take in the first number and store
-                it in the named memory location (a variable) - Num1<b><font face="Courier New, Courier, mono" size="+1"><br>
-                ACCEPT Num1.</font></b></p>
+                it in the named memory location (a variable) - Num1</p>
+<pre class="language-cobol"><code class="language-cobol">ACCEPT Num1.</code></pre>
             </blockquote>
-            <blockquote> 
+            <blockquote>
               <p>We will need a statement to take in the second number and store
-                it in the named memory location - Num2<b><font size="+1" face="Courier New, Courier, mono"><br>
-                ACCEPT Num2.</font></b></p>
+                it in the named memory location - Num2</p>
+<pre class="language-cobol"><code class="language-cobol">ACCEPT Num2.</code></pre>
             </blockquote>
-            <blockquote> 
+            <blockquote>
               <p>We will need a statement to multiply the two numbers together
-                and to store the result in the named location - Result<font size="+1"><b><br>
-                <font face="Courier New, Courier, mono">MULTIPLY Num1 BY Num2 GIVING Result.</font></b></font></p>
+                and to store the result in the named location - Result</p>
+<pre class="language-cobol"><code class="language-cobol">MULTIPLY Num1 BY Num2 GIVING Result.</code></pre>
               <p>We will need a statement to display the value in the named memory
-                location &quot;<b>Result</b>&quot; on the computer screen -<br>
-                <b><font size="+1"><font face="Courier New, Courier, mono">DISPLAY &quot;Result is = &quot;, Result.</font></font></b></p>
+                location &quot;<b>Result</b>&quot; on the computer screen -</p>
+<pre class="language-cobol"><code class="language-cobol">DISPLAY "Result is = ", Result.</code></pre>
             </blockquote>
             <hr size="1" width="100%">
           </td>
@@ -834,10 +837,8 @@
             <p align="left">Since the ellipsis symbol is placed outside the curly 
               brackets we can interpret this to mean that each result field can 
               have its own <font size="-1">ROUNDED</font> phase. In other words 
-              we could have a <font size="-1">COMPUTE</font> statement like -<br>
-              <br>
-              <b><font face="Courier New, Courier, mono">COMPUTE Result1 ROUNDED, 
-              Result2 = ((9*9)+8)/5</font></b></p>
+              we could have a <font size="-1">COMPUTE</font> statement like -</p>
+<pre class="language-cobol"><code class="language-cobol">COMPUTE Result1 ROUNDED, Result2 = ((9*9)+8)/5</code></pre>
             <p align="left">where Result1 would be assigned a value of 18 and 
               Result2 would be assigned a value of 17.8.</p>
             <p align="left">The square brackets after the Arithmetic Expression 
@@ -936,11 +937,10 @@
               by the language. A section name is followed by the word <font size="-1">SECTION</font> 
               and a period. <br>
               See the two example names below -</p>
-            <blockquote> 
-              <p> <b><font face="Courier New, Courier, mono">SelectUnpaidBills 
-                SECTION.<br>
-                </font></b><font face="Courier New, Courier, mono"><b>FILE SECTION.</b></font></p>
-              </blockquote>
+            <blockquote>
+<pre class="language-cobol"><code class="language-cobol">SelectUnpaidBills SECTION.
+FILE SECTION.</code></pre>
+            </blockquote>
             <p><font face="Arial, Helvetica, sans-serif"><b>Paragraphs</b></font><br>
               A paragraph is a block of code made up of one or more sentences. 
               A paragraph begins with the paragraph name and ends with the next 
@@ -948,28 +948,25 @@
             <p>A paragraph name is devised by the programmer or defined by the 
               language, and is followed by a period. <br>
               See the two example names below -</p>
-            <blockquote> 
-              <p><font face="Courier New, Courier, mono"><b>PrintFinalTotals.<br>
-                </b></font><font face="Courier New, Courier, mono"><b>PROGRAM-ID.</b></font><br>
-              </p>
+            <blockquote>
+<pre class="language-cobol"><code class="language-cobol">PrintFinalTotals.
+PROGRAM-ID.</code></pre>
             </blockquote>
             <p><font face="Arial, Helvetica, sans-serif"><b>Sentences and statements</b></font><br>
               A sentence consists of one or more statements and is terminated 
               by a period.<br>
               For example:</p>
-            <blockquote> 
-              <p><b><font face="Courier New, Courier, mono">MOVE .21 TO VatRate<br>
-                &nbsp;&nbsp;&nbsp;MOVE 1235.76 TO ProductCost<br>
-                &nbsp;&nbsp;&nbsp;COMPUTE VatAmount = ProductCost * VatRate.</font></b></p>
+            <blockquote>
+<pre class="language-cobol"><code class="language-cobol">MOVE .21 TO VatRate
+   MOVE 1235.76 TO ProductCost
+   COMPUTE VatAmount = ProductCost * VatRate.</code></pre>
             </blockquote>
             <p><br>
-              A statement consists of a COBOL verb and an operand or operands. 
+              A statement consists of a COBOL verb and an operand or operands.
               <br>
               For example:</p>
-            <blockquote> 
-              <p><b><font face="Courier New, Courier, mono">SUBTRACT Tax FROM 
-                GrossPay GIVING NetPay</font></b><br>
-              </p>
+            <blockquote>
+<pre class="language-cobol"><code class="language-cobol">SUBTRACT Tax FROM GrossPay GIVING NetPay</code></pre>
             </blockquote>
           </td>
         </tr>
@@ -1034,11 +1031,11 @@
               to a subprogram.</p>
             <p>The <font size="-1">IDENTIFICATION DIVISION </font>has the following 
               structure:</p>
-            <blockquote> 
-              <p><font face="Courier New, Courier, mono"><b>IDENTIFICATION DIVISION<br>
-                PROGRAM-ID. NameOfProgram.<br>
-                [AUTHOR. YourName.]<br>
-                other entries here</b></font></p>
+            <blockquote>
+<pre class="language-cobol"><code class="language-cobol">IDENTIFICATION DIVISION
+PROGRAM-ID. NameOfProgram.
+[AUTHOR. YourName.]
+other entries here</code></pre>
             </blockquote>
             <p>The keywords - <font size="-1">IDENTIFICATION DIVISION</font> - 
               represent the division header, and signal the commencement of the 
@@ -1051,9 +1048,9 @@
             <table width="374" border="1" align="center" background="Resources/pics/code.gif" cellpadding="5">
               <tr> 
                 <td> 
-                  <pre><font face="Courier New, Courier, mono">IDENTIFICATION DIVISION.
+                  <pre class="language-cobol"><code class="language-cobol"><font face="Courier New, Courier, mono">IDENTIFICATION DIVISION.
 PROGRAM-ID. SequenceProgram.
-AUTHOR. Michael Coughlan.</font></pre>
+AUTHOR. Michael Coughlan.</font></code></pre>
                 </td>
               </tr>
             </table>
@@ -1111,7 +1108,7 @@ AUTHOR. Michael Coughlan.</font></pre>
             <table width="406" border="1" align="center" background="Resources/pics/code.gif" cellpadding="5">
               <tr> 
                 <td> 
-                  <pre><font face="Courier New, Courier, mono">IDENTIFICATION DIVISION.
+                  <pre class="language-cobol"><code class="language-cobol"><font face="Courier New, Courier, mono">IDENTIFICATION DIVISION.
 PROGRAM-ID. SequenceProgram.
 AUTHOR. Michael Coughlan.
 
@@ -1119,7 +1116,7 @@ DATA DIVISION.
 WORKING-STORAGE SECTION.
 01 Num1   PIC 9  VALUE ZEROS.
 01 Num2   PIC 9  VALUE ZEROS.
-01 Result PIC 99 VALUE ZEROS.</font></pre>
+01 Result PIC 99 VALUE ZEROS.</font></code></pre>
                 </td>
               </tr>
             </table>
@@ -1148,7 +1145,7 @@ WORKING-STORAGE SECTION.
             <table width="390" border="1" align="center" background="Resources/pics/code.gif" cellpadding="5">
               <tr> 
                 <td> 
-                  <pre><font face="Courier New, Courier, mono">IDENTIFICATION DIVISION.
+                  <pre class="language-cobol"><code class="language-cobol"><font face="Courier New, Courier, mono">IDENTIFICATION DIVISION.
 PROGRAM-ID. SequenceProgram.
 AUTHOR. Michael Coughlan.
 
@@ -1165,7 +1162,7 @@ CalculateResult.
    MULTIPLY Num1 BY Num2
        GIVING Result.
    DISPLAY &quot;Result is = &quot;, Result.
-   STOP RUN.</font></pre>
+   STOP RUN.</font></code></pre>
                 </td>
               </tr>
             </table>
@@ -1178,13 +1175,13 @@ CalculateResult.
             <table width="390" border="1" align="center" background="Resources/pics/code.gif" cellpadding="5">
               <tr> 
                 <td> 
-                  <pre><font face="Courier New, Courier, mono">IDENTIFICATION DIVISION.
+                  <pre class="language-cobol"><code class="language-cobol"><font face="Courier New, Courier, mono">IDENTIFICATION DIVISION.
 PROGRAM-ID. SmallestProgram.
 
 PROCEDURE DIVISION.
 DisplayGreeting.
    DISPLAY &quot;Hello world&quot;.
-   STOP RUN.</font></pre>
+   STOP RUN.</font></code></pre>
                 </td>
               </tr>
             </table>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -2,6 +2,9 @@
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Basic Procedure Division commands</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" rel="stylesheet"/>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cobol.min.js"></script>
 <meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -262,11 +265,10 @@
 <p align="left"><b><font size="-1">DISPLAY</font> examples</b></p>
 </div>
 <blockquote>
-<pre align="left">
-DISPLAY "My name is " ProgrammerName.
+<pre class="language-cobol" align="left"><code class="language-cobol">DISPLAY "My name is " ProgrammerName.
 DISPLAY "The vat rate is " VatRate. 
 DISPLAY PrinterSetupCodes UPON PrinterPort1.
-</pre>
+</code></pre>
 <hr width="50%"/>
 </blockquote>
 </td>
@@ -319,7 +321,7 @@ DISPLAY PrinterSetupCodes UPON PrinterPort1.
 </div>
 <div align="center">
 <div align="left">
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
 01 CurrentDate         PIC 9(6).
 *&gt; CurrentDate is the date in YYMMDD format
 
@@ -334,7 +336,7 @@ DISPLAY PrinterSetupCodes UPON PrinterPort1.
 
 01 CurrentTime         PIC 9(8).
 *&gt; CurrentTime is the time in HHMMSSss format where s = S/100
-</pre>
+</code></pre>
 </div>
 </div>
 <blockquote>
@@ -365,10 +367,10 @@ DISPLAY PrinterSetupCodes UPON PrinterPort1.
 <p>When the new formatting instructions are used, the receiving fields 
               must be defined as; </p>
 <blockquote>
-<pre>01 Y2KDate PIC 9(8).
-*&gt; Y2KDate is the date in YYYYMMDD format </pre>
-<pre>01 Y2KDayOfYear PIC 9(7).
-*&gt; Y2KDayOfYear is current day in YYYYDDD format </pre>
+<pre class="language-cobol"><code class="language-cobol">01 Y2KDate PIC 9(8).
+*&gt; Y2KDate is the date in YYYYMMDD format </code></pre>
+<pre class="language-cobol"><code class="language-cobol">01 Y2KDayOfYear PIC 9(7).
+*&gt; Y2KDayOfYear is current day in YYYYDDD format </code></pre>
 </blockquote>
 <hr width="50%"/>
 </td>
@@ -393,7 +395,7 @@ DISPLAY PrinterSetupCodes UPON PrinterPort1.
 <tr>
 <td height="333">
 <div align="left">
-<pre>       &gt;&gt;SOURCE FORMAT FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  AcceptAndDisplay.
 AUTHOR.  Michael Coughlan.
@@ -451,7 +453,7 @@ Begin.
     DISPLAY "Today is day " YearDay " of the year".
     DISPLAY "The time is " CurrentHour ":" CurrentMinute.
     STOP RUN.
-</pre>
+</code></pre>
 </div>
 </td>
 </tr>
@@ -461,7 +463,7 @@ Begin.
 <tr bgcolor="#E1FFE1">
 <td>
 <p align="center"><b>Results of running <font size="-1">ACCEPT.CBL</font></b></p>
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
 Enter student details using template below
 Enter - ID,Surname,Initials,CourseCode,Gender
 SSSSSSSNNNNNNNNIICCCCG
@@ -470,7 +472,7 @@ Name is NS Power
 Date is 01 03 1999
 Today is day 060 of the year
 The time is 14:41
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -2,6 +2,9 @@
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>The COPY verb</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" rel="stylesheet"/>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cobol.min.js"></script>
 <meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -395,11 +398,11 @@
               in the <font size="-1">REPLACING</font> phrase.</p>
 <h4>Some example COPY statements</h4>
 <blockquote>
-<pre>COPY CopyFile2 REPLACING XYZ BY 120. 
+<pre class="language-cobol"><code class="language-cobol">COPY CopyFile2 REPLACING XYZ BY 120. 
 COPY CopyFile5 REPLACING X(3) BY X(19).
 COPY CopyFile3 IN EGLIB.
 COPY CopyFile5 REPLACING ==X(3)== BY ==X(19)==.
-COPY CopyFile4 IN EGLIB.</pre>
+COPY CopyFile4 IN EGLIB.</code></pre>
 </blockquote>
 <hr align="center" size="1" width="100%"/>
 </td>
@@ -507,7 +510,7 @@ COPY CopyFile4 IN EGLIB.</pre>
 <td valign="top">
 <div align="center"><font color="#009933"><b><font color="#000099" face="Arial, Helvetica, sans-serif">Source 
                     Text</font><font color="#000099"> </font></b> </font> </div>
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. COPYEG1.
 AUTHOR.  Michael Coughlan.
@@ -535,7 +538,7 @@ BeginProg.
          AT END SET EndOfSF TO TRUE
       END-READ
    END-PERFORM
-   STOP RUN.<b><br/></b></pre>
+   STOP RUN.<b><br/></b></code></pre>
 </td>
 </tr>
 <tr>
@@ -544,7 +547,7 @@ BeginProg.
                     in COPYFILE1</font></b><br/>
 <br/>
 </div>
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
 01  StudentRec.
     88  EndOfSF      VALUE HIGH-VALUES.
     02  StudentNumber                PIC 9(7).
@@ -552,7 +555,7 @@ BeginProg.
     02  CourseCode                   PIC X(4).
     02  FeesOwed                     PIC 9(4).
     02  AmountPaid                   PIC 9(4)V99.
-				  </pre>
+				  </code></pre>
 </td>
 </tr>
 <tr>
@@ -560,7 +563,7 @@ BeginProg.
 <div align="center"><b><font color="#000099" face="Arial, Helvetica, sans-serif">Source 
                     Text after processing</font><br/>
 </b> </div>
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.                                 
 PROGRAM-ID. COPYEG1.                                     
@@ -596,7 +599,7 @@ BeginProg.
          AT END SET EndOfSF TO TRUE                      
       END-READ                                           
    END-PERFORM                                           
-   STOP RUN.</pre>
+   STOP RUN.</code></pre>
 </td>
 </tr>
 </table>
@@ -668,7 +671,7 @@ BeginProg.
 <td valign="top">
 <div align="center"><font color="#009933"><b><font color="#000099" face="Arial, Helvetica, sans-serif">Source 
                     Text</font><font color="#000099"> </font></b> </font> </div>
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. COPYEG2.
 AUTHOR.  Michael Coughlan.
@@ -705,7 +708,7 @@ PROCEDURE DIVISION.
 BeginProg.
 
 STOP RUN.				  
-				  </pre>
+				  </code></pre>
 </td>
 </tr>
 <tr>
@@ -713,9 +716,9 @@ STOP RUN.
 <div align="center"> <b><font color="#000099">Text in CopyFile2</font></b><br/>
 <br/>
 </div>
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
     02 StudName PIC X(20) OCCURS XYZ TIMES.
-				  </pre>
+				  </code></pre>
 </td>
 </tr>
 <tr>
@@ -723,9 +726,9 @@ STOP RUN.
 <div align="center"><b><font color="#000099">Text in CopyFile3</font></b><br/>
 <br/>
 </div>
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
     02  CustOrder           PIC 9(R).
-		</pre>
+		</code></pre>
 </td>
 </tr>
 <tr>
@@ -733,9 +736,9 @@ STOP RUN.
 <div align="center"><b><font color="#000099">Text in CopyFile4</font></b><br/>
 <br/>
 </div>
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
     02 CustOrder2           PIC 9(6)V99.
-		</pre>
+		</code></pre>
 </td>
 </tr>
 <tr>
@@ -743,9 +746,9 @@ STOP RUN.
 <div align="center"><b><font color="#000099">Text in CopyFile5</font></b><br/>
 <br/>
 </div>
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
     02 CustKey              PIC X(3) VALUE "KEY".
-		</pre>
+		</code></pre>
 </td>
 </tr>
 <tr>
@@ -753,7 +756,7 @@ STOP RUN.
 <div align="center"><b><font color="#000099" face="Arial, Helvetica, sans-serif">Source 
                     Text after processing</font><br/>
 </b> </div>
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.                         
 PROGRAM-ID. COPYEG2.                             
@@ -800,7 +803,7 @@ BeginProg.
                <b>                         
                                                  
 </b>STOP RUN.  <b>                                      
-</b></pre>
+</b></code></pre>
 </td>
 </tr>
 </table>
@@ -866,7 +869,7 @@ BeginProg.
 <td valign="top">
 <div align="center"><font color="#009933"><b><font color="#000099" face="Arial, Helvetica, sans-serif">Source 
                     Text</font><font color="#000099"> </font></b> </font> </div>
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. COPYEG3.
 AUTHOR.  Michael Coughlan.
@@ -904,7 +907,7 @@ BeginProg.
    STOP RUN.				  
 				  
 				  
-				  </pre>
+				  </code></pre>
 </td>
 </tr>
 <tr>
@@ -913,9 +916,9 @@ BeginProg.
                     CopyFile5</font></b><br/>
 <br/>
 </div>
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
     02 CustKey              PIC X(3) VALUE "KEY".
-		</pre>
+		</code></pre>
 </td>
 </tr>
 <tr>
@@ -923,7 +926,7 @@ BeginProg.
 <div align="center"><b><font color="#000099" face="Arial, Helvetica, sans-serif">Source 
                     Text after processing</font><br/>
 </b> </div>
-<pre><b>
+<pre class="language-cobol"><code class="language-cobol"><b>
 </b>       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION. 
 PROGRAM-ID. COPYEG3. 
@@ -969,7 +972,7 @@ PROCEDURE DIVISION.
 BeginProg. 
 
    STOP RUN.  <b>                                    
-</b></pre>
+</b></code></pre>
 </td>
 </tr>
 </table>
@@ -1010,7 +1013,7 @@ BeginProg.
 <td valign="top">
 <div align="center"><font color="#009933"><b><font color="#000099" face="Arial, Helvetica, sans-serif">Source 
                     Text</font><font color="#000099"> </font></b> </font> </div>
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. COPYEG4.
@@ -1035,7 +1038,7 @@ BeginProg.
                          R1 BY Result.</b></font>
    DISPLAY "The result is = " Result.
    STOP RUN.
-</pre>
+</code></pre>
 </td>
 </tr>
 <tr>
@@ -1044,10 +1047,10 @@ BeginProg.
                     CopyFile6</font></b><br/>
 <br/>
 </div>
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
     02 CustKey              PIC X(4) VALUE "Mike".
 01  NameTable               PIC X(10)  OCCURS ?? TIMES.
-		</pre>
+		</code></pre>
 </td>
 </tr>
 <tr>
@@ -1056,9 +1059,9 @@ BeginProg.
                     CopyFile7</font></b><br/>
 <br/>
 </div>
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
     ADD N1, N2 GIVING R1.
-		</pre>
+		</code></pre>
 </td>
 </tr>
 <tr>
@@ -1066,7 +1069,7 @@ BeginProg.
 <div align="center"><b><font color="#000099" face="Arial, Helvetica, sans-serif">Source 
                     Text after processing</font><br/>
 </b> </div>
-<pre><b>
+<pre class="language-cobol"><code class="language-cobol"><b>
 </b>       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.                               
 PROGRAM-ID. COPYEG4.                                   
@@ -1095,7 +1098,7 @@ BeginProg.
                          N2 BY Num2                    
                          R1 BY Result.  </b></font>               
 <b><font color="#FF0000">    ADD Num1, Num2 GIVING Result. </font></b><font color="#FF0000"> </font>
-    STOP RUN.</pre>
+    STOP RUN.</code></pre>
 </td>
 </tr>
 </table>

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -2,6 +2,9 @@
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Declaring Data in COBOL</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" rel="stylesheet"/>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cobol.min.js"></script>
 <meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -548,11 +551,11 @@
 <p>Recurring symbols may be specified by using a 'repeat' factor inside 
               brackets. For instance: </p>
 <blockquote>
-<pre>PIC 9(6)       is equivalent to PICTURE 999999
+<pre class="language-cobol"><code class="language-cobol">PIC 9(6)       is equivalent to PICTURE 999999
 PIC 9(6)V99    is equivalent to PIC 999999V99
 PICTURE X(10)  is equivalent to PIC XXXXXXXXXX
 PIC S9(4)V9(4) is equivalent to PIC S9999V9999
-PIC 9(18)      is equivalent to PIC 999999999999999999 </pre>
+PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 </blockquote>
 <p>Numeric values can have a maximum of 18 (eighteen) digits. </p>
 <p>The limit on string values is usually system dependent. </p>
@@ -620,13 +623,13 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </pre>
               called the <font size="-1">VALUE</font> clause. </p>
 <p align="left"><b>Some examples:</b></p>
 <blockquote>
-<pre>01 GrossPay       PIC 9(5)V99 VALUE ZEROS.
+<pre class="language-cobol"><code class="language-cobol">01 GrossPay       PIC 9(5)V99 VALUE ZEROS.
 
 01 NetPay         PIC 9(5)V99 VALUE ZEROS.
 
 01 CustomerName   PIC X(20) VALUE SPACES.
 
-01 CustDiscount   PIC V99 VALUE .25.</pre>
+01 CustDiscount   PIC V99 VALUE .25.</code></pre>
 </blockquote>
 <hr width="50%"/>
 </td>
@@ -707,7 +710,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </pre>
 </tr>
 <tr>
 <td width="51%">
-<pre>01 StudentDetails.
+<pre class="language-cobol"><code class="language-cobol">01 StudentDetails.
    02 StudentId        PIC 9(7). 
    02 StudentName. 
       03 FirstName     PIC X(10).
@@ -718,7 +721,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </pre>
       03 MonthOfBirth  PIC 99.
       03 YearOfBirth   PIC 9(4).
    02 CourseCode       PIC X(4).
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>
@@ -731,7 +734,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </pre>
 </tr>
 <tr>
 <td width="49%">
-<pre>01 StudentDetails.
+<pre class="language-cobol"><code class="language-cobol">01 StudentDetails.
    05 StudentId        PIC 9(7). 
    05 StudentName. 
       07 FirstName     PIC X(10).
@@ -742,7 +745,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </pre>
       07 MonthOfBirth  PIC 99.
       07 YearOfBirth   PIC 9(4).
    05 CourseCode       PIC X(4).
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -2,6 +2,9 @@
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Edited Pictures</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" rel="stylesheet"/>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cobol.min.js"></script>
 <meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -1599,7 +1602,7 @@
 <tr>
 <td bgcolor="#FFFFCC" height="192" valign="top" width="15%">
 <div align="center">
-<pre>P
+<pre class="language-cobol"><code class="language-cobol">P
 B
 0
 /
@@ -1610,11 +1613,11 @@ B
 CR or DB
 $
 9
-V</pre>
+V</code></pre>
 </div>
 </td>
 <td height="192" valign="top" width="85%">
-<pre>P B 0 / , + - CR DB 9 V
+<pre class="language-cobol"><code class="language-cobol">P B 0 / , + - CR DB 9 V
 P B 0 / , . + - CR DB 9 V
 P B 0 / , . + - CR DB 9 V
 P B 0 / , . + - CR DB 9 V
@@ -1625,7 +1628,7 @@ P B 0 / , . - $ 9 V
 Nothing at all
 P B 0 / , . + - CR DB $ 9 V
 P B 0 / , . + - CR DB 9 V
-B 0 / , + - CR DB 9</pre>
+B 0 / , + - CR DB 9</code></pre>
 </td>
 </tr>
 </table>

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -2,6 +2,9 @@
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Indexed Files</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" rel="stylesheet"/>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cobol.min.js"></script>
 <style type="text/css">
 <!--
 -->
@@ -238,7 +241,7 @@
 <td>
 <p><iframe height="541" src="Resources/pdf-viewer.html?src=ppz/IdxFile2.pdf" style="border:1px solid #ccc; width:100%; aspect-ratio: 520/541;" width="520"></iframe></p>
 <p>Below we see the results produced by two runs of the program.</p>
-<pre><b>RUN OF INDEX-EG2.EXE USING VIDEOCODE KEY</b>
+<pre class="language-cobol"><code class="language-cobol"><b>RUN OF INDEX-EG2.EXE USING VIDEOCODE KEY</b>
 Enter key : 1=VideoCode, 2=VideoTitle -&gt;1
 00121  FLIGHT OF THE CONDOR, THE     03
 00333  PREDATOR                      02
@@ -296,7 +299,7 @@ Enter key : 1=VideoCode, 2=VideoTitle -&gt;2
 11111  TERMINATOR, THE               02
 08081  WHALE NATION                  03
 10001  WICKED WALTZING               04
-03032  YACHT MASTER                  05</pre>
+03032  YACHT MASTER                  05</code></pre>
 <hr/>
 </td>
 </tr>
@@ -337,7 +340,7 @@ Enter key : 1=VideoCode, 2=VideoTitle -&gt;2
 <td>
 <p><iframe height="541" src="Resources/pdf-viewer.html?src=ppz/IdxFile3.pdf" style="border:1px solid #ccc; width:100%; aspect-ratio: 520/541;" width="520"></iframe></p>
 <p>Below we see the results produced by a number of runs of the program.</p>
-<pre><b>RUN OF INDEX-EG3.EXE USING VIDEOCODE</b>
+<pre class="language-cobol"><code class="language-cobol"><b>RUN OF INDEX-EG3.EXE USING VIDEOCODE</b>
 Chose key VideoCode = 1,  VideoTitle = 2 -&gt;  1
 Enter Video Code (5 digits) -&gt; 02121
 02121    DIRTY DANCING                               04
@@ -360,7 +363,7 @@ Enter Video Title (40 chars) -&gt; DIRTY DANCING
 <b>RUN OF INDEX-EG3.EXE USING NON EXISTANT VIDEOCODE</b>
 Chose key VideoCode = 1,  VideoTitle = 2 -&gt;  1
 Enter Video Code (5 digits) -&gt; 44444
-VIDEO STATUS :- 23</pre>
+VIDEO STATUS :- 23</code></pre>
 <hr/>
 </td>
 </tr>
@@ -481,7 +484,7 @@ VIDEO STATUS :- 23</pre>
               and how this index is used to read a record directly.</p>
 <p>The algorithm used for traversing both indexes is -</p>
 <blockquote>
-<pre>IF RecordKeyValue &gt; RequiredKeyValue <br/>   take this branch<br/>ELSE<br/>   go to next index record<br/>END-IF</pre>
+<pre class="language-cobol"><code class="language-cobol">IF RecordKeyValue &gt; RequiredKeyValue <br/>   take this branch<br/>ELSE<br/>   go to next index record<br/>END-IF</code></pre>
 </blockquote>
 
 </td>
@@ -974,7 +977,7 @@ VIDEO STATUS :- 23</pre>
 </tr>
 <tr>
 <td background="Resources/pics/code.gif" colspan="2" width="100">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.   WirthMemLib.
 AUTHOR.  Michael Coughlan.
@@ -1173,7 +1176,7 @@ ProcessOneBook.
     END-REWRITE.
 
 
-</pre>
+</code></pre>
 <hr/>
 </td>
 </tr>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -2,6 +2,9 @@
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>The INSPECT verb</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" rel="stylesheet"/>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cobol.min.js"></script>
 <style type="text/css">
 <!--
 -->
@@ -272,7 +275,7 @@
 </tr>
 <tr>
 <td background="Resources/pics/code.gif" width="525">
-<pre>PROCEDURE DIVISION.
+<pre class="language-cobol"><code class="language-cobol">PROCEDURE DIVISION.
 Begin.
     OPEN INPUT TextFile
     READ TextFile 
@@ -296,7 +299,7 @@ Begin.
     END-PERFORM
     CLOSE TextFile
     STOP RUN.
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>
@@ -383,11 +386,11 @@ Begin.
 <h3><font color="#800000">Examples</font></h3>
 </td>
 <td width="525">
-<pre>INSPECT FullName TALLYING UnstrPtr FOR LEADING SPACES.
+<pre class="language-cobol"><code class="language-cobol">INSPECT FullName TALLYING UnstrPtr FOR LEADING SPACES.
 
 INSPECT SourceLine TALLYING ECount
         FOR ALL "e" AFTER  INITIAL "start"
-                    BEFORE INITIAL "end".   </pre>
+                    BEFORE INITIAL "end".   </code></pre>
 </td>
 </tr>
 </table>
@@ -444,7 +447,7 @@ INSPECT SourceLine TALLYING ECount
         </font>statements (use left click or PageDown for next item and right 
         click or PageUp for previsou item) .  </p>
 <blockquote>
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
 1. INSPECT StringData REPLACING ALL "<b>R</b><b><font color="#0000FF"></font></b>" BY "<font color="#0000FF"><b>G</b></font><font color="#0000FF"><b></b></font><font color="#FF0000"><b></b></font><font color="#FF0000"><b></b></font><b></b>" 
        AFTER INITIAL "<font color="#FF0000"><b>A</b></font><font color="#008000"><b></b></font><b></b>" BEFORE INITIAL "<font color="#FF0000"><b>Q</b></font><font color="#008000"><b></b></font><font color="#009900"><b></b></font><font color="#00CC33"><b></b></font><font color="#00CC33"><b></b></font><font color="#00FF00"><b></b></font><b></b>".
 
@@ -460,7 +463,7 @@ INSPECT SourceLine TALLYING ECount
 5. INSPECT StringData REPLACING 
        ALL "<b>RRRR</b>" BY "<font color="#0000FF"><b>FROG</b></font><b></b>" 
        AFTER INITIAL "<font color="#FF0000"><b>A</b></font><b></b>" BEFORE INITIAL "<font color="#FF0000"><b>Q</b></font><b></b>".
-</pre>
+</code></pre>
 </blockquote>
 <center>
 <p><iframe height="125" src="Resources/pdf-viewer.html?src=ppz/Inspect1.pdf" style="border:1px solid #ccc; width:100%; aspect-ratio: 500/125;" width="500"></iframe> </p>
@@ -476,9 +479,9 @@ INSPECT SourceLine TALLYING ECount
 <p>This example inspects the string TextLine and checks it for each of the 
         4 letter swear words in the table. If one is found it is replaced by the 
         text *#@!.</p>
-<pre>PERFORM VARYING idx FROM 1 BY 1 UNTIL idx &gt; 10
+<pre class="language-cobol"><code class="language-cobol">PERFORM VARYING idx FROM 1 BY 1 UNTIL idx &gt; 10
   INSPECT TextLine REPLACING SwearWord(idx) BY "*#@!"
-END-PERFORM</pre>
+END-PERFORM</code></pre>
 <hr/>
 </td>
 </tr>
@@ -567,7 +570,7 @@ END-PERFORM</pre>
         in Convert$il on a one for one basis. </p>
 <p>For instance the statement - </p>
 <blockquote>
-<pre>INSPECT StringData CONVERTING "abc" TO "XYZ". </pre>
+<pre class="language-cobol"><code class="language-cobol">INSPECT StringData CONVERTING "abc" TO "XYZ". </code></pre>
 </blockquote>
 <p> replaces "a" with "X", "b" with "Y" and "c" with "Z". </p>
 <hr/>
@@ -608,7 +611,7 @@ END-PERFORM</pre>
         </p>
 <blockquote>
 <div align="LEFT">
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
 1. INSPECT StringData CONVERTING "<b>fxtd"</b> TO "<b><font color="#FF0000">ZYAB</font></b>".
 
 2. INSPECT StringData REPLACING "<b>fxtd"</b> BY "<b><font color="#FF0000">ZYAB</font></b>".
@@ -617,7 +620,7 @@ END-PERFORM</pre>
                                     "<b>d</b>" BY "<b><font color="#FF0000">Z</font></b>"
                                     "<b>f</b>" BY "<b><font color="#FF0000">S</font></b>".
 
-</pre>
+</code></pre>
 </div>
 </blockquote>
 <p><iframe height="125" src="Resources/pdf-viewer.html?src=ppz/Inspect1.pdf" style="border:1px solid #ccc; width:100%; aspect-ratio: 500/125;" width="500"></iframe> </p>
@@ -635,9 +638,9 @@ END-PERFORM</pre>
 <p>It converts the character 0 to character 5, 1 to 2, 2 to 9, 3 to 8 etc. 
         Conversion starts when the word "codeon" is encountered in the string 
         and stops when "codeoff" is encountered. </p>
-<pre>INSPECT TextLine 
+<pre class="language-cobol"><code class="language-cobol">INSPECT TextLine 
     CONVERTING "0123456789" TO "5298317046"
-    AFTER INITIAL "codeon" BEFORE INITIAL "codeoff". </pre>
+    AFTER INITIAL "codeon" BEFORE INITIAL "codeoff". </code></pre>
 <hr/>
 </td>
 </tr>
@@ -653,19 +656,20 @@ END-PERFORM</pre>
         strings in data items makes the conversion operation more versatile.</p>
 <p>Actually, these days we can do this with the <font size="2">UPPER-CASE</font> 
         and <font size="2">LOWER-CASE</font> Intrinsic Functions. </p>
-<pre>*&gt; Data Division entries 
-01 AlphaChars. 
-   02 AlphaLower PIC X(26) VALUE "abcdefghijklmnopqrstuvwxyz". 
-   02 AlphaUpper PIC X(26) VALUE "ABCDEFGHIJKLMNOPQRSTUVWXYZ".</pre>
-<pre>*&gt; Procedure Division entries 
+<pre class="language-cobol"><code class="language-cobol">*&gt; Data Division entries
+01 AlphaChars.
+   02 AlphaLower PIC X(26) VALUE "abcdefghijklmnopqrstuvwxyz".
+   02 AlphaUpper PIC X(26) VALUE "ABCDEFGHIJKLMNOPQRSTUVWXYZ".
+
+*&gt; Procedure Division entries
     INSPECT CustAddress
         CONVERTING "abcdefghijklmnopqrstuvwxyz"
             TO     "ABCDEFGHIJKLMNOPQRSTUVWXYZ".
 
-    INSPECT CustAddress 
-        CONVERTING AlphaLower TO AlphaUpper. </pre>
-<pre>    INSPECT CustAddress
-        CONVERTING AlphaUpper TO AlphaLower.    </pre>
+    INSPECT CustAddress
+        CONVERTING AlphaLower TO AlphaUpper.
+    INSPECT CustAddress
+        CONVERTING AlphaUpper TO AlphaLower.    </code></pre>
 </td>
 </tr>
 </table>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -2,6 +2,9 @@
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Introduction to Direct Access Files</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" rel="stylesheet"/>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cobol.min.js"></script>
 <style type="text/css">
 <!--
 -->
@@ -529,7 +532,7 @@
                 record we.</p>
 <p>The algorithm used for traversing the index is -</p>
 <blockquote>
-<pre>IF RecordKeyValue &gt; RequiredKeyValue <br/>   take this branch<br/>ELSE<br/>   go to next index record<br/>END-IF</pre>
+<pre class="language-cobol"><code class="language-cobol">IF RecordKeyValue &gt; RequiredKeyValue <br/>   take this branch<br/>ELSE<br/>   go to next index record<br/>END-IF</code></pre>
 </blockquote>
 
 </td>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -2,6 +2,9 @@
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>COBOL Interation Constructs</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" rel="stylesheet"/>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cobol.min.js"></script>
 <meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -481,7 +484,7 @@
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="83%">
 <tr>
 <td>
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  PerformFormat1.
 AUTHOR.  Michael Coughlan.
@@ -509,7 +512,7 @@ OneLevelDown.
 
 ThreeLevelsDown.
     DISPLAY "&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Now in ThreeLevelsDown".
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>
@@ -667,7 +670,7 @@ ThreeLevelsDown.
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="49%">
 <tr valign="top">
 <td>
-<pre>PROCEDURE DIVISION.
+<pre class="language-cobol"><code class="language-cobol">PROCEDURE DIVISION.
 Begin.
    PERFORM SumSales
    STOP RUN.
@@ -689,7 +692,7 @@ SumSales.
             Statements
          END-IF
       END-IF       
-   END-IF.</pre>
+   END-IF.</code></pre>
 </td>
 </tr>
 </table>
@@ -730,7 +733,7 @@ SumSales.
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="49%">
 <tr valign="top">
 <td>
-<pre>PROCEDURE DIVISION
+<pre class="language-cobol"><code class="language-cobol">PROCEDURE DIVISION
 Begin.
    PERFORM SumSales THRU SumSalesExit
    STOP RUN.
@@ -755,7 +758,7 @@ SumSales.
    Statements
 
 SumSalesExit.
-   EXIT.</pre>
+   EXIT.</code></pre>
 </td>
 </tr>
 </table>
@@ -883,7 +886,7 @@ SumSalesExit.
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="49%">
 <tr valign="top">
 <td>
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  InLineVsOutOfLine.
 AUTHOR.  Michael Coughlan.
@@ -908,7 +911,7 @@ Begin.
 OutOfLineEG.
     DISPLAY "&gt;&gt;&gt;&gt; This is an out of line Perform".
 
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>
@@ -1073,7 +1076,7 @@ OutOfLineEG.
 </tr>
 <tr>
 <td>
-<pre>READ StudentRecords
+<pre class="language-cobol"><code class="language-cobol">READ StudentRecords
    AT END SET EndOfStudentFile TO TRUE
 END-READ
 PERFORM WITH TEST BEFORE UNTIL EndOfStudentFile
@@ -1083,7 +1086,7 @@ PERFORM WITH TEST BEFORE UNTIL EndOfStudentFile
 </i>   READ StudentRecords
      AT END SET EndOfStudentFile TO TRUE
    END-READ
-END-PERFORM</pre>
+END-PERFORM</code></pre>
 </td>
 </tr>
 </table>
@@ -1181,8 +1184,8 @@ END-PERFORM</pre>
               the counter, it is not mandatory. For instance, the statement that 
               follows is perfectly valid: </p>
 <blockquote>
-<pre>PERFORM CountRecords
-        VARYING RecCount FROM 1 BY 1 UNTIL EndOfFile </pre>
+<pre class="language-cobol"><code class="language-cobol">PERFORM CountRecords
+        VARYING RecCount FROM 1 BY 1 UNTIL EndOfFile </code></pre>
 </blockquote>
 
 <hr width="50%"/>
@@ -1268,7 +1271,7 @@ END-PERFORM</pre>
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="486">
 <tr valign="top">
 <td>
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  MileageCounter.
 AUTHOR.  Michael Coughlan.
@@ -1319,7 +1322,7 @@ CountMileage.
    MOVE UnitsCnt    TO PrnUnits
    DISPLAY PrnHunds "-" PrnTens "-" PrnUnits.
 
- </pre>
+ </code></pre>
 </td>
 </tr>
 </table>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -2,6 +2,9 @@
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Reference Modification</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" rel="stylesheet"/>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cobol.min.js"></script>
 <meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -259,12 +262,12 @@
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Examples</font></h4>
 </td>
 <td valign="top" width="525">
-<pre>WORKING-STORAGE SECTION.
+<pre class="language-cobol"><code class="language-cobol">WORKING-STORAGE SECTION.
 01 xString    PIC X(38) VALUE "This is the alphanumeric string". 
 01 nString    PIC 9(5)V99 VALUE 34526.56. 
 01 SubStrSize PIC 99 VALUE 12. 
 01 StartPos   PIC 99 VALUE 18.
-             </pre>
+             </code></pre>
 <p align="center"> <iframe height="333" src="Resources/pdf-viewer.html?src=ppz/TC-RefModEg.pdf" style="border:1px solid #ccc; width:100%; aspect-ratio: 520/333;" width="520"></iframe> </p>
 <hr/>
 </td>
@@ -354,8 +357,8 @@
               is one or more parameters supplied to the function.</p>
 <p>Example declarations.</p>
 <blockquote>
-<pre>MOVE <b>FUNCTION RANDOM(99)</b> TO RandNum. </pre>
-<pre>DISPLAY <b>FUNCTION UPPER-CASE("this will be in upper case")</b>.</pre>
+<pre class="language-cobol"><code class="language-cobol">MOVE <b>FUNCTION RANDOM(99)</b> TO RandNum. </code></pre>
+<pre class="language-cobol"><code class="language-cobol">DISPLAY <b>FUNCTION UPPER-CASE("this will be in upper case")</b>.</code></pre>
 </blockquote>
 <hr/>
 </td>
@@ -390,9 +393,9 @@
 <p>For instance the ORD-MAX function may take a parameter list or 
               an array may be used: </p>
 <blockquote>
-<pre>MOVE FUNCTION ORD-MAX(12 23 03 78 65) TO OrdPos
+<pre class="language-cobol"><code class="language-cobol">MOVE FUNCTION ORD-MAX(12 23 03 78 65) TO OrdPos
                      <b>or</b>
-MOVE FUNCTION ORD-MAX(IntElement(ALL)) TO OrdPos             </pre>
+MOVE FUNCTION ORD-MAX(IntElement(ALL)) TO OrdPos             </code></pre>
 </blockquote>
 <hr/>
 </td>
@@ -534,7 +537,7 @@ MOVE FUNCTION ORD-MAX(IntElement(ALL)) TO OrdPos             </pre>
 <table background="Resources/pics/code.gif" border="0" width="100%">
 <tr>
 <td>
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
 WORKING-STORAGE SECTION. 
 01 xString PIC X(38) VALUE "This is the alphanumeric string". 
 01 OrdPos PIC 99. 
@@ -565,7 +568,7 @@ Begin.
   DISPLAY FUNCTION LOWER-CASE(xString)
   STOP RUN.
 
-</pre>
+</code></pre>
 </td>
 </tr></table>
 <hr/>
@@ -722,7 +725,7 @@ Begin.
 <table background="Resources/pics/code.gif" border="0" width="100%">
 <tr>
 <td>
-<pre>IDENTIFICATION DIVISION.
+<pre class="language-cobol"><code class="language-cobol">IDENTIFICATION DIVISION.
 PROGRAM-ID. DateFunctions.
 AUTHOR. Michael Coughlan.
 DATA DIVISION.
@@ -793,7 +796,7 @@ Begin.
   DISPLAY "The date in "
   NumOfDays " days time will be " MonthD "/" DayD "/" YearD
   STOP RUN.
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>
@@ -1159,7 +1162,7 @@ Begin.
 <table background="Resources/pics/code.gif" border="0" width="100%">
 <tr>
 <td valign="top">
-<pre>IDENTIFICATION DIVISION.
+<pre class="language-cobol"><code class="language-cobol">IDENTIFICATION DIVISION.
 PROGRAM-ID.  OtherFunctions.
 AUTHOR.  Michael Coughlan.
 *&gt; An example program using misc Intrinsic Functions
@@ -1202,7 +1205,7 @@ Begin.
 
   MOVE FUNCTION VARIANCE(Ielement(ALL)) TO IResult
   DISPLAY "The variance of the values is " IResult
-  STOP RUN.</pre>
+  STOP RUN.</code></pre>
 </td>
 </tr>
 </table>
@@ -1252,7 +1255,7 @@ Begin.
 <table background="Resources/pics/code.gif" border="0" width="100%">
 <tr>
 <td valign="top">
-<pre>IDENTIFICATION DIVISION.
+<pre class="language-cobol"><code class="language-cobol">IDENTIFICATION DIVISION.
 PROGRAM-ID.  Lotto.
 AUTHOR.  Michael Coughlan.
 *&gt; This program displays six unique random lotto numbers.
@@ -1287,7 +1290,7 @@ Begin.
    END-PERFORM
    STOP RUN.
                                       
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -2,6 +2,9 @@
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Relative Files</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" rel="stylesheet"/>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cobol.min.js"></script>
 <style type="text/css">
 <!--
 -->
@@ -248,7 +251,7 @@
 <td>
 <p><iframe height="541" src="Resources/pdf-viewer.html?src=ppz/RelFile2.pdf" style="border:1px solid #ccc; width:100%; aspect-ratio: 520/541;" width="520"></iframe></p>
 <p>Below we see the results produced by two runs of the program.</p>
-<pre>RUN USING SEQUENTIAL READING
+<pre class="language-cobol"><code class="language-cobol">RUN USING SEQUENTIAL READING
 Enter Read type (Direct=1, Seq=2)-&gt; 2
   01  VESTRON VIDEOS        OVER THE SEA SOMEWHERE IN LONDON
   02  EMI STUDIOS           HOLLYWOOD, CALIFORNIA, USA 
@@ -261,7 +264,7 @@ Enter Read type (Direct=1, Seq=2)-&gt; 2
 RUN USING DIRECT READ
 Enter Read type (Direct=1, Seq=2)-&gt; 1
 Enter supplier key (2 digits)-&gt; 05
-  05  YACHTING MONTHLY      TREE HOUSE, LONDON, ENGLAND</pre>
+  05  YACHTING MONTHLY      TREE HOUSE, LONDON, ENGLAND</code></pre>
 <hr/>
 </td>
 </tr>
@@ -758,7 +761,7 @@ Enter supplier key (2 digits)-&gt; 05
 <table border="5" cellpadding="10" width="89%">
 <tr>
 <td background="Resources/pics/code.gif" height="365" valign="TOP" width="44%">
-<pre>PROCEDURE DIVISION.
+<pre class="language-cobol"><code class="language-cobol">PROCEDURE DIVISION.
 DECLARATIVES. 
 SectionOne SECTION. 
     USE clause for file1.
@@ -779,7 +782,7 @@ ParSectTwo2.
    ????????????????  
 END-DECLARATIVES. 
 Main SECTION. 
-Begin.</pre>
+Begin.</code></pre>
 </td>
 </tr>
 </table>
@@ -829,7 +832,7 @@ Begin.</pre>
 <h3 align="CENTER"><font color="#800000">Example program - fragment</font></h3>
 </td>
 <td background="Resources/pics/code.gif" width="525">
-<pre> PROCEDURE DIVISION. 
+<pre class="language-cobol"><code class="language-cobol"> PROCEDURE DIVISION. 
  DECLARATIVES. 
  FileError SECTION.
     USE AFTER ERROR PROCEDURE ON RelativeFile.
@@ -841,7 +844,7 @@ Begin.</pre>
     END-EVALUATE. 
  END-DECLARATIVES.
  Main SECTION.
- Begin.</pre>
+ Begin.</code></pre>
 </td>
 </tr>
 </table>

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -2,6 +2,9 @@
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>COBOL Report Writer</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" rel="stylesheet"/>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cobol.min.js"></script>
 <meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -292,7 +295,7 @@
 <table background="Resources/pics/code.gif" border="0" width="100%">
 <tr>
 <td height="333">
-<pre>PROCEDURE DIVISION.
+<pre class="language-cobol"><code class="language-cobol">PROCEDURE DIVISION.
 Begin.
     OPEN INPUT SalesFile.
     OPEN OUTPUT PrintFile.
@@ -311,7 +314,7 @@ PrintSalaryReport.
     GENERATE DetailLine.
     READ SalesFile
           AT END SET EndOfFile TO TRUE
-    END-READ.                                                       </pre>
+    END-READ.                                                       </code></pre>
 </td>
 </tr>
 </table>
@@ -509,7 +512,7 @@ PrintSalaryReport.
 <table background="Resources/pics/code.gif" border="1" width="100%">
 <tr>
 <td height="333">
-<pre>           An example COBOL Report Program              
+<pre class="language-cobol"><code class="language-cobol">           An example COBOL Report Program              
      Bible Salesperson - Sales and Salary Report        
                                                         
  City      Salesperson     Sale                         
@@ -562,7 +565,7 @@ Cork          1           $333.50
                                                         
                                                         
 Programmer - Michael Coughlan               Page :  1
-                                                    </pre>
+                                                    </code></pre>
 </td>
 </tr>
 </table>
@@ -667,7 +670,7 @@ Programmer - Michael Coughlan               Page :  1
 <table background="Resources/pics/code.gif" border="0" width="100%">
 <tr>
 <td valign="top">
-<pre>REPORT SECTION.
+<pre class="language-cobol"><code class="language-cobol">REPORT SECTION.
 RD  SalesReport
     CONTROLS ARE <b><font color="#FF0000">FINAL
                  CityCode</font></b>
@@ -741,7 +744,7 @@ RD  SalesReport
        03 COLUMN 45     PIC X(6) VALUE "Page :".
        03 COLUMN 52     PIC Z9 SOURCE PAGE-COUNTER.
 
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>
@@ -858,7 +861,7 @@ RD  SalesReport
 <table background="Resources/pics/code.gif" border="0" width="100%">
 <tr>
 <td valign="top">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  ReportExampleFull.
 AUTHOR.  Michael Coughlan.
@@ -1066,7 +1069,7 @@ PrintSalaryReport.
     GENERATE DetailLine.
     READ SalesFile
           AT END SET EndOfFile TO TRUE
-    END-READ.</pre>
+    END-READ.</code></pre>
 </td>
 </tr>
 </table>
@@ -1075,7 +1078,7 @@ PrintSalaryReport.
 <table background="Resources/pics/code.gif" border="0" width="100%">
 <tr>
 <td valign="top">
-<pre>           An example COBOL Report Program              
+<pre class="language-cobol"><code class="language-cobol">           An example COBOL Report Program              
      Bible Salesperson - Sales and Salary Report        
                                                         
  City      Salesperson     Sale                         
@@ -1127,7 +1130,7 @@ Belfast       1           $111.50
                                                         
                                                         
                                                         
-Programmer - Michael Coughlan               Page :  1 </pre>
+Programmer - Michael Coughlan               Page :  1 </code></pre>
 </td>
 </tr>
 </table>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -2,6 +2,9 @@
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>COBOL Report Writer - Syntax and Semantics</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" rel="stylesheet"/>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cobol.min.js"></script>
 <meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -264,7 +267,7 @@
 <table background="Resources/pics/code.gif" border="1" width="100%">
 <tr>
 <td>
-<pre>ENVIRONMENT DIVISION.
+<pre class="language-cobol"><code class="language-cobol">ENVIRONMENT DIVISION.
 INPUT-OUTPUT SECTION.
 FILE-CONTROL.
     SELECT SalesFile ASSIGN TO "GBPAY.DAT"
@@ -297,7 +300,7 @@ FD  SalesFile.
     FIRST DETAIL 6
     LAST DETAIL 42
     FOOTING 52.</font></font><b><font color="#FF0000"><font color="#000000">
-</font></font></b></pre>
+</font></font></b></code></pre>
 </td>
 </tr>
 </table>
@@ -662,13 +665,13 @@ FD  SalesFile.
 <table background="Resources/pics/code.gif" border="1" width="100%">
 <tr>
 <td>
-<pre>01  DetailLine TYPE IS DETAIL.
+<pre class="language-cobol"><code class="language-cobol">01  DetailLine TYPE IS DETAIL.
     02 LINE IS PLUS 1.
        03 COLUMN 1      PIC X(9)
                         SOURCE CityName(CityCode) <font color="#FF0000"><b>GROUP INDICATE</b></font>.
        03 COLUMN 15     PIC 9
                         SOURCE SalesPersonNum  <b><font color="#FF0000">GROUP INDICATE</font></b>.
-       03 COLUMN 25     PIC $$,$$$.99 SOURCE ValueOfSale.</pre>
+       03 COLUMN 25     PIC $$,$$$.99 SOURCE ValueOfSale.</code></pre>
 </td>
 </tr>
 </table>
@@ -732,7 +735,7 @@ FD  SalesFile.
 <table background="Resources/pics/code.gif" border="1" width="100%">
 <tr>
 <td>
-<pre>01  SalesPersonGrp
+<pre class="language-cobol"><code class="language-cobol">01  SalesPersonGrp
     TYPE IS CONTROL FOOTING SalesPersonNum  NEXT GROUP PLUS 2.
                       :<i> other entries</i> :
                       :<i> other entries</i> :
@@ -750,7 +753,7 @@ FD  SalesFile.
 01  TotalSalesGrp TYPE IS CONTROL FOOTING FINAL.
                       :<i> other entries</i> :
                       :<i> other entries</i> :
-       03 COLUMN 45     PIC $$$$$,$$$.99 <b><font color="#FF0000">SUM CS</font></b>.</pre>
+       03 COLUMN 45     PIC $$$$$,$$$.99 <b><font color="#FF0000">SUM CS</font></b>.</code></pre>
 </td>
 </tr>
 </table>
@@ -766,14 +769,14 @@ FD  SalesFile.
 <table background="Resources/pics/code.gif" border="1" width="100%">
 <tr>
 <td>
-<pre>01  ShopTotalsGrp
+<pre class="language-cobol"><code class="language-cobol">01  ShopTotalsGrp
     TYPE IS CONTROL FOOTING ShopNum  NEXT GROUP PLUS 2.
                       :<i> other entries</i> :
                       :<i> other entries</i> :
        03 <font color="#FF0000"><b>SPS</b></font> COLUMN 20 PIC $$$,$$$.99  <font color="#FF0000"><b>SUM SalesPersonSale</b></font>.
        03 <font color="#FF0000"><b>SCS</b></font> COLUMN 40 PIC $$$,$$$.99  <font color="#FF0000"><b>SUM CounterSale</b></font>.
        03     COLUMN 60 PIC $$$$,$$$.99 <font color="#FF0000"><b>SUM SPS, SCS</b></font>.
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>
@@ -884,12 +887,12 @@ FD  SalesFile.
 <table background="Resources/pics/code.gif" border="1" width="100%">
 <tr>
 <td>
-<pre>01  TYPE IS PAGE FOOTING.
+<pre class="language-cobol"><code class="language-cobol">01  TYPE IS PAGE FOOTING.
     02 LINE IS 53.
        03 COLUMN 1      PIC X(29) 
                         VALUE "Programmer - Michael Coughlan".
        03 COLUMN 45     PIC X(6) VALUE "Page :".
-       03 COLUMN 52     PIC Z9 SOURCE<b><font color="#FF0000"> PAGE-COUNTER.</font></b></pre>
+       03 COLUMN 52     PIC Z9 SOURCE<b><font color="#FF0000"> PAGE-COUNTER.</font></b></code></pre>
 </td>
 </tr>
 </table>
@@ -1016,7 +1019,7 @@ FD  SalesFile.
 <table background="Resources/pics/code.gif" border="0" width="100%">
 <tr>
 <td valign="top">
-<pre>          An example COBOL Report Program              
+<pre class="language-cobol"><code class="language-cobol">          An example COBOL Report Program              
      Bible Salesperson - Sales and Salary Report        
                                                         
  City      Salesperson     Sale                         
@@ -1070,7 +1073,7 @@ FD  SalesFile.
                                                         
 Programmer - Michael Coughlan               Page :  1   
                                                         
-  </pre>
+  </code></pre>
 </td>
 </tr>
 </table>
@@ -1162,7 +1165,7 @@ Programmer - Michael Coughlan               Page :  1
 <table background="Resources/pics/code.gif" border="1" width="90%">
 <tr>
 <td>
-<pre>PROCEDURE DIVISION.
+<pre class="language-cobol"><code class="language-cobol">PROCEDURE DIVISION.
 <b><font color="#FF0000">DECLARATIVES.
 Calc SECTION.
     USE BEFORE REPORTING SalesPersonGrp.
@@ -1178,7 +1181,7 @@ Begin.
     OPEN INPUT SalesFile.
     OPEN OUTPUT PrintFile.
        : etc :
-       : etc : </pre>
+       : etc : </code></pre>
 </td>
 </tr>
 </table>
@@ -1208,7 +1211,7 @@ Begin.
 <tr>
 <td>
 <blockquote>
-<pre><font color="#000000">PROCEDURE DIVISION.
+<pre class="language-cobol"><code class="language-cobol"><font color="#000000">PROCEDURE DIVISION.
 DECLARATIVES.
 CheckShopSales SECTION.
     USE BEFORE REPORTING ShopTotalGrp.
@@ -1216,7 +1219,7 @@ PrintMajorShopsOnly.
     IF SalesTotal &lt; 10000<b>
        <font color="#FF3300">SUPPRESS PRINTING</font>
 </b>    END-IF.
-END DECLARATIVES.</font></pre>
+END DECLARATIVES.</font></code></pre>
 </blockquote>
 </td>
 </tr>

--- a/course/Search.html
+++ b/course/Search.html
@@ -2,6 +2,9 @@
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Searching Tables</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" rel="stylesheet"/>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cobol.min.js"></script>
 <meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -466,21 +469,21 @@
               we might encounter with the index item. For instance, to display 
               the value of the index item we would require following code - </p>
 <blockquote>
-<pre>SET LetterPos TO LetterIdx
+<pre class="language-cobol"><code class="language-cobol">SET LetterPos TO LetterIdx
 MOVE LetterPos TO PrnPos
 DISPLAY LetterIn, " is in position ", PrnPos
-</pre>
+</code></pre>
 </blockquote>
 <p>The example below is not meant to be a practical example of how 
               to find the position of a letter in the alphabet. Nowadays, this 
               task would be accomplished in much the same way as it would in C 
               or Modula-2 except that, in COBOL, we would use the Intrinsic Function 
               - ORD - as shown below. </p>
-<pre>COMPUTE PrnIdx = FUNCTION ORD(LetterIn) - FUNCTION ORD("A") + 1 </pre>
+<pre class="language-cobol"><code class="language-cobol">COMPUTE PrnIdx = FUNCTION ORD(LetterIn) - FUNCTION ORD("A") + 1 </code></pre>
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="475">
 <tr>
 <td>
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. LetterSearch.
 AUTHOR. Michael Coughlan.
@@ -517,7 +520,7 @@ Begin.
             MOVE LetterPos TO PrnPos
             DISPLAY LetterIn, " is in position ", PrnPos
     END-SEARCH
-    STOP RUN.</pre>
+    STOP RUN.</code></pre>
 </td>
 </tr>
 </table>
@@ -565,7 +568,7 @@ Begin.
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="475">
 <tr>
 <td>
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. CountyTaxTable.
 AUTHOR. Michael Coughlan.
@@ -664,7 +667,7 @@ DisplayCountyTaxes.
       MOVE CountyTax(Idx)  TO PrnTax
       MOVE PayerCount(Idx) TO PrnPayers
       DISPLAY CountyTaxLine
-   END-IF.</pre>
+   END-IF.</code></pre>
 </td>
 </tr>
 </table>
@@ -708,20 +711,20 @@ DisplayCountyTaxes.
 <p align="left">For instance, suppose a hotel keeps an Occupancy Table 
               showing which rooms in the hotel are currently occupied. The table 
               might be described as - </p>
-<pre align="left">01 HotelOccupanyTable.
+<pre class="language-cobol" align="left"><code class="language-cobol">01 HotelOccupanyTable.
    02 Floor OCCURS 5 TIMES INDEXED BY Fidx.
       03 Room OCCURS 25 TIMES INDEXED BY Ridx.
          04 CustomerId  PIC 9(6).
-         04 NumOfOccupants PIC 9.</pre>
+         04 NumOfOccupants PIC 9.</code></pre>
 <p align="left"> and we can represent this diagrammatically as follows 
               -</p>
 <div align="center">
-<pre align="left">
+<pre class="language-cobol" align="left"><code class="language-cobol">
 <img height="170" src="Resources/pics/Search5.gif" width="411"/>
-</pre>
+</code></pre>
 </div>
-<pre align="left"> 
-</pre>
+<pre class="language-cobol" align="left"><code class="language-cobol"> 
+</code></pre>
 <p align="left"> Suppose we want to search the table to discover which 
               room is occupied by customer 126789. We can't use the <font size="-1">SEARCH</font> 
               to search the whole two-dimension table directly but we can use 
@@ -741,7 +744,7 @@ DisplayCountyTaxes.
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="475">
 <tr>
 <td>
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. HotelSearch.
 AUTHOR. Michael Coughlan.
@@ -805,7 +808,7 @@ LoadTable.
         AT END SET EndOfFile TO TRUE
       END-READ
    END-PERFORM
-   CLOSE OccupancyFile.</pre>
+   CLOSE OccupancyFile.</code></pre>
 </td>
 </tr>
 </table>
@@ -825,14 +828,14 @@ LoadTable.
 <p>Suppose that we want to use a two-dimension table to hold the finishing 
               positions of drivers in fifteen races. The table to hold these details 
               may be described as - </p>
-<pre>01 RaceResultsTable. 
+<pre class="language-cobol"><code class="language-cobol">01 RaceResultsTable. 
    02 Race OCCURS 15 TIMES INDEXED BY Ridx.
       03 Venue  PIC X(20).
       03 RacePos OCCURS 50 TIMES INDEXED BY Pidx.
          04 DriverId    PIC 9(4).
       
 
-</pre>
+</code></pre>
 <p>We can represent this diagramatically as follows - </p>
 <p align="center"><img height="109" src="Resources/pics/Search6.gif" width="469"/></p>
 <p>In the example program below, the first dimension of the table 
@@ -852,7 +855,7 @@ LoadTable.
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="475">
 <tr>
 <td>
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. RaceSearch.
 AUTHOR. Michael Coughlan.
@@ -920,7 +923,7 @@ LoadTable.
         AT END SET EndOfFile TO TRUE
       END-READ
    END-PERFORM
-   CLOSE RaceResultsFile.</pre>
+   CLOSE RaceResultsFile.</code></pre>
 </td>
 </tr>
 </table>
@@ -928,7 +931,7 @@ LoadTable.
               <font size="-1">SEARCH</font>. This was not strictly necessary. 
               The same result could have been achieved with nested <font size="-1">SEARCH</font> 
               statements. For instance - </p>
-<pre>SET Ridx TO 1
+<pre class="language-cobol"><code class="language-cobol">SET Ridx TO 1
 SEARCH Race
    AT END DISPLAY "Venue not found."
    WHEN Venue(Ridx) = VenueName 
@@ -941,7 +944,7 @@ SEARCH Race
              DISPLAY "Driver " DriverIdNum
                      " finished in position " PosNum
      END-SEARCH
-END-SEARCH</pre>
+END-SEARCH</code></pre>
 </td>
 </tr>
 <tr>
@@ -1031,7 +1034,7 @@ END-SEARCH</pre>
 <table align="center" bgcolor="#E1FFE1" border="1" cellpadding="5" width="93%">
 <tr>
 <td>
-<pre>PERFORM UNTIL ItemFound OR ItemNotInTable
+<pre class="language-cobol"><code class="language-cobol">PERFORM UNTIL ItemFound OR ItemNotInTable
   COMPUTE Middle = (Lower + Upper) / 2 
   EVALUATE TRUE
     WHEN Key(Middle) &lt; SearchItem COMPUTE Lower = Middle + 1
@@ -1039,7 +1042,7 @@ END-SEARCH</pre>
     WHEN Key(Middle) = SearchItem SET ItemFound TO TRUE
     WHEN Lower &gt; Upper THEN SET ItemNotInTable TO TRUE
   END-EVALUATE 
-END-PERFORM</pre>
+END-PERFORM</code></pre>
 </td>
 </tr>
 </table>
@@ -1049,7 +1052,7 @@ END-PERFORM</pre>
               <font size="-1">SEARCH ALL</font> the description of the table has 
               to be amended to include a <font size="-1">KEY IS</font> phrase 
               as shown below. </p>
-<pre>01  LetterTable.
+<pre class="language-cobol"><code class="language-cobol">01  LetterTable.
     02 LetterValues.
        03 FILLER PIC X(13) 
           VALUE "ABCDEFGHIJKLM".
@@ -1059,16 +1062,16 @@ END-PERFORM</pre>
        03 Letter PIC X OCCURS 26 TIMES 
                        <b><font color="#FF0000">ASCENDING KEY IS Letter</font></b>
                        INDEXED BY LetterIdx.
-</pre>
+</code></pre>
 <p>When the table description contains a KEY IS phrase we can search 
               it using the following statement - </p>
 <blockquote>
-<pre>SEARCH ALL Letter
+<pre class="language-cobol"><code class="language-cobol">SEARCH ALL Letter
   AT END DISPLAY "Letter " SearchLetter " was not found!"
   WHEN Letter(LetterIdx) = SearchLetter
        SET LetterPos TO LetterIdx
        DISPLAY SearchLetter " is in position " LetterPos
-END-SEARCH.</pre>
+END-SEARCH.</code></pre>
 </blockquote>
 <p align="center"><a href="Resources/ppz/TC-Search2.html"><img border="0" height="62" src="Resources/pics/i-Animation.gif" width="62"/></a>
 </p>
@@ -1085,7 +1088,7 @@ END-SEARCH.</pre>
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="475">
 <tr>
 <td>
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. LetterSearchAll.
 AUTHOR. Michael Coughlan.
@@ -1123,7 +1126,7 @@ Begin.
        DISPLAY SearchLetter " is in position " LetterPos
     END-SEARCH
     STOP RUN.
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>
@@ -1151,7 +1154,7 @@ Begin.
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="475">
 <tr>
 <td>
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. CountyTaxTable4.
 AUTHOR. Michael Coughlan.
@@ -1251,7 +1254,7 @@ DisplayCountyTaxes.
       MOVE CountyTax(Idx)  TO PrnTax
       MOVE PayerCount(Idx) TO PrnPayers
       DISPLAY CountyTaxLine
-   END-IF.</pre>
+   END-IF.</code></pre>
 </td>
 </tr>
 </table>

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -2,6 +2,9 @@
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>COBOL Selection Constructs</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" rel="stylesheet"/>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cobol.min.js"></script>
 <meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -271,7 +274,7 @@
 <table align="center" border="0" width="85%">
 <tr>
 <td valign="top" width="46%">
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
 Statement1
 Statement2
 IF VarA &gt; VarD THEN
@@ -279,16 +282,16 @@ IF VarA &gt; VarD THEN
    Statement4
 END-IF
 Statement5
-Statement6.</pre>
+Statement6.</code></pre>
 </td>
 <td valign="top" width="46%">
-<pre>Statement1
+<pre class="language-cobol"><code class="language-cobol">Statement1
 Statement2
 IF VarA &gt; VarD THEN
    Statement3
    Statement4
 Statement5
-Statement6.</pre>
+Statement6.</code></pre>
 </td>
 </tr>
 </table>
@@ -365,10 +368,10 @@ Statement6.</pre>
 <p align="left">Note that the values of the compared items must 
                   be type compatible. For instance, it is not valid to have a 
                   statement that says </p>
-<pre align="left">IF "mike" IS EQUAL TO 123 THEN etc
-                  </pre>
+<pre class="language-cobol" align="left"><code class="language-cobol">IF "mike" IS EQUAL TO 123 THEN etc
+                  </code></pre>
 <div align="left">
-<pre align="left">  </pre>
+<pre class="language-cobol" align="left"><code class="language-cobol">  </code></pre>
 </div>
 </div>
 </div>
@@ -420,13 +423,13 @@ Statement6.</pre>
               consist entirely of the characters listed in the definition of the 
               UserDefinedClassName.</p>
 <p><b>Example </b></p>
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
 *&gt; Uses the UPPER Intrinsic Function to convert to uppercase
 IF InputChar IS ALPHABETIC-LOWER
    MOVE FUNCTION UPPER (InputChar) TO InputChar
 END-IF
 
-</pre>
+</code></pre>
 </td>
 </tr>
 <tr>
@@ -525,14 +528,14 @@ END-IF
 </table>
 <p><b>Example</b></p>
 <blockquote>
-<pre>IF Row &gt; 0 AND Row &lt; 26 THEN
+<pre class="language-cobol"><code class="language-cobol">IF Row &gt; 0 AND Row &lt; 26 THEN
    DISPLAY "On Screen" 
 END-IF 
 
 IF NOT Amnt1 &lt; 10 OR Amnt2 = 50 AND Amnt3 &gt; 150 THEN
    DISPLAY "Done"
 END-IF
-</pre>
+</code></pre>
 </blockquote>
 <p><b>The effect of bracketing<br/>
 </b>Let's examine the last example above to see what difference 
@@ -570,7 +573,7 @@ END-IF
 <p align="center"><font size="-1">Expressed as</font></p>
 </td>
 <td bgcolor="#E1FFE1" width="84%">
-<pre>   (NOT    (T))   OR      ((T)   AND      (T)) </pre>
+<pre class="language-cobol"><code class="language-cobol">   (NOT    (T))   OR      ((T)   AND      (T)) </code></pre>
 </td>
 </tr>
 <tr>
@@ -578,7 +581,7 @@ END-IF
 <div align="center"><font size="-1">Evaluates to</font></div>
 </td>
 <td bgcolor="#E1FFE1" height="17" width="84%">
-<pre>      (F)         OR             (T) </pre>
+<pre class="language-cobol"><code class="language-cobol">      (F)         OR             (T) </code></pre>
 </td>
 </tr>
 <tr>
@@ -586,7 +589,7 @@ END-IF
 <div align="center"><font size="-1">Evaluates to</font></div>
 </td>
 <td bgcolor="#E1FFE1" width="84%">
-<pre>                 <b><font color="#FF0000">True </font></b></pre>
+<pre class="language-cobol"><code class="language-cobol">                 <b><font color="#FF0000">True </font></b></code></pre>
 </td>
 </tr>
 </table>
@@ -608,7 +611,7 @@ END-IF
 <p align="center"><font size="-1">Expressed as</font></p>
 </td>
 <td bgcolor="#E1FFE1" width="84%">
-<pre>   NOT     ((T)   OR      (T))   AND      (T)</pre>
+<pre class="language-cobol"><code class="language-cobol">   NOT     ((T)   OR      (T))   AND      (T)</code></pre>
 </td>
 </tr>
 <tr>
@@ -616,7 +619,7 @@ END-IF
 <div align="center"><font size="-1">Evaluates to</font></div>
 </td>
 <td bgcolor="#E1FFE1" height="17" width="84%">
-<pre>   NOT            (T)            AND      (T)</pre>
+<pre class="language-cobol"><code class="language-cobol">   NOT            (T)            AND      (T)</code></pre>
 </td>
 </tr>
 <tr>
@@ -624,7 +627,7 @@ END-IF
 <div align="center"><font size="-1">Evaluates to</font></div>
 </td>
 <td bgcolor="#E1FFE1" width="84%">
-<pre>          (F)                    AND      (T)</pre>
+<pre class="language-cobol"><code class="language-cobol">          (F)                    AND      (T)</code></pre>
 </td>
 </tr>
 <tr>
@@ -632,7 +635,7 @@ END-IF
 <div align="center"><font size="-1">Evaluates to</font></div>
 </td>
 <td bgcolor="#E1FFE1" width="84%">
-<pre>                 <font color="#FF0000"><b>False</b></font></pre>
+<pre class="language-cobol"><code class="language-cobol">                 <font color="#FF0000"><b>False</b></font></code></pre>
 </td>
 </tr>
 </table>
@@ -665,13 +668,13 @@ END-IF
               we check to see if Row is greater than 0 and Row is less than 26. 
               We could rewrite this statement using Implied Subjects as-</p>
 <blockquote>
-<pre>IF Row &gt; 0 AND &lt; 26 THEN etc</pre>
+<pre class="language-cobol"><code class="language-cobol">IF Row &gt; 0 AND &lt; 26 THEN etc</code></pre>
 </blockquote>
 <p>the Implied Subject here is Row.</p>
 <p><b>Examples</b><br/>
               In these examples the full condition is shown first and is followed 
               by the condition using Implied Subjects</p>
-<pre>IF TotalAmt &gt; 10000 AND TotalAmt &lt; 50000 THEN etc. 
+<pre class="language-cobol"><code class="language-cobol">IF TotalAmt &gt; 10000 AND TotalAmt &lt; 50000 THEN etc. 
 IF TotalAmt &gt; 10000 AND &lt; 50000 THEN etc
 *&gt; The Implied Subject is - TotalAmt
 
@@ -687,7 +690,7 @@ IF VarA &gt; VarB AND VarC AND VarD
 END-IF 
 *&gt; The Implied Subject is - VarA &gt;
 
-</pre>
+</code></pre>
 <hr width="50%"/>
 </td>
 </tr>
@@ -710,7 +713,7 @@ END-IF
 <p> COBOL allows nested <font size="-1">IF</font> statements.</p>
 <p> For example: </p>
 <blockquote>
-<pre>IF ( VarA &lt; 10 ) AND ( VarB NOT &gt; VarC ) THEN 
+<pre class="language-cobol"><code class="language-cobol">IF ( VarA &lt; 10 ) AND ( VarB NOT &gt; VarC ) THEN 
    IF VarG = 14 THEN 
         DISPLAY "First"
     ELSE 
@@ -718,7 +721,7 @@ END-IF
    END-IF 
  ELSE DISPLAY "Third" 
 END-IF 
-</pre>
+</code></pre>
 </blockquote>
 <p>The table below contains representations of the variables used 
               in the nested <font size="-1">Ifs</font> above. In each instance, 
@@ -836,8 +839,8 @@ END-IF
 </form>
 
 <blockquote>
-<pre> 
-</pre>
+<pre class="language-cobol"><code class="language-cobol"> 
+</code></pre>
 </blockquote>
 </td>
 </tr>
@@ -894,8 +897,8 @@ END-IF
             </p>
 <blockquote>
 <div align="left">
-<pre align="left">e.g. 02 DeptCode          PIC X. 
-        88 ProductionDept VALUE "I","L","T". </pre>
+<pre class="language-cobol" align="left"><code class="language-cobol">e.g. 02 DeptCode          PIC X. 
+        88 ProductionDept VALUE "I","L","T". </code></pre>
 </div>
 </blockquote>
 <p align="left">To specify a range, use the keyword <font size="-1">THRU</font>, 
@@ -903,19 +906,19 @@ END-IF
               values.</p>
 <blockquote>
 <div align="left">
-<pre align="left">E.g. 02 AgeInYears  PIC 9(3). 
-        88 Teenager VALUE 13 THRU 19. </pre>
+<pre class="language-cobol" align="left"><code class="language-cobol">E.g. 02 AgeInYears  PIC 9(3). 
+        88 Teenager VALUE 13 THRU 19. </code></pre>
 </div>
 <div align="left"></div>
 </blockquote>
 <p align="left">Several Condition Names may be associated with a single 
               data item, </p>
 <blockquote>
-<pre align="left">e.g. 02 AgeInYears  PIC 9(3). 
+<pre class="language-cobol" align="left"><code class="language-cobol">e.g. 02 AgeInYears  PIC 9(3). 
         88 Child    VALUE 0  THRU 12. 
         88 Teenager VALUE 13 THRU 19. 
         88 Adult    VALUE 21 THRU 999. 
-</pre>
+</code></pre>
 </blockquote>
 <blockquote>
 <div align="left"></div>
@@ -925,12 +928,12 @@ END-IF
               time. For instance, if AgeInYears contains the value 20 both Teenager 
               and Voter will be true.</p>
 <blockquote>
-<pre align="left">E.g. 02 AgeInYears  PIC 9(3). 
+<pre class="language-cobol" align="left"><code class="language-cobol">E.g. 02 AgeInYears  PIC 9(3). 
         88 Child    VALUE 0  THRU 12. 
         88 Teenager VALUE 13 THRU 19. 
         88 Adult    VALUE 21 THRU 999.
         88 Voter    VALUE 18 THRU 999. 
-</pre>
+</code></pre>
 </blockquote>
 
 <p align="left"><b>Condition Name notes</b></p>
@@ -980,7 +983,7 @@ END-IF
 <table align="center" border="1" width="75%">
 <tr align="left" bgcolor="#E1FFE1">
 <td>
-<pre>01 EUCountryCode PIC 99. 
+<pre class="language-cobol"><code class="language-cobol">01 EUCountryCode PIC 99. 
    88 CodeIs1 VALUE 1. 
    88 CodeIs2 VALUE 2. 
    88 CodeIs3 VALUE 3. 
@@ -992,7 +995,7 @@ END-IF
 IF CodeIs1 THEN 
    SUBTRACT Bonus FROM StructuralFunds(EUCountry) 
 END-IF 
-                 </pre>
+                 </code></pre>
 </td>
 </tr>
 </table>
@@ -1009,7 +1012,7 @@ END-IF
 <table align="center" border="1" width="75%">
 <tr bgcolor="#E1FFE1">
 <td>
-<pre>01 EUCountryCode PIC 99. 
+<pre class="language-cobol"><code class="language-cobol">01 EUCountryCode PIC 99. 
    88 France  VALUE 1. 
    88 Ireland VALUE 2. 
    88 Denmark VALUE 3. 
@@ -1022,7 +1025,7 @@ END-IF
 IF France THEN 
    SUBTRACT Bonus FROM StructuralFunds(EUCountry) 
 END-IF 
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>
@@ -1134,7 +1137,7 @@ END-IF
 <table align="center" background="Resources/pics/code.gif" border="1" height="93" width="95%">
 <tr>
 <td>
-<pre>DATA DIVISION.
+<pre class="language-cobol"><code class="language-cobol">DATA DIVISION.
 FILE SECTION.
 FD StudentFile.
 01 StudentDetails.
@@ -1172,7 +1175,7 @@ Begin.
    STOP RUN.
 
 
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>
@@ -1279,7 +1282,7 @@ Begin.
 <table align="center" border="1" cellpadding="5" cellspacing="0" width="76%">
 <tr bgcolor="#E1FFE1">
 <td>
-<pre>EVALUATE TRUE   ALSO Position
+<pre class="language-cobol"><code class="language-cobol">EVALUATE TRUE   ALSO Position
    WHEN L-Arrow ALSO 2 THRU 10 SUBTRACT 1 FROM Position
    WHEN R-Arrow ALSO 1 THRU 9  ADD 1 TO Position
    WHEN L-Arrow ALSO    1      MOVE 10 TO Position
@@ -1290,7 +1293,7 @@ Begin.
    WHEN Char ALSO     10       PERFORM InsertChar 
    WHEN OTHER PERFORM DisplayErrorMessage
 END-EVALUATE
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>
@@ -1601,7 +1604,7 @@ END-EVALUATE
 <table align="center" bgcolor="#E1FFE1" border="1" cellpadding="5" width="96%">
 <tr valign="top">
 <td height="331">
-<pre>EVALUATE Qty     ALSO    TRUE    ALSO Member 
+<pre class="language-cobol"><code class="language-cobol">EVALUATE Qty     ALSO    TRUE    ALSO Member 
  WHEN  1 THRU 5  ALSO VOP &lt; 501  ALSO "Y"  MOVE 2  TO Discount
  WHEN  6 THRU 16 ALSO VOP &lt; 501  ALSO "Y"  MOVE 3  TO Discount
  WHEN 17 THRU 99 ALSO VOP &lt; 501  ALSO "Y"  MOVE 5  TO Discount
@@ -1621,7 +1624,7 @@ END-EVALUATE
  WHEN  6 THRU 16 ALSO VOP &gt; 2000 ALSO "N"  MOVE 23 TO Discount
  WHEN 17 THRU 99 ALSO VOP &gt; 2000 ALSO "N"  MOVE 28 TO Discount
 END-EVALUATE
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>
@@ -1632,9 +1635,9 @@ END-EVALUATE
               problems later. For instance, at the moment, a discount of 23% is 
               offered in two places in the table. A programmer writing in C might 
               be tempted to take advantage of this by coding;</p>
-<pre>if((Qty &gt; 5) &amp;&amp; (Qty &lt; 17)) &amp;&amp; (VOP &gt; 2000)
+<pre class="language-cobol"><code class="language-cobol">if((Qty &gt; 5) &amp;&amp; (Qty &lt; 17)) &amp;&amp; (VOP &gt; 2000)
  { Discount = 23;
- }//end-if</pre>
+ }//end-if</code></pre>
 <p>This immediately causes problems of readability. You have to ask 
               yourself; is this an accurate reflection of the decision table or 
               has the programmer introduced an error? </p>

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -2,6 +2,9 @@
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Introduction to Sequential Files</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" rel="stylesheet"/>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cobol.min.js"></script>
 <meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -445,12 +448,12 @@
 <table align="center" bgcolor="#E1FFE1" border="1" cellpadding="5" width="58%">
 <tr>
 <td>
-<pre>01 StudentRec.
+<pre class="language-cobol"><code class="language-cobol">01 StudentRec.
    02 StudentId         PIC 9(7).
    02 StudentName       PIC X(10).
    02 DateOfBirth       PIC 9(8).
    02 CourseCode        PIC X(4).
-   02 Gender            PIC X.</pre>
+   02 Gender            PIC X.</code></pre>
 </td>
 </tr>
 </table>
@@ -466,7 +469,7 @@
 <table align="center" bgcolor="#E1FFE1" border="1" cellpadding="5" width="58%">
 <tr>
 <td>
-<pre>01 StudentRec.
+<pre class="language-cobol"><code class="language-cobol">01 StudentRec.
    02 StudentId         PIC 9(7).
    02 StudentName.
       03 Surname        PIC X(8).
@@ -476,7 +479,7 @@
       03 MOBirth        PIC 99.
       03 DOBirth        PIC 99.
    02 CourseCode        PIC X(4).
-   02 Gender            PIC X.</pre>
+   02 Gender            PIC X.</code></pre>
 </td>
 </tr>
 </table>
@@ -506,7 +509,7 @@
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="58%">
 <tr>
 <td>
-<pre>DATA DIVISION.
+<pre class="language-cobol"><code class="language-cobol">DATA DIVISION.
 FILE SECTION.
 FD StudentFile.
 01 StudentRec.
@@ -519,7 +522,7 @@ FD StudentFile.
       03 MOBirth        PIC 99.
       03 DOBirth        PIC 99.
    02 CourseCode        PIC X(4).
-   02 Gender            PIC X.</pre>
+   02 Gender            PIC X.</code></pre>
 </td>
 </tr>
 </table>
@@ -554,7 +557,7 @@ FD StudentFile.
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="58%">
 <tr>
 <td>
-<pre>ENVIRONMENT DIVISION.
+<pre class="language-cobol"><code class="language-cobol">ENVIRONMENT DIVISION.
 INPUT-OUTPUT SECTION.
 FILE-CONTROL.
    SELECT StudentFile 
@@ -572,7 +575,7 @@ FD StudentFile.
       03 MOBirth        PIC 99.
       03 DOBirth        PIC 99.
    02 CourseCode        PIC X(4).
-   02 Gender            PIC X.</pre>
+   02 Gender            PIC X.</code></pre>
 </td>
 </tr>
 </table>
@@ -623,12 +626,12 @@ FD StudentFile.
                 with an actual file using statements like:</p>
 </div>
 <blockquote>
-<pre align="left">SELECT StudentFile 
+<pre class="language-cobol" align="left"><code class="language-cobol">SELECT StudentFile 
        ASSIGN TO "D:\Cobol\ExampleProgs\Students.Dat"
 
 SELECT StudentFile 
        ASSIGN TO "A:\Students.Dat"
-</pre>
+</code></pre>
 </blockquote>
 <div align="center">
 <div align="left"></div>
@@ -800,13 +803,13 @@ SELECT StudentFile
 <table align="center" bgcolor="#E1FFE1" border="1" cellpadding="5" width="58%">
 <tr>
 <td>
-<pre>FD StudentFile.
+<pre class="language-cobol"><code class="language-cobol">FD StudentFile.
 01 StudentRec.
    88 EndOfFile     VALUE HIGH-VALUES.
 
    02 StudentId     PIC 9(7).
        etc
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>
@@ -885,7 +888,7 @@ SELECT StudentFile
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="486">
 <tr valign="top">
 <td>
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  SeqWriteRead.
 AUTHOR.  Michael Coughlan.
@@ -951,7 +954,7 @@ GetStudentRecord.
 
 
 
- </pre>
+ </code></pre>
 </td>
 </tr>
 </table>

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -2,6 +2,9 @@
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Processing Sequential Files</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" rel="stylesheet"/>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cobol.min.js"></script>
 <meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -545,7 +548,7 @@
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="392">
 <tr valign="top">
 <td height="188">
-<pre>PERFORM UNTIL EndTF AND EndMF  
+<pre class="language-cobol"><code class="language-cobol">PERFORM UNTIL EndTF AND EndMF  
   IF TFKey &lt; MFKey
      MOVE TFRec TO NFRec
      WRITE NFRec
@@ -558,7 +561,7 @@
      END-IF
   END-IF
 END-PERFORM
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -2,6 +2,9 @@
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Print files and variable-length records</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" rel="stylesheet"/>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cobol.min.js"></script>
 <meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -283,7 +286,7 @@
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="58%">
 <tr>
 <td>
-<pre>ENVIRONMENT DIVISION.
+<pre class="language-cobol"><code class="language-cobol">ENVIRONMENT DIVISION.
 INPUT-OUTPUT SECTION.
 FILE-CONTROL.
    SELECT TransFile 
@@ -312,7 +315,7 @@ FD TransFile.
 <b><font color="#008000">01 UpdateRec.
    02 StudentId         PIC 9(7).
    02 NewCourseCode     PIC X(4).
-</font></b></pre>
+</font></b></code></pre>
 </td>
 </tr>
 </table>
@@ -439,7 +442,7 @@ FD TransFile.
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="58%">
 <tr>
 <td>
-<pre>ENVIRONMENT DIVISION.
+<pre class="language-cobol"><code class="language-cobol">ENVIRONMENT DIVISION.
 INPUT-OUTPUT SECTION.
 FILE-CONTROL.
    SELECT TransFile 
@@ -469,7 +472,7 @@ FD TransFile.
    02 TransCode         PIC X.
    02 StudentId         PIC 9(7).
    02 NewCourseCode     PIC X(4).
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>
@@ -529,7 +532,7 @@ FD TransFile.
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="58%">
 <tr>
 <td>
-<pre>ENVIRONMENT DIVISION.
+<pre class="language-cobol"><code class="language-cobol">ENVIRONMENT DIVISION.
 INPUT-OUTPUT SECTION.
 FILE-CONTROL.
    SELECT TransFile 
@@ -558,7 +561,7 @@ FD TransFile.
 01 UpdateRec.
    02 FILLER            PIC X(8).
    02 NewCourseCode     PIC X(4).
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>
@@ -655,7 +658,7 @@ FD TransFile.
 </tr>
 <tr valign="top">
 <td>
-<pre>  01 Heading1.
+<pre class="language-cobol"><code class="language-cobol">  01 Heading1.
      02 FILLER      PIC X(7)  VALUE SPACES.
      02 FILLER      PIC X(25) 
                       VALUE "UL Student Details Report".
@@ -664,7 +667,7 @@ FD TransFile.
      02 FILLER      PIC X(21) VALUE "StudentId StudentName".
      02 FILLER      PIC X(14) VALUE " Gender Course".
 
-</pre>
+</code></pre>
 </td>
 </tr>
 <tr>
@@ -675,13 +678,13 @@ FD TransFile.
 </tr>
 <tr valign="top">
 <td>
-<pre>  01 StudentDetailLine.
+<pre class="language-cobol"><code class="language-cobol">  01 StudentDetailLine.
      02 PrnStudId   PIC B9(7)BB.
      02 PrnStudName PIC X(10).
      02 PrnGender   PIC BBBBX.
      02 PrnCourse   PIC BBBBX(4).
 
-</pre>
+</code></pre>
 </td>
 </tr>
 <tr>
@@ -691,12 +694,12 @@ FD TransFile.
 </tr>
 <tr valign="top">
 <td>
-<pre>  01 PageFooting.
+<pre class="language-cobol"><code class="language-cobol">  01 PageFooting.
      02 FILLER      PIC X(19) VALUE SPACES.
      02 FILLER      PIC X(7) VALUE "Page : ".
      02 PageNum     PIC Z9.
 
-</pre>
+</code></pre>
 </td>
 </tr>
 <tr>
@@ -706,9 +709,9 @@ FD TransFile.
 </tr>
 <tr valign="top">
 <td>
-<pre>  01 ReportFooting  PIC X(38)
+<pre class="language-cobol"><code class="language-cobol">  01 ReportFooting  PIC X(38)
            VALUE "*** End of Student Details Report ***".
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>
@@ -818,7 +821,7 @@ FD TransFile.
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="58%">
 <tr>
 <td>
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  StudDetailsRpt.
 AUTHOR.  Michael Coughlan.
@@ -928,7 +931,7 @@ PrintPageHeadings.
          AFTER ADVANCING 2 LINES
    MOVE 3 TO LineCount.
     
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>
@@ -1002,7 +1005,7 @@ PrintPageHeadings.
               declared in the <font size="-1">WORKING-STORAGE SECTION</font>.</p>
 <p align="left"><b>Examples</b></p>
 <blockquote>
-<pre align="left">FD TransFile
+<pre class="language-cobol" align="left"><code class="language-cobol">FD TransFile
    RECORD IS VARYING IN SIZE 
    FROM 8 TO 31 CHARACTERS.
 
@@ -1010,7 +1013,7 @@ PrintPageHeadings.
 FD Stringfile
    RECORD IS VARYING IN SIZE
    FROM 1 TO 80 CHARACTERS
-   DEPENDING ON StringSize.</pre>
+   DEPENDING ON StringSize.</code></pre>
 <div align="left"></div>
 </blockquote>
 <hr align="center" width="50%"/>
@@ -1064,7 +1067,7 @@ FD Stringfile
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="370">
 <tr valign="top">
 <td>
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  VarLenRecs.
 AUTHOR.  Michael Coughlan.
@@ -1167,7 +1170,7 @@ DisplayTransactions.
      AT END SET EndOfTrans TO TRUE
    END-READ.
 
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -2,6 +2,9 @@
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Sorting and Merging files</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" rel="stylesheet"/>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cobol.min.js"></script>
 <meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -290,22 +293,22 @@
 <p>The calls file in an unordered Sequential file. The record 
                       description is as follows; </p>
 <blockquote>
-<pre><b>FIELD          TYPE   LENGTH        VALUE
+<pre class="language-cobol"><code class="language-cobol"><b>FIELD          TYPE   LENGTH        VALUE
 </b>SubscriberNum    9      8    00000001 - 99999999
-UnitsUsed        9      5       00001 - 99999</pre>
+UnitsUsed        9      5       00001 - 99999</code></pre>
 </blockquote>
 <p>The report must be printed on ascending subscriber number 
                       and has the following format;</p>
 <blockquote>
-<pre>Telephone Analysis Monthly Report</pre>
-<pre>
+<pre class="language-cobol"><code class="language-cobol">Telephone Analysis Monthly Report</code></pre>
+<pre class="language-cobol"><code class="language-cobol">
 SubscriberNum      ValueOfCalls
 
   99999999         999,999.99
   99999999         999,999.99
   99999999         999,999.99
 -------------------------------
-Total value =  999,999,999.99</pre>
+Total value =  999,999,999.99</code></pre>
 </blockquote>
 </td>
 </tr>
@@ -345,14 +348,14 @@ Total value =  999,999,999.99</pre>
                   in the file we would have to;</p>
 <blockquote>
 <blockquote>
-<pre>Read the Sequential File
+<pre class="language-cobol"><code class="language-cobol">Read the Sequential File
 IF the record already exists THEN
    Read the Relative Record
    Add the units to the total units
    Write the Relative Record to the file
 ELSE
    Write a new Relative Record to the file
-END-IF</pre>
+END-IF</code></pre>
 </blockquote>
 </blockquote>
 <p align="left">And when the calls file ended we would have to 
@@ -426,7 +429,7 @@ END-IF</pre>
 <blockquote>
 <div align="center">
 <div align="left">
-<pre align="left">SORT WorkFile ON ASCENDING KEY CourseCode
+<pre class="language-cobol" align="left"><code class="language-cobol">SORT WorkFile ON ASCENDING KEY CourseCode
      USING  StudentFile
      GIVING SortedStudentsFile.
 
@@ -434,7 +437,7 @@ END-IF</pre>
 SORT WorkFile ON ASCENDING ProvinceCode 
                  DESCENDING VendorNumber
                  USING SalesFile
-                 GIVING SortedSalesFile.</pre>
+                 GIVING SortedSalesFile.</code></pre>
 </div>
 </div>
 </blockquote>
@@ -509,7 +512,7 @@ SORT WorkFile ON ASCENDING ProvinceCode
 <table background="Resources/pics/code.gif" border="1" cellpadding="5" width="475">
 <tr>
 <td>
-<pre>ENVIRONMENT DIVISION.
+<pre class="language-cobol"><code class="language-cobol">ENVIRONMENT DIVISION.
 INPUT-OUTPUT SECTION.
 FILE-CONTROL.
    SELECT CallsFile 
@@ -551,7 +554,7 @@ Begin.
 
         etc.
 
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>
@@ -578,10 +581,10 @@ Begin.
 <p align="center"><img height="270" src="Resources/pics/Sort2.gif" width="470"/>
 </p>
 <blockquote>
-<pre align="center">SORT <font color="#000000">WorkFile</font> ON ASCENDING <font color="#000000">SubscriberNumWF</font>
+<pre class="language-cobol" align="center"><code class="language-cobol">SORT <font color="#000000">WorkFile</font> ON ASCENDING <font color="#000000">SubscriberNumWF</font>
      USING  CallsFile
      GIVING SortedCallsFile.
-</pre>
+</code></pre>
 </blockquote>
 <hr align="center" size="1" width="100%"/>
 </td>
@@ -601,10 +604,10 @@ Begin.
               descending VendorNumber, within ascending ProvinceCode, by the following 
               <font size="-1">SORT</font> statement; </p>
 <blockquote>
-<pre align="left">SORT WorkFile ON ASCENDING ProvinceCode 
+<pre class="language-cobol" align="left"><code class="language-cobol">SORT WorkFile ON ASCENDING ProvinceCode 
                  DESCENDING VendorNumber
                  USING SalesFile
-                 GIVING SortedSalesFile</pre>
+                 GIVING SortedSalesFile</code></pre>
 </blockquote>
 <p align="left">Notice that ProvinceCode is the major key, and that 
               VendorNumber is only in descending sequence, <i>within</i> ProvinceCode. 
@@ -637,7 +640,7 @@ Begin.
 <tr>
 <td valign="top" width="58">
 <div align="center">
-<pre>1
+<pre class="language-cobol"><code class="language-cobol">1
 1
 1
 1
@@ -659,12 +662,12 @@ Begin.
 3
 4
 4
-4</pre>
+4</code></pre>
 </div>
 </td>
 <td valign="top" width="64">
 <div align="center">
-<pre>91234
+<pre class="language-cobol"><code class="language-cobol">91234
 91234
 81234
 71234
@@ -686,12 +689,12 @@ Begin.
 11111
 56789
 56789
-44444</pre>
+44444</code></pre>
 </div>
 </td>
 <td valign="top" width="45">
 <div align="center">
-<pre>etc.
+<pre class="language-cobol"><code class="language-cobol">etc.
 etc.
 etc.
 etc.
@@ -713,7 +716,7 @@ etc.
 etc.
 etc.
 etc.
-etc.</pre>
+etc.</code></pre>
 </div>
 </td>
 </tr>
@@ -763,7 +766,7 @@ etc.</pre>
 <p align="left"><img height="274" src="Resources/pics/Sort3.gif" width="486"/></p>
             e.g. 
 
-              <pre align="left">
+              <pre class="language-cobol" align="left"><code class="language-cobol">
 SORT WorkFile ON ASCENDING CountyNumWF, VendorNumWF
               INPUT PROCEDURE RejectNorthernRecs 
               GIVING SortedSalesFile.
@@ -777,7 +780,7 @@ SORT WorkFile ON ASCENDING CountryNameWF
 SORT WorkFile ON ASCENDING CountryNameWF, CustomerNameWF
               INPUT PROCEDURE IS RestructureRecords 
               GIVING SortedSubscriptionsFile. 
-</pre>
+</code></pre>
 <p align="left"><font size="-1"><b>INPUT PROCEDURE</b></font><b> notes</b><br/>
               When an <font size="-1">INPUT PROCEDURE</font> is used, it replaces 
               the <font size="-1">USING </font>phrase. The <i>ProcName</i> in 
@@ -851,10 +854,10 @@ SORT WorkFile ON ASCENDING CountryNameWF, CustomerNameWF
 
 <p align="center"><img height="240" src="Resources/pics/Sort5.gif" width="435"/></p>
 <blockquote>
-<pre>SORT WorkFile ON ASCENDING CountryNameWF
+<pre class="language-cobol"><code class="language-cobol">SORT WorkFile ON ASCENDING CountryNameWF
               INPUT PROCEDURE IS SelectForeignGuests
               GIVING SortedGuestsFile.
-</pre>
+</code></pre>
 </blockquote>
 <hr align="center" size="1" width="100%"/>
 </td>
@@ -883,14 +886,14 @@ SORT WorkFile ON ASCENDING CountryNameWF, CustomerNameWF
 <table bgcolor="#E1FFE1" border="1" cellpadding="10" width="40%">
 <tr>
 <td>
-<pre>OPEN INPUT InFileName
+<pre class="language-cobol"><code class="language-cobol">OPEN INPUT InFileName
 READ InFileName
 PERFORM UNTIL TerminatingCondition
    <i>Process input record
 </i>   RELEASE SDWorkRec
    READ InFileName
 END-PERFORM 
-CLOSE InFileName</pre>
+CLOSE InFileName</code></pre>
 </td>
 </tr>
 </table>
@@ -938,7 +941,7 @@ CLOSE InFileName</pre>
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="10" width="475">
 <tr>
 <td>
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  ForeignGuestsRpt.
 AUTHOR.  Michael Coughlan.
@@ -1057,7 +1060,7 @@ PrintReportBody.
    MOVE VisitorCount TO PrnVisitorCount
    WRITE PrintLine FROM CountryLine 
          AFTER ADVANCING 1 LINE.
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>
@@ -1102,7 +1105,7 @@ PrintReportBody.
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="10" height="962" width="475">
 <tr>
 <td>
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  SortInput.
 AUTHOR.  Michael Coughlan.
@@ -1166,7 +1169,7 @@ GetStudentDetails.
     PERFORM UNTIL WorkRec = SPACES
        RELEASE WorkRec
        ACCEPT WorkRec
-    END-PERFORM.</pre>
+    END-PERFORM.</code></pre>
 </td>
 </tr>
 </table>
@@ -1230,7 +1233,7 @@ GetStudentDetails.
               the <font size="-1">SORT</font> verb.</p>
 <p><img height="306" src="Resources/pics/Sort4.gif" width="502"/></p>
 <p>e.g.</p>
-<pre>SORT WorkFile ON ASCENDING CustNameWF
+<pre class="language-cobol"><code class="language-cobol">SORT WorkFile ON ASCENDING CustNameWF
      INPUT PROCEDURE IS SelectEssentialOils
      OUTPUT PROCEDURE IS PrintOilSalesReport.
 
@@ -1238,7 +1241,7 @@ GetStudentDetails.
 SORT WorkFile ON ASCENDING KEY SalespersonNumWF
      USING SalesFile
      OUTPUT PROCEDURE IS SummariseSales.
-             </pre>
+             </code></pre>
 <p><font size="-1"><b>OUTPUT PROCEDURE </b></font><b>notes</b><br/>
               An <font size="-1">OUTPUT PROCEDURE</font> is used to retrieve sorted 
               records from the work file using the <font size="-1">RETURN</font> 
@@ -1279,10 +1282,10 @@ SORT WorkFile ON ASCENDING KEY SalespersonNumWF
               the records have been sorted into salesperson number order, the 
               quantities sold cannot be summed.</p>
 <p align="center"><img height="235" src="Resources/pics/Sort7.gif" width="435"/></p>
-<pre align="center">SORT WorkFile ON ASCENDING KEY SalespersonNumWF
+<pre class="language-cobol" align="center"><code class="language-cobol">SORT WorkFile ON ASCENDING KEY SalespersonNumWF
      USING SalesFile
      OUTPUT PROCEDURE IS SummariseSales.
-</pre>
+</code></pre>
 <hr align="center" size="1" width="100%"/>
 </td>
 </tr>
@@ -1312,7 +1315,7 @@ SORT WorkFile ON ASCENDING KEY SalespersonNumWF
 <table bgcolor="#E1FFE1" border="1" cellpadding="10" height="121" width="40%">
 <tr>
 <td>
-<pre>OPEN OUTPUT OutFile
+<pre class="language-cobol"><code class="language-cobol">OPEN OUTPUT OutFile
 RETURN SDWorkFile RECORD
 PERFORM UNTIL TerminatingCondition
    <i>Setup OutRec
@@ -1320,7 +1323,7 @@ PERFORM UNTIL TerminatingCondition
    RETURN SDWorkFile RECORD
 END-PERFORM
 CLOSE OutFile
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>
@@ -1350,7 +1353,7 @@ CLOSE OutFile
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="10" height="930" width="475">
 <tr>
 <td>
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. MakeSummaryFile.
 AUTHOR. Michael Coughlan.
@@ -1407,7 +1410,7 @@ SummariseSales.
       WRITE SummaryRec
     END-PERFORM
     CLOSE SalesSummaryFile.
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>
@@ -1433,7 +1436,7 @@ SummariseSales.
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="10" width="475">
 <tr>
 <td>
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  ForeignGuestsRpt2.
 AUTHOR.  Michael Coughlan.
@@ -1544,7 +1547,7 @@ PrintReportBody.
    MOVE VisitorCount TO PrnVisitorCount
    WRITE PrintLine FROM CountryLine 
          AFTER ADVANCING 1 LINE.
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>
@@ -1596,10 +1599,10 @@ PrintReportBody.
 <td valign="top" width="525">
 <p><img height="229" src="Resources/pics/Sort8.gif" width="494"/></p>
 <p>e.g.</p>
-<pre>MERGE MergeWorkFile 
+<pre class="language-cobol"><code class="language-cobol">MERGE MergeWorkFile 
    ON ASCENDING KEY TransDateWF, TransCodeWF, StudentIdWF
    USING InsertTransFile, DeleteTransFile, UpdateTransFile
-   GIVING CombinedTransFile. </pre>
+   GIVING CombinedTransFile. </code></pre>
 <p><font size="-1"><b>MERGE</b></font><b> notes</b><br/>
               The results of the <font size="-1">MERGE</font> verb are predictable 
               only when the records in the input files are ordered as described 
@@ -1653,7 +1656,7 @@ PrintReportBody.
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="10" width="475">
 <tr>
 <td>
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. MergeFiles.
 AUTHOR. MICHAEL COUGHLAN.
@@ -1698,7 +1701,7 @@ Begin.
        USING InsertionsFile,  StudentFile
        GIVING NewStudentFile.
     STOP RUN.
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>

--- a/course/String.html
+++ b/course/String.html
@@ -2,6 +2,9 @@
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>The STRING verb</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" rel="stylesheet"/>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cobol.min.js"></script>
 <style type="text/css">
 <!--
 -->
@@ -184,7 +187,7 @@
         partial contents of Ident2 (all the characters up to the first space) 
         and Ident3 (all the characters up to the word "frogs").</p>
 <blockquote>
-<pre>STRING Ident1, Ident2, "10" DELIMITED BY SIZE
+<pre class="language-cobol"><code class="language-cobol">STRING Ident1, Ident2, "10" DELIMITED BY SIZE
     INTO DestString
 END-STRING        
 
@@ -193,7 +196,7 @@ STRING
    Ident2 DELIMITED BY SPACES
    Ident3 DELIMITED BY "Frogs"
 INTO Ident4 WITH POINTER StrPtr
-END-STRING.</pre>
+END-STRING.</code></pre>
 </blockquote>
 <hr/>
 </td>
@@ -414,7 +417,7 @@ END-STRING.</pre>
         the frame below write down your own answer. </p>
 
 <p><b>Data Declarations. </b></p>
-<pre>01 StringFields.
+<pre class="language-cobol"><code class="language-cobol">01 StringFields.
    02 Field1   PIC X(18) VALUE "Where does this go".
    02 Field2   PIC X(30) VALUE "This is the destination string".
    02 Field3   PIC X(15) VALUE "Here is another".
@@ -422,9 +425,9 @@ END-STRING.</pre>
 
 01 StrPointers.
    02 StrPtr  PIC 99.
-   02 NewPtr  PIC 9.</pre>
+   02 NewPtr  PIC 9.</code></pre>
 <p><b>STRING examples. </b></p>
-<pre>1. STRING Field1 DELIMITED BY SPACES INTO Field2.
+<pre class="language-cobol"><code class="language-cobol">1. STRING Field1 DELIMITED BY SPACES INTO Field2.
    DISPLAY Field2.
 
 2. STRING Field1 DELIMITED BY SIZE INTO Field2.
@@ -459,7 +462,7 @@ END-STRING.</pre>
        ON OVERFLOW DISPLAY "String Error"
        NOT ON OVERFLOW DISPLAY "No Error"
    END-STRING.
-   DISPLAY Field2. </pre>
+   DISPLAY Field2. </code></pre>
 </td>
 </tr>
 <tr>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -2,6 +2,9 @@
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Contained and external sub-programs</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" rel="stylesheet"/>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cobol.min.js"></script>
 <meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -406,8 +409,8 @@
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="399">
 <tr>
 <td>
-<pre><b>
-CALL "DateValidate"<br/>     USING BY CONTENT TempDate<br/>     USING BY REFERENCE DateCheckResult.<br/></b></pre>
+<pre class="language-cobol"><code class="language-cobol"><b>
+CALL "DateValidate"<br/>     USING BY CONTENT TempDate<br/>     USING BY REFERENCE DateCheckResult.<br/></b></code></pre>
 </td>
 </tr>
 </table>
@@ -418,7 +421,7 @@ CALL "DateValidate"<br/>     USING BY CONTENT TempDate<br/>     USING BY REFEREN
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="374">
 <tr>
 <td>
-<pre><b><br/>IDENTIFICATION DIVISION.<br/>PROGRAM-ID DateValidate IS INITIAL.<br/>DATA DIVISION.<br/>WORKING-STORAGE SECTION.<br/>          ? ? ? ? ? ? ? ? ? ? ? ? <br/>LINKAGE SECTION.<br/>01  DateParam            PIC X(8).<br/>01  DateResult           PIC 9.<br/>PROCEDURE DIVISION USING DateParam, DateResult.<br/>Begin. <br/>       ? ? ? ? ? ? ? ? ? ? ? ? <br/>       ? ? ? ? ? ? ? ? ? ? ? ?<br/>       EXIT PROGRAM.<br/>??????.<br/>       ? ? ? ? ? ? ? ? ? ? ? ?<br/><br/></b></pre>
+<pre class="language-cobol"><code class="language-cobol"><b><br/>IDENTIFICATION DIVISION.<br/>PROGRAM-ID DateValidate IS INITIAL.<br/>DATA DIVISION.<br/>WORKING-STORAGE SECTION.<br/>          ? ? ? ? ? ? ? ? ? ? ? ? <br/>LINKAGE SECTION.<br/>01  DateParam            PIC X(8).<br/>01  DateResult           PIC 9.<br/>PROCEDURE DIVISION USING DateParam, DateResult.<br/>Begin. <br/>       ? ? ? ? ? ? ? ? ? ? ? ? <br/>       ? ? ? ? ? ? ? ? ? ? ? ?<br/>       EXIT PROGRAM.<br/>??????.<br/>       ? ? ? ? ? ? ? ? ? ? ? ?<br/><br/></b></code></pre>
 </td>
 </tr>
 </table>
@@ -494,7 +497,7 @@ CALL "DateValidate"<br/>     USING BY CONTENT TempDate<br/>     USING BY REFEREN
 <table background="Resources/pics/code.gif" border="1" cellpadding="5" width="412">
 <tr>
 <td valign="top" width="0">
-<pre><b>
+<pre class="language-cobol"><code class="language-cobol"><b>
 ? ? ? ? ? ? ? ? ? ? 
 MOVE 12 TO IncrementVal.
 CALL "Steadfast" USING BY CONTENT IncrementVal.<br/>
@@ -509,7 +512,7 @@ MOVE 5 TO IncrementVal.
 CALL "Fickle" USING BY CONTENT IncrementVal.
 MOVE 12 TO IncrementVal.
 CALL "Fickle" USING BY CONTENT IncrementVal.
-? ? ? ? ? ? ? ? ? ? <br/></b></pre>
+? ? ? ? ? ? ? ? ? ? <br/></b></code></pre>
 </td>
 </tr>
 </table>
@@ -520,17 +523,17 @@ CALL "Fickle" USING BY CONTENT IncrementVal.
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="439">
 <tr>
 <td valign="top">
-<pre><b>       &gt;&gt;SOURCE FORMAT IS FREE<br/>IDENTIFICATION DIVISION.<br/>PROGRAM-ID. Steadfast IS INITIAL.</b></pre>
-<pre><b>DATA DIVISION.
+<pre class="language-cobol"><code class="language-cobol"><b>       &gt;&gt;SOURCE FORMAT IS FREE<br/>IDENTIFICATION DIVISION.<br/>PROGRAM-ID. Steadfast IS INITIAL.</b></code></pre>
+<pre class="language-cobol"><code class="language-cobol"><b>DATA DIVISION.
 WORKING-STORAGE SECTION.
-01 RunningTotal PIC 9(5) VALUE 50.</b></pre>
-<pre><b>LINKAGE SECTION.
-01 ParamValue PIC 99.</b></pre>
-<pre><b>PROCEDURE DIVISION USING ParamValue.
+01 RunningTotal PIC 9(5) VALUE 50.</b></code></pre>
+<pre class="language-cobol"><code class="language-cobol"><b>LINKAGE SECTION.
+01 ParamValue PIC 99.</b></code></pre>
+<pre class="language-cobol"><code class="language-cobol"><b>PROCEDURE DIVISION USING ParamValue.
 Begin.
    ADD ParamValue TO RunningTotal.
    DISPLAY "Total = ", RunningTotal.
-   EXIT PROGRAM.</b><b><br/></b></pre>
+   EXIT PROGRAM.</b><b><br/></b></code></pre>
 </td>
 <td bgcolor="#FFFFFF" valign="top">
 <div align="left">
@@ -568,10 +571,10 @@ Begin.
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="439">
 <tr>
 <td valign="top">
-<pre><b>       &gt;&gt;SOURCE FORMAT IS FREE<br/>IDENTIFICATION DIVISION.<br/>PROGRAM-ID. Fickle.
+<pre class="language-cobol"><code class="language-cobol"><b>       &gt;&gt;SOURCE FORMAT IS FREE<br/>IDENTIFICATION DIVISION.<br/>PROGRAM-ID. Fickle.
 <br/>DATA DIVISION.<br/>WORKING-STORAGE SECTION.<br/>01 RunningTotal   PIC 9(5) VALUE 50.
 <br/>LINKAGE SECTION.<br/>01 ParamValue     PIC 99.
-<br/>PROCEDURE DIVISION USING ParamValue.<br/>Begin.<br/>   ADD ParamValue TO RunningTotal.<br/>   DISPLAY "Total = ", RunningTotal.<br/>   EXIT PROGRAM.</b><b><br/></b></pre>
+<br/>PROCEDURE DIVISION USING ParamValue.<br/>Begin.<br/>   ADD ParamValue TO RunningTotal.<br/>   DISPLAY "Total = ", RunningTotal.<br/>   EXIT PROGRAM.</b><b><br/></b></code></pre>
 </td>
 <td bgcolor="#FFFFFF" valign="top">
 <div align="left">
@@ -632,9 +635,9 @@ Begin.
               clauses).</p>
 <p>By using the following statements in our main program</p>
 <blockquote>
-<pre><b>CALL "Fickle" USING BY CONTENT IncValue.
+<pre class="language-cobol"><code class="language-cobol"><b>CALL "Fickle" USING BY CONTENT IncValue.
 CANCEL "Fickle"
-CALL "Fickle" USING BY CONTENT IncValue</b>.</pre>
+CALL "Fickle" USING BY CONTENT IncValue</b>.</code></pre>
 </blockquote>
 <p>we can force "Fickle" to act like "Steadfast".<br/>
 </p>
@@ -779,7 +782,7 @@ CALL "Fickle" USING BY CONTENT IncValue</b>.</pre>
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="383">
 <tr>
 <td width="0">
-<pre>      <b>&gt;&gt;SOURCE FORMAT IS FREE<br/>IDENTIFICATION DIVISION.<br/>PROGRAM-ID. ContainerProgram.
+<pre class="language-cobol"><code class="language-cobol">      <b>&gt;&gt;SOURCE FORMAT IS FREE<br/>IDENTIFICATION DIVISION.<br/>PROGRAM-ID. ContainerProgram.
    ? ? ? ? ? ? ? ? ?<br/><font color="#FF0000">01 NameTable IS GLOBAL.
 <font size="-1">   02 SName OCCURS 200 TIMES PIC X(20).</font></font><font size="-1">
    </font>? ? ? ? ? ? ? ? ? <br/>PROCEDURE DIVISION.
@@ -794,7 +797,7 @@ CALL "Fickle" USING BY CONTENT IncValue</b>.</pre>
 
 <font color="#0000CC">IDENTIFICATION DIVISION.<br/>PROGRAM-ID. ReportFromTable.<br/>   ? ? ? ? ? ? ? ? ?</font><font color="#0000FF">
    <font color="#FF0000">DISPLAY "Student " SNum " = " SName(SNum).</font><br/><font color="#0000CC">   ? ? ? ? ? ? ? ? ? 
-   EXIT PROGRAM<br/>END-PROGRAM ReportFromTable.</font></font><br/>END-PROGRAM ContainerProgram.</b></pre>
+   EXIT PROGRAM<br/>END-PROGRAM ReportFromTable.</font></font><br/>END-PROGRAM ContainerProgram.</b></code></pre>
 </td>
 </tr>
 </table>
@@ -892,13 +895,13 @@ CALL "Fickle" USING BY CONTENT IncValue</b>.</pre>
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="374">
 <tr>
 <td valign="top" width="0">
-<pre>      <b>&gt;&gt;SOURCE FORMAT IS FREE<br/>IDENTIFICATION DIVISION.<br/>PROGRAM-ID. MainProgram.<br/>DATA DIVISION.<br/>WORKING-STORAGE SECTION.<br/>01 SharedItem     PIC X(25) IS GLOBAL.<br/>PROCEDURE DIVISION.
+<pre class="language-cobol"><code class="language-cobol">      <b>&gt;&gt;SOURCE FORMAT IS FREE<br/>IDENTIFICATION DIVISION.<br/>PROGRAM-ID. MainProgram.<br/>DATA DIVISION.<br/>WORKING-STORAGE SECTION.<br/>01 SharedItem     PIC X(25) IS GLOBAL.<br/>PROCEDURE DIVISION.
 Begin.<br/>    CALL "InsertData"<br/>    MOVE "Main can also use the share" TO SharedItem<br/>    CALL "DisplayData"<br/>    STOP RUN.
 <font color="#000099"><br/>IDENTIFICATION DIVISION.<br/>PROGRAM-ID. InsertData.<br/>PROCEDURE DIVISION.
 Begin.<br/>    MOVE "Shared area works" TO SharedItem<br/>    CALL "DisplayData"<br/>    EXIT PROGRAM.<br/>END PROGRAM InsertData.</font>
 <br/><font color="#000099">IDENTIFICATION DIVISION.<br/>PROGRAM-ID. DisplayData IS COMMON PROGRAM.<br/>PROCEDURE DIVISION.
 Begin.<br/>    DISPLAY SharedItem.<br/>    EXIT PROGRAM<br/>END PROGRAM DisplayData.</font>
-<br/>END PROGRAM MainProgram.<br/></b></pre>
+<br/>END PROGRAM MainProgram.<br/></b></code></pre>
 </td>
 </tr>
 </table>
@@ -928,14 +931,14 @@ Begin.<br/>    DISPLAY SharedItem.<br/>    EXIT PROGRAM<br/>END PROGRAM DisplayD
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="374">
 <tr>
 <td valign="top" width="0">
-<pre><b>       &gt;&gt;SOURCE FORMAT IS FREE<br/>IDENTIFICATION DIVISION.<br/>PROGRAM-ID. Counter.<br/>DATA DIVISION.<br/>WORKING-STORAGE SECTION.<br/>01 Increment      PIC 99 VALUE ZERO.<br/>   88 EndOfData VALUE ZERO.<br/>PROCEDURE DIVISION.<br/>Begin.<br/>*&gt; Demonstrates the difference between Fickle<br/>*&gt; and Steadfast.  Entering a 0 ends the iteration<br/>  DISPLAY "Enter value - " WITH NO ADVANCING.<br/>  ACCEPT Increment.<br/>  PERFORM UNTIL EndOfData<br/>     CALL "Fickle"    USING BY CONTENT Increment<br/>     CALL "Steadfast" USING BY CONTENT Increment<br/>     DISPLAY "Enter value - " WITH NO ADVANCING<br/>     ACCEPT Increment<br/>  END-PERFORM.
+<pre class="language-cobol"><code class="language-cobol"><b>       &gt;&gt;SOURCE FORMAT IS FREE<br/>IDENTIFICATION DIVISION.<br/>PROGRAM-ID. Counter.<br/>DATA DIVISION.<br/>WORKING-STORAGE SECTION.<br/>01 Increment      PIC 99 VALUE ZERO.<br/>   88 EndOfData VALUE ZERO.<br/>PROCEDURE DIVISION.<br/>Begin.<br/>*&gt; Demonstrates the difference between Fickle<br/>*&gt; and Steadfast.  Entering a 0 ends the iteration<br/>  DISPLAY "Enter value - " WITH NO ADVANCING.<br/>  ACCEPT Increment.<br/>  PERFORM UNTIL EndOfData<br/>     CALL "Fickle"    USING BY CONTENT Increment<br/>     CALL "Steadfast" USING BY CONTENT Increment<br/>     DISPLAY "Enter value - " WITH NO ADVANCING<br/>     ACCEPT Increment<br/>  END-PERFORM.
 <br/>*&gt; Shows how CANCEL may be used to initialise<br/>*&gt; Fickle periodically.  Fickle is used to get the<br/>*&gt; square of a number by repeated addition.<br/>  DISPLAY "Enter the value to be squared"<br/>  DISPLAY "Value - " WITH NO ADVANCING.<br/>  ACCEPT Increment.<br/>  PERFORM UNTIL EndOfData<br/>     CANCEL "Fickle"<br/>     PERFORM Increment TIMES<br/>       CALL "Fickle" USING BY CONTENT Increment<br/>     END-PERFORM<br/>     DISPLAY "Value - " WITH NO ADVANCING<br/>     ACCEPT Increment<br/>  END-PERFORM.<br/>  STOP RUN.
 
 <br/><font color="#000099">IDENTIFICATION DIVISION.<br/>PROGRAM-ID. Fickle.<br/>DATA DIVISION.<br/>WORKING-STORAGE SECTION.<br/>01 RunningTotal   PIC 9(5) VALUE ZERO.<br/>LINKAGE SECTION.<br/>01 ParamValue     PIC 99.<br/>PROCEDURE DIVISION USING ParamValue.<br/>Begin.<br/>  ADD ParamValue TO RunningTotal.<br/>  DISPLAY "Fickle total    = " WITH NO ADVANCING<br/>  CALL "DisplayTotal" USING BY CONTENT RunningTotal<br/>  EXIT PROGRAM.<br/>END PROGRAM Fickle.</font>
 
 <font color="#0000CC"><br/>IDENTIFICATION DIVISION.<br/>PROGRAM-ID. Steadfast IS INITIAL.<br/>DATA DIVISION.<br/>WORKING-STORAGE SECTION.<br/>01 RunningTotal PIC 9(5) VALUE ZERO.<br/>LINKAGE SECTION.<br/>01 ParamValue PIC 99.<br/>PROCEDURE DIVISION USING ParamValue.<br/>Begin.<br/>  ADD ParamValue TO RunningTotal.<br/>  DISPLAY "Steadfast total = " WITH NO ADVANCING<br/>  CALL "DisplayTotal" USING BY CONTENT RunningTotal<br/>  EXIT PROGRAM.<br/>END PROGRAM Steadfast.
 </font>
-<font color="#000099"><br/>IDENTIFICATION DIVISION.<br/>PROGRAM-ID. DisplayTotal IS COMMON INITIAL PROGRAM.<br/>DATA DIVISION.<br/>WORKING-STORAGE SECTION.<br/>01 PrnTotal  PIC ZZ,ZZ9.<br/>LINKAGE SECTION.<br/>01 Total     PIC 9(5).<br/>PROCEDURE DIVISION USING Total.<br/>Begin.<br/>  MOVE Total TO PrnTotal.<br/>  DISPLAY PrnTotal.<br/>  EXIT PROGRAM.<br/>END PROGRAM DisplayTotal.</font><br/>END PROGRAM Counter.</b></pre>
+<font color="#000099"><br/>IDENTIFICATION DIVISION.<br/>PROGRAM-ID. DisplayTotal IS COMMON INITIAL PROGRAM.<br/>DATA DIVISION.<br/>WORKING-STORAGE SECTION.<br/>01 PrnTotal  PIC ZZ,ZZ9.<br/>LINKAGE SECTION.<br/>01 Total     PIC 9(5).<br/>PROCEDURE DIVISION USING Total.<br/>Begin.<br/>  MOVE Total TO PrnTotal.<br/>  DISPLAY PrnTotal.<br/>  EXIT PROGRAM.<br/>END PROGRAM DisplayTotal.</font><br/>END PROGRAM Counter.</b></code></pre>
 </td>
 </tr>
 <tr>
@@ -947,7 +950,7 @@ Begin.<br/>    DISPLAY SharedItem.<br/>    EXIT PROGRAM<br/>END PROGRAM DisplayD
                       by the computer are shown in <font color="#FF0000">red</font>.</font></p>
 </div>
 <blockquote>
-<pre align="left"><b><font color="#000000">Enter value -</font> <font color="#0000FF">13</font>
+<pre class="language-cobol" align="left"><code class="language-cobol"><b><font color="#000000">Enter value -</font> <font color="#0000FF">13</font>
 <font color="#000000">Fickle total    = </font><font color="#FF0000">13</font>
 <font color="#000000">Steadfast total =</font><font color="#FF0000"> 13</font>
 Enter value - <font color="#0000FF">3</font>
@@ -973,7 +976,7 @@ Value - <font color="#0000FF">3</font>
 <font color="#000000">Fickle total = </font><font color="#FF0000"> 3
 <font color="#000000">Fickle total =</font>  6
 <font color="#000000">Fickle total = </font> 9</font>
-Value - <font color="#0000FF">0</font></b></pre>
+Value - <font color="#0000FF">0</font></b></code></pre>
 </blockquote>
 </td>
 </tr>
@@ -1005,13 +1008,13 @@ Value - <font color="#0000FF">0</font></b></pre>
               clause to set up a shared area of memory but both both programs 
               must contain the declarations below. These set up, and allow access 
               to, the shared area.</p>
-<pre>Example:
+<pre class="language-cobol"><code class="language-cobol">Example:
      WORKING-STORAGE SECTION.
      01 SharedRec IS EXTERNAL.
         02 PartA     PIC X(4).
         02 PartB     PIC 9(5).
                
-             </pre>
+             </code></pre>
 <p align="center">SharedRecord<br/>
               Program<br/>
 <a href="Resources/ppz/TC-Call.html"><img align="middle" border="0" height="62" src="Resources/pics/i-Animation.gif" width="62"/></a>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -2,6 +2,9 @@
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Using Tables</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" rel="stylesheet"/>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cobol.min.js"></script>
 <meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -236,12 +239,12 @@
 <table bgcolor="#E1FFE1" border="1" cellpadding="5" width="40%">
 <tr>
 <td height="71">
-<pre>01 TaxRec.
+<pre class="language-cobol"><code class="language-cobol">01 TaxRec.
    88 EndOfTaxFile  VALUE HIGH-VALUES.
    02 PAYENum    PIC 9(8)
    02 CountyCode PIC 99.
    02 TaxPaid    PIC 9(7)V99.
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>
@@ -252,7 +255,7 @@
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="475">
 <tr>
 <td>
-<pre>PROCEDURE DIVISION.
+<pre class="language-cobol"><code class="language-cobol">PROCEDURE DIVISION.
 Begin.
    OPEN INPUT TaxFile
    READ TaxFile
@@ -267,7 +270,7 @@ Begin.
    DISPLAY "Total taxes are ", TaxTotal
    CLOSE TaxFile
    STOP RUN. 
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>
@@ -306,13 +309,13 @@ Begin.
 <blockquote>
 <div align="center">
 <div align="left">
-<pre align="left">
+<pre class="language-cobol" align="left"><code class="language-cobol">
 EVALUATE CountyCode
    WHEN      1      ADD TaxPaid TO County1TaxTotal
    WHEN      2      ADD TaxPaid TO County2TaxTotal
    WHEN      3      ADD TaxPaid TO County3TaxTotal
          ..... 23 more WHEN branches
-END-EVALUATE</pre>
+END-EVALUATE</code></pre>
 </div>
 </div>
 </blockquote>
@@ -328,10 +331,10 @@ END-EVALUATE</pre>
 <blockquote>
 <div align="center">
 <div align="left">
-<pre>DISPLAY "County 1 total is ", County1TaxTotal
+<pre class="language-cobol"><code class="language-cobol">DISPLAY "County 1 total is ", County1TaxTotal
 DISPLAY "County 2 total is ", County2TaxTotal
 DISPLAY "County 3 total is ", County3TaxTotal
-        ..... 23 more DISPLAY statements </pre>
+        ..... 23 more DISPLAY statements </code></pre>
 </div>
 </div>
 </blockquote>
@@ -420,8 +423,8 @@ DISPLAY "County 3 total is ", County3TaxTotal
               specifying that the data-item is to be repeated <i>x</i> number 
               of times. For instance, the CountyTax table might be defined as 
               - </p>
-<pre align="left">01 CountyTaxTable.
-   02 CountyTax       PIC 9(8)V99  OCCURS 26 TIMES.</pre>
+<pre class="language-cobol" align="left"><code class="language-cobol">01 CountyTaxTable.
+   02 CountyTax       PIC 9(8)V99  OCCURS 26 TIMES.</code></pre>
 <p align="left">The CountyTax table can be represented diagrammatically 
               as shown below. All the elements of the table have the name CountyTax 
               and we can refer to a specific one by using that name, followed 
@@ -434,10 +437,10 @@ DISPLAY "County 3 total is ", County3TaxTotal
               arithmetic expression.</p>
 <p align="left"><a href="Resources/ppz/TC-Tables1.html"><img border="0" height="71" src="Resources/pics/Tables1.gif" width="456"/></a></p>
 <blockquote>
-<pre align="left">MOVE 10 TO CountyTax(3)
+<pre class="language-cobol" align="left"><code class="language-cobol">MOVE 10 TO CountyTax(3)
 ADD TaxPaid TO CountyTax(CountyCode)
 ADD TaxPaid TO CountyTax(CountyCode + 1)
-ADD TaxPaid TO CountyTax(CountyCode - 2)</pre>
+ADD TaxPaid TO CountyTax(CountyCode - 2)</code></pre>
 </blockquote>
 <hr align="center" size="1" width="100%"/>
 </td>
@@ -468,7 +471,7 @@ ADD TaxPaid TO CountyTax(CountyCode - 2)</pre>
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="475">
 <tr>
 <td>
-<pre>PROCEDURE DIVISION.
+<pre class="language-cobol"><code class="language-cobol">PROCEDURE DIVISION.
 Begin.
    OPEN INPUT TaxFile
    READ TaxFile
@@ -486,7 +489,7 @@ Begin.
               " tax total is " CountyTax(Idx)
    END-PERFORM
    CLOSE TaxFile
-   STOP RUN.</pre>
+   STOP RUN.</code></pre>
 </td>
 </tr>
 </table>
@@ -546,11 +549,11 @@ Begin.
 <p>One solution might be to use an <font size="-1">EVALUATE</font> 
                   to examine the CountyCode and then display the appropriate message. 
                   For example - </p>
-<pre align="left">EVALUATE CountyCode
+<pre class="language-cobol" align="left"><code class="language-cobol">EVALUATE CountyCode
   WHEN      1       DISPLAY "Carlow tax total is " CountyTax(1)
   WHEN      2       DISPLAY "Cavan tax total is "  CountyTax(2)
          .... 24 more WHEN branches
-END-EVALUATE.</pre>
+END-EVALUATE.</code></pre>
 <p>But this solution is not very satisfactory. It is simply reverting 
               to the 26 <font size="-1">WHEN</font> branch solution presented 
               earlier. But this time, we know that there must be a more elegant 
@@ -559,15 +562,15 @@ END-EVALUATE.</pre>
               names of the counties, we can replace the <font size="-1">EVALUATE</font> 
               solution above, with one simple statement -</p>
 <blockquote>
-<pre>DISPLAY CountyName(Idx) " tax total is " CountyTax(Idx).
-</pre>
+<pre class="language-cobol"><code class="language-cobol">DISPLAY CountyName(Idx) " tax total is " CountyTax(Idx).
+</code></pre>
 </blockquote>
 <p>We can incorporate this statement into the County Tax Report program 
               as follows - </p>
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="475">
 <tr>
 <td>
-<pre>PROCEDURE DIVISION.
+<pre class="language-cobol"><code class="language-cobol">PROCEDURE DIVISION.
 Begin.
    OPEN INPUT TaxFile
    READ TaxFile
@@ -584,7 +587,7 @@ Begin.
   <b>    <font color="#FF0000">DISPLAY CountyName(Idx) " tax total is " CountyTax(Id</font></b><font color="#FF0000">x)</font>
    END-PERFORM
    CLOSE TaxFile
-   STOP RUN.</pre>
+   STOP RUN.</code></pre>
 </td>
 </tr>
 </table>
@@ -645,12 +648,12 @@ Begin.
 <table bgcolor="#E1FFE1" border="1" cellpadding="5" width="40%">
 <tr>
 <td height="71">
-<pre>01 TaxRec.
+<pre class="language-cobol"><code class="language-cobol">01 TaxRec.
    88 EndOfTaxFile  VALUE HIGH-VALUES.
    02 PAYENum    PIC 9(8)
    02 County     PIC X(9).
    02 TaxPaid    PIC 9(7)V99.
-</pre>
+</code></pre>
 </td>
 </tr>
 </table>
@@ -676,12 +679,12 @@ Begin.
 <p align="left">One approach we might try, is the now discredited<font size="-1"> 
               EVALUATE</font> based solution. For example -</p>
 <blockquote>
-<pre>EVALUATE County
+<pre class="language-cobol"><code class="language-cobol">EVALUATE County
    WHEN "Carlow" MOVE 1 TO CountyNum
    WHEN "Cavan"  MOVE 2 TO CountyNum
    ..... 24 more WHEN branches
 END-EVALUATE
-ADD TaxPaid TO CountyTax(CountyNum)</pre>
+ADD TaxPaid TO CountyTax(CountyNum)</code></pre>
 </blockquote>
 <p align="left">But by now we realise that there must be a more elegant 
               solution. The question is - what is it?</p>
@@ -715,10 +718,10 @@ ADD TaxPaid TO CountyTax(CountyNum)</pre>
 <p align="left">To compare the value of County with each element of 
               the CountyNames table we can use a <font size="-1">PERFORM..VARYING</font>. 
               For example - </p>
-<pre align="left">    PERFORM VARYING CountyNum FROM 1 BY 1
+<pre class="language-cobol" align="left"><code class="language-cobol">    PERFORM VARYING CountyNum FROM 1 BY 1
          UNTIL CountyName(CountyNum) = County
     END-PERFORM
-    ADD TaxPaid TO CountyTax(CountyNum)</pre>
+    ADD TaxPaid TO CountyTax(CountyNum)</code></pre>
 <p align="left">You can see how this <font size="-1">PERFORM..VARYING</font> 
               works, in the following animation -</p>
 <p align="center"><a href="Resources/ppz/TC-Tables2.html"><img border="0" height="62" src="Resources/pics/i-Animation.gif" width="62"/></a></p>
@@ -727,7 +730,7 @@ ADD TaxPaid TO CountyTax(CountyNum)</pre>
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="475">
 <tr>
 <td>
-<pre>PROCEDURE DIVISION.
+<pre class="language-cobol"><code class="language-cobol">PROCEDURE DIVISION.
 Begin.
    OPEN INPUT TaxFile
    READ TaxFile
@@ -749,7 +752,7 @@ Begin.
               " tax total is " CountyTax(CountyNum)
 </font>   END-PERFORM
    CLOSE TaxFile
-   STOP RUN.</pre>
+   STOP RUN.</code></pre>
 </td>
 </tr>
 </table>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -2,6 +2,9 @@
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Creating tables - syntax and semantics</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" rel="stylesheet"/>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cobol.min.js"></script>
 <meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -294,12 +297,12 @@
               element. For instance, we might declare the <i>CountyTaxTable</i> 
               as - </p>
 <blockquote>
-<pre>01 CountyTax   PIC 9(8)V99  OCCURS 26 TIMES.</pre>
+<pre class="language-cobol"><code class="language-cobol">01 CountyTax   PIC 9(8)V99  OCCURS 26 TIMES.</code></pre>
 <blockquote>
 <p>or as</p>
 </blockquote>
-<pre>01 CountyTax   OCCURS 26 TIMES PIC 9(8)V99.
-</pre>
+<pre class="language-cobol"><code class="language-cobol">01 CountyTax   OCCURS 26 TIMES PIC 9(8)V99.
+</code></pre>
 </blockquote>
 <div align="left">
 <p>We can represent the county tax table diagrammatically as follows;</p>
@@ -312,9 +315,9 @@
                 the whole table and so it is usual to define a table as subordinate 
                 to a group item which is named to indicate the whole table. For 
                 example the CountyTax table would probably be described as -</p>
-<pre align="left">01 CountyTaxTable.
+<pre class="language-cobol" align="left"><code class="language-cobol">01 CountyTaxTable.
 
-   02 CountyTax  PIC 9(8)V99  OCCURS 26 TIMES.</pre>
+   02 CountyTax  PIC 9(8)V99  OCCURS 26 TIMES.</code></pre>
 <p>When declared like this we can refer to <i>CountyTax(sub)</i> 
                 when we want to access an element of the table and <i>CountyTaxTable</i> 
                 when we want to refer to the whole table.</p>
@@ -389,7 +392,7 @@
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" height="171" width="475">
 <tr>
 <td>
-<pre>WORKING-STORAGE SECTION.
+<pre class="language-cobol"><code class="language-cobol">WORKING-STORAGE SECTION.
 01 DeptTotalsTable.
    02 DeptTotal PIC 9(6) OCCURS 7.
 
@@ -405,7 +408,7 @@
 
 
 
-01 MonthName   PIC X(3)OCCURS 12 TIMES. </pre>
+01 MonthName   PIC X(3)OCCURS 12 TIMES. </code></pre>
 </td>
 </tr>
 </table>
@@ -500,9 +503,9 @@
                 the first dimension of a table.</li>
 </ol>
 <p><b>Example</b></p>
-<pre>01 BooksReservedTable. 
+<pre class="language-cobol"><code class="language-cobol">01 BooksReservedTable. 
    02 BookId PIC 9(7) OCCURS 1 TO 10 
-                      DEPENDING ON NumOfReservations. </pre>
+                      DEPENDING ON NumOfReservations. </code></pre>
 </td>
 </tr>
 <tr>
@@ -544,21 +547,21 @@
 <p>One way we could satisfy this change to the specification would 
               involve setting up separate tables to hold the county tax totals 
               and county tax payer counts. For example- </p>
-<pre>01 CountyTaxTable.
+<pre class="language-cobol"><code class="language-cobol">01 CountyTaxTable.
    02 CountyTax   PIC 9(8)V99  OCCURS 26 TIMES.
 
 
 01 CountyPayerTable.
-   02 PayerCount  PIC 9(7) OCCURS 26 TIMES.</pre>
+   02 PayerCount  PIC 9(7) OCCURS 26 TIMES.</code></pre>
 <p>But we could also solve the problem by setting up just a single 
               table and defining each element as a group item. The group item 
               would consist of the <i>CountyTax</i> and the <i>PayerCount</i>. 
             </p>
 <p>For example -</p>
-<pre>01 CountyTaxTable.
+<pre class="language-cobol"><code class="language-cobol">01 CountyTaxTable.
    02 CountyTaxDetails OCCURS 26 TIMES.
       03 CountyTax   PIC 9(8)V99.  
-      03 PayerCount  PIC 9(7). </pre>
+      03 PayerCount  PIC 9(7). </code></pre>
 <p>In this example, <i>CountyTaxTable</i> is the name for the whole 
               table and each element is called <i>CountyTaxDetails</i>. The element 
               is further subdivided into the elementary items <i>CountyTax </i>and 
@@ -589,11 +592,11 @@
 <p>Q1. Examine the CountyTaxTable described above. Suppose that in 
               our program we have the following statements;</p>
 <blockquote>
-<pre>MOVE ZEROS TO CountyTax(3)
+<pre class="language-cobol"><code class="language-cobol">MOVE ZEROS TO CountyTax(3)
 MOVE 67 TO PayerCount(6)
 MOVE 1234.45 TO CountyTax(4)
 MOVE ZEROS TO CountyTaxDetails(4)
-MOVE ZEROS TO CountyTaxTable</pre>
+MOVE ZEROS TO CountyTaxTable</code></pre>
 </blockquote>
             What effect on the table will each of these statements have? Copy 
             the table diagram above, fill in your answer and then click on the 
@@ -602,7 +605,7 @@ MOVE ZEROS TO CountyTaxTable</pre>
 
 <p>Q2. What is the difference between the following data descriptions;</p>
 <blockquote>
-<pre>01 CountyTaxTable1.
+<pre class="language-cobol"><code class="language-cobol">01 CountyTaxTable1.
    02 CountyTaxDetails OCCURS 26 TIMES.
       03 CountyTax   PIC 9(8)V99.  
       03 PayerCount  PIC 9(7). 
@@ -613,7 +616,7 @@ MOVE ZEROS TO CountyTaxTable</pre>
    02 CountyTaxDetails 
       03 CountyTax   PIC 9(8)V99 OCCURS 26 TIMES.  
       03 PayerCount  PIC 9(7)OCCURS 26 TIMES. 
-</pre>
+</code></pre>
 </blockquote>
 <form action="Tables2.html" method="post">
 <div align="center">
@@ -680,7 +683,7 @@ MOVE ZEROS TO CountyTaxTable</pre>
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="475">
 <tr>
 <td>
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. CountyTaxTable.
 AUTHOR. Michael Coughlan.
@@ -741,7 +744,7 @@ DisplayCountyTaxes.
       MOVE CountyTax(Idx) TO PrnTax
       MOVE PayerCount(Idx) TO PrnPayers
       DISPLAY CountyTaxLine
-   END-IF.</pre>
+   END-IF.</code></pre>
 </td>
 </tr>
 </table>
@@ -858,8 +861,8 @@ DisplayCountyTaxes.
               so we might think that the six element, single-dimension, table 
               shown below might do the trick.</p>
 <blockquote>
-<pre>01 PopulationTable.
-   02 PopTotal PIC 9(6) OCCURS 6 TIMES.</pre>
+<pre class="language-cobol"><code class="language-cobol">01 PopulationTable.
+   02 PopTotal PIC 9(6) OCCURS 6 TIMES.</code></pre>
 </blockquote>
 <p align="left">The problem with this is - what can we use as an index 
               into the table? No single item in the record will do. The index 
@@ -868,13 +871,13 @@ DisplayCountyTaxes.
               below, to map the <i>AgeCategory</i> and <i>Gender</i> to a combined 
               index value.</p>
 <blockquote>
-<pre align="left">EVALUATE AgeCategory ALSO Gender
+<pre class="language-cobol" align="left"><code class="language-cobol">EVALUATE AgeCategory ALSO Gender
   WHEN        1      ALSO    1      MOVE 1 TO Idx
   WHEN        1      ALSO    2      MOVE 2 TO Idx
   WHEN        2      ALSO    1      MOVE 3 TO Idx
           etc...
 END-EVALUATE.
-</pre>
+</code></pre>
 </blockquote>
 <p align="left">Or we could manipulate the values arithmetically to 
               map them to the index value. For instance <i>COMPUTE Idx = ((AgeCategory 
@@ -899,19 +902,19 @@ END-EVALUATE.
 <p align="left">A multi-dimension table is declared by nesting <font size="-1">OCCURS</font> 
               clauses. So we can define the two dimension <i>PopulationTable</i> 
               as follows - </p>
-<pre align="left">01 PopulationTable.
+<pre class="language-cobol" align="left"><code class="language-cobol">01 PopulationTable.
    02 Age OCCURS 3 TIMES.
       03 PopTotal   PIC 9(6)OCCURS 2 TIMES.
 
-      </pre>
+      </code></pre>
 <p align="left">While the table description shown above is correct; 
               it is not, perhaps, as understandable as it might be. You might 
               prefer to define the table as shown below.</p>
-<pre align="left"><b>01 PopulationTable.
+<pre class="language-cobol" align="left"><code class="language-cobol"><b>01 PopulationTable.
 <font color="#FF0000">   02 Age OCCURS 3 TIMES</font>.
       <font color="#008000">03 Gender OCCURS 2 TIMES.
 </font>         <font color="#666666">04 PopTotal   PIC 9(6).</font><font color="#008040"> </font></b>
-</pre>
+</code></pre>
 <p align="left">We can represent this table diagrammatically as -</p>
 <p align="center"><img height="170" src="Resources/pics/Tables4.gif" width="470"/></p>
 <p align="left">Two dimension tables are sometimes represented as 
@@ -936,11 +939,11 @@ END-EVALUATE.
               the contents of the table are effected when the following statements 
               are executed.</p>
 <blockquote>
-<pre>MOVE ZEROS TO PopulationTable
+<pre class="language-cobol"><code class="language-cobol">MOVE ZEROS TO PopulationTable
 MOVE 123 TO PopTotal(3,1)
 MOVE 456 TO Gender(3,2)
 ADD 1255 TO PopTotal(2,2)
-MOVE ZEROS TO Age(3)</pre>
+MOVE ZEROS TO Age(3)</code></pre>
 </blockquote>
 <p>Click on the animation icon below to see an animated answer.</p>
 <p align="center"><a href="Resources/ppz/TC-Tables4.html"><img border="0" height="62" src="Resources/pics/i-Animation.gif" width="62"/></a></p>
@@ -961,7 +964,7 @@ MOVE ZEROS TO Age(3)</pre>
 <p>If we are asked to display the six Age/Gender totals for each county 
               then we will obviously need to store 26 instances of the Age/Gender 
               totals. We could of course do this as</p>
-<pre>01 CountyTotal01.
+<pre class="language-cobol"><code class="language-cobol">01 CountyTotal01.
    02 Age OCCURS 3 TIMES.
       03 Gender OCCURS 2 TIMES.
          04 PopTotal   PIC 9(6).
@@ -973,7 +976,7 @@ MOVE ZEROS TO Age(3)</pre>
       03 Gender OCCURS 2 TIMES.
          04 PopTotal   PIC 9(6).
 
-         etc....</pre>
+         etc....</code></pre>
 <p>But by now you are aware of the arguments against this approach 
               so let's go directly to the table based solution.</p>
 <p>What we want to do is to create a 26 element table, each element 
@@ -995,12 +998,12 @@ MOVE ZEROS TO Age(3)</pre>
               dimension <i>PopulationTable</i> may be defined as shown below. 
               To access the <i>PopTotal</i> element three subscripts are now required, 
               one for each <font size="-1">OCCURS </font>clause.</p>
-<pre><b>01 PopulationTable.
+<pre class="language-cobol"><code class="language-cobol"><b>01 PopulationTable.
 <font color="#FF0000">   02 County OCCURS 26 TIMES.
 </font><font color="#008000">      03 Age OCCURS 3 TIMES.
 </font><font color="#000080">         04 Gender OCCURS 2 TIMES.
 </font>          <font color="#666666">  05 PopTotal   PIC 9(6). </font> 
-</b></pre>
+</b></code></pre>
 <p>This table may be represented diagrammatically as follows - </p>
 <p align="center"><img height="145" src="Resources/pics/Tables5.gif" width="480"/></p>
 <hr size="1" width="100%"/>
@@ -1017,12 +1020,12 @@ MOVE ZEROS TO Age(3)</pre>
               the contents of the table are effected when the following statements 
               are executed.</p>
 <blockquote>
-<pre>MOVE ZEROS TO County(1)
+<pre class="language-cobol"><code class="language-cobol">MOVE ZEROS TO County(1)
 MOVE ZEROS TO Age(2,3)
 MOVE ZEROS TO PopTotal(2,1,2)
 MOVE 56 TO PopTotal(1,3,2)
 MOVE 12 TO PopTotal(2,1,1) 
-MOVE ZEROS TO PopulationTable</pre>
+MOVE ZEROS TO PopulationTable</code></pre>
 </blockquote>
 <p>Click on the animation icon below to see an animated answer.</p>
 <p align="center"><a href="Resources/ppz/TC-Tables5.html"><img border="0" height="62" src="Resources/pics/i-Animation.gif" width="62"/></a></p>
@@ -1051,11 +1054,11 @@ MOVE ZEROS TO PopulationTable</pre>
               would we insert the CarOwnersTotal. </p>
 <p>Let's examine the existing table and see if we can figure out where 
               the CarOwnersTotal should go.</p>
-<pre><font color="#000000">01 PopulationTable.
+<pre class="language-cobol"><code class="language-cobol"><font color="#000000">01 PopulationTable.
    02 County OCCURS 26 TIMES.
       03 Age OCCURS 3 TIMES.
          04 Gender OCCURS 2 TIMES.
-</font>          <font color="#000000">  05 PopTotal   PIC 9(6). </font><b> </b></pre>
+</font>          <font color="#000000">  05 PopTotal   PIC 9(6). </font><b> </b></code></pre>
 <p>We can't add <i>CarOwnersTotal </i>to the same level as the <i>PopTotal</i> 
               because that would create six CarOwnersTotals for each county - 
               one for each Age/Gender combination. We only want one CarOwnersTotal 
@@ -1067,12 +1070,12 @@ MOVE ZEROS TO PopulationTable</pre>
               element consists of the <i>CarOwnersTotal</i> and a two dimension 
               table containing the rest of the population information for the 
               county.</p>
-<pre><font color="#000000"><b>01 PopulationTable.
+<pre class="language-cobol"><code class="language-cobol"><font color="#000000"><b>01 PopulationTable.
 <font color="#FF0000">   02 County OCCURS 26 TIMES.
 </font><font color="#616161">      03 CarOwnersTotal   PIC 9(6).</font><font color="#808080">
 </font><font color="#004000">      03 Age OCCURS 3 TIMES.
 </font><font color="#000080">         04 Gender OCCURS 2 TIMES.
-</font></b></font>          <font color="#616161"><b>  05 PopTotal   PIC 9(6).  </b></font></pre>
+</font></b></font>          <font color="#616161"><b>  05 PopTotal   PIC 9(6).  </b></font></code></pre>
 <p>We can represent the declaration above diagrammatically as follows 
               - </p>
 <p align="center"><img height="156" src="Resources/pics/Tables6.gif" width="481"/></p>
@@ -1094,11 +1097,11 @@ MOVE ZEROS TO PopulationTable</pre>
               <font size="-1">OCCURS</font> clauses).</p>
 <p><b>Examples of use</b></p>
 <blockquote>
-<pre>MOVE ZEROS TO County(23)
+<pre class="language-cobol"><code class="language-cobol">MOVE ZEROS TO County(23)
 ADD 1643 TO CarOwnersTotal(15)
 MOVE ZEROS TO Age(17,3)
 MOVE ZEROS TO Gender(18,3,2)
-ADD 56 TO PopTotal(12,3,2)</pre>
+ADD 56 TO PopTotal(12,3,2)</code></pre>
 </blockquote>
 
 </td>
@@ -1167,8 +1170,8 @@ ADD 56 TO PopTotal(12,3,2)</pre>
               the number into <i>TextValue</i> and then treat <i>TextValue </i>as 
               if it were described as PIC 9(5)V99. For instance - </p>
 <blockquote>
-<pre align="left">01  TextValue    PIC X(7).
-01  NumericValue REDEFINES TextValue PIC 9(5)V99.</pre>
+<pre class="language-cobol" align="left"><code class="language-cobol">01  TextValue    PIC X(7).
+01  NumericValue REDEFINES TextValue PIC 9(5)V99.</code></pre>
 </blockquote>
 <p align="left"><b>Example 2<br/>
 </b>The<font size="-1"> REDEFINES</font> clause is not just used 
@@ -1194,7 +1197,7 @@ ADD 56 TO PopTotal(12,3,2)</pre>
               month and year fields without recourse to special programming. For 
               instance, if define the <i>InputDate</i> as - </p>
 <blockquote>
-<pre align="left">01 InputDate.
+<pre class="language-cobol" align="left"><code class="language-cobol">01 InputDate.
    02 DateType         PIC 9.
       88 DateIsSort    VALUE 1.
       88 DateIsEuro    VALUE 2.
@@ -1211,11 +1214,11 @@ ADD 56 TO PopTotal(12,3,2)</pre>
       03 USMonth       PIC 99.
       03 USDay         PIC 99.
       03 USYear        PIC 9(4).
-</pre>
+</code></pre>
 </blockquote>
 <p>we can use statements like -</p>
 <blockquote>
-<pre align="left">EVALUATE TRUE
+<pre class="language-cobol" align="left"><code class="language-cobol">EVALUATE TRUE
     WHEN DateIsSort
            DISPLAY "SortDate format is yyyy-mm-dd "
            DISPLAY  SortYear "-" SortMonth "-" SortYear
@@ -1225,7 +1228,7 @@ ADD 56 TO PopTotal(12,3,2)</pre>
     WHEN DateIsUS 
            DISPLAY "USDate format is mm-dd-yyyy "
            DISPLAY  USMonth "-" USDay "-" USYear
-END-EVALUATE </pre>
+END-EVALUATE </code></pre>
 </blockquote>
 <p>- and still get the correct values displayed.</p>
 <p align="left"><b>Example 3<br/>
@@ -1235,10 +1238,10 @@ END-EVALUATE </pre>
               it were 12.345 if we refer to <i>10Rate</i>, 123.45 if we refer 
               to <i>100Rate</i>, and 1234.5 if we refer to <i>1000Rate</i>.</p>
 <blockquote>
-<pre align="left">01 Rates.
+<pre class="language-cobol" align="left"><code class="language-cobol">01 Rates.
    02 10Rate                    PIC 99V999.
    02 100Rate  REDEFINES 10Rate PIC 999V99.
-   02 1000Rate REDEFINES 10Rate PIC 9999V9.</pre>
+   02 1000Rate REDEFINES 10Rate PIC 9999V9.</code></pre>
 </blockquote>
 
 <p align="left"><b>Animated versions of the examples above</b></p>
@@ -1296,7 +1299,7 @@ END-EVALUATE </pre>
 <p>For example, if we want to declare a table pre-filled with the 
               names of the months, the first step is to reserve an area of storage 
               and fill it with the names of the months -</p>
-<pre>01 MonthTable.
+<pre class="language-cobol"><code class="language-cobol">01 MonthTable.
    02 MonthValues.
       03 FILLER       PIC X(18) VALUE "January  February".
       03 FILLER       PIC X(18) VALUE "March    April".
@@ -1304,10 +1307,10 @@ END-EVALUATE </pre>
       03 FILLER       PIC X(18) VALUE "July     August".
       03 FILLER       PIC X(18) VALUE "SeptemberOctober".
       03 FILLER       PIC X(18) VALUE "November December".
-</pre>
+</code></pre>
 <p>then we redefine is as a table as follows - </p>
-<pre>   02 FILLER REDEFINES MonthValues.
-      03 Month OCCURS 12 TIMES PIC X(9).</pre>
+<pre class="language-cobol"><code class="language-cobol">   02 FILLER REDEFINES MonthValues.
+      03 Month OCCURS 12 TIMES PIC X(9).</code></pre>
 <p> Examine the animation below to view this and other examples. </p>
 <p align="center"><a href="Resources/ppz/TC-Tables8.html"><img border="0" height="62" src="Resources/pics/i-Animation.gif" width="62"/></a>
 </p>
@@ -1337,7 +1340,7 @@ END-EVALUATE </pre>
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="475">
 <tr>
 <td>
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. CountyTaxTable.
 AUTHOR. Michael Coughlan.
@@ -1435,7 +1438,7 @@ DisplayCountyTaxes.
 </b></font>      MOVE CountyTax(Idx) TO PrnTax
       MOVE PayerCount(Idx) TO PrnPayers
       DISPLAY CountyTaxLine
-   END-IF.</pre>
+   END-IF.</code></pre>
 </td>
 </tr>
 </table>
@@ -1460,13 +1463,13 @@ DisplayCountyTaxes.
               <i>Day </i>actually declares the table but we have given the table 
               the overall group name <i>- DayTable</i>. Assigning the values to 
               this groupname fills the area of the table with the values.</p>
-<pre>01 DayTable VALUE "<font color="#FF0000"><b>MonTueWedThrFriSatSun</b></font>". 
+<pre class="language-cobol"><code class="language-cobol">01 DayTable VALUE "<font color="#FF0000"><b>MonTueWedThrFriSatSun</b></font>". 
    02 Day OCCURS 7 TIMES PIC X(3). 
 
-</pre>
+</code></pre>
 <div align="center">
-<pre>
-<img height="84" src="Resources/pics/Tables7.gif" width="369"/></pre>
+<pre class="language-cobol"><code class="language-cobol">
+<img height="84" src="Resources/pics/Tables7.gif" width="369"/></code></pre>
 </div>
 </td>
 </tr>
@@ -1484,28 +1487,28 @@ DisplayCountyTaxes.
               items. All that was required was to move the initialising value 
               to the table's group name. For instance, the statement <i>- MOVE 
               ZEROS TO TaxTable</i> - initialises the table below to zeros.</p>
-<pre>01 TaxTable. 
+<pre class="language-cobol"><code class="language-cobol">01 TaxTable. 
    02 CountyTax  PIC 9(5) OCCURS 26 TIMES. 
-</pre>
+</code></pre>
 <p>But initialising a table was much more difficult if each element 
               was a group item that contained different types of data. For example, 
               in the table below, the <i>CountyTax</i> part of the element has 
               to be initialised to zeros and the CountyName part has to be initialised 
               to spaces. The only way do this is to initialise the items, element 
               by element, using an iteration.</p>
-<pre>01 TaxTable. 
+<pre class="language-cobol"><code class="language-cobol">01 TaxTable. 
    02 County OCCURS 26 TIMES. 
       03 CountyTax  PIC 9(5). 
-      03 CountyName PIC X(12).</pre>
+      03 CountyName PIC X(12).</code></pre>
 <p>At least that was the way it had to be done before the 1985 COBOL 
               standard. Now the table can be initialised by assigning an initial 
               value to each part of an element using the <font size="-1">VALUE 
               </font>clause. The description below initialises the CountyTax part 
               of the element to zeros and the CountyName part to spaces.</p>
-<pre>01 TaxTable. 
+<pre class="language-cobol"><code class="language-cobol">01 TaxTable. 
    02 County OCCURS 26 TIMES. 
       03 CountyTax  PIC 9(5) VALUE ZEROS. 
-      03 CountyName PIC X(12) VALUE SPACES.</pre>
+      03 CountyName PIC X(12) VALUE SPACES.</code></pre>
 </td>
 </tr>
 <tr>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -2,6 +2,9 @@
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>The UNSTRING verb</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" rel="stylesheet"/>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cobol.min.js"></script>
 <style type="text/css">
 <!--
 -->
@@ -189,7 +192,7 @@
 <p>Since not all addresses will have six parts exactly, we use the <font size="2">TALLYING</font> 
         clause to discover how many parts there are.</p>
 <blockquote>
-<pre>UNSTRING FullName DELIMITED BY ALL SPACES
+<pre class="language-cobol"><code class="language-cobol">UNSTRING FullName DELIMITED BY ALL SPACES
     INTO FirstName, SecondName, Surname
 END-UNSTRING.
 
@@ -197,7 +200,7 @@ UNSTRING CustAddress DELIMITED BY ","
    INTO AdrLine(1), AdrLine(2), AdrLine(3), 
         AdrLine(4), AdrLine(5), AdrLine(6) 
    TALLYING IN AdrLinesUsed
-END-UNSTRING.</pre>
+END-UNSTRING.</code></pre>
 </blockquote>
 <hr/>
 </td>
@@ -503,7 +506,7 @@ END-UNSTRING.</pre>
 <table background="Resources/pics/code.gif" border="1" bordercolor="#C0C0C0" cellpadding="10" cellspacing="0" width="75%">
 <tr>
 <td>
-<pre>IDENTIFICATION DIVISION.
+<pre class="language-cobol"><code class="language-cobol">IDENTIFICATION DIVISION.
 PROGRAM-ID. CDFILE.
 AUTHOR. Michael Coughlan.
 
@@ -556,7 +559,7 @@ Begin.
        END-READ
     END-PERFORM
     CLOSE CommaDelimitedFile, CustomerFile
-    STOP RUN.</pre>
+    STOP RUN.</code></pre>
 </td>
 </tr>
 </table>
@@ -596,7 +599,7 @@ Begin.
 <h3><font color="#800000">Data items used in the example</font> </h3>
 </td>
 <td width="525">
-<pre>01 OldName  PIC X(80).
+<pre class="language-cobol"><code class="language-cobol">01 OldName  PIC X(80).
   
 01 TempName.
    02 NameInitial  PIC X.
@@ -607,7 +610,7 @@ Begin.
 01 Pointers.
    02 StrPtr       PIC 99 VALUE 1.
    02 UnstrPtr     PIC 99 VALUE 1.
-      88 NameProcessed VALUE 81.</pre>
+      88 NameProcessed VALUE 81.</code></pre>
 <p>
 <center>
 </center>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -2,6 +2,9 @@
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>The USAGE clause</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" rel="stylesheet"/>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cobol.min.js"></script>
 <meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -291,12 +294,12 @@
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="289">
 <tr>
 <td>
-<pre><b>   ? ? ? ? ? ? ? ? ? ? ? ? 
+<pre class="language-cobol"><code class="language-cobol"><b>   ? ? ? ? ? ? ? ? ? ? ? ? 
 WORKING-STORAGE SECTION.
 01 Num1    PIC 9 VALUE 4.
 01 NUM2    PIC 9 VALUE 1.
 01 Num3    PIC 9 VALUE ZERO.<br/>   ? ? ? ? ? ? ? ? ? ? ? ? <br/><br/>PROCEDURE DIVISION.<br/>Begin. 
-   ? ? ? ? ? ? ? ? ? ? ? ? <br/>   ADD Num1, Num2 GIVING Num3<br/>   ? ? ? ? ? ? ? ? ? ? ? ?</b></pre>
+   ? ? ? ? ? ? ? ? ? ? ? ? <br/>   ADD Num1, Num2 GIVING Num3<br/>   ? ? ? ? ? ? ? ? ? ? ? ?</b></code></pre>
 </td>
 </tr>
 </table>
@@ -2233,7 +2236,7 @@ WORKING-STORAGE SECTION.
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="374">
 <tr>
 <td>
-<pre><b><br/>01 Num1 PIC 9(5)V99 USAGE IS COMP.
+<pre class="language-cobol"><code class="language-cobol"><b><br/>01 Num1 PIC 9(5)V99 USAGE IS COMP.
 01 Num2 PIC 99 USAGE IS PACKED-DECIMAL.
 01 IdxItem USAGE IS INDEX.<br/>
 01 GroupItems USAGE IS COMP.
@@ -2242,14 +2245,14 @@ WORKING-STORAGE SECTION.
    02 New1 PIC S9(5) COMP SYNC.
 <br/>01 Group2.
    02 NumItem1 PIC 9(3)V99 USAGE IS COMP.
-   02 NumItem2 PIC 99V99   USAGE IS COMP.<br/></b></pre>
+   02 NumItem2 PIC 99V99   USAGE IS COMP.<br/></b></code></pre>
 </td>
 </tr>
 </table>
 <div align="center"></div>
-<pre> 
+<pre class="language-cobol"><code class="language-cobol"> 
 
-</pre>
+</code></pre>
 <p><b>COMP/COMPUTATIONAL/BINARY</b><br/>
 <font size="-1">COMP</font> items are held in memory as pure binary 
               two's complement numbers. The storage requirements for fields described 

--- a/course/index.html
+++ b/course/index.html
@@ -2,6 +2,9 @@
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>COBOL Programming Course</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" rel="stylesheet"/>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cobol.min.js"></script>
 <meta name="resource-type" content="document">
 <meta name="description" content="" on-line cobol programming course - includes tutorials, example programs and exercises.">
 <meta name="keywords" content="COBOL programming course, COBOL training, COBOL tutorial, COBOL exercises, COBOL examples, example programs, tutorials, learning">


### PR DESCRIPTION
## Summary

- Wires Prism.js (loaded from cdnjs) into all 26 course HTML pages so COBOL keywords, strings, and numbers get colored.
- Converts every existing `<pre>` block into `<pre><code class=\"language-cobol\">` — Prism in this version only tokenizes `<code>` children, not bare `<pre>`.
- In `COBOLIntro.html`, lifts Courier-font snippets that were buried inside `<blockquote>` / `<font face=\"Courier...\">` / `<br>` markup into proper `<pre><code>` blocks so they pick up highlighting too.
- Removes a leading blank line in the `COBOLcommands.html` DISPLAY example so the first line of code sits at the top of the block.

## Why

The course is free-format COBOL (`>>SOURCE FORMAT IS FREE`, `*>` comments). The standard `highlightjs-cobol` package is fixed-form only, so Prism's `cobol` component is used instead — it handles free-form fine.

## Notes for reviewer

- Prism is loaded from `cdnjs.cloudflare.com` — no local vendoring. If we'd rather self-host, we can pull the three files into `course/Resources/`.
- `exercises/` and `course/Resources/ppz/*.html` are intentionally **not** touched in this PR.
- Diff is large because every `<pre>` got the class added and every block got wrapped in `<code>`. Most of it is mechanical.

## Test plan

- [ ] Open `course/Inspect.html`, `course/Tables2.html`, `course/COBOLIntro.html` in a browser and confirm code blocks are colored.
- [ ] Check that the `MOVE .21 TO VatRate` example in `COBOLIntro.html` (previously a Courier `<font>` blob) now renders as a code block with highlighting.
- [ ] Confirm the leading blank line above `DISPLAY \"My name is \" ProgrammerName.` in `COBOLcommands.html` is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)