### PR TITLE
Use semantic <ul> for Iteration prerequisites list

### DIFF
--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -230,11 +230,12 @@
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font></h4>
 </td>
 <td height="77" valign="top" width="525">
-<p>Introduction to COBOL </p>
-<p>Declaring data in COBOL </p>
-<p>Basic Procedure Division Commands</p>
-<p>Selection Constructs</p>
-
+<ul>
+<li>Introduction to COBOL</li>
+<li>Declaring data in COBOL</li>
+<li>Basic Procedure Division Commands</li>
+<li>Selection Constructs</li>
+</ul>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
## Summary
- The Prerequisites section in `course/Iteration.html` rendered a list of four items as a sequence of `<p>` tags. Converted to a proper `<ul>`/`<li>` so the markup matches the meaning.
- Continues the semantic-HTML cleanup pattern from #54 (top-level TOC) and #55 (homepage link list).

## Test plan
- [ ] Open `course/Iteration.html` and confirm the Prerequisites cell renders as a bulleted list of the four items.
- [ ] Sanity-check the rest of the page is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)