### PR TITLE
Remove semantically incorrect blockquote wrappers from Inspect.html code samples

### DIFF
--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -444,25 +444,23 @@ INSPECT SourceLine TALLYING ECount
 <p>Click on the storage schematic to see the result of each of these <font size="2">INSPECT 
         </font>statements (use left click or PageDown for next item and right 
         click or PageUp for previsou item) .  </p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">
-1. INSPECT StringData REPLACING ALL "R" BY "G" 
+1. INSPECT StringData REPLACING ALL "R" BY "G"
        AFTER INITIAL "A" BEFORE INITIAL "Q".
 
-2. INSPECT StringData REPLACING LEADING "R" BY "G" 
+2. INSPECT StringData REPLACING LEADING "R" BY "G"
        AFTER INITIAL "A" BEFORE INITIAL "Z".
 
-3. INSPECT StringData REPLACING ALL "R" BY "G" 
+3. INSPECT StringData REPLACING ALL "R" BY "G"
        AFTER INITIAL "A" BEFORE INITIAL "Z".
 
-4. INSPECT StringData REPLACING FIRST "R" BY "G" 
+4. INSPECT StringData REPLACING FIRST "R" BY "G"
        AFTER INITIAL "A" BEFORE INITIAL "Q".
 
-5. INSPECT StringData REPLACING 
-       ALL "RRRR" BY "FROG" 
+5. INSPECT StringData REPLACING
+       ALL "RRRR" BY "FROG"
        AFTER INITIAL "A" BEFORE INITIAL "Q".
 </code></pre>
-</blockquote>
 <center>
 <p><iframe height="125" src="Resources/pdf-viewer.html?src=ppz/Inspect1.pdf" style="border:1px solid #ccc; width:100%; aspect-ratio: 500/125;" width="500"></iframe> </p>
 <hr/>
@@ -567,9 +565,7 @@ END-PERFORM</code></pre>
         Compare$il is a list of characters that will be replaced with the characters 
         in Convert$il on a one for one basis. </p>
 <p>For instance the statement - </p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">INSPECT StringData CONVERTING "abc" TO "XYZ". </code></pre>
-</blockquote>
 <p> replaces "a" with "X", "b" with "Y" and "c" with "Z". </p>
 <hr/>
 </td>
@@ -607,8 +603,6 @@ END-PERFORM</code></pre>
           of these <font size="2">INSPECT </font>statements (use left click or 
           PageDown for next item and right click or PageUp for previsou item).  
         </p>
-<blockquote>
-<div align="LEFT">
 <pre class="language-cobol"><code class="language-cobol">
 1. INSPECT StringData CONVERTING "fxtd" TO "ZYAB".
 
@@ -619,8 +613,6 @@ END-PERFORM</code></pre>
                                     "f" BY "S".
 
 </code></pre>
-</div>
-</blockquote>
 <p><iframe height="125" src="Resources/pdf-viewer.html?src=ppz/Inspect1.pdf" style="border:1px solid #ccc; width:100%; aspect-ratio: 500/125;" width="500"></iframe> </p>
 <hr/>
 </div>


### PR DESCRIPTION
## Summary
- Three `<pre><code>` code samples in [course/Inspect.html](course/Inspect.html) were wrapped in `<blockquote>` purely to indent them.
- `<blockquote>` is for quotations from another source, not a layout/indentation primitive — using it for code conveys the wrong semantics to assistive tech and feed readers.
- Removing the wrappers is also visually consistent with the rest of the page, where most code samples are not wrapped in a blockquote.

## Test plan
- [ ] Open `course/Inspect.html` in the preview and confirm the three affected sections (replacing-INSPECT examples, converting-INSPECT explanation, converting-INSPECT example 1) still render readably.
- [ ] Confirm syntax highlighting via Prism still applies to those code blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)