### PR TITLE
Replace <p> list with semantic <ul> in Search prerequisites

### DIFF
--- a/course/Search.html
+++ b/course/Search.html
@@ -188,18 +188,19 @@
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font></h4>
 </td>
 <td valign="top" width="525">
-<p>Introduction to COBOL </p>
-<p>Declaring data in COBOL </p>
-<p>Basic Procedure Division Commands</p>
-<p>Selection Constructs</p>
-<p>Iteration Constructs</p>
-<p>Introduction to Sequential files</p>
-<p>Processing Sequential files</p>
-<p>Print files and variable length records</p>
-<p>Sorting and Merging files</p>
-<p>Using Tables</p>
-<p>Creating Tables - syntax and semantics</p>
-
+<ul>
+<li>Introduction to COBOL</li>
+<li>Declaring data in COBOL</li>
+<li>Basic Procedure Division Commands</li>
+<li>Selection Constructs</li>
+<li>Iteration Constructs</li>
+<li>Introduction to Sequential files</li>
+<li>Processing Sequential files</li>
+<li>Print files and variable length records</li>
+<li>Sorting and Merging files</li>
+<li>Using Tables</li>
+<li>Creating Tables - syntax and semantics</li>
+</ul>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
## Summary
- The Prerequisites section on [course/Search.html](course/Search.html) rendered a list of topics as a sequence of `<p>` paragraphs. Converted to a `<ul>` so the markup matches the meaning.
- Same pattern as the recent fix on Iteration.html (58439a9) and the index.html cleanup (eab0d91).

## Test plan
- [ ] Open course/Search.html in a browser; confirm the Prerequisites list renders cleanly with bullets and no broken layout.
- [ ] Spot-check mobile width (<=600px) — the section uses default `<ul>` styling, not the `ul.toc` rules, so existing media queries are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)