### PR TITLE
Replace <p> list with semantic <ul> in Search prerequisites

### DIFF
--- a/course/Search.html
+++ b/course/Search.html
@@ -188,17 +188,19 @@
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font></h4>
 </td>
 <td valign="top" width="525">
-<p>Introduction to COBOL </p>
-<p>Declaring data in COBOL </p>
-<p>Basic Procedure Division Commands</p>
-<p>Selection Constructs</p>
-<p>Iteration Constructs</p>
-<p>Introduction to Sequential files</p>
-<p>Processing Sequential files</p>
-<p>Print files and variable length records</p>
-<p>Sorting and Merging files</p>
-<p>Using Tables</p>
-<p>Creating Tables - syntax and semantics</p>
+<ul>
+<li>Introduction to COBOL</li>
+<li>Declaring data in COBOL</li>
+<li>Basic Procedure Division Commands</li>
+<li>Selection Constructs</li>
+<li>Iteration Constructs</li>
+<li>Introduction to Sequential files</li>
+<li>Processing Sequential files</li>
+<li>Print files and variable length records</li>
+<li>Sorting and Merging files</li>
+<li>Using Tables</li>
+<li>Creating Tables - syntax and semantics</li>
+</ul>
 
 </td>
 </tr>


### PR DESCRIPTION
## Summary
- The Prerequisites section on the Searching Tables page enumerated items using a series of bare `<p>` tags, which doesn't convey list semantics to assistive technologies and is inconsistent with how the same content is structured elsewhere in the course.
- Converted the eleven `<p>` items to a single `<ul>` with `<li>` children.
- Mirrors the fix applied on the Iteration page in commit 58439a9.

## Test plan
- [ ] Open `course/Search.html` and confirm the Prerequisites section renders as a bulleted list visually consistent with the Iteration page.
- [ ] Verify no layout regression in the surrounding two-column table cell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)