### PR TITLE
Remove stray empty h2 at top of Relative Files page

### DIFF
--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -76,9 +76,6 @@
 </style>
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000"><table border="1" width="715"><tbody><tr><td>
 <center>
-<h2> </h2>
-</center>
-<center>
 <div align="LEFT">
 <table border="0" width="710">
 <tr>


### PR DESCRIPTION
## Summary
- Removes a stray empty `<h2>&nbsp;</h2>` (and its wrapping `<center>` tags) at the top of [course/RelativeFiles.html](course/RelativeFiles.html) that produced unwanted whitespace before the course header image.

## Test plan
- [ ] Open `course/RelativeFiles.html` in a browser and confirm the page now starts directly with the COBOL Course header image, with no leading blank line above it.
- [ ] Visually compare against another course page (e.g. `course/IndexedFiles.html`) to confirm the top-of-page spacing is consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)