### PR TITLE
Replace <p><br/> list with semantic <ul> in Copy prerequisites

### DIFF
--- a/course/Copy.html
+++ b/course/Copy.html
@@ -166,25 +166,26 @@
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font></h4>
 </td>
 <td valign="top" width="525">
-<p>Introduction to COBOL<br/>
-              Declaring data in COBOL<br/>
-              Basic Procedure Division commands <br/>
-              Selection in COBOL<br/>
-              Iteration in COBOL <br/>
-              Introduction to Sequential files<br/>
-              Processing Sequential files<br/>
-              Edited Pictures <br/>
-              The USAGE clause<br/>
-              COBOL print files and variable-length records<br/>
-              Sorting and Merging<br/>
-              Introduction to direct access files<br/>
-              Relative Files<br/>
-              Indexed Files <br/>
-              Using tables<br/>
-              Creating tables - syntax and semantics<br/>
-              Searching tables<br/>
-              CALLing subprograms<br/>
-</p>
+<ul>
+<li>Introduction to COBOL</li>
+<li>Declaring data in COBOL</li>
+<li>Basic Procedure Division commands</li>
+<li>Selection in COBOL</li>
+<li>Iteration in COBOL</li>
+<li>Introduction to Sequential files</li>
+<li>Processing Sequential files</li>
+<li>Edited Pictures</li>
+<li>The USAGE clause</li>
+<li>COBOL print files and variable-length records</li>
+<li>Sorting and Merging</li>
+<li>Introduction to direct access files</li>
+<li>Relative Files</li>
+<li>Indexed Files</li>
+<li>Using tables</li>
+<li>Creating tables - syntax and semantics</li>
+<li>Searching tables</li>
+<li>CALLing subprograms</li>
+</ul>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
## Summary
- The Prerequisites section in `course/Copy.html` was a single `<p>` with `<br/>`-separated lines for what is clearly a list.
- Converted to a semantic `<ul>` with one `<li>` per prerequisite.
- Matches the pattern from prior cleanups (Search, SequentialFiles2, EditedPics, Iteration prerequisites).

## Test plan
- [ ] Open `course/Copy.html` and verify the Prerequisites section renders as a bulleted list.
- [ ] Confirm no visual regressions on desktop and mobile widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)