### PR TITLE
Retarget mobile media rule from blockquote to ul.toc on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
   @media (max-width: 600px) {
     body { margin: 4px; }
-    blockquote { margin-left: 12px; margin-right: 12px; }
+    ul.toc { margin-left: 12px; margin-right: 12px; padding-left: 1.5em; }
     h1 font { font-size: medium; }
   }
 </style>


### PR DESCRIPTION
## Summary
- The homepage's `@media (max-width: 600px)` rule still scoped its margin override to `blockquote`, but that element was removed in [#55](https://github.com/bushidocodes/limerick-cobol/pull/55) when the link list was converted to a semantic `<ul>` (later classed `ul.toc` in [#56](https://github.com/bushidocodes/limerick-cobol/pull/56)). The rule was dead code.
- Retarget the rule at `ul.toc` so the list keeps tight 12px side margins on small screens, and override the desktop `padding-left: 2.5em` with `1.5em` so the BallBlueG.gif bullets don't push link text off the right edge on narrow viewports.

## Test plan
- [ ] Open `index.html` on a viewport ≤600px wide and confirm the link list is indented but not overflowing
- [ ] Open `index.html` on a desktop viewport and confirm bullets/spacing are unchanged from current master

🤖 Generated with [Claude Code](https://claude.com/claude-code)