### PR TITLE
Fix subtle widening of outer table on Searching Tables page

### DIFF
--- a/course/Search.html
+++ b/course/Search.html
@@ -11,7 +11,8 @@
   table { max-width: 100%; }
   body > table, body > hr { margin-left: auto; margin-right: auto; }
   pre { overflow-x: auto; max-width: 100%; }
-  pre[class*="language-"] { max-width: 510px; box-sizing: border-box; }
+  /* Keep Prism code blocks within the page's 525px content cells; 510px = 525px minus 15px to account for Prism's horizontal padding/gutter and avoid widening the table layout. */
+  pre[class*="language-"] { max-width: min(100%, calc(525px - 15px)); box-sizing: border-box; }
   body { -webkit-text-size-adjust: 100%; }
   @media (max-width: 600px) {
     body { margin: 4px; overflow-wrap: break-word; word-wrap: break-word; }

--- a/course/Search.html
+++ b/course/Search.html
@@ -11,6 +11,7 @@
   table { max-width: 100%; }
   body > table, body > hr { margin-left: auto; margin-right: auto; }
   pre { overflow-x: auto; max-width: 100%; }
+  pre[class*="language-"] { max-width: 510px; box-sizing: border-box; }
   body { -webkit-text-size-adjust: 100%; }
   @media (max-width: 600px) {
     body { margin: 4px; overflow-wrap: break-word; word-wrap: break-word; }


### PR DESCRIPTION
## Summary
- The outer table on [course/Search.html](course/Search.html) rendered ~21px wider than other course pages (741px vs ~720px). Long-lined `<pre class="language-cobol">` blocks (e.g. `COMPUTE PrnIdx = FUNCTION ORD(LetterIn) - FUNCTION ORD("A") + 1`) had an intrinsic width of ~613px, stretching the 525px content cell to 621px and dragging the outer table with it.
- Added one CSS rule capping prism `<pre>` blocks at 510px with `box-sizing: border-box`. Long lines now scroll horizontally inside the cell (`overflow-x: auto` was already declared) instead of widening the layout.
- Verified in a local preview: outer table 741px → 720px, matching Selection/Subprograms/SortMerge/Tables2. 9 of 15 prism blocks become horizontally scrollable; none lose content.

## Test plan
- [ ] Open `course/Search.html` and confirm the outer border lines up with `course/Selection.html` at desktop widths.
- [ ] Spot-check that long code samples (Hotel Occupancy, Race Results, binary search) are still readable via horizontal scroll.
- [ ] Verify mobile rendering (≤600px) is unchanged — the existing `@media` block already wraps prism blocks there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)