### PR TITLE
Drop non-standard word-break from Prism wrap rule

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -44,7 +44,7 @@
     td[width="175"] h4 { margin: 0; }
     blockquote { margin-left: 12px; margin-right: 12px; }
     pre { overflow-x: auto; }
-    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; overflow-wrap: break-word; }
     pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; max-width: min(100%, calc(100vw - 16px)); }
     blockquote font[face*="Courier"] { font-size: 0.8em; }
     table[background] { table-layout: fixed; }

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -21,7 +21,7 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
-    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; overflow-wrap: break-word; }
     pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -21,7 +21,7 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
-    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; overflow-wrap: break-word; }
     pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -21,7 +21,7 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
-    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; overflow-wrap: break-word; }
     pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -21,7 +21,7 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
-    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; overflow-wrap: break-word; }
     pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -24,7 +24,7 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
-    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; overflow-wrap: break-word; }
     pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -24,7 +24,7 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
-    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; overflow-wrap: break-word; }
     pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -24,7 +24,7 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
-    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; overflow-wrap: break-word; }
     pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -21,7 +21,7 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
-    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; overflow-wrap: break-word; }
     pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -21,7 +21,7 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
-    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; overflow-wrap: break-word; }
     pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -24,7 +24,7 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
-    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; overflow-wrap: break-word; }
     pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -21,7 +21,7 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
-    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; overflow-wrap: break-word; }
     pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -21,7 +21,7 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
-    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; overflow-wrap: break-word; }
     pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,

--- a/course/Search.html
+++ b/course/Search.html
@@ -21,7 +21,7 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
-    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; overflow-wrap: break-word; }
     pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -21,7 +21,7 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
-    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; overflow-wrap: break-word; }
     pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -21,7 +21,7 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
-    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; overflow-wrap: break-word; }
     pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -21,7 +21,7 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
-    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; overflow-wrap: break-word; }
     pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -21,7 +21,7 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
-    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; overflow-wrap: break-word; }
     pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -21,7 +21,7 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
-    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; overflow-wrap: break-word; }
     pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,

--- a/course/String.html
+++ b/course/String.html
@@ -24,7 +24,7 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
-    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; overflow-wrap: break-word; }
     pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -21,7 +21,7 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
-    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; overflow-wrap: break-word; }
     pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -21,7 +21,7 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
-    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; overflow-wrap: break-word; }
     pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -21,7 +21,7 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
-    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; overflow-wrap: break-word; }
     pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -24,7 +24,7 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
-    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; overflow-wrap: break-word; }
     pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -21,7 +21,7 @@
     hr[width] { width: 100% !important; }
     img, iframe, video, embed, object { max-width: min(100%, calc(100vw - 16px)) !important; height: auto; }
     pre { max-width: min(100%, calc(100vw - 16px)) !important; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; }
-    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; word-break: break-word; overflow-wrap: break-word; }
+    pre[class*="language-"], code[class*="language-"] { white-space: pre-wrap !important; overflow-wrap: break-word; }
     pre[class*="language-"] { font-size: 0.8em; line-height: 1.35; padding: 0.6em; overflow-x: auto; }
     table[width="715"], table[width="725"],
     table[width="715"] > tbody, table[width="725"] > tbody,


### PR DESCRIPTION
## Summary
- Removes `word-break: break-word` from the `pre[class*="language-"], code[class*="language-"]` rule across 25 course pages.
- `word-break: break-word` is a non-standard/legacy alias with inconsistent browser support; `overflow-wrap: break-word` is already declared on the same selector and provides the wrapping behavior we want.

## Test plan
- [ ] Open a course page with long inline code (e.g. course/COBOLcommands.html) on a narrow viewport and confirm code blocks still wrap.
- [ ] Spot-check a couple of other modified pages (course/SequentialFiles1.html, course/Tables1.html) for the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)