### PR TITLE
Center course pages on wider viewports

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -10,6 +10,7 @@
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
+  body > table, body > hr { margin-left: auto; margin-right: auto; }
   td[width="175"] h4 {
     font-family: Arial, Helvetica, sans-serif;
     color: #800000;

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -9,6 +9,7 @@
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
+  body > table, body > hr { margin-left: auto; margin-right: auto; }
   pre { overflow-x: auto; max-width: 100%; }
   body { -webkit-text-size-adjust: 100%; }
   @media (max-width: 600px) {

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -9,6 +9,7 @@
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
+  body > table, body > hr { margin-left: auto; margin-right: auto; }
   pre { overflow-x: auto; max-width: 100%; }
   body { -webkit-text-size-adjust: 100%; }
   @media (max-width: 600px) {

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -9,6 +9,7 @@
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
+  body > table, body > hr { margin-left: auto; margin-right: auto; }
   pre { overflow-x: auto; max-width: 100%; }
   body { -webkit-text-size-adjust: 100%; }
   @media (max-width: 600px) {

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -9,6 +9,7 @@
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
+  body > table, body > hr { margin-left: auto; margin-right: auto; }
   pre { overflow-x: auto; max-width: 100%; }
   body { -webkit-text-size-adjust: 100%; }
   @media (max-width: 600px) {

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -12,6 +12,7 @@
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
+  body > table, body > hr { margin-left: auto; margin-right: auto; }
   pre { overflow-x: auto; max-width: 100%; }
   body { -webkit-text-size-adjust: 100%; }
   @media (max-width: 600px) {

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -12,6 +12,7 @@
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
+  body > table, body > hr { margin-left: auto; margin-right: auto; }
   pre { overflow-x: auto; max-width: 100%; }
   body { -webkit-text-size-adjust: 100%; }
   @media (max-width: 600px) {

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -12,6 +12,7 @@
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
+  body > table, body > hr { margin-left: auto; margin-right: auto; }
   pre { overflow-x: auto; max-width: 100%; }
   body { -webkit-text-size-adjust: 100%; }
   @media (max-width: 600px) {

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -9,6 +9,7 @@
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
+  body > table, body > hr { margin-left: auto; margin-right: auto; }
   pre { overflow-x: auto; max-width: 100%; }
   body { -webkit-text-size-adjust: 100%; }
   @media (max-width: 600px) {

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -9,6 +9,7 @@
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
+  body > table, body > hr { margin-left: auto; margin-right: auto; }
   pre { overflow-x: auto; max-width: 100%; }
   body { -webkit-text-size-adjust: 100%; }
   @media (max-width: 600px) {

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -12,6 +12,7 @@
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
+  body > table, body > hr { margin-left: auto; margin-right: auto; }
   pre { overflow-x: auto; max-width: 100%; }
   body { -webkit-text-size-adjust: 100%; }
   @media (max-width: 600px) {

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -9,6 +9,7 @@
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
+  body > table, body > hr { margin-left: auto; margin-right: auto; }
   pre { overflow-x: auto; max-width: 100%; }
   body { -webkit-text-size-adjust: 100%; }
   @media (max-width: 600px) {

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -9,6 +9,7 @@
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
+  body > table, body > hr { margin-left: auto; margin-right: auto; }
   pre { overflow-x: auto; max-width: 100%; }
   body { -webkit-text-size-adjust: 100%; }
   @media (max-width: 600px) {

--- a/course/Search.html
+++ b/course/Search.html
@@ -9,6 +9,7 @@
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
+  body > table, body > hr { margin-left: auto; margin-right: auto; }
   pre { overflow-x: auto; max-width: 100%; }
   body { -webkit-text-size-adjust: 100%; }
   @media (max-width: 600px) {

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -9,6 +9,7 @@
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
+  body > table, body > hr { margin-left: auto; margin-right: auto; }
   pre { overflow-x: auto; max-width: 100%; }
   body { -webkit-text-size-adjust: 100%; }
   @media (max-width: 600px) {

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -9,6 +9,7 @@
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
+  body > table, body > hr { margin-left: auto; margin-right: auto; }
   pre { overflow-x: auto; max-width: 100%; }
   body { -webkit-text-size-adjust: 100%; }
   @media (max-width: 600px) {

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -9,6 +9,7 @@
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
+  body > table, body > hr { margin-left: auto; margin-right: auto; }
   pre { overflow-x: auto; max-width: 100%; }
   body { -webkit-text-size-adjust: 100%; }
   @media (max-width: 600px) {

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -9,6 +9,7 @@
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
+  body > table, body > hr { margin-left: auto; margin-right: auto; }
   pre { overflow-x: auto; max-width: 100%; }
   body { -webkit-text-size-adjust: 100%; }
   @media (max-width: 600px) {

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -9,6 +9,7 @@
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
+  body > table, body > hr { margin-left: auto; margin-right: auto; }
   pre { overflow-x: auto; max-width: 100%; }
   body { -webkit-text-size-adjust: 100%; }
   @media (max-width: 600px) {

--- a/course/String.html
+++ b/course/String.html
@@ -12,6 +12,7 @@
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
+  body > table, body > hr { margin-left: auto; margin-right: auto; }
   pre { overflow-x: auto; max-width: 100%; }
   body { -webkit-text-size-adjust: 100%; }
   @media (max-width: 600px) {

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -9,6 +9,7 @@
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
+  body > table, body > hr { margin-left: auto; margin-right: auto; }
   pre { overflow-x: auto; max-width: 100%; }
   body { -webkit-text-size-adjust: 100%; }
   @media (max-width: 600px) {

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -9,6 +9,7 @@
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
+  body > table, body > hr { margin-left: auto; margin-right: auto; }
   pre { overflow-x: auto; max-width: 100%; }
   body { -webkit-text-size-adjust: 100%; }
   @media (max-width: 600px) {

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -9,6 +9,7 @@
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
+  body > table, body > hr { margin-left: auto; margin-right: auto; }
   pre { overflow-x: auto; max-width: 100%; }
   body { -webkit-text-size-adjust: 100%; }
   @media (max-width: 600px) {

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -12,6 +12,7 @@
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
+  body > table, body > hr { margin-left: auto; margin-right: auto; }
   pre { overflow-x: auto; max-width: 100%; }
   body { -webkit-text-size-adjust: 100%; }
   @media (max-width: 600px) {

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -9,6 +9,7 @@
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
+  body > table, body > hr { margin-left: auto; margin-right: auto; }
   pre { overflow-x: auto; max-width: 100%; }
   body { -webkit-text-size-adjust: 100%; }
   @media (max-width: 600px) {

--- a/course/index.html
+++ b/course/index.html
@@ -19,6 +19,7 @@
   table { max-width: 100%; }
   h1 img { max-width: 100%; height: auto; }
   hr { max-width: 100%; }
+  body > table, body > hr { margin-left: auto; margin-right: auto; }
   @media (max-width: 600px) {
     body { margin: 4px; padding-bottom: 65px; }
     h1 font { font-size: medium; }


### PR DESCRIPTION
## Summary
- Adds `body > table, body > hr { margin-left: auto; margin-right: auto; }` to every course page so the fixed-width tutorial tables sit centered on desktop instead of left-aligned.
- Applied to `course/index.html` plus all 25 other top-level course pages.
- Mobile behavior is unchanged — the existing `@media (max-width: 600px)` rules still collapse the tables to full width.

## Test plan
- [x] Desktop preview of `course/index.html` — landing page is centered.
- [x] Desktop preview of `course/COBOLIntro.html` — tutorial body is centered.
- [x] Mobile preview (375px) — layout still fills the viewport, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)