### PR TITLE
Remove blockquote wrapper around pre/code block on String page

### DIFF
--- a/course/String.html
+++ b/course/String.html
@@ -185,18 +185,16 @@
 <p>The second example concatenates the entire contents of Ident1, with the 
         partial contents of Ident2 (all the characters up to the first space) 
         and Ident3 (all the characters up to the word "frogs").</p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">STRING Ident1, Ident2, "10" DELIMITED BY SIZE
     INTO DestString
-END-STRING        
+END-STRING
 
-STRING 
+STRING
    Ident1 DELIMITED BY SIZE
    Ident2 DELIMITED BY SPACES
    Ident3 DELIMITED BY "Frogs"
 INTO Ident4 WITH POINTER StrPtr
 END-STRING.</code></pre>
-</blockquote>
 <hr/>
 </td>
 </tr>


### PR DESCRIPTION
## Summary
- `<blockquote>` is intended for quoted prose, not for indenting code blocks.
- Drops the wrapper around the STRING example on [course/String.html](course/String.html) so the markup is more semantic and matches the other code blocks on the same page.
- Mirrors the cleanup already applied to the Inspect page in commit f2ccf80.

## Test plan
- [ ] Open `course/String.html` and confirm the STRING example code block still renders with Prism syntax highlighting.
- [ ] Verify layout on mobile (<=600px) — surrounding `<p>` paragraphs and `<hr/>` separators look unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)