### PR TITLE
Standardize header banner to "Cobol Tutorial" across course pages

### DIFF
--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -83,7 +83,7 @@
 <tr>
 <td>
 <center>
-<h2><a name="top"></a> <img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<h2><a name="top"></a> <img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
 <h2> <b>Indexed Files</b></h2>

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -83,7 +83,7 @@
 <tr>
 <td>
 <center>
-<h2><a name="top"></a> <img align="MIDDLE" alt="Cobol Course" border="0" height="56" src="Resources/pics/t-CobolCourse.gif" width="161"/></h2>
+<h2><a name="top"></a> <img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
 <h2> <b>Indexed Files</b></h2>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -83,7 +83,7 @@
 <tr>
 <td>
 <center>
-<h2><a name="top"></a> <img align="MIDDLE" alt="Cobol Course" border="0" height="56" src="Resources/pics/t-CobolCourse.gif" width="161"/></h2>
+<h2><a name="top"></a> <img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
 <h2> <b>The INSPECT verb</b></h2>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -83,7 +83,7 @@
 <tr>
 <td>
 <center>
-<h2><a name="top"></a> <img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<h2><a name="top"></a> <img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
 <h2> <b>The INSPECT verb</b></h2>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -80,7 +80,7 @@
 <tr>
 <td>
 <center>
-<h2><a name="top"></a> <img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<h2><a name="top"></a> <img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
 <h2> <b>Introduction to Direct Access Files</b></h2>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -80,7 +80,7 @@
 <tr>
 <td>
 <center>
-<h2><a name="top"></a> <img align="MIDDLE" alt="Cobol Course" border="0" height="56" src="Resources/pics/t-CobolCourse.gif" width="161"/></h2>
+<h2><a name="top"></a> <img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
 <h2> <b>Introduction to Direct Access Files</b></h2>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -80,7 +80,7 @@
 <tr>
 <td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
 <center>
-<h2><img align="MIDDLE" alt="Cobol Course" border="0" height="56" src="Resources/pics/t-CobolCourse.gif" width="161"/></h2>
+<h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
 <h2> <b>Reference Modification and Intrinsic Functions</b></h2>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -80,7 +80,7 @@
 <tr>
 <td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
 <center>
-<h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<h2><img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
 <h2> <b>Reference Modification and Intrinsic Functions</b></h2>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -84,7 +84,7 @@
 <tr>
 <td>
 <center>
-<h2><a name="top"></a> <img align="MIDDLE" alt="Cobol Course" border="0" height="56" src="Resources/pics/t-CobolCourse.gif" width="161"/></h2>
+<h2><a name="top"></a> <img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
 <h2> <b>Relative Files</b></h2>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -84,7 +84,7 @@
 <tr>
 <td>
 <center>
-<h2><a name="top"></a> <img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<h2><a name="top"></a> <img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
 <h2> <b>Relative Files</b></h2>

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -80,7 +80,7 @@
 <tr>
 <td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
 <center>
-<h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<h2><img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
 <h2> <b>The COBOL Report Writer</b></h2>

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -80,7 +80,7 @@
 <tr>
 <td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
 <center>
-<h2><img align="MIDDLE" alt="Cobol Course" border="0" height="56" src="Resources/pics/t-CobolCourse.gif" width="161"/></h2>
+<h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
 <h2> <b>The COBOL Report Writer</b></h2>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -80,7 +80,7 @@
 <tr>
 <td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
 <center>
-<h2><img align="MIDDLE" alt="Cobol Course" border="0" height="56" src="Resources/pics/t-CobolCourse.gif" width="161"/></h2>
+<h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
 <h2> <b>The COBOL Report Writer - Syntax and Semantics</b></h2>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -80,7 +80,7 @@
 <tr>
 <td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
 <center>
-<h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<h2><img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
 <h2> <b>The COBOL Report Writer - Syntax and Semantics</b></h2>

--- a/course/String.html
+++ b/course/String.html
@@ -83,7 +83,7 @@
 <tr>
 <td>
 <center>
-<h2><a name="top"></a> <img align="MIDDLE" alt="Cobol Course" border="0" height="56" src="Resources/pics/t-CobolCourse.gif" width="161"/></h2>
+<h2><a name="top"></a> <img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
 <h2> <b>The STRING verb</b></h2>

--- a/course/String.html
+++ b/course/String.html
@@ -83,7 +83,7 @@
 <tr>
 <td>
 <center>
-<h2><a name="top"></a> <img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<h2><a name="top"></a> <img alt="Cobol Tutorial" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
 <h2> <b>The STRING verb</b></h2>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -83,7 +83,7 @@
 <tr>
 <td>
 <center>
-<h2><a name="top"></a> <img align="MIDDLE" alt="Cobol Course" border="0" height="56" src="Resources/pics/t-CobolCourse.gif" width="161"/></h2>
+<h2><a name="top"></a> <img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
 <h2> <b>The UNSTRING verb</b></h2>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -83,7 +83,7 @@
 <tr>
 <td>
 <center>
-<h2><a name="top"></a> <img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<h2><a name="top"></a> <img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
 <h2> <b>The UNSTRING verb</b></h2>


### PR DESCRIPTION
## Summary
- Nine course pages were using the older `t-CobolCourse.gif` header banner while the other 16 used `t-CobolTut.gif`. This switches the holdouts to the Tutorial banner so every course page renders a consistent header.
- Pages updated: `IndexedFiles.html`, `Inspect.html`, `Intro2DirectAccess.html`, `RefMod.html`, `RelativeFiles.html`, `ReportWriter.html`, `ReportWriterSS.html`, `String.html`, `Unstring.html`.
- The unused `t-CobolCourse.gif` is intentionally left in `course/Resources/pics/` rather than deleted.

## Notes for reviewer
- Markup is normalized to match the existing Tutorial-banner pattern (`<img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/>`), preserving any pre-existing `<a name="top">` anchors so in-page links keep working.
- The legacy `align="MIDDLE"`, `border="0"`, and `alt="Cobol Course"` attributes are dropped to match the simpler markup already in use on the other 16 pages.

## Test plan
- [ ] Open each updated page and confirm the Tutorial banner renders and the page layout is unchanged otherwise.
- [ ] Verify in-page anchor navigation (`#top`) still works on pages that had `<a name="top">` (e.g. `Inspect.html`, `IndexedFiles.html`, `String.html`, `Unstring.html`, `RelativeFiles.html`, `Intro2DirectAccess.html`).