### PR TITLE
Add missing <head> opening tag in BookshopLectReqRpt page

### DIFF
--- a/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html
+++ b/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Reading an Indexed file directly by key</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
## Summary
- The exercise page `exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html` had a closing `</head>` tag but was missing the opening `<head>` tag, so `<title>`, `<meta>`, and `<style>` were sitting directly under `<html>` instead of inside `<head>`.
- Added the opening `<head>` tag to give the page valid, semantic structure consistent with the other lecture/course pages.

## Test plan
- [ ] Open `exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html` in a browser and confirm the page still renders with the correct title and styles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)