### PR TITLE
Replace blockquote/p list on index with semantic UL

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,27 +51,25 @@
     </tr>
 </table>
 <hr>
-<blockquote> 
-  <p><img src="pics/BallBlueG.gif" hspace="4" height="13" width="13"><a href="course/index.html">COBOL
-    programming course <font size="-1">(comprehensive COBOL tutorials)</font></a></p>
-  <p><img src="pics/BallBlueG.gif" hspace="4" height="13" width="13"><a href="lectures/CS4312Topics.html#ReportWriter1">Report 
-    Writer Tutorials<font size="-1"> (part of the COBOL course)</font></a> </p>
-  <p><img src="pics/BallBlueG.gif" hspace="4" height="13" width="13"><a href="exercises/index.html">COBOL 
-    programming exercises</a> </p>
-  <p><img src="pics/BallBlueG.gif" hspace="4" height="13" width="13"><a href="examples/default.html">Example 
-    COBOL programs</a> </p>
-  <p> <img src="pics/BallBlueG.gif" hspace="4" height="13" width="13"><a href="lectures/">COBOL 
-    lecture notes</a> </p>
-  <p><img src="pics/BallBlueG.gif" hspace="4" height="13" width="13"><a href="https://www.infogoal.com/cbd/index.htm">The 
-    COBOL Centre</a></p>
-  
-<p><img src="pics/BallBlueG.gif" hspace="4" height="13" width="13"><a href="https://web.archive.org/web/20130424202748/http://www.cobug.com/">The 
-COBUG portal site for COBOL users</a></p>
-<p><img src="pics/BallBlueG.gif" hspace="4" height="13" width="13"><a href="https://web.archive.org/web/20100201014654/http://www-949.ibm.com/software/rational/cafe/community/cobol/">IBM's 
-COBOL Cafe</a></p>
-  
-<p><img src="pics/BallBlueG.gif" hspace="4" height="13" width="13"><a href="faq/COBOLFAQ.html">COBOL 
-FAQ</a> </p>
-</blockquote>
+<ul>
+  <li><a href="course/index.html">COBOL
+    programming course <font size="-1">(comprehensive COBOL tutorials)</font></a></li>
+  <li><a href="lectures/CS4312Topics.html#ReportWriter1">Report
+    Writer Tutorials<font size="-1"> (part of the COBOL course)</font></a></li>
+  <li><a href="exercises/index.html">COBOL
+    programming exercises</a></li>
+  <li><a href="examples/default.html">Example
+    COBOL programs</a></li>
+  <li><a href="lectures/">COBOL
+    lecture notes</a></li>
+  <li><a href="https://www.infogoal.com/cbd/index.htm">The
+    COBOL Centre</a></li>
+  <li><a href="https://web.archive.org/web/20130424202748/http://www.cobug.com/">The
+    COBUG portal site for COBOL users</a></li>
+  <li><a href="https://web.archive.org/web/20100201014654/http://www-949.ibm.com/software/rational/cafe/community/cobol/">IBM's
+    COBOL Cafe</a></li>
+  <li><a href="faq/COBOLFAQ.html">COBOL
+    FAQ</a></li>
+</ul>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- The top-level link list on the homepage was rendered as `<p>` tags with image bullets inside a `<blockquote>`. Converted it to a proper `<ul>` / `<li>`.
- Consistent with the recent semantic-UL cleanup in `course/` and `lectures/` (commit 59a70c2).
- Drops the `<img src="pics/BallBlueG.gif">` bullets and the inline `hspace`/`height`/`width` attributes — the browser's native list bullet replaces them.

## Test plan
- [ ] Open `index.html` locally; confirm all 9 links render as a bulleted list
- [ ] Confirm all link targets still resolve (course, lectures, exercises, examples, FAQ, external archive links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)