### PR TITLE
Wrap COBOL code blocks on mobile

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -43,6 +43,8 @@
     td[width="175"] h4 { margin: 0; }
     blockquote { margin-left: 12px; margin-right: 12px; }
     pre { overflow-x: auto; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; max-width: min(100%, calc(100vw - 16px)); }
     blockquote font[face*="Courier"] { font-size: 0.8em; }
     table[background] { table-layout: fixed; }
     h2 { font-size: 1.4em; }

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -20,6 +20,8 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,
     table[width="715"] > tbody > tr, table[width="725"] > tbody > tr,

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -20,6 +20,8 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,
     table[width="715"] > tbody > tr, table[width="725"] > tbody > tr,

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -20,6 +20,8 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,
     table[width="715"] > tbody > tr, table[width="725"] > tbody > tr,

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -20,6 +20,8 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,
     table[width="715"] > tbody > tr, table[width="725"] > tbody > tr,

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -23,6 +23,8 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,
     table[width="715"] > tbody > tr, table[width="725"] > tbody > tr,

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -23,6 +23,8 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,
     table[width="715"] > tbody > tr, table[width="725"] > tbody > tr,

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -23,6 +23,8 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,
     table[width="715"] > tbody > tr, table[width="725"] > tbody > tr,

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -20,6 +20,8 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,
     table[width="715"] > tbody > tr, table[width="725"] > tbody > tr,

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -20,6 +20,8 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,
     table[width="715"] > tbody > tr, table[width="725"] > tbody > tr,

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -23,6 +23,8 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,
     table[width="715"] > tbody > tr, table[width="725"] > tbody > tr,

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -20,6 +20,8 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,
     table[width="715"] > tbody > tr, table[width="725"] > tbody > tr,

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -20,6 +20,8 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,
     table[width="715"] > tbody > tr, table[width="725"] > tbody > tr,

--- a/course/Search.html
+++ b/course/Search.html
@@ -20,6 +20,8 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,
     table[width="715"] > tbody > tr, table[width="725"] > tbody > tr,

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -20,6 +20,8 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,
     table[width="715"] > tbody > tr, table[width="725"] > tbody > tr,

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -20,6 +20,8 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,
     table[width="715"] > tbody > tr, table[width="725"] > tbody > tr,

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -20,6 +20,8 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,
     table[width="715"] > tbody > tr, table[width="725"] > tbody > tr,

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -20,6 +20,8 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,
     table[width="715"] > tbody > tr, table[width="725"] > tbody > tr,

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -20,6 +20,8 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,
     table[width="715"] > tbody > tr, table[width="725"] > tbody > tr,

--- a/course/String.html
+++ b/course/String.html
@@ -23,6 +23,8 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,
     table[width="715"] > tbody > tr, table[width="725"] > tbody > tr,

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -20,6 +20,8 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,
     table[width="715"] > tbody > tr, table[width="725"] > tbody > tr,

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -20,6 +20,8 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,
     table[width="715"] > tbody > tr, table[width="725"] > tbody > tr,
@@ -311,10 +313,10 @@ Begin.
 <div align="left">
 <pre class="language-cobol" align="left"><code class="language-cobol">
 EVALUATE CountyCode
-   WHEN      1      ADD TaxPaid TO County1TaxTotal
-   WHEN      2      ADD TaxPaid TO County2TaxTotal
-   WHEN      3      ADD TaxPaid TO County3TaxTotal
-         ..... 23 more WHEN branches
+   WHEN 1 ADD TaxPaid TO County1TaxTotal
+   WHEN 2 ADD TaxPaid TO County2TaxTotal
+   WHEN 3 ADD TaxPaid TO County3TaxTotal
+   ..... 23 more WHEN branches
 END-EVALUATE</code></pre>
 </div>
 </div>
@@ -550,9 +552,9 @@ Begin.
                   to examine the CountyCode and then display the appropriate message. 
                   For example - </p>
 <pre class="language-cobol" align="left"><code class="language-cobol">EVALUATE CountyCode
-  WHEN      1       DISPLAY "Carlow tax total is " CountyTax(1)
-  WHEN      2       DISPLAY "Cavan tax total is "  CountyTax(2)
-         .... 24 more WHEN branches
+  WHEN 1 DISPLAY "Carlow tax total is " CountyTax(1)
+  WHEN 2 DISPLAY "Cavan tax total is "  CountyTax(2)
+   .... 24 more WHEN branches
 END-EVALUATE.</code></pre>
 <p>But this solution is not very satisfactory. It is simply reverting 
               to the 26 <font size="-1">WHEN</font> branch solution presented 

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -20,6 +20,8 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,
     table[width="715"] > tbody > tr, table[width="725"] > tbody > tr,

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -23,6 +23,8 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,
     table[width="715"] > tbody > tr, table[width="725"] > tbody > tr,

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -20,6 +20,8 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,
     table[width="715"] > tbody > tr, table[width="725"] > tbody > tr,


### PR DESCRIPTION
## Summary
- Prism's stylesheet was setting `white-space: pre` on `pre[class*="language-"]` with higher specificity than the page-level `pre` rule, causing COBOL code blocks to overflow the viewport on phones. Added a matching-specificity override (`white-space: pre-wrap !important`), shrank font to `0.8em`, and tightened padding across 25 course pages that load Prism.
- Reduced excess spacing in two `EVALUATE`/`WHEN` examples in `Tables1.html` so each line fits a 375px viewport.

## Test plan
- [x] Verified in preview at 375×812 on `Inspect.html`, `COBOLIntro.html`, `Tables1.html`: `whiteSpace` resolves to `pre-wrap`, no internal `<pre>` overflow, no document-level horizontal scroll.
- [x] Visual screenshot of the long `INSPECT TextLine ... CONVERTING ...` block on `Inspect.html` — wraps cleanly within the viewport.
- [x] First `EVALUATE CountyCode` block on `Tables1.html` — all `WHEN` lines fit on one line each.
- [ ] Sanity-check on a real phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)