### PR TITLE
Unwrap diagram images from Prism code blocks

### DIFF
--- a/course/Search.html
+++ b/course/Search.html
@@ -722,7 +722,7 @@ DisplayCountyTaxes.
 <p align="left"> and we can represent this diagrammatically as follows 
               -</p>
 <div align="center">
-<img height="170" src="Resources/pics/Search5.gif" width="411"/>
+<img alt="Diagram of the hotel occupancy table showing floors and rooms" height="170" src="Resources/pics/Search5.gif" width="411"/>
 </div>
 <pre class="language-cobol" align="left"><code class="language-cobol"> 
 </code></pre>

--- a/course/Search.html
+++ b/course/Search.html
@@ -722,9 +722,7 @@ DisplayCountyTaxes.
 <p align="left"> and we can represent this diagrammatically as follows 
               -</p>
 <div align="center">
-<pre class="language-cobol" align="left"><code class="language-cobol">
 <img height="170" src="Resources/pics/Search5.gif" width="411"/>
-</code></pre>
 </div>
 <pre class="language-cobol" align="left"><code class="language-cobol"> 
 </code></pre>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -1475,8 +1475,7 @@ DisplayCountyTaxes.
 
 </code></pre>
 <div align="center">
-<pre class="language-cobol"><code class="language-cobol">
-<img height="84" src="Resources/pics/Tables7.gif" width="369"/></code></pre>
+<img height="84" src="Resources/pics/Tables7.gif" width="369"/>
 </div>
 </td>
 </tr>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -1475,7 +1475,7 @@ DisplayCountyTaxes.
 
 </code></pre>
 <div align="center">
-<img height="84" src="Resources/pics/Tables7.gif" width="369"/>
+<img alt="Diagram showing DayTable filling a 7-entry table with the values Mon, Tue, Wed, Thr, Fri, Sat, and Sun" height="84" src="Resources/pics/Tables7.gif" width="369"/>
 </div>
 </td>
 </tr>


### PR DESCRIPTION
## Summary
- `course/Search.html` and `course/Tables2.html` had `<img>` diagrams nested inside `<pre><code class=\"language-cobol\">`. Prism reads `code.textContent` and then replaces `code.innerHTML`, which strips the image at runtime — the diagrams were vanishing on page load.
- Fix: drop the `<pre><code>` wrapper and leave the `<img>` directly inside its centered `<div>`.

## Test plan
- [ ] Load `course/Search.html`, scroll to the Search5 diagram (~ \"we can represent this diagrammatically as follows\"), confirm the image renders.
- [ ] Load `course/Tables2.html`, scroll to the Tables7 diagram (DayTable section), confirm the image renders.
- [ ] Spot-check that surrounding COBOL code blocks on both pages still get Prism syntax highlighting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)