### PR TITLE
Collapse invalid nested <ol><ol> in RefMod.html

### DIFF
--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -300,12 +300,10 @@
 <td valign="top" width="525">
 <p>An Intrinsic Function consists of three parts;</p>
 <ol>
-<ol>
 <li>The start of the function is signalled by the keyword - FUNCTION.</li>
 <li>The keyword is followed by the name of the function.</li>
-<li>The name of the function is immediately followed by the bracketed 
+<li>The name of the function is immediately followed by the bracketed
                   list of parameters or arguments.</li>
-</ol>
 </ol>
 <p align="left">The template for Intrinsic Functions is shown below:</p>
 <blockquote>


### PR DESCRIPTION
## Summary
- The Intrinsic Function Template section in `course/RefMod.html` had an `<ol>` directly nested inside another `<ol>` with no intervening `<li>`.
- Per the HTML spec, `<ol>` may only contain `<li>` elements, so the doubled wrapper was invalid markup. Collapsed it to a single `<ol>` — no visual change, valid semantics.

## Test plan
- [ ] Open `course/RefMod.html` and confirm the "Intrinsic Function Template" numbered list still renders as a 3-item ordered list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)