### PR TITLE
Fix IndexedFiles page width overflow

### DIFF
--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -1190,7 +1190,7 @@ ProcessOneBook.
 <tr>
 <td colspan="2" width="100%">
 <div align="CENTER">
-<p><a href="Resources/progs/wirthmemlib.cbl" target="">Download this example
+<p><a href="Resources/progs/wirthmemlib.cbl">Download this example
           program</a></p>
 </div>
 </td>

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -13,7 +13,7 @@
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
   body > table, body > hr { margin-left: auto; margin-right: auto; }
-  pre { overflow-x: auto; max-width: 100%; }
+  pre { overflow-x: auto; max-width: 700px; box-sizing: border-box; }
   body { -webkit-text-size-adjust: 100%; }
   @media (max-width: 600px) {
     body { margin: 4px; overflow-wrap: break-word; word-wrap: break-word; }
@@ -983,7 +983,7 @@ END-IF</code></pre>
 </td>
 </tr>
 <tr>
-<td background="Resources/pics/code.gif" colspan="2" width="100">
+<td background="Resources/pics/code.gif" colspan="2" width="100%">
 <pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.   WirthMemLib.
@@ -1188,9 +1188,9 @@ ProcessOneBook.
 </td>
 </tr>
 <tr>
-<td colspan="2" width="100">
+<td colspan="2" width="100%">
 <div align="CENTER">
-<p><a href="Resources/progs/wirthmemlib.cbl" target="">Download this example 
+<p><a href="Resources/progs/wirthmemlib.cbl" target="">Download this example
           program</a></p>
 </div>
 </td>


### PR DESCRIPTION
## Summary

The Indexed Files course page was rendering ~70px wider than every other course page (787px wrapper vs the standard ~718px), with extra whitespace on the right side of the bordered content area.

## Root cause

The "comprehensive example" section contains a COBOL `<pre>` block whose longest line (`04 FILLER PIC X(36) VALUE "QUARTER BORROWINGS FOR THIS AUTHOR ="`, 84 chars) is wider than the inner table column. Because HTML tables use auto-layout by default, that one wide line forced the cell, the inner `width="710"` table, and the outer `width="715"` wrapper to all stretch to fit.

## Changes

- `pre { ... max-width: 100%; }` → `pre { ... max-width: 700px; box-sizing: border-box; }` so wide code blocks scroll horizontally inside their container instead of stretching the page.
- Two `<td ... width="100">` typos → `width="100%"` (these were meant to be 100% but were rendered as 100 pixels).

## Test plan

- [x] Open `course/IndexedFiles.html` locally and confirm wrapper width is ~718px (matches `RelativeFiles.html`, `SequentialFiles1.html`, etc.)
- [x] Confirm the wide code block in the comprehensive example scrolls horizontally instead of overflowing the page
- [x] Confirm the table-of-contents, "Aims/Objectives" two-column layout, and other sections still render correctly
- [ ] Spot-check on mobile (existing `@media (max-width: 600px)` rules should still apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)