### PR TITLE
Remove blockquote wrapper around code example on String page

### DIFF
--- a/course/String.html
+++ b/course/String.html
@@ -185,18 +185,16 @@
 <p>The second example concatenates the entire contents of Ident1, with the 
         partial contents of Ident2 (all the characters up to the first space) 
         and Ident3 (all the characters up to the word "frogs").</p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">STRING Ident1, Ident2, "10" DELIMITED BY SIZE
     INTO DestString
-END-STRING        
+END-STRING
 
-STRING 
+STRING
    Ident1 DELIMITED BY SIZE
    Ident2 DELIMITED BY SPACES
    Ident3 DELIMITED BY "Frogs"
 INTO Ident4 WITH POINTER StrPtr
 END-STRING.</code></pre>
-</blockquote>
 <hr/>
 </td>
 </tr>


### PR DESCRIPTION
## Summary
- The `<blockquote>` element is semantically intended for quotations, not code samples. On [course/String.html](course/String.html), a `<blockquote>` was wrapping a `<pre><code>` STRING-verb example.
- Removed the wrapper; the `<pre><code>` block conveys the structure on its own.
- Follows the same semantic-cleanup pattern as the recent Unstring page change (fecd6b9).

## Test plan
- [ ] Open course/String.html and confirm the STRING example block renders correctly with Prism syntax highlighting intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)