### PR TITLE
Replace <p> list with semantic <ul> in SortMerge prerequisites

### DIFF
--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -180,14 +180,16 @@
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font></h4>
 </td>
 <td valign="top" width="525">
-<p>Introduction to COBOL </p>
-<p>Declaring data in COBOL </p>
-<p>Basic Procedure Division Commands</p>
-<p>Selection Constructs</p>
-<p>Iteration Constructs</p>
-<p>Introduction to Sequential files</p>
-<p>Processing Sequential files</p>
-<p>Print files and variable length records</p>
+<ul>
+<li>Introduction to COBOL</li>
+<li>Declaring data in COBOL</li>
+<li>Basic Procedure Division Commands</li>
+<li>Selection Constructs</li>
+<li>Iteration Constructs</li>
+<li>Introduction to Sequential files</li>
+<li>Processing Sequential files</li>
+<li>Print files and variable length records</li>
+</ul>
 
 </td>
 </tr>


### PR DESCRIPTION
## Summary
- Replaces the eight sibling `<p>` tags in the Prerequisites section of `course/SortMerge.html` with a semantic `<ul>`/`<li>` list, matching the cleanup pattern already applied to Iteration, Search, EditedPics, and SequentialFiles2.

## Test plan
- [ ] Open `course/SortMerge.html` and confirm the Prerequisites section renders as a bulleted list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)