### PR TITLE
Remove dead SAQ mobile CSS from non-form course pages

### DIFF
--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -69,11 +69,6 @@
     td[width="160"] > h3, td[width="160"] > h4, td[width="160"] > p {
       margin: 0.2em 0;
     }
-
-    form table:has(select) select { max-width: 100%; width: 100%; box-sizing: border-box; }
-    form table:has(select) > tbody > tr { display: block; border-bottom: 2px solid #999; }
-    form table:has(select) > tbody > tr > td { display: block; width: auto !important; padding: 6px 8px; }
-    form table:has(select) > tbody > tr > td[bgcolor="#FFFFCC"] { font-weight: bold; padding-bottom: 2px; }
   }
 </style>
 

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -69,11 +69,6 @@
     td[width="160"] > h3, td[width="160"] > h4, td[width="160"] > p {
       margin: 0.2em 0;
     }
-
-    form table:has(select) select { max-width: 100%; width: 100%; box-sizing: border-box; }
-    form table:has(select) > tbody > tr { display: block; border-bottom: 2px solid #999; }
-    form table:has(select) > tbody > tr > td { display: block; width: auto !important; padding: 6px 8px; }
-    form table:has(select) > tbody > tr > td[bgcolor="#FFFFCC"] { font-weight: bold; padding-bottom: 2px; }
   }
 </style>
 

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -69,11 +69,6 @@
     td[width="160"] > h3, td[width="160"] > h4, td[width="160"] > p {
       margin: 0.2em 0;
     }
-
-    form table:has(select) select { max-width: 100%; width: 100%; box-sizing: border-box; }
-    form table:has(select) > tbody > tr { display: block; border-bottom: 2px solid #999; }
-    form table:has(select) > tbody > tr > td { display: block; width: auto !important; padding: 6px 8px; }
-    form table:has(select) > tbody > tr > td[bgcolor="#FFFFCC"] { font-weight: bold; padding-bottom: 2px; }
   }
 </style>
 


### PR DESCRIPTION
## Summary

- Follow-up to [#42](https://github.com/bushidocodes/limerick-cobol/pull/42) addressing Copilot review feedback.
- The mobile stacking rules targeting `form table:has(select)` were added to six course pages, but three of them — [Tables1.html](course/Tables1.html), [SortMerge.html](course/SortMerge.html), and [RefMod.html](course/RefMod.html) — contain no `<form>`/`<select>` elements, so the four rules never match anything there.
- Removes the dead CSS from those three files. Tables2, SequentialFiles2, and Iteration keep the rules since they actually have SAQ forms.

## Test plan

- [ ] Verify Tables1 / SortMerge / RefMod still render correctly on mobile (no SAQ tables to stack — these pages were unaffected by the rules anyway).
- [ ] Spot-check Tables2 / SequentialFiles2 / Iteration on mobile to confirm the SAQ-stacking behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)