### PR TITLE
Use CSS margin instead of <br/><br/> for ol spacing on Inspect page

### DIFF
--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -10,6 +10,7 @@
 -->
   ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
+  ol > li + li { margin-top: 0.6em; }
 </style><meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -226,17 +227,11 @@
 <td width="525">
 <p>The <font size="2">INSPECT</font> has four formats;</p>
 <ol>
-<li>The first format is used for counting characters in a string.<br/>
-<br/>
-</li>
-<li>The second replaces a group of characters in a stringwith another 
-          group of characters.<br/>
-<br/>
-</li>
-<li>The third combines both operations in one statement.<br/>
-<br/>
-</li>
-<li>The fourth format converts each of a set of characters to its corresponding 
+<li>The first format is used for counting characters in a string.</li>
+<li>The second replaces a group of characters in a stringwith another
+          group of characters.</li>
+<li>The third combines both operations in one statement.</li>
+<li>The fourth format converts each of a set of characters to its corresponding
           character in another set of characters.</li>
 </ol>
 <hr/>
@@ -576,15 +571,10 @@ END-PERFORM</code></pre>
 </td>
 <td width="525">
 <ol>
-<li>Compare$il and Convert$il must be equal in size. <br/>
-<br/>
-</li>
-<li>When Convert$il is a figurative constant its size equals that of Compare$il. 
-          <br/>
-<br/>
-</li>
-<li>The same character cannot appear more than once in the Compare$il 
-          (because each character in the Compare$il string is associated with 
+<li>Compare$il and Convert$il must be equal in size.</li>
+<li>When Convert$il is a figurative constant its size equals that of Compare$il.</li>
+<li>The same character cannot appear more than once in the Compare$il
+          (because each character in the Compare$il string is associated with
           a replacement). </li>
 </ol>
 <hr/>


### PR DESCRIPTION
## Summary
- Two ordered lists on `course/Inspect.html` used `<br/><br/>` inside `<li>` elements to create vertical spacing between items — presentational markup mixed into list content.
- Moved the spacing to a single CSS rule (`ol > li + li { margin-top: 0.6em; }`) and stripped the `<br/><br/>` pairs from the affected list items (the four INSPECT formats and the converting INSPECT rules).

## Test plan
- [ ] Open `course/Inspect.html` and verify the "Using the INSPECT > Introduction" ordered list still has visible spacing between items
- [ ] Verify the "The converting INSPECT > Rules" ordered list still has visible spacing between items
- [ ] Confirm no other lists on the page were affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)