### PR TITLE
Clean up nested <ol> in ReportWriterSS Procedure Division verbs list

### DIFF
--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -863,20 +863,12 @@ RD  SalesReport
 <p align="left">The Report Writer introduces four new verbs for 
                 processing reports. These are -</p>
 </div>
-<div align="left">
-<ol>
-<ol>
-<ol>
 <ol>
 <li>INITIATE</li>
-<li> GENERATE</li>
-<li> TERMINATE</li>
-<li> SUPPRESS PRINTING</li>
+<li>GENERATE</li>
+<li>TERMINATE</li>
+<li>SUPPRESS PRINTING</li>
 </ol>
-</ol>
-</ol>
-</ol>
-</div>
 <div align="center">
 <p align="left">The first three are normal Procedure Division verbs 
                 but the last can only be used in the Declaratives Section. </p>


### PR DESCRIPTION
## Summary
- Replace a quadruple-nested `<ol><ol><ol><ol>` wrapper around the Procedure Division verbs list in [course/ReportWriterSS.html](course/ReportWriterSS.html) with a single semantic `<ol>`.
- The original markup nested `<ol>` directly inside another `<ol>` (no intervening `<li>`), which is invalid HTML. The nesting was purely cosmetic — used to push the list further to the right.

## Test plan
- [ ] Open `course/ReportWriterSS.html` and verify the INITIATE / GENERATE / TERMINATE / SUPPRESS PRINTING list still renders as a numbered list under the "Introduction" subheading of the Procedure Division verbs section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)