### PR TITLE
Replace <p> list with semantic <ul> in SequentialFiles2 prerequisites

### DIFF
--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -167,12 +167,14 @@
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font></h4>
 </td>
 <td height="77" valign="top" width="525">
-<p>Introduction to COBOL </p>
-<p>Declaring data in COBOL </p>
-<p>Basic Procedure Division Commands</p>
-<p>Selection Constructs</p>
-<p>Iteration Constructs</p>
-<p>Introduction to Sequential files</p>
+<ul>
+<li>Introduction to COBOL</li>
+<li>Declaring data in COBOL</li>
+<li>Basic Procedure Division Commands</li>
+<li>Selection Constructs</li>
+<li>Iteration Constructs</li>
+<li>Introduction to Sequential files</li>
+</ul>
 
 </td>
 </tr>


### PR DESCRIPTION
## Summary
- The Prerequisites cell on `course/SequentialFiles2.html` listed six items as sibling `<p>` paragraphs.
- Converted them to a single `<ul>` so screen readers and other consumers see the items as a list.
- Mirrors the same fix recently applied to the Iteration page in fecd6b9.

## Test plan
- [ ] Open `course/SequentialFiles2.html` and verify the Prerequisites section renders as a bulleted list.
- [ ] Confirm no visual regressions in surrounding cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)