### PR TITLE
Fix course content errors flagged in review

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -878,7 +878,7 @@
             <p>When a COBOL compiler recognizes the two areas, all division names, 
               section names, paragraph names, FD entries and 01 level numbers 
               must start in Area A. All other sentences must start in Area B.</p>
-            <p>In our example programs we use the compiler directive <font size="-1">&gt;&gt;SOURCE FORMAT FREE</font>
+            <p>In our example programs we use the compiler directive <font size="-1">&gt;&gt;SOURCE FORMAT IS FREE</font>
               to free us from these formatting restrictions.<br>
             </p>
             <p align="center"><b>Ancient COBOL coding form</b><img src="Resources/pics/CodingForm.jpg" width="498" height="415" border="1"></p>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -395,7 +395,7 @@ DISPLAY PrinterSetupCodes UPON PrinterPort1.
 <tr>
 <td height="333">
 <div align="left">
-<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  AcceptAndDisplay.
 AUTHOR.  Michael Coughlan.
@@ -419,13 +419,13 @@ WORKING-STORAGE SECTION.
     02  CourseCode      PIC X(4).
     02  Gender          PIC X.
 
-*&gt; YYMMDD
+*&gt; YYYYMMDD
 01 CurrentDate.
     02  CurrentYear     PIC 9(4).
     02  CurrentMonth    PIC 99.
     02  CurrentDay      PIC 99.
 
-*&gt; YYDDD
+*&gt; YYYYDDD
 01 DayOfYear.
     02  FILLER          PIC 9(4).
     02  YearDay         PIC 9(3).

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -1228,7 +1228,7 @@ ADD 56 TO PopTotal(12,3,2)</code></pre>
 <pre class="language-cobol" align="left"><code class="language-cobol">EVALUATE TRUE
     WHEN DateIsSort
            DISPLAY "SortDate format is yyyy-mm-dd "
-           DISPLAY  SortYear "-" SortMonth "-" SortYear
+           DISPLAY  SortYear "-" SortMonth "-" SortDay
     WHEN DateIsEuro
            DISPLAY "EuroDate format is dd-mm-yyyy "
            DISPLAY  EuroDay "-" EuroMonth "-" EuroYear

--- a/examples/Accept/ACCEPT.CBL
+++ b/examples/Accept/ACCEPT.CBL
@@ -21,13 +21,13 @@ WORKING-STORAGE SECTION.
    02  CourseCode      PIC X(4).
    02  Gender          PIC X.
 
-*> YYMMDD
+*> YYYYMMDD
 01 CurrentDate.
    02  CurrentYear     PIC 9(4).
    02  CurrentMonth    PIC 99.
    02  CurrentDay      PIC 99.
 
-*> YYDDD
+*> YYYYDDD
 01 DayOfYear.
    02  FILLER          PIC 9(4).
    02  YearDay         PIC 9(3).


### PR DESCRIPTION
## Summary
- Address review comments on review-flagged content errors in the course pages and one shipped example.
- `course/Tables2.html`: the SortDate branch of an EVALUATE example was displaying `SortYear "-" SortMonth "-" SortYear`; the third field is now `SortDay` so the output matches the stated `yyyy-mm-dd` format.
- `course/COBOLIntro.html` and the listing in `course/COBOLcommands.html`: the cited compiler directive now reads `>>SOURCE FORMAT IS FREE`, matching what the shipped examples (e.g. `examples/Accept/ACCEPT.CBL`) actually use.
- `course/COBOLcommands.html` AcceptAndDisplay listing and `examples/Accept/ACCEPT.CBL`: the inline comments labelled `YYMMDD` / `YYDDD` are now `YYYYMMDD` / `YYYYDDD`, matching the `PIC 9(4)` year and the `FROM DATE YYYYMMDD` / `FROM DAY YYYYDDD` clauses.

The earlier `YYMMDD` / `YYDDD` references at `course/COBOLcommands.html:327,330` were intentionally left alone — they describe the original (pre-Y2K) `PIC 9(6)` / `PIC 9(5)` formats, which the page then contrasts with the `Y2KDate` / `Y2KDayOfYear` 4-digit-year variants.

## Test plan
- [ ] Open `course/Tables2.html` and confirm the SortDate EVALUATE branch reads `SortYear "-" SortMonth "-" SortDay`.
- [ ] Open `course/COBOLIntro.html` and confirm the directive cited reads `>>SOURCE FORMAT IS FREE`.
- [ ] Open `course/COBOLcommands.html`, scroll to the AcceptAndDisplay listing, and confirm the directive header reads `>>SOURCE FORMAT IS FREE` and the inline comments above `01 CurrentDate` and `01 DayOfYear` read `*> YYYYMMDD` and `*> YYYYDDD`.
- [ ] Diff `examples/Accept/ACCEPT.CBL` against the listing on the COBOLcommands page and confirm the comments match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)