### PR TITLE
Replace <p>/<br> list with semantic <ul> in Usage prerequisites

### DIFF
--- a/course/Usage.html
+++ b/course/Usage.html
@@ -157,16 +157,17 @@
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font></h4>
 </td>
 <td valign="top" width="525">
-<p>Introduction to COBOL <br/>
-              Declaring data in COBOL<br/>
-              Basic Procedure Division commands <br/>
-              Selection in COBOL<br/>
-              Iteration in COBOL <br/>
-              Introduction to Sequential files<br/>
-              Processing Sequential files<br/>
-              Reading Sequential Files <br/>
-              Edited Pictures <br/>
-</p>
+<ul>
+<li>Introduction to COBOL</li>
+<li>Declaring data in COBOL</li>
+<li>Basic Procedure Division commands</li>
+<li>Selection in COBOL</li>
+<li>Iteration in COBOL</li>
+<li>Introduction to Sequential files</li>
+<li>Processing Sequential files</li>
+<li>Reading Sequential Files</li>
+<li>Edited Pictures</li>
+</ul>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
## Summary
- The Prerequisites section on [course/Usage.html](course/Usage.html) rendered its list of prerequisite topics as a single `<p>` with `<br/>` separators.
- Replaced with a proper `<ul>`/`<li>` so the markup matches the content's actual structure.
- Consistent with the same cleanup recently merged for the Iteration page (#59) and Search page (#63).

## Test plan
- [ ] Open course/Usage.html in a browser and confirm the Prerequisites list still renders as a vertical list of items.
- [ ] Verify no visual regression in the surrounding table cell layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)