### PR TITLE
Replace table-based top-level TOC with semantic UL

### DIFF
--- a/.claude/scripts/convert_toc.py
+++ b/.claude/scripts/convert_toc.py
@@ -1,0 +1,226 @@
+"""Convert the table-based top-of-page TOC index into a `<ul class="toc">`.
+
+Two transformations are applied to each course/*.html file (idempotent):
+
+1. The single `<table ... width="700">` block at the top of the page (whose
+   rows have a 3%/4%/93% column layout, the 4% column being a BallGreenG.gif
+   bullet) is replaced by a semantic `<ul class="toc">` with one `<li>` per
+   row containing the original 93%-column content.
+
+2. Pages that were converted earlier and used an inline
+   `style="list-style-image: ..."` on the `<ul class="toc">` get that inline
+   style stripped — styling is centralised in the page's `<style>` block.
+
+3. The page's `<style>` block has the .toc rules injected (once).
+
+Run with no arguments to process every file in the course directory:
+
+    python .claude/scripts/convert_toc.py
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+TARGET_DIRS = [ROOT / "course", ROOT / "lectures"]
+
+TOC_TABLE_RE = re.compile(
+    r'<table\b[^>]*\bwidth="700"[^>]*>.*?</table>',
+    re.DOTALL | re.IGNORECASE,
+)
+
+ROW_RE = re.compile(r'<tr\b[^>]*>(.*?)</tr>', re.DOTALL | re.IGNORECASE)
+TD93_RE = re.compile(
+    r'<td\b[^>]*\bwidth="93%"[^>]*>(.*?)</td>',
+    re.DOTALL | re.IGNORECASE,
+)
+
+# Already-converted pages used an inline style on the UL — strip it.
+INLINE_TOC_UL_RE = re.compile(
+    r'<ul\b([^>]*?)\bclass="toc"([^>]*?)>',
+    re.IGNORECASE,
+)
+INLINE_LIST_STYLE_RE = re.compile(
+    r'\s*style="[^"]*list-style-image[^"]*"',
+    re.IGNORECASE,
+)
+
+CSS_MARKER = 'ul.toc {'
+
+BALL_IMG_RE = re.compile(
+    r'(?:src="|url\()([^"\)]*[Bb]all[Gg]reen[Gg]\.gif)',
+)
+
+# Match the contiguous block of `ul.toc ...` rules we wrote previously, so
+# subsequent runs can replace them in place without leaving stale rules behind.
+EXISTING_TOC_CSS_RE = re.compile(
+    r'(?:^[ \t]*ul\.toc[^\n]*\n)+',
+    re.MULTILINE,
+)
+
+TOC_UL_RE = re.compile(
+    r'(<ul\b[^>]*\bclass="toc"[^>]*>)(.*?)(</ul>)',
+    re.DOTALL | re.IGNORECASE,
+)
+LI_RE = re.compile(r'<li\b[^>]*>(.*?)</li>', re.DOTALL | re.IGNORECASE)
+# Trailing <br>/<br/> sequences (possibly nested in stray empty </font>, </b>,
+# whitespace, etc.) at the end of a block of content.
+TRAILING_BR_RE = re.compile(
+    r'(?:\s*<br\s*/?\s*>)+\s*$',
+    re.IGNORECASE,
+)
+
+
+def toc_css(ball_url: str) -> str:
+    return (
+        f'  ul.toc {{ list-style-image: url({ball_url}); padding-left: 2.5em; margin: 1em 0; }}\n'
+        '  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }'
+    )
+
+
+def convert_toc_table(table_html: str) -> str | None:
+    if not BALL_IMG_RE.search(table_html):
+        return None
+    items = []
+    for row_match in ROW_RE.finditer(table_html):
+        cell_match = TD93_RE.search(row_match.group(1))
+        if cell_match:
+            items.append(cell_match.group(1).strip())
+    if not items:
+        return None
+    li_html = '\n'.join(f'<li>{item}</li>' for item in items)
+    return f'<ul class="toc">\n{li_html}\n</ul>'
+
+
+def strip_inline_toc_style(text: str) -> str:
+    def repl(match: re.Match) -> str:
+        before, after = match.group(1), match.group(2)
+        before = INLINE_LIST_STYLE_RE.sub('', before).rstrip()
+        after = INLINE_LIST_STYLE_RE.sub('', after).rstrip()
+        prefix = f' {before}' if before else ''
+        suffix = f' {after}' if after else ''
+        return f'<ul{prefix} class="toc"{suffix}>'
+    return INLINE_TOC_UL_RE.sub(repl, text)
+
+
+def inject_toc_css(text: str, ball_url: str) -> str:
+    new_css = toc_css(ball_url) + '\n'
+    if CSS_MARKER in text:
+        return EXISTING_TOC_CSS_RE.sub(new_css, text, count=1)
+    # Inject just before the closing </style> of the first style block.
+    m = re.search(r'</style>', text, re.IGNORECASE)
+    if not m:
+        return text
+    insert_at = m.start()
+    return text[:insert_at] + new_css + text[insert_at:]
+
+
+CLOSING_TAG_RE = re.compile(
+    r'(.*)(</(p|div|font|b|i|center)\s*>\s*)$',
+    re.DOTALL | re.IGNORECASE,
+)
+
+
+def strip_trailing_brs_in_block(content: str) -> str:
+    """Recursively strip trailing <br/> tags from the end of `content`,
+    descending through any closing wrapper tags (e.g., </p>, </div>, </font>)
+    so trailing breaks like `text<br/></p>` or `text<br/><br/></font></p>`
+    are removed. Also collapses any wrapper that becomes empty after stripping.
+    """
+    m = CLOSING_TAG_RE.search(content)
+    if m:
+        inside = strip_trailing_brs_in_block(m.group(1))
+        tag = m.group(3).lower()
+        open_re = re.compile(rf'<{tag}\b[^>]*>\s*$', re.IGNORECASE)
+        if open_re.search(inside):
+            return open_re.sub('', inside).rstrip()
+        return inside + m.group(2)
+    return TRAILING_BR_RE.sub('', content)
+
+
+WRAPPER_RE = re.compile(
+    r'^(\s*)<(p|div)\b[^>]*>(.*)</\2>(\s*)$',
+    re.DOTALL | re.IGNORECASE,
+)
+
+
+def unwrap_block_in_li(content: str) -> str:
+    """If the LI's content is a single <p>...</p> or <div>...</div> wrapper,
+    remove the wrapper tags so its children become direct children of <li>.
+    Repeats until the content is no longer wrapped (handles nested wrappers
+    like <div><p>...</p></div>)."""
+    while True:
+        m = WRAPPER_RE.match(content)
+        if not m:
+            return content
+        tag = m.group(2).lower()
+        inner = m.group(3)
+        # Only unwrap if the inner has no other top-level closer for the same
+        # tag — guards against unwrapping `<p>a</p><p>b</p>` style siblings.
+        if f'</{tag}>' in inner.lower() or f'</{tag.upper()}>' in inner:
+            return content
+        content = m.group(1) + inner + m.group(4)
+
+
+def transform_toc(text: str) -> str:
+    def fix_li(li_match: re.Match) -> str:
+        inner = li_match.group(1)
+        inner = unwrap_block_in_li(inner)
+        inner = strip_trailing_brs_in_block(inner)
+        return f'<li>{inner}</li>'
+
+    def fix_ul(ul_match: re.Match) -> str:
+        opening, body, closing = ul_match.group(1), ul_match.group(2), ul_match.group(3)
+        new_body = LI_RE.sub(fix_li, body)
+        return opening + new_body + closing
+
+    return TOC_UL_RE.sub(fix_ul, text)
+
+
+def detect_ball_url(text: str) -> str | None:
+    m = BALL_IMG_RE.search(text)
+    return m.group(1) if m else None
+
+
+def process_file(path: Path) -> bool:
+    text = path.read_text(encoding='utf-8')
+    new_text = TOC_TABLE_RE.sub(
+        lambda m: convert_toc_table(m.group(0)) or m.group(0),
+        text,
+    )
+    new_text = strip_inline_toc_style(new_text)
+    new_text = transform_toc(new_text)
+    if 'class="toc"' in new_text:
+        ball_url = detect_ball_url(text) or detect_ball_url(new_text)
+        if ball_url:
+            new_text = inject_toc_css(new_text, ball_url)
+    if new_text == text:
+        return False
+    path.write_text(new_text, encoding='utf-8')
+    return True
+
+
+def main(argv):
+    if len(argv) > 1:
+        files = []
+        for a in argv[1:]:
+            p = Path(a)
+            if p.exists():
+                files.append(p)
+                continue
+            for d in TARGET_DIRS:
+                if (d / p.name).exists():
+                    files.append(d / p.name)
+                    break
+    else:
+        files = []
+        for d in TARGET_DIRS:
+            files.extend(sorted(d.glob('*.html')))
+    for path in files:
+        changed = process_file(path)
+        print(f'{"CHANGED" if changed else "       "}  {path.name}')
+
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/.claude/scripts/serve.py
+++ b/.claude/scripts/serve.py
@@ -1,0 +1,25 @@
+"""Static file dev server that respects the PORT env var.
+
+The Claude Preview harness assigns a port via PORT when autoPort is on, but
+`python -m http.server` only takes a positional arg. This wrapper bridges
+the two so the launch config remains simple.
+"""
+
+import os
+import sys
+from functools import partial
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def main():
+    port = int(os.environ.get('PORT', sys.argv[1] if len(sys.argv) > 1 else '8000'))
+    handler = partial(SimpleHTTPRequestHandler, directory=ROOT)
+    server = HTTPServer(('127.0.0.1', port), handler)
+    print(f'Serving {ROOT} at http://127.0.0.1:{port}/', flush=True)
+    server.serve_forever()
+
+
+if __name__ == '__main__':
+    main()

--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -50,6 +50,8 @@
     table[background] { table-layout: fixed; }
     h2 { font-size: 1.4em; }
   }
+  ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
+  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 </head>
 <body text="#000000" bgcolor="#FFFFFF" link="#0000FF" vlink="#FF0000" alink="#009B00">
@@ -66,68 +68,35 @@
               <h2> Introduction to COBOL</h2>
               <hr>
             </center>
-            <table border="0" width="700" vspace="15">
-              <tr> 
-                <td width="3%" valign="TOP">&nbsp;</td>
-                <td width="4%" valign="TOP"><img src="../pics/BallGreenG.gif" hspace="4" height="13" width="13" align="TOP" vspace="4"></td>
-                <td width="93%"> <b><a href="#intro" target="">Introduction</a><br>
-                  </b><font size="-1">Unit aims, objectives, prerequisites.</font><br>
-                </td>
-              </tr>
-              <tr> 
-                <td width="3%" valign="TOP">&nbsp;</td>
-                <td width="4%" valign="TOP"><img src="../pics/BallGreenG.gif" hspace="4" height="13" width="13" align="TOP" vspace="4"></td>
-                <td width="93%" valign="top"> 
-                  <p><b><a href="#part1" target="">What is COBOL?</a><br>
+            <ul class="toc">
+<li><b><a href="#intro" target="">Introduction</a><br>
+                  </b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><b><a href="#part1" target="">What is COBOL?</a><br>
                     </b><font size="-1">A brief introduction to the COBOL programming 
                     language. A historical overview. COBOL's dominance in the 
                     business computing domain. Characteristics of COBOL applications. 
-                    Some reasons for COBOL's success.</font><br>
-                  </p>
-                </td>
-              </tr>
-              <tr> 
-                <td width="3%" valign="TOP">&nbsp;</td>
-                <td width="4%" valign="TOP"><img src="../pics/BallGreenG.gif" hspace="4" height="13" width="13" align="TOP" vspace="4"></td>
-                <td width="93%" valign="top"> 
-                  <div align="left"> 
-                    <p><b><a href="#part2" target="">Introduction to Programming 
+                    Some reasons for COBOL's success.</font></li>
+<li> 
+                    <b><a href="#part2" target="">Introduction to Programming 
                       </a><br>
                       </b><font size="-1">This section provides a gentle introduction 
                       to programing in general and to programming in COBOL in 
-                      particular by means of writing some simple COBOL programs.<br>
-                      </font> </p>
-                  </div>
-                </td>
-              </tr>
-              <tr> 
-                <td width="3%" valign="TOP">&nbsp;</td>
-                <td width="4%" valign="TOP"><img src="../pics/BallGreenG.gif" hspace="4" height="13" width="13" align="TOP" vspace="4"></td>
-                <td width="93%"> 
-                  <div align="left"> 
-                    <p><b><a href="#part3" target="">COBOL basics</a><br>
+                      particular by means of writing some simple COBOL programs.</font> 
+                  </li>
+<li> 
+                    <b><a href="#part3" target="">COBOL basics</a><br>
                       </b><font size="-1">This section presents the fundamentals 
                       of constructing COBOL programs. It explains the notation 
                       used in COBOL syntax diagrams, enumerates the COBOL coding 
                       rules, and examines the hierarchical structure of COBOL 
-                      programs.</font><font size="-1"><br>
-                      </font> </p>
-                  </div>
-                </td>
-              </tr>
-              <tr> 
-                <td width="3%" valign="TOP">&nbsp;</td>
-                <td width="4%" valign="TOP"><img src="../pics/BallGreenG.gif" hspace="4" height="13" width="13" align="TOP" vspace="4"></td>
-                <td width="93%"> 
-                  <div align="left"> 
-                    <p><b><a href="#part4" target="">The Four Divisions</a><br>
+                      programs.</font>
+                  </li>
+<li> 
+                    <b><a href="#part4" target="">The Four Divisions</a><br>
                       </b><font size="-1">Provides an introduction to the structure 
-                      and purpose of the four COBOL divisions.<br>
-                      </font> </p>
-                  </div>
-                </td>
-              </tr>
-            </table>
+                      and purpose of the four COBOL divisions.</font> 
+                  </li>
+</ul>
             <hr>
           </td>
         </tr>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -70,6 +70,8 @@
       margin: 0.2em 0;
     }
   }
+  ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
+  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
@@ -86,51 +88,23 @@
 <h2> <b>Basic Procedure Division Commands</b></h2>
 <hr/>
 </center>
-<table border="0" vspace="15" width="700">
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%"> <b><a href="#intro" target="">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites.</font><br/>
-<br/>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%"><b><a href="#part1" target="">Basic User Input 
+<ul class="toc">
+<li><b><a href="#intro" target="">Introduction</a><br/>
+</b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><b><a href="#part1" target="">Basic User Input 
                   and Output</a><br/>
 </b><font size="-1">This section introduces the ACCEPT and DISPLAY 
                   verbs and shows how the ACCEPT may be used to get the system 
-                  date and time. <br/>
-<br/>
-</font> </td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<div align="left"><b><a href="#part2" target="">Assignment using 
+                  date and time.</font></li>
+<li><b><a href="#part2" target="">Assignment using 
                     the MOVE verb</a><br/>
 </b><font size="-1">This section demonstrates how assignment 
-                    is achieved in COBOL. <br/>
-</font> <br/>
-</div>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<div align="left"><b><a href="#part3" target="">Arithmetic in 
+                    is achieved in COBOL.</font></li>
+<li><b><a href="#part3" target="">Arithmetic in 
                     COBOL</a><br/>
 </b><font size="-1">This section introduces the ADD, SUBTRACT, 
-                    MULTIPLY, DIVIDE and COMPUTE verbs.<br/>
-</font> <br/>
-</div>
-</td>
-</tr>
-</table>
+                    MULTIPLY, DIVIDE and COMPUTE verbs.</font></li>
+</ul>
 <hr width="100%"/>
 </td>
 </tr>

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -70,6 +70,8 @@
       margin: 0.2em 0;
     }
   }
+  ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
+  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
@@ -86,42 +88,23 @@
 <h2> The COPY verb</h2>
 <hr/>
 </center>
-<table border="0" vspace="15" width="700">
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%"> <b><a href="#intro" target="">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites.</font><br/>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td valign="top" width="93%">
-<p><b><a href="#part1" target="">Using COPY statements</a><br/>
+<ul class="toc">
+<li><b><a href="#intro" target="">Introduction</a><br/>
+</b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><b><a href="#part1" target="">Using COPY statements</a><br/>
 </b><font size="-1">Introduction to the COPY verb. Using the 
-                    COPY verb when creating large software systems</font></p>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td valign="top" width="93%"><b><a href="#part2" target="">The 
+                    COPY verb when creating large software systems</font></li>
+<li><b><a href="#part2" target="">The 
                   COPY verb - Syntax and Semantics</a><br/>
 </b><font size="-1">The COPY syntax. How the COPY works. How 
-                  the REPLACING phrase works. COPY rules.</font></td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td valign="top" width="93%"><b><a href="#part3" target="">COPY 
+                  the REPLACING phrase works. COPY rules.</font></li>
+<li><b><a href="#part3" target="">COPY 
                   examples </a><br/>
 </b><font size="-1">Four example programs showing the program 
                   source text before processing the COPY statements, the copy 
                   library text, and the program source text after processing the 
-                  COPY statements in the program.</font></td>
-</tr>
-</table>
+                  COPY statements in the program.</font></li>
+</ul>
 <hr/>
 </td>
 </tr>

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -70,6 +70,8 @@
       margin: 0.2em 0;
     }
   }
+  ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
+  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
@@ -86,51 +88,24 @@
 <h2> <b>Declaring Data in COBOL</b></h2>
 <hr/>
 </center>
-<table border="0" vspace="15" width="700">
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%"> <b><a href="#intro" target="">Introduction</a><br/>
+<ul class="toc">
+<li><b><a href="#intro" target="">Introduction</a><br/>
 </b><font size="-1">Unit aims, objectives, prerequisites and 
-                  further reading.</font> <br/>
-<br/>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%"><b><a href="#part1" target="">Categories of COBOL 
+                  further reading.</font></li>
+<li><b><a href="#part1" target="">Categories of COBOL 
                   data </a><br/>
 </b><font size="-1">This section introduces the three categories 
-                  of COBOL data - Literals, Variables and Figurative Constants. 
-                  <br/>
-<br/>
-</font> </td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%"><b><a href="#part2" target="">Declaring Data-Items 
+                  of COBOL data - Literals, Variables and Figurative Constants.</font></li>
+<li><b><a href="#part2" target="">Declaring Data-Items 
                   in COBOL</a><br/>
 </b><font size="-1">In this section we show how variables are 
-                  declared in COBOL using the PICTURE clause. <br/>
-<br/>
-</font> </td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<div align="left"><b><a href="#part3" target="">Group and Elementary 
+                  declared in COBOL using the PICTURE clause.</font></li>
+<li><b><a href="#part3" target="">Group and Elementary 
                     Data-Items </a><br/>
 </b><font size="-1">This section demonstrates how record structures 
                     can be specified using an appropriate arrangement of level 
-                    numbers.<br/>
-</font> <br/>
-</div>
-</td>
-</tr>
-</table>
+                    numbers.</font></li>
+</ul>
 </td>
 </tr>
 <tr>

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -70,6 +70,8 @@
       margin: 0.2em 0;
     }
   }
+  ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
+  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000"><table border="1" width="715">
@@ -85,57 +87,27 @@
 <h2> <b>Edited Pictures</b></h2>
 <hr/>
 </center>
-<table border="0" vspace="15" width="700">
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%"> <b><a href="#intro" target="">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites.</font><br/>
-<br/>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td valign="top" width="93%">
-<p><b><a href="#part1" target="">What is an Edited Picture?</a><br/>
+<ul class="toc">
+<li><b><a href="#intro" target="">Introduction</a><br/>
+</b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><b><a href="#part1" target="">What is an Edited Picture?</a><br/>
 </b><font size="-1">This section introduces Edited Pictures, 
-                    the types of edited pictures, and the edit symbols used.</font><br/>
-<br/>
-</p>
-</td>
-</tr>
-<tr>
-<td height="2" valign="TOP" width="3%"> </td>
-<td height="2" valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td height="2" valign="top" width="93%">
-<div align="left">
-<p><b><a href="#part2" target="">Insertion Editing</a><br/>
+                    the types of edited pictures, and the edit symbols used.</font></li>
+<li>
+<b><a href="#part2" target="">Insertion Editing</a><br/>
 </b><font size="-1">This section introduces the four types 
                       of Insertion Editing - Simple Insertion, Special Insertion, 
-                      Fixed Insertion, and Floating Insertion</font><font size="-1"><br/>
-</font><font size="-1"> <br/>
-</font> </p>
-</div>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<div align="left">
-<p><b><a href="#part3" target="">Suppression and Replacement 
+                      Fixed Insertion, and Floating Insertion</font>
+</li>
+<li>
+<b><a href="#part3" target="">Suppression and Replacement 
                       Editing</a><br/>
 </b><font size="-1">This section introduces the two types 
                       Suppresion and Replacement Editng - suppression of leading 
                       zeros and replacement with spaces, and suppresion and replacement 
-                      with asterisks.</font><font size="-1"><br/>
-</font> <br/>
-</p>
-</div>
-</td>
-</tr>
-</table>
+                      with asterisks.</font>
+</li>
+</ul>
 <hr/>
 </td>
 </tr>

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -8,6 +8,8 @@
 <style type="text/css">
 <!--
 -->
+  ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
+  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style><meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -94,7 +96,7 @@
 </table>
 </div>
 </center>
-<ul class="toc" style="list-style-image: url(Resources/pics/BallGreenG.gif);"><li> <b><a href="#intro" target="">Introduction</a><br/>
+<ul class="toc"><li> <b><a href="#intro" target="">Introduction</a><br/>
 </b><font size="-1">Unit aims, objectives and prerequisites.</font> </li><li> <b><a href="#progs" target="">A look at some programs that 
       use Indexed files</a><br/>
 </b><font size="-1">We begin with three example programs. The first creates 
@@ -110,9 +112,9 @@
 </b><font size="-1">Examines the Procedure Division verbs used to process 
       Indexed files - OPEN, CLOSE, READ, WRITE, REWRITE, DELETE, START</font>
 </li><li>
-<p><a href="#example" target=""><b>A comprehensive example</b></a><br/>
+<a href="#example" target=""><b>A comprehensive example</b></a><br/>
 <font size="-1">We end with a comprehensive problem specification and 
-        solution.</font></p>
+        solution.</font>
 </li></ul>
 <table border="0" cellpadding="4" cellspacing="0" width="710">
 <tr>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -8,6 +8,8 @@
 <style type="text/css">
 <!--
 -->
+  ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
+  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style><meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -94,29 +96,22 @@
 </table>
 </div>
 </center>
-<ul class="toc" style="list-style-image: url(Resources/pics/BallGreenG.gif);"><li>
+<ul class="toc"><li>
 <b><a href="#intro" target="">Introduction</a><br/>
 </b><font size="-1">Unit aims, objectives, prerequisites and a legend for 
-      this unit's syntax diagrams. <br/>
-</font>
+      this unit's syntax diagrams.</font>
 </li><li> <b><a href="#inspect" target="">Using the INSPECT</a><br/>
 </b>T<font size="-1">he INSPECT is introduced by looking at an example program. 
-      The way the INSPECT works is explained and its modifying phrases are explored.<br/>
-</font></li><li> <a href="#count" target=""><b>The counting format</b></a><br/>
+      The way the INSPECT works is explained and its modifying phrases are explored.</font></li><li> <a href="#count" target=""><b>The counting format</b></a><br/>
 <font size="-1">Presents the syntax and rules of the counting format of 
-      the INSPECT.<br/>
-</font></li><li><b><a href="#replace" target="">The replacing format</a><br/>
+      the INSPECT.</font></li><li><b><a href="#replace" target="">The replacing format</a><br/>
 </b><font size="-1">Presents the syntax and rules of the replacing format 
-      of the INSPECT<br/>
-</font></li><li> <b><a href="#combine" target="">The combined format</a><br/>
+      of the INSPECT</font></li><li> <b><a href="#combine" target="">The combined format</a><br/>
 </b><font size="-1">This version combines the syntax and rules of the other 
-      two formats. The syntax of this combined format is presented.</font> <br/>
-</li><li>
-<p><a href="#convert" target=""><b>The converting format</b></a><br/>
+      two formats. The syntax of this combined format is presented.</font></li><li>
+<a href="#convert" target=""><b>The converting format</b></a><br/>
 <font size="-1">Presents the syntax and rules of the converting format 
-        of the INSPECT.<br/>
-<br/>
-</font></p>
+        of the INSPECT.</font>
 </li></ul>
 <table border="0" cellpadding="4" cellspacing="0" width="710">
 <tr>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -8,6 +8,8 @@
 <style type="text/css">
 <!--
 -->
+  ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
+  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style><meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -92,7 +94,7 @@
 </div>
 </center>
 <div align="LEFT">
-<ul class="toc" style="list-style-image: url(Resources/pics/BallGreenG.gif);"><li> <b><a href="#intro" target="">Introduction</a><br/>
+<ul class="toc"><li> <b><a href="#intro" target="">Introduction</a><br/>
 </b><font size="-1">Unit aims, objectives and prerequisites. </font></li><li> <b><a href="#seq" target="">Organization of Sequential 
         files</a><br/>
 </b><font size="-1">Provides a recap of Sequential file organization and 
@@ -104,9 +106,9 @@
         how records may be added, deleted or updated and describes how records 
         in an Indexed file may be processed directly or sequentially on any key. 
         </font></li><li>
-<p><b><a href="#comp">Comparison of COBOL file organizations</a></b><br/>
+<b><a href="#comp">Comparison of COBOL file organizations</a></b><br/>
 <font size="-1">Summarizes the advantages and disadvantages of each 
-          of the file organizations above.</font> </p>
+          of the file organizations above.</font> 
 </li></ul>
 </div>
 <table border="0" cellpadding="4" cellspacing="0" width="710">

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -75,6 +75,8 @@
     form table:has(select) > tbody > tr > td { display: block; width: auto !important; padding: 6px 8px; }
     form table:has(select) > tbody > tr > td[bgcolor="#FFFFCC"] { font-weight: bold; padding-bottom: 2px; }
   }
+  ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
+  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
@@ -91,73 +93,28 @@
 <h2> <b>COBOL Iteration Constructs</b></h2>
 <hr/>
 </center>
-<table border="0" vspace="15" width="700">
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%"> <b><a href="#intro" target="">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites.</font><br/>
-<br/>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td valign="top" width="93%">
-<p><b><a href="#part1" target="">PERFORM..Proc</a><br/>
+<ul class="toc">
+<li><b><a href="#intro" target="">Introduction</a><br/>
+</b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><b><a href="#part1" target="">PERFORM..Proc</a><br/>
 </b><font size="-1">This section introduces the format of 
                     the PERFORM that is used to transfer control to a paragraph 
-                    or section.<br/>
-<br/>
-</font></p>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td valign="top" width="93%">
-<div align="left"><b><a href="#part2" target="">Using the PERFORM..THRU</a><br/>
+                    or section.</font></li>
+<li><b><a href="#part2" target="">Using the PERFORM..THRU</a><br/>
 </b><font size="-1">This section demonstrates how the PERFORM..THRU 
-                    can be used to implement an emergency exit from a paragraph. 
-                    <br/>
-<br/>
-</font> </div>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<div align="left"><b><a href="#part3" target="">PERFORM..TIMES</a><br/>
+                    can be used to implement an emergency exit from a paragraph.</font> </li>
+<li><b><a href="#part3" target="">PERFORM..TIMES</a><br/>
 </b><font size="-1">This section introduces the PERFORM..TIMES 
                     which allow us to create an iteration that executes x number 
                     of times. Also discusses the use of in-line versus out-of-line 
-                    PERFORMs <br/>
-</font> <br/>
-</div>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%"><b><a href="#part4" target="">PERFORM..UNTIL </a><br/>
+                    PERFORMs</font></li>
+<li><b><a href="#part4" target="">PERFORM..UNTIL </a><br/>
 </b><font size="-1">In this section COBOL's version of of the 
-                  while and do/repeat loops is introduced.<br/>
-</font> <br/>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<div align="left"><b><a href="#part5" target="">PERFORM..VARYING</a><br/>
+                  while and do/repeat loops is introduced.</font></li>
+<li><b><a href="#part5" target="">PERFORM..VARYING</a><br/>
 </b><font size="-1">This section demonstrates COBOL's version 
-                    of the for loop.<br/>
-</font> <br/>
-</div>
-</td>
-</tr>
-</table>
+                    of the for loop.</font></li>
+</ul>
 <hr/>
 </td>
 </tr>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -70,6 +70,8 @@
       margin: 0.2em 0;
     }
   }
+  ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
+  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
@@ -86,78 +88,33 @@
 <h2> <b>Reference Modification and Intrinsic Functions</b></h2>
 <hr/>
 </center>
-<table border="0" vspace="15" width="700">
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%"> <b><a href="#intro" target="">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives and prerequisites.</font>
-<br/>
-<br/>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%"><b><a href="#part1" target="">Reference Modification</a><br/>
+<ul class="toc">
+<li><b><a href="#intro" target="">Introduction</a><br/>
+</b><font size="-1">Unit aims, objectives and prerequisites.</font></li>
+<li><b><a href="#part1" target="">Reference Modification</a><br/>
 </b><font size="-1">This section examines the syntax and semantics 
                   of Reference Modification. The section ends with some animated 
-                  examples.<br/>
-<br/>
-</font> </td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<div align="left"><b><a href="#part2" target="">Intrinsic Functions 
+                  examples.</font></li>
+<li><b><a href="#part2" target="">Intrinsic Functions 
                     - Introduction</a><br/>
 </b><font size="-1">This section introduces COBOL's predefined 
                     functions - called Intrinsic Functions. It explains how they 
                     may be used and introduces the notation used in the Intrinsic 
-                    Function definitions in the later sections.</font><br/>
-<br/>
-</div>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<p><a href="#part3" target=""><b>String Functions</b></a><br/>
+                    Function definitions in the later sections.</font></li>
+<li><a href="#part3" target=""><b>String Functions</b></a><br/>
 <font size="-1">This section presents the definitions of the 
                     Intrinsic Functions used for string handling . The section 
-                    ends with some examples.<br/>
-<br/>
-</font></p>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<p><a href="#part4" target=""><b>Date Functions</b></a><br/>
+                    ends with some examples.</font></li>
+<li><a href="#part4" target=""><b>Date Functions</b></a><br/>
 <font size="-1">This section presents the definitions of the 
                     Intrinsic Functions used for date manipulations . The section 
-                    ends with a set of comprehensive examples.<br/>
-<br/>
-</font></p>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<p><a href="#part5" target=""><b>Miscellaneous Functions</b></a><br/>
+                    ends with a set of comprehensive examples.</font></li>
+<li><a href="#part5" target=""><b>Miscellaneous Functions</b></a><br/>
 <font size="-1">This section presents the definitions of the 
                     other (mainly maths) Intrinsic Functions including used for 
                     string handling . The section ends with an example using the 
-                    RANDOM Intrinsic Function..<br/>
-<br/>
-</font></p>
-</td>
-</tr>
-</table>
+                    RANDOM Intrinsic Function..</font></li>
+</ul>
 </td>
 </tr>
 <tr>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -8,6 +8,8 @@
 <style type="text/css">
 <!--
 -->
+  ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
+  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style><meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -101,7 +103,7 @@
 </center>
 </p>
 <div align="LEFT">
-<ul class="toc" style="list-style-image: url(Resources/pics/BallGreenG.gif);"><li> <b><a href="#intro" target="">Introduction</a><br/>
+<ul class="toc"><li> <b><a href="#intro" target="">Introduction</a><br/>
 </b><font size="-1">Unit aims, objectives and prerequisites. </font></li><li> <b><a href="#progs" target="">A look at some programs that 
         use Relative files</a><br/>
 </b><font size="-1">We begin with two example programs. The first creates 
@@ -112,9 +114,9 @@
 </b><font size="-1">Examines the Procedure Division verbs used to process 
         Relative files - OPEN, CLOSE, READ, WRITE, REWRITE, DELETE, START</font>
 </li><li>
-<p><b><a href="#declaratives" target="">Introduction to Declaratives</a></b><br/>
+<b><a href="#declaratives" target="">Introduction to Declaratives</a></b><br/>
 <font size="-1">Introduces Declaratives, showing when and how to use 
-          them.</font> </p>
+          them.</font> 
 </li></ul>
 </div>
 <table border="0" cellpadding="4" cellspacing="0" width="710">

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -70,6 +70,8 @@
       margin: 0.2em 0;
     }
   }
+  ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
+  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
@@ -86,73 +88,36 @@
 <h2> <b>The COBOL Report Writer</b></h2>
 <hr/>
 </center>
-<table border="0" vspace="15" width="700">
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%"> <b><a href="#intro" target="">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives and prerequisites.</font>
-<br/>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%"><b><a href="#part1" target="">The Report Writer 
+<ul class="toc">
+<li><b><a href="#intro" target="">Introduction</a><br/>
+</b><font size="-1">Unit aims, objectives and prerequisites.</font></li>
+<li><b><a href="#part1" target="">The Report Writer 
                   in action</a><br/>
 </b><font size="-1">This section examines a report produced 
                   by a Report Writer program and then examines the Procedure Division 
-                  of the program that produced the report. <br/>
-</font> </td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%"><b><a href="#part1b" target="">How the Report 
+                  of the program that produced the report.</font></li>
+<li><b><a href="#part1b" target="">How the Report 
                   Writer works</a><br/>
 </b><font size="-1">This section explains how the Report Writer 
                   works. It examines the seven report groups a report produced 
                   by a Report Writer program and then examines the Procedure Division 
-                  of the program that produced the report. <br/>
-</font> </td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<div align="left">
-<p><b><a href="#part2" target="">Let's write a Report Writer 
+                  of the program that produced the report.</font></li>
+<li>
+<b><a href="#part2" target="">Let's write a Report Writer 
                       p</a></b><b><a href="#part2" target="">rogram</a><br/>
 </b><font size="-1">This section uses learning by doing 
                       as its mode of instruction. We learn how to write a simple 
-                      version of the report program shown in the previous section.</font><br/>
-</p>
-</div>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<p><a href="#part3" target=""><b>Let's add some features to 
+                      version of the report program shown in the previous section.</font>
+</li>
+<li><a href="#part3" target=""><b>Let's add some features to 
                     our Report Program</b></a><br/>
 <font size="-1">In this section we amend the report program 
-                    to include more functionality</font><font size="-1">.<br/>
-</font></p>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<p><a href="#part4" target=""><b>Report Writer Declaratives</b></a><br/>
+                    to include more functionality</font><font size="-1">.</font></li>
+<li><a href="#part4" target=""><b>Report Writer Declaratives</b></a><br/>
 <font size="-1">When the requirements of the report do not 
                     coincide with the way the Report Writer works Declaratives 
-                    can be used to extend the functionality of the Report Writer.</font><font size="-1"><br/>
-</font></p>
-</td>
-</tr>
-</table>
+                    can be used to extend the functionality of the Report Writer.</font></li>
+</ul>
 </td>
 </tr>
 <tr>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -70,6 +70,8 @@
       margin: 0.2em 0;
     }
   }
+  ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
+  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
@@ -86,104 +88,47 @@
 <h2> <b>The COBOL Report Writer - Syntax and Semantics</b></h2>
 <hr/>
 </center>
-<table border="0" vspace="15" width="700">
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<p><b><a href="#intro" target="">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives and prerequisites.</font>
-<br/>
-</p>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<p><b><a href="#part1" target="">Defining the Report - Report 
+<ul class="toc">
+<li><b><a href="#intro" target="">Introduction</a><br/>
+</b><font size="-1">Unit aims, objectives and prerequisites.</font></li>
+<li><b><a href="#part1" target="">Defining the Report - Report 
                     File entries</a><br/>
 </b><font size="-1">This section examines the Environment 
                     Division and File Section entries required when we create 
                     <br/>
-                    a Report Writer program.</font><font size="-1"> <br/>
-</font></p>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<p><b><a href="#part2" target="">Defining the Report - Report 
+                    a Report Writer program.</font></li>
+<li><b><a href="#part2" target="">Defining the Report - Report 
                     Description (RD) entries </a><br/>
 </b><font size="-1">In this section we examine the Report 
                     Section and the Report Description (RD) entries required to 
                     <br/>
-                    define a report. <br/>
-</font></p>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<p><b><a href="#part3" target="">Defining the Report - Report 
+                    define a report.</font></li>
+<li><b><a href="#part3" target="">Defining the Report - Report 
                     Group entries</a><br/>
 </b><font size="-1">This section examines the entries required 
-                    to define a report group record.<br/>
-</font></p>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<p><b><a href="#part4" target="">Defining the Report - Lines 
+                    to define a report group record.</font></li>
+<li><b><a href="#part4" target="">Defining the Report - Lines 
                     and Columns</a><br/>
 </b><font size="-1">This section examines the entries the 
                     vertical and horizontal placement of print items. </font><font size="-1">It 
                     examines <br/>
                     clauses such as - </font><font size="-1">LINE NUMBER, COLUMN 
-                    NUMBER, GROUP INDICATE , SOURCE and SUM</font><font size="-1">.<br/>
-</font></p>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<p><a href="#part5" target=""><b>Special Report Writer registers</b></a><br/>
+                    NUMBER, GROUP INDICATE , SOURCE and SUM</font><font size="-1">.</font></li>
+<li><a href="#part5" target=""><b>Special Report Writer registers</b></a><br/>
 <font size="-1">In this section the LINE-COUNTER and PAGE-COUNTER 
-                    registers are examined.<br/>
-</font></p>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<p><b><a href="#part6" target="">The Procedure Division Verbs 
+                    registers are examined.</font></li>
+<li><b><a href="#part6" target="">The Procedure Division Verbs 
                     </a><br/>
 </b><font size="-1">This section introduces the INITIATE, 
-                    GENERATE and TERMINATE verbs. <br/>
-</font></p>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<div align="left">
-<p><b><a href="#part7" target="">Report Writer Declaratives</a></b><b>
+                    GENERATE and TERMINATE verbs.</font></li>
+<li>
+<b><a href="#part7" target="">Report Writer Declaratives</a></b><b>
 <br/>
 </b><font size="-1">In this section elements of the Declaratives, 
                       such as USE BEFORE REPORTING, SUPPRESS PRINTING and <br/>
-                      control break registers, are examined.<br/>
-</font></p>
-</div>
-</td>
-</tr>
-</table>
+                      control break registers, are examined.</font>
+</li>
+</ul>
 </td>
 </tr>
 <tr>

--- a/course/Search.html
+++ b/course/Search.html
@@ -72,6 +72,8 @@
       margin: 0.2em 0;
     }
   }
+  ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
+  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
@@ -88,76 +90,37 @@
 <h2> Searching Tables</h2>
 <hr/>
 </center>
-<table border="0" vspace="15" width="700">
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%"> <b><a href="#intro" target="">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites.</font><br/>
-<br/>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td valign="top" width="93%">
-<p><b><a href="#part1" target="">OCCURS clause extensions</a><br/>
+<ul class="toc">
+<li><b><a href="#intro" target="">Introduction</a><br/>
+</b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><b><a href="#part1" target="">OCCURS clause extensions</a><br/>
 </b><font size="-1">The SEARCH and SEARCH ALL require that 
                     the description of the table to be searched contain a number 
                     of new extensions to the OCCURS clause. In this section the 
-                    syntax of these new extensions is introduced</font> <br/>
-<br/>
-</p>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td valign="top" width="93%">
-<div align="left">
-<p><b><a href="#part2" target="">The SEARCH verb</a><br/>
+                    syntax of these new extensions is introduced</font></li>
+<li>
+<b><a href="#part2" target="">The SEARCH verb</a><br/>
 </b><font size="-1">This section demonstrates how the SEARCH 
-                      verb may be used to search through a table sequentially.<br/>
-</font>
-<br/>
-</p>
-</div>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<div align="left">
-<p><b><a href="#part3" target="">Searching multi-dimension 
+                      verb may be used to search through a table sequentially.</font>
+</li>
+<li>
+<b><a href="#part3" target="">Searching multi-dimension 
                       tables </a><br/>
 </b><font size="-1">The SEARCH cannot be applied directly 
                       to search a multi-dimension table. This section demonstrates 
                       how to overcome this restriction by treating the multi-dimension 
                       table as a collection of single dimension tables and applying 
-                      the SEARCH to each single dimension table.</font><font size="-1">.</font><font size="-1"><br/>
-<br/>
-</font> </p>
-</div>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<div align="left">
-<p><b><a href="#part4" target="">The SEARCH ALL verb</a><br/>
+                      the SEARCH to each single dimension table.</font><font size="-1">.</font>
+</li>
+<li>
+<b><a href="#part4" target="">The SEARCH ALL verb</a><br/>
 </b><font size="-1">The SEARCH ALL is used when a binary 
                       search is required. This section introduces the syntax of 
                       the SEARCH ALL, demonstrates how a binary search works and 
                       shows how the SEARCH ALL can be used to search an ordered 
-                      table.</font><font size="-1"><br/>
-<br/>
-</font><font size="-1"> </font> </p>
-</div>
-</td>
-</tr>
-</table>
+                      table.</font>
+</li>
+</ul>
 <hr/>
 </td>
 </tr>

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -70,6 +70,8 @@
       margin: 0.2em 0;
     }
   }
+  ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
+  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
@@ -86,65 +88,26 @@
 <h2> <b>COBOL Selection Constructs</b></h2>
 <hr/>
 </center>
-<table border="0" vspace="15" width="700">
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%"> <b><a href="#intro" target="">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites.</font><br/>
-<br/>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td valign="top" width="93%">
-<p><b><a href="#part1" target="">Selection using IF</a><br/>
+<ul class="toc">
+<li><b><a href="#intro" target="">Introduction</a><br/>
+</b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><b><a href="#part1" target="">Selection using IF</a><br/>
 </b><font size="-1">This section demonstrates selection using 
                     the IF statement. It introduces Relation Conditions, Class 
                     Condition, Sign Condition and Complex Conditions. It also 
-                    covers Implied Subjects and Nested IFs.</font><font size="-1">
-<br/>
-<br/>
-</font> </p>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td valign="top" width="93%">
-<div align="left"><b><a href="#part2" target="">Condition Names</a><br/>
+                    covers Implied Subjects and Nested IFs.</font></li>
+<li><b><a href="#part2" target="">Condition Names</a><br/>
 </b><font size="-1">In this section the concept of a Condition 
-                    Name is explained. <br/>
-<br/>
-</font> </div>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<div align="left"><b><a href="#part3" target="">Using the SET 
+                    Name is explained.</font> </li>
+<li><b><a href="#part3" target="">Using the SET 
                     verb with Condition Names</a><br/>
 </b><font size="-1">This section demonstrates how the SET 
-                    verb may be used to set a Condition Name to true.<br/>
-</font> <br/>
-</div>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<div align="left"><b><a href="#part4" target="">The EVALUATE 
+                    verb may be used to set a Condition Name to true.</font></li>
+<li><b><a href="#part4" target="">The EVALUATE 
                     verb </a><br/>
 </b><font size="-1">In this section COBOL's version of Case/Switch 
-                    is introduced.<br/>
-</font> <br/>
-</div>
-</td>
-</tr>
-</table>
+                    is introduced.</font></li>
+</ul>
 <hr/>
 </td>
 </tr>

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -70,6 +70,8 @@
       margin: 0.2em 0;
     }
   }
+  ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
+  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
@@ -86,57 +88,27 @@
 <h2> <b>Introduction to Sequential Files</b></h2>
 <hr/>
 </center>
-<table border="0" vspace="15" width="700">
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%"> <b><a href="#intro" target="">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites.</font><br/>
-<br/>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td valign="top" width="93%">
-<p><b><a href="#part1" target="">Introduction to record-based 
+<ul class="toc">
+<li><b><a href="#intro" target="">Introduction</a><br/>
+</b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><b><a href="#part1" target="">Introduction to record-based 
                     files </a><br/>
 </b><font size="-1">This section introduces record-based files, 
                     the concept of the record buffer and defines terminology such 
-                    as file, record and field.<br/>
-<br/>
-</font></p>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td valign="top" width="93%">
-<div align="left">
-<p><b><a href="#part2" target="">Declaring records and files</a><br/>
+                    as file, record and field.</font></li>
+<li>
+<b><a href="#part2" target="">Declaring records and files</a><br/>
 </b><font size="-1">This section demonstrates how the FD 
                       entry is used to describe a files record buffer and show 
                       how to use the SELECT and ASSIGN clause to connect an internal 
-                      file name to an external data repository.</font><font size="-1"><br/>
-<br/>
-</font> </p>
-</div>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<div align="left"><b><a href="#part3" target="">COBOL file handling 
+                      file name to an external data repository.</font>
+</li>
+<li><b><a href="#part3" target="">COBOL file handling 
                     verbs </a><br/>
 </b><font size="-1">The COBOL verbs for processing Sequential 
                     Files are introduced in this section. The section ends with 
-                    a full example program.<br/>
-</font> <br/>
-</div>
-</td>
-</tr>
-</table>
+                    a full example program.</font></li>
+</ul>
 <hr/>
 </td>
 </tr>

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -75,6 +75,8 @@
     form table:has(select) > tbody > tr > td { display: block; width: auto !important; padding: 6px 8px; }
     form table:has(select) > tbody > tr > td[bgcolor="#FFFFCC"] { font-weight: bold; padding-bottom: 2px; }
   }
+  ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
+  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
@@ -91,59 +93,28 @@
 <h2> <b>Processing Sequential Files</b></h2>
 <hr/>
 </center>
-<table border="0" vspace="15" width="700">
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%"> <b><a href="#intro" target="">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites.</font><br/>
-<br/>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td valign="top" width="93%">
-<p><b><a href="#part1" target="">Organization and Access</a><br/>
+<ul class="toc">
+<li><b><a href="#intro" target="">Introduction</a><br/>
+</b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><b><a href="#part1" target="">Organization and Access</a><br/>
 </b><font size="-1">This section introduces the concepts of 
                     file organization and access. It describes how Sequential 
                     files are organized and introduces the idea of ordered and 
-                    unordered Sequential files.</font><br/>
-<br/>
-</p>
-</td>
-</tr>
-<tr>
-<td height="48" valign="TOP" width="3%"> </td>
-<td height="48" valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td height="48" valign="top" width="93%">
-<div align="left">
-<p><b><a href="#part2" target="">Processing unordered Sequential 
+                    unordered Sequential files.</font></li>
+<li>
+<b><a href="#part2" target="">Processing unordered Sequential 
                       files </a><br/>
 </b><font size="-1">This section explores the processing 
                       restrictions of unordered Sequential files. It demonstrates 
                       that, while records can be easily added to unordered files, 
-                      deleting and updating records is not really feasible.<br/>
-</font><font size="-1">
-<br/>
-</font> </p>
-</div>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<div align="left"><b><a href="#part3" target="">Processing ordered 
+                      deleting and updating records is not really feasible.</font>
+</li>
+<li><b><a href="#part3" target="">Processing ordered 
                     Sequential files</a><br/>
 </b><font size="-1">This section demonstrates how to use a 
                     file of batched transactions to insert (add), delete and update 
-                    records in an ordered Sequential file..<br/>
-</font> <br/>
-</div>
-</td>
-</tr>
-</table>
+                    records in an ordered Sequential file..</font></li>
+</ul>
 <hr/>
 </td>
 </tr>

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -70,6 +70,8 @@
       margin: 0.2em 0;
     }
   }
+  ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
+  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
@@ -86,57 +88,27 @@
 <h2> Print files and variable-length records</h2>
 <hr/>
 </center>
-<table border="0" vspace="15" width="700">
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%"> <b><a href="#intro" target="">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites.</font><br/>
-<br/>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td valign="top" width="93%">
-<p><b><a href="#part1" target="">Multiple record-type files</a><br/>
+<ul class="toc">
+<li><b><a href="#intro" target="">Introduction</a><br/>
+</b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><b><a href="#part1" target="">Multiple record-type files</a><br/>
 </b><font size="-1">This section demonstrates how to declare 
-                    and use files that contain multiple types of record.</font><br/>
-<br/>
-</p>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td valign="top" width="93%">
-<div align="left">
-<p><b><a href="#part2" target="">COBOL print files </a><br/>
+                    and use files that contain multiple types of record.</font></li>
+<li>
+<b><a href="#part2" target="">COBOL print files </a><br/>
 </b><font size="-1">This section introduces COBOL print 
                       files, demonstrates how a print file may be set up and shows 
-                      how a print file is used to print a report.<br/>
-</font><font size="-1"> <br/>
-</font> </p>
-</div>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<div align="left"><b><a href="#part3" target="">Variable length 
+                      how a print file is used to print a report.</font>
+</li>
+<li><b><a href="#part3" target="">Variable length 
                     records </a><br/>
 </b><font size="-1">This section introduces variable length 
                     records, demonstrates how variable length records may be declared 
                     and shows how variable length records with the DEPENDING ON 
                     phrase may be processed. In addition, this section demonstrates 
                     how a file name may be assigned to a file at run-time rather 
-                    than at compile-time.<br/>
-</font> <br/>
-</div>
-</td>
-</tr>
-</table>
+                    than at compile-time.</font></li>
+</ul>
 <hr/>
 </td>
 </tr>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -70,6 +70,8 @@
       margin: 0.2em 0;
     }
   }
+  ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
+  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
@@ -86,72 +88,34 @@
 <h2> Sorting and Merging files</h2>
 <hr/>
 </center>
-<table border="0" vspace="15" width="700">
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%"> <b><a href="#intro" target="">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites.</font><br/>
-<br/>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td valign="top" width="93%">
-<p><b><a href="#part1" target="">Simple SORTing</a><br/>
+<ul class="toc">
+<li><b><a href="#intro" target="">Introduction</a><br/>
+</b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><b><a href="#part1" target="">Simple SORTing</a><br/>
 </b><font size="-1">This section introduces a simplified version 
                     of SORT verb syntax, and discusses why we might need to sort 
-                    a file as part of a solution to a programming problem..</font><br/>
-<br/>
-</p>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td valign="top" width="93%">
-<div align="left">
-<p><b><a href="#part2" target="">Sorting with an INPUT PROCEDURE 
+                    a file as part of a solution to a programming problem..</font></li>
+<li>
+<b><a href="#part2" target="">Sorting with an INPUT PROCEDURE 
                       </a><br/>
 </b><font size="-1">This section introduces a SORT with 
                       an INPUT PROCEDURE and demonstrates how an INPUT PROCEDURE 
                       may be used to filter, or alter, records before they are 
-                      supplied to the sort process.<br/>
-</font><font size="-1"> <br/>
-</font> </p>
-</div>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<div align="left">
-<p><b><a href="#part3" target="">Sorting with an OUTPUT PROCEDURE</a><br/>
+                      supplied to the sort process.</font>
+</li>
+<li>
+<b><a href="#part3" target="">Sorting with an OUTPUT PROCEDURE</a><br/>
 </b><font size="-1">This section shows how an OUTPUT PROCEDURE 
                       may be used to filter, or alter, records after they have 
-                      been sorted.</font><font size="-1"><br/>
-</font> <br/>
-</p>
-</div>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<div align="left">
-<p><b><a href="#part4" target="">MERGEing files</a><br/>
+                      been sorted.</font>
+</li>
+<li>
+<b><a href="#part4" target="">MERGEing files</a><br/>
 </b><font size="-1">In this section the MERGE verb is introduced. 
                       The MERGE verb may be used to merge two or more ordered 
-                      files.</font><font size="-1"><br/>
-</font> <br/>
-</p>
-</div>
-</td>
-</tr>
-</table>
+                      files.</font>
+</li>
+</ul>
 <hr/>
 </td>
 </tr>

--- a/course/String.html
+++ b/course/String.html
@@ -8,6 +8,8 @@
 <style type="text/css">
 <!--
 -->
+  ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
+  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style><meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -94,21 +96,15 @@
 </table>
 </div>
 </center>
-<ul class="toc" style="list-style-image: url(Resources/pics/BallGreenG.gif);"><li>
-<p><b><a href="#intro" target="">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives and prerequisites.<br/>
-<br/>
-</font></p>
+<ul class="toc"><li>
+<b><a href="#intro" target="">Introduction</a><br/>
+</b><font size="-1">Unit aims, objectives and prerequisites.</font>
 </li><li> <b><a href="#verb" target="">The STRING verb</a><br/>
 </b><font size="-1">This section examines the syntax, functioning and rules 
-      of the STRING verb<br/>
-<br/>
-</font></li><li>
-<p><a href="#examples" target=""><b>STRING examples</b></a><br/>
+      of the STRING verb</font></li><li>
+<a href="#examples" target=""><b>STRING examples</b></a><br/>
 <font size="-1">This section starts with some animated examples and ends 
-        with some examples that take the form of Self Assessment Questions (SAQ).<br/>
-<br/>
-</font></p>
+        with some examples that take the form of Self Assessment Questions (SAQ).</font>
 </li></ul>
 <table border="0" cellpadding="4" cellspacing="0" width="710">
 <tr>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -70,6 +70,8 @@
       margin: 0.2em 0;
     }
   }
+  ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
+  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
@@ -86,40 +88,21 @@
 <h2> Subprograms</h2>
 <hr/>
 </center>
-<table border="0" vspace="15" width="700">
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%"> <b><a href="#intro" target="">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites.</font><br/>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td valign="top" width="93%">
-<p><b><a href="#part1" target="">The CALL verb</a><br/>
+<ul class="toc">
+<li><b><a href="#intro" target="">Introduction</a><br/>
+</b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><b><a href="#part1" target="">The CALL verb</a><br/>
 </b><font size="-1">Subprograms, the syntax and semantics 
                     of the CALL verb and parameter passing mechanisms. State memory, 
-                    the IS INITIAL clause and the CANCEL command.</font><br/>
-</p>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td valign="top" width="93%">
-<div align="left">
-<p><b><a href="#part2" target="">Contained Subprograms</a><br/>
+                    the IS INITIAL clause and the CANCEL command.</font></li>
+<li>
+<b><a href="#part2" target="">Contained Subprograms</a><br/>
 </b><font size="-1">C</font><font size="-1">ontained subprogram 
                       defined. Sharing data with the IS GLOBAL and IS EXTERNAL 
                       clause. Using the IS COMMON PROGRAM clause. Measuring the 
-                      quality of subprograms.<br/>
-</font> </p>
-</div>
-</td>
-</tr>
-</table>
+                      quality of subprograms.</font> 
+</li>
+</ul>
 <hr/>
 </td>
 </tr>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -70,6 +70,8 @@
       margin: 0.2em 0;
     }
   }
+  ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
+  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
@@ -86,64 +88,32 @@
 <h2> Using Tables </h2>
 <hr/>
 </center>
-<table border="0" vspace="15" width="700">
-<tr>
-<td height="49" valign="TOP" width="3%"> </td>
-<td height="49" valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td height="49" width="93%"> <b><a href="#intro" target="">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites.</font><br/>
-</td>
-</tr>
-<tr>
-<td height="57" valign="TOP" width="3%"> </td>
-<td height="57" valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td height="57" valign="top" width="93%">
-<p><b><a href="#part1" target="">Why use tables?</a><br/>
+<ul class="toc">
+<li><b><a href="#intro" target="">Introduction</a><br/>
+</b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><b><a href="#part1" target="">Why use tables?</a><br/>
 </b><font size="-1">This section starts with a problem specification, 
                     explores possible solutions and ends with the realisation 
-                    that a table-based solution is probably best.</font> <br/>
-</p>
-</td>
-</tr>
-<tr>
-<td height="41" valign="TOP" width="3%"> </td>
-<td height="41" valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td height="41" valign="top" width="93%">
-<div align="left">
-<p><b><a href="#part2" target="">Using a CountyTax table</a><br/>
+                    that a table-based solution is probably best.</font></li>
+<li>
+<b><a href="#part2" target="">Using a CountyTax table</a><br/>
 </b><font size="-1">This section explores how the table-based 
-                      solution may be implemented. </font> </p>
-</div>
-</td>
-</tr>
-<tr>
-<td height="44" valign="TOP" width="3%"> </td>
-<td height="44" valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td height="44" width="93%">
-<div align="left">
-<p><b><a href="#part3" target="">Displaying the CountyName</a><br/>
+                      solution may be implemented. </font> 
+</li>
+<li>
+<b><a href="#part3" target="">Displaying the CountyName</a><br/>
 </b><font size="-1">In this section we explore how we might 
                       deal with an extension to the problem specification that 
                       requires us to display a county name instead of a county 
-                      code.</font><font size="-1"><br/>
-</font> </p>
-</div>
-</td>
-</tr>
-<tr>
-<td height="48" valign="TOP" width="3%"> </td>
-<td height="48" valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td height="48" width="93%">
-<div align="left">
-<p><b><a href="#part3" target="">Using one table to index 
+                      code.</font>
+</li>
+<li>
+<b><a href="#part3" target="">Using one table to index 
                       into another</a><br/>
 </b><font size="-1">In this section we show how the subscript 
-                      of one table may be used to index into another. </font><font size="-1">
-</font> </p>
-</div>
-</td>
-</tr>
-</table>
+                      of one table may be used to index into another. </font>
+</li>
+</ul>
 <hr/>
 </td>
 </tr>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -74,6 +74,8 @@
     form table:has(select) > tbody > tr > td { display: block; width: auto !important; padding: 6px 8px; }
     form table:has(select) > tbody > tr > td[bgcolor="#FFFFCC"] { font-weight: bold; padding-bottom: 2px; }
   }
+  ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
+  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
@@ -90,76 +92,38 @@
 <h2> Creating Tables - syntax and semantics</h2>
 <hr/>
 </center>
-<table border="0" vspace="15" width="700">
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%"> <b><a href="#intro" target="">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites.</font><br/>
-<br/>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td valign="top" width="93%">
-<p><b><a href="#part1" target="">Declaring a single dimension 
+<ul class="toc">
+<li><b><a href="#intro" target="">Introduction</a><br/>
+</b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><b><a href="#part1" target="">Declaring a single dimension 
                     table </a><br/>
 </b><font size="-1">In this section we demonstrate how the 
                     OCCURS clause is used to declare a single dimension table. 
                     We also show how it may be used to declare a variable length 
-                    table.</font> <br/>
-<br/>
-</p>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td valign="top" width="93%">
-<div align="left">
-<p><b><a href="#part2" target="">Group items as elements</a><br/>
+                    table.</font></li>
+<li>
+<b><a href="#part2" target="">Group items as elements</a><br/>
 </b><font size="-1">The elements of a table do not have 
                       to be elementary items - they can be group items. This section 
                       demonstrates how to create a table, the elements of which, 
-                      are group items.</font> <br/>
-<br/>
-</p>
-</div>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<div align="left">
-<p><b><a href="#part3" target="">Declaring multi-dimension 
+                      are group items.</font>
+</li>
+<li>
+<b><a href="#part3" target="">Declaring multi-dimension 
                       tables </a><br/>
 </b><font size="-1">This section demonstrates how nested 
-                      OCCURS clauses are used to create multi-dimension tables</font><font size="-1">.</font><font size="-1"><br/>
-<br/>
-</font> </p>
-</div>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<div align="left">
-<p><b><a href="#part4" target="">Creating pre-filled tables 
+                      OCCURS clauses are used to create multi-dimension tables</font><font size="-1">.</font>
+</li>
+<li>
+<b><a href="#part4" target="">Creating pre-filled tables 
                       with the REDEFINES clause.</a><br/>
 </b><font size="-1">This section first demonstrates non-table 
                       related uses for the REDEFINES clause and then shows how 
                       it may be used to create pre-filled tables. The new COBOL'85 
                       approaches to creating pre-filled tables and to initialising 
-                      tables are also demonstrated.<br/>
-<br/>
-</font><font size="-1"> </font> </p>
-</div>
-</td>
-</tr>
-</table>
+                      tables are also demonstrated.</font>
+</li>
+</ul>
 <hr/>
 </td>
 </tr>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -8,6 +8,8 @@
 <style type="text/css">
 <!--
 -->
+  ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
+  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style><meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -94,23 +96,15 @@
 </table>
 </div>
 </center>
-<ul class="toc" style="list-style-image: url(Resources/pics/BallGreenG.gif);"><li> <b><a href="#intro" target="">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives and prerequisites.</font> <br/>
-<br/>
-</li><li><b><a href="#verb" target="">The UNSTRING verb</a><br/>
+<ul class="toc"><li> <b><a href="#intro" target="">Introduction</a><br/>
+</b><font size="-1">Unit aims, objectives and prerequisites.</font></li><li><b><a href="#verb" target="">The UNSTRING verb</a><br/>
 </b><font size="-1">This section examines the syntax, functioning and rules 
-      of the UNSTRING.<br/>
-<br/>
-</font></li><li> <b><a href="#examples" target="">UNSTRING examples</a><br/>
+      of the UNSTRING.</font></li><li> <b><a href="#examples" target="">UNSTRING examples</a><br/>
 </b><font size="-1">This section starts with some abstract examples, goes 
-      on to a more practical example and ends with a example program</font> <br/>
-<br/>
-</li><li>
-<p><a href="#combined" target=""><b>A combined example</b></a><br/>
+      on to a more practical example and ends with a example program</font></li><li>
+<a href="#combined" target=""><b>A combined example</b></a><br/>
 <font size="-1">The unit ends with a practical example that uses the STRING 
-        and UNSTRING verbs in combination.<br/>
-<br/>
-</font></p>
+        and UNSTRING verbs in combination.</font>
 </li></ul>
 <table border="0" cellpadding="4" cellspacing="0" width="710">
 <tr>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -70,6 +70,8 @@
       margin: 0.2em 0;
     }
   }
+  ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
+  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
@@ -86,26 +88,14 @@
 <h2> The USAGE clause</h2>
 <hr/>
 </center>
-<table border="0" vspace="15" width="700">
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td width="93%"> <b><a href="#intro" target="">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites.</font><br/>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Resources/pics/BallGreenG.gif" vspace="4" width="13"/></td>
-<td valign="top" width="93%">
-<p><b><a href="#part1" target="">The USAGE clause</a><br/>
+<ul class="toc">
+<li><b><a href="#intro" target="">Introduction</a><br/>
+</b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><b><a href="#part1" target="">The USAGE clause</a><br/>
 </b><font size="-1">Subprograms, the syntax and semantics 
                     of the CALL verb and parameter passing mechanisms. State memory, 
-                    the IS INITIAL clause and the CANCEL command.</font><br/>
-</p>
-</td>
-</tr>
-</table>
+                    the IS INITIAL clause and the CANCEL command.</font></li>
+</ul>
 <hr/>
 </td>
 </tr>

--- a/lectures/ReportWriterSSWeb.html
+++ b/lectures/ReportWriterSSWeb.html
@@ -64,6 +64,8 @@
       margin: 0.2em 0;
     }
   }
+  ul.toc { list-style-image: url(Ballgreeng.gif); padding-left: 2.5em; margin: 1em 0; }
+  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
@@ -80,104 +82,47 @@
 <h2> <b>The COBOL Report Writer - Syntax and Semantics</b></h2>
 <hr/>
 </center>
-<table border="0" vspace="15" width="700">
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Ballgreeng.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<p><b><a href="#intro" target="">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives and prerequisites.</font>
-<br/>
-</p>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Ballgreeng.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<p><b><a href="#part1" target="">Defining the Report - Report 
+<ul class="toc">
+<li><b><a href="#intro" target="">Introduction</a><br/>
+</b><font size="-1">Unit aims, objectives and prerequisites.</font></li>
+<li><b><a href="#part1" target="">Defining the Report - Report 
                     File entries</a><br/>
 </b><font size="-1">This section examines the Environment 
                     Division and File Section entries required when we create 
                     <br/>
-                    a Report Writer program.</font><font size="-1"> <br/>
-</font></p>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Ballgreeng.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<p><b><a href="#part2" target="">Defining the Report - Report 
+                    a Report Writer program.</font></li>
+<li><b><a href="#part2" target="">Defining the Report - Report 
                     Description (RD) entries </a><br/>
 </b><font size="-1">In this section we examine the Report 
                     Section and the Report Description (RD) entries required to 
                     <br/>
-                    define a report. <br/>
-</font></p>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Ballgreeng.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<p><b><a href="#part3" target="">Defining the Report - Report 
+                    define a report.</font></li>
+<li><b><a href="#part3" target="">Defining the Report - Report 
                     Group entries</a><br/>
 </b><font size="-1">This section examines the entries required 
-                    to define a report group record.<br/>
-</font></p>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Ballgreeng.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<p><b><a href="#part4" target="">Defining the Report - Lines 
+                    to define a report group record.</font></li>
+<li><b><a href="#part4" target="">Defining the Report - Lines 
                     and Columns</a><br/>
 </b><font size="-1">This section examines the entries the 
                     vertical and horizontal placement of print items. </font><font size="-1">It 
                     examines <br/>
                     clauses such as - </font><font size="-1">LINE NUMBER, COLUMN 
-                    NUMBER, GROUP INDICATE , SOURCE and SUM</font><font size="-1">.<br/>
-</font></p>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Ballgreeng.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<p><a href="#part5" target=""><b>Special Report Writer registers</b></a><br/>
+                    NUMBER, GROUP INDICATE , SOURCE and SUM</font><font size="-1">.</font></li>
+<li><a href="#part5" target=""><b>Special Report Writer registers</b></a><br/>
 <font size="-1">In this section the LINE-COUNTER and PAGE-COUNTER 
-                    registers are examined.<br/>
-</font></p>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Ballgreeng.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<p><b><a href="#part6" target="">The Procedure Division Verbs 
+                    registers are examined.</font></li>
+<li><b><a href="#part6" target="">The Procedure Division Verbs 
                     </a><br/>
 </b><font size="-1">This section introduces the INITIATE, 
-                    GENERATE and TERMINATE verbs. <br/>
-</font></p>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Ballgreeng.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<div align="left">
-<p><b><a href="#part7" target="">Report Writer Declaratives</a></b><b>
+                    GENERATE and TERMINATE verbs.</font></li>
+<li>
+<b><a href="#part7" target="">Report Writer Declaratives</a></b><b>
 <br/>
 </b><font size="-1">In this section elements of the Declaratives, 
                       such as USE BEFORE REPORTING, SUPPRESS PRINTING and <br/>
-                      control break registers, are examined.<br/>
-</font></p>
-</div>
-</td>
-</tr>
-</table>
+                      control break registers, are examined.</font>
+</li>
+</ul>
 </td>
 </tr>
 <tr>

--- a/lectures/ReportWriterWeb.html
+++ b/lectures/ReportWriterWeb.html
@@ -64,6 +64,8 @@
       margin: 0.2em 0;
     }
   }
+  ul.toc { list-style-image: url(Ballgreeng.gif); padding-left: 2.5em; margin: 1em 0; }
+  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
@@ -80,73 +82,36 @@
 <h2> <b>The COBOL Report Writer</b></h2>
 <hr/>
 </center>
-<table border="0" vspace="15" width="700">
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Ballgreeng.gif" vspace="4" width="13"/></td>
-<td width="93%"> <b><a href="#intro" target="">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives and prerequisites.</font>
-<br/>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Ballgreeng.gif" vspace="4" width="13"/></td>
-<td width="93%"><b><a href="#part1" target="">The Report Writer 
+<ul class="toc">
+<li><b><a href="#intro" target="">Introduction</a><br/>
+</b><font size="-1">Unit aims, objectives and prerequisites.</font></li>
+<li><b><a href="#part1" target="">The Report Writer 
                   in action</a><br/>
 </b><font size="-1">This section examines a report produced 
                   by a Report Writer program and then examines the Procedure Division 
-                  of the program that produced the report. <br/>
-</font> </td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Ballgreeng.gif" vspace="4" width="13"/></td>
-<td width="93%"><b><a href="#part1b" target="">How the Report 
+                  of the program that produced the report.</font></li>
+<li><b><a href="#part1b" target="">How the Report 
                   Writer works</a><br/>
 </b><font size="-1">This section explains how the Report Writer 
                   works. It examines the seven report groups a report produced 
                   by a Report Writer program and then examines the Procedure Division 
-                  of the program that produced the report. <br/>
-</font> </td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Ballgreeng.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<div align="left">
-<p><b><a href="#part2" target="">Let's write a Report Writer 
+                  of the program that produced the report.</font></li>
+<li>
+<b><a href="#part2" target="">Let's write a Report Writer 
                       p</a></b><b><a href="#part2" target="">rogram</a><br/>
 </b><font size="-1">This section uses learning by doing 
                       as its mode of instruction. We learn how to write a simple 
-                      version of the report program shown in the previous section.</font><br/>
-</p>
-</div>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Ballgreeng.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<p><a href="#part3" target=""><b>Let's add some features to 
+                      version of the report program shown in the previous section.</font>
+</li>
+<li><a href="#part3" target=""><b>Let's add some features to 
                     our Report Program</b></a><br/>
 <font size="-1">In this section we amend the report program 
-                    to include more functionality</font><font size="-1">.<br/>
-</font></p>
-</td>
-</tr>
-<tr>
-<td valign="TOP" width="3%"> </td>
-<td valign="TOP" width="4%"><img align="TOP" height="13" hspace="4" src="Ballgreeng.gif" vspace="4" width="13"/></td>
-<td width="93%">
-<p><a href="#part4" target=""><b>Report Writer Declaratives</b></a><br/>
+                    to include more functionality</font><font size="-1">.</font></li>
+<li><a href="#part4" target=""><b>Report Writer Declaratives</b></a><br/>
 <font size="-1">When the requirements of the report do not 
                     coincide with the way the Report Writer works Declaratives 
-                    can be used to extend the functionality of the Report Writer.</font><font size="-1"><br/>
-</font></p>
-</td>
-</tr>
-</table>
+                    can be used to extend the functionality of the Report Writer.</font></li>
+</ul>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
## Summary

- Each course tutorial page (and two lecture pages) had a top-of-page section index built with a 3-column `<table width="700">`: a 3% spacer cell, a 4% cell containing a `BallGreenG.gif` bullet, and a 93% cell with the section link and short description. The mobile stylesheet had to do extensive flexbox surgery via `:has()` selectors to make those tables reflow.
- This PR replaces every one of those TOCs with a semantic `<ul class="toc">`. The green ball is now a `list-style-image`, so each `<li>` only carries the link and description. Inner `<p>` and `<div align="left">` wrappers are unwrapped so the link/description are direct children of the `<li>`, and trailing `<br/>` filler tags inside list items are dropped.
- A small `.toc` ruleset is injected into each page's `<style>` block (no shared stylesheet) and is idempotent — re-running the conversion produces no new diff.

## Why

The screenshot in the original ask shows the section index Michael Coughlan's tutorial uses on every page; it was the last large piece of layout still done with HTML tables. Moving it to a list:

- removes the responsive-table CSS hacks needed to make the tables behave on small viewports (lists reflow naturally),
- makes the markup much shorter (~440 fewer lines across 27 files),
- improves screen-reader output (a list of links is a list of links).

The original look — green-ball bullet, bold link, small description below — is preserved.

## Reviewer notes

- The conversion is mechanical and reproducible. `.claude/scripts/convert_toc.py` performs it (idempotent; run with no args to process every file under `course/` and `lectures/`).
- `.claude/scripts/serve.py` is a tiny static-file dev server I used during local verification — not required to ship, kept because it pairs with `.claude/launch.json`.
- Pages affected: 25 under `course/`, 2 under `lectures/`. Verified rendering at desktop and mobile widths against the original screenshots — visually unchanged apart from the natural layout simplification.

## Test plan

- [ ] Open a sampling of converted pages (`course/Tables1.html`, `course/Selection.html`, `course/Inspect.html`, `course/SequentialFiles3.html`, `lectures/ReportWriterWeb.html`) and confirm the top-of-page TOC has the green-ball bullet, bold link, and description, with comfortable spacing.
- [ ] Resize to ~400px wide and confirm the TOC reflows cleanly without horizontal scroll.
- [ ] Click a TOC entry and confirm the `#anchor` jump still lands on the right section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)