### PR TITLE
Replace <p> list with semantic <ul> in EditedPics prerequisites

### DIFF
--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -160,14 +160,15 @@
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font></h4>
 </td>
 <td height="77" valign="top" width="525">
-<p>Introduction to COBOL </p>
-<p>Declaring data in COBOL </p>
-<p>Basic Procedure Division Commands</p>
-<p>Selection Constructs</p>
-<p>Iteration Constructs</p>
-<p>Introduction to Sequential files</p>
-<p>Processing Sequential files</p>
-
+<ul>
+<li>Introduction to COBOL</li>
+<li>Declaring data in COBOL</li>
+<li>Basic Procedure Division Commands</li>
+<li>Selection Constructs</li>
+<li>Iteration Constructs</li>
+<li>Introduction to Sequential files</li>
+<li>Processing Sequential files</li>
+</ul>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
## Summary
- The Prerequisites cell on `course/EditedPics.html` rendered seven sibling `<p>` tags as a list of items.
- Replaced with a single `<ul>` containing one `<li>` per prerequisite — proper semantic markup for assistive tech and consistency.
- Mirrors the same fix applied recently to `course/Iteration.html` in [58439a9](https://github.com/bushidocodes/limerick-cobol/commit/58439a9).

## Test plan
- [ ] Open `course/EditedPics.html` in a browser; confirm the Prerequisites section in the Introduction renders as a bulleted list and visually matches the Iteration page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)