### PR TITLE
Remove blockquote wrappers around UL lists on Unstring page

### DIFF
--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -264,24 +264,20 @@ END-UNSTRING.</code></pre>
 <h3><font color="#800000">Data movement termination</font></h3>
 </td>
 <td width="525">
-<p>When the <font size="2">DELIMITED BY</font> clause is used data movement 
-        from the source string to the current destination string ends when either 
+<p>When the <font size="2">DELIMITED BY</font> clause is used data movement
+        from the source string to the current destination string ends when either
         ;</p>
-<blockquote>
 <ul>
 <li>a delimiter is encountered in the source string</li>
 <li>the end of the source string is reached.</li>
 </ul>
-</blockquote>
-<p>When the <font size="2">DELIMITED BY</font> clause is not used, data 
-        movement from the source string to the current destination string ends 
+<p>When the <font size="2">DELIMITED BY</font> clause is not used, data
+        movement from the source string to the current destination string ends
         when either;</p>
-<blockquote>
 <ul>
 <li>the destination string is full</li>
 <li>the end of the source string is reached</li>
 </ul>
-</blockquote>
 <hr/>
 </td>
 </tr>
@@ -290,16 +286,14 @@ END-UNSTRING.</code></pre>
 <h3><font color="#800000">UNSTRING termination</font></h3>
 </td>
 <td width="525">
-<p>The <font size="2">UNSTRING</font> statement terminates when either; 
+<p>The <font size="2">UNSTRING</font> statement terminates when either;
       </p>
-<blockquote>
 <ul>
 <li>All the characters in the source string have been examined </li>
 <li> All the destination strings have been processed </li>
-<li>Some error condition is encountered (such as the pointer pointing 
+<li>Some error condition is encountered (such as the pointer pointing
             outside the source string).</li>
 </ul>
-</blockquote>
 <hr/>
 </td>
 </tr>


### PR DESCRIPTION
## Summary
- `course/Unstring.html` wrapped three plain `<ul>` lists in `<blockquote>` purely for visual indentation. `<blockquote>` is for extended quotations, so this is non-semantic markup.
- Removed the three `<blockquote>` wrappers, leaving the lists as bare `<ul>`. Same cleanup that landed on the index page in eab0d91.

## Test plan
- [ ] Open `course/Unstring.html` and confirm the three bullet lists in the "Data movement termination" and "UNSTRING termination" sections still render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)