### PR TITLE
Fix malformed meta description on course index

### DIFF
--- a/course/index.html
+++ b/course/index.html
@@ -6,7 +6,7 @@
 <script src="Resources/vendor/prism/prism.min.js" charset="utf-8" defer></script>
 <script src="Resources/vendor/prism/components/prism-cobol.min.js" charset="utf-8" defer></script>
 <meta name="resource-type" content="document">
-<meta name="description" content="" on-line cobol programming course - includes tutorials, example programs and exercises.">
+<meta name="description" content="On-line COBOL programming course - includes tutorials, example programs and exercises.">
 <meta name="keywords" content="COBOL programming course, COBOL training, COBOL tutorial, COBOL exercises, COBOL examples, example programs, tutorials, learning">
 <meta name="revisit-after" content="15 days">
 <meta name="distribution" content="Global">


### PR DESCRIPTION
## Summary
- The meta description on `course/index.html` had `content=""` followed by stray text, leaving the description empty and the rest of the line as invalid attribute syntax.
- Restored a proper, non-empty description.

## Test plan
- [x] Visual check of the page renders identically (description is meta-only, no visible content change)
- [x] Resulting tag parses as valid HTML