### PR TITLE
Stack self-assessment Q&A tables on mobile

### DIFF
--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -68,6 +68,11 @@
     td[width="160"] > h3, td[width="160"] > h4, td[width="160"] > p {
       margin: 0.2em 0;
     }
+
+    form table:has(select) select { max-width: 100%; width: 100%; box-sizing: border-box; }
+    form table:has(select) > tbody > tr { display: block; border-bottom: 2px solid #999; }
+    form table:has(select) > tbody > tr > td { display: block; width: auto !important; padding: 6px 8px; }
+    form table:has(select) > tbody > tr > td[bgcolor="#FFFFCC"] { font-weight: bold; padding-bottom: 2px; }
   }
 </style>
 

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -68,6 +68,11 @@
     td[width="160"] > h3, td[width="160"] > h4, td[width="160"] > p {
       margin: 0.2em 0;
     }
+
+    form table:has(select) select { max-width: 100%; width: 100%; box-sizing: border-box; }
+    form table:has(select) > tbody > tr { display: block; border-bottom: 2px solid #999; }
+    form table:has(select) > tbody > tr > td { display: block; width: auto !important; padding: 6px 8px; }
+    form table:has(select) > tbody > tr > td[bgcolor="#FFFFCC"] { font-weight: bold; padding-bottom: 2px; }
   }
 </style>
 

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -68,6 +68,11 @@
     td[width="160"] > h3, td[width="160"] > h4, td[width="160"] > p {
       margin: 0.2em 0;
     }
+
+    form table:has(select) select { max-width: 100%; width: 100%; box-sizing: border-box; }
+    form table:has(select) > tbody > tr { display: block; border-bottom: 2px solid #999; }
+    form table:has(select) > tbody > tr > td { display: block; width: auto !important; padding: 6px 8px; }
+    form table:has(select) > tbody > tr > td[bgcolor="#FFFFCC"] { font-weight: bold; padding-bottom: 2px; }
   }
 </style>
 

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -68,6 +68,11 @@
     td[width="160"] > h3, td[width="160"] > h4, td[width="160"] > p {
       margin: 0.2em 0;
     }
+
+    form table:has(select) select { max-width: 100%; width: 100%; box-sizing: border-box; }
+    form table:has(select) > tbody > tr { display: block; border-bottom: 2px solid #999; }
+    form table:has(select) > tbody > tr > td { display: block; width: auto !important; padding: 6px 8px; }
+    form table:has(select) > tbody > tr > td[bgcolor="#FFFFCC"] { font-weight: bold; padding-bottom: 2px; }
   }
 </style>
 

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -68,6 +68,11 @@
     td[width="160"] > h3, td[width="160"] > h4, td[width="160"] > p {
       margin: 0.2em 0;
     }
+
+    form table:has(select) select { max-width: 100%; width: 100%; box-sizing: border-box; }
+    form table:has(select) > tbody > tr { display: block; border-bottom: 2px solid #999; }
+    form table:has(select) > tbody > tr > td { display: block; width: auto !important; padding: 6px 8px; }
+    form table:has(select) > tbody > tr > td[bgcolor="#FFFFCC"] { font-weight: bold; padding-bottom: 2px; }
   }
 </style>
 

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -68,6 +68,10 @@
     td[width="160"] > h3, td[width="160"] > h4, td[width="160"] > p {
       margin: 0.2em 0;
     }
+    form table:has(select) select { max-width: 100%; width: 100%; box-sizing: border-box; }
+    form table:has(select) > tbody > tr { display: block; border-bottom: 2px solid #999; }
+    form table:has(select) > tbody > tr > td { display: block; width: auto !important; padding: 6px 8px; }
+    form table:has(select) > tbody > tr > td[bgcolor="#FFFFCC"] { font-weight: bold; padding-bottom: 2px; }
   }
 </style>
 


### PR DESCRIPTION
## Summary
- The self-assessment Q&A tables (Q# / question / answer dropdown) overflowed the viewport on phones because `<select>` elements expand to fit their longest `<option>`, and several options contain 60+ dashes (`---...---`) that pushed each table wider than the screen.
- On `≤600px`, switch the form-wrapped Q&A tables to a stacked layout: each row becomes a vertical block with a bold Q# header, full-width question, and full-width dropdown beneath. Constrains `<select>` to 100% width so it no longer dictates table width.
- Targeted via `form table:has(select)` to avoid affecting decorative `#E1FFE1` tables (code boxes, summary tables) that share the color but aren't Q&A.

Applies to Tables1, Tables2, SequentialFiles2, SortMerge, Iteration, RefMod.

## Test plan
- [x] Verified at 375×812 on Tables2.html: each Q&A renders as bold Q# header → full-width question → full-width dropdown, no horizontal overflow.
- [x] Verified SequentialFiles2.html (uses inverted color scheme — `#FFFFCC` table with `#E1FFE1` cells) — stacks correctly.
- [x] Confirmed non-Q&A `#E1FFE1` tables on Tables1.html (code boxes, no `<select>`) are unaffected.
- [ ] Sanity check on a real phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)