### PR TITLE
Replace <p> prerequisite lists with semantic <ul> across course pages

### DIFF
--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -149,8 +149,10 @@
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font></h4>
 </td>
 <td height="77" valign="top" width="525">
-<p>Introduction to COBOL </p>
-<p>Declaring data in COBOL </p>
+<ul>
+<li>Introduction to COBOL</li>
+<li>Declaring data in COBOL</li>
+</ul>
 </td>
 </tr>
 <tr>

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -162,9 +162,11 @@
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font></h4>
 </td>
 <td height="77" valign="top" width="525">
-<p>Introduction to COBOL </p>
-<p>Declaring data in COBOL </p>
-<p>Basic Procedure Division Commands</p>
+<ul>
+<li>Introduction to COBOL</li>
+<li>Declaring data in COBOL</li>
+<li>Basic Procedure Division Commands</li>
+</ul>
 </td>
 </tr>
 <tr>

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -186,12 +186,13 @@
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font></h4>
 </td>
 <td height="77" valign="top" width="525">
-<p>Introduction to COBOL </p>
-<p>Declaring data in COBOL </p>
-<p>Basic Procedure Division Commands</p>
-<p>Selection Constructs</p>
-<p>Iteration Constructs</p>
-
+<ul>
+<li>Introduction to COBOL</li>
+<li>Declaring data in COBOL</li>
+<li>Basic Procedure Division Commands</li>
+<li>Selection Constructs</li>
+<li>Iteration Constructs</li>
+</ul>
 </td>
 </tr>
 <tr>

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -161,14 +161,15 @@
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font></h4>
 </td>
 <td valign="top" width="525">
-<p>Introduction to COBOL </p>
-<p>Declaring data in COBOL </p>
-<p>Basic Procedure Division Commands</p>
-<p>Selection Constructs</p>
-<p>Iteration Constructs</p>
-<p>Introduction to Sequential files</p>
-<p>Processing Sequential files</p>
-
+<ul>
+<li>Introduction to COBOL</li>
+<li>Declaring data in COBOL</li>
+<li>Basic Procedure Division Commands</li>
+<li>Selection Constructs</li>
+<li>Iteration Constructs</li>
+<li>Introduction to Sequential files</li>
+<li>Processing Sequential files</li>
+</ul>
 </td>
 </tr>
 <tr>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -177,25 +177,26 @@
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font></h4>
 </td>
 <td valign="top" width="525">
-<p>Introduction to COBOL <br/>
-              Declaring data in COBOL<br/>
-              Basic Procedure Division commands <br/>
-              Selection in COBOL<br/>
-              Iteration in COBOL <br/>
-              Introduction to Sequential files<br/>
-              Processing Sequential files<br/>
-              Reading Sequential Files <br/>
-              Edited Pictures <br/>
-              The USAGE clause<br/>
-              COBOL print files and variable-length records<br/>
-              Sorting and Merging<br/>
-              Introduction to direct access files<br/>
-              Relative Files<br/>
-              Indexed Files <br/>
-              Using tables<br/>
-              Creating tables - syntax and semantics<br/>
-              Searching tables<br/>
-</p>
+<ul>
+<li>Introduction to COBOL</li>
+<li>Declaring data in COBOL</li>
+<li>Basic Procedure Division commands</li>
+<li>Selection in COBOL</li>
+<li>Iteration in COBOL</li>
+<li>Introduction to Sequential files</li>
+<li>Processing Sequential files</li>
+<li>Reading Sequential Files</li>
+<li>Edited Pictures</li>
+<li>The USAGE clause</li>
+<li>COBOL print files and variable-length records</li>
+<li>Sorting and Merging</li>
+<li>Introduction to direct access files</li>
+<li>Relative Files</li>
+<li>Indexed Files</li>
+<li>Using tables</li>
+<li>Creating tables - syntax and semantics</li>
+<li>Searching tables</li>
+</ul>
 </td>
 </tr>
 <tr>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -159,16 +159,17 @@
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font></h4>
 </td>
 <td height="77" valign="top" width="525">
-<p>Introduction to COBOL </p>
-<p>Declaring data in COBOL </p>
-<p>Basic Procedure Division Commands</p>
-<p>Selection Constructs</p>
-<p>Iteration Constructs</p>
-<p>Introduction to Sequential files</p>
-<p>Processing Sequential files</p>
-<p>Print files and variable length records</p>
-<p>Sorting and Merging files</p>
-
+<ul>
+<li>Introduction to COBOL</li>
+<li>Declaring data in COBOL</li>
+<li>Basic Procedure Division Commands</li>
+<li>Selection Constructs</li>
+<li>Iteration Constructs</li>
+<li>Introduction to Sequential files</li>
+<li>Processing Sequential files</li>
+<li>Print files and variable length records</li>
+<li>Sorting and Merging files</li>
+</ul>
 </td>
 </tr>
 <tr>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -176,17 +176,18 @@
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font></h4>
 </td>
 <td valign="top" width="525">
-<p>Introduction to COBOL </p>
-<p>Declaring data in COBOL </p>
-<p>Basic Procedure Division Commands</p>
-<p>Selection Constructs</p>
-<p>Iteration Constructs</p>
-<p>Introduction to Sequential files</p>
-<p>Processing Sequential files</p>
-<p>Print files and variable length records</p>
-<p>Sorting and Merging files</p>
-<p>Using Tables</p>
-
+<ul>
+<li>Introduction to COBOL</li>
+<li>Declaring data in COBOL</li>
+<li>Basic Procedure Division Commands</li>
+<li>Selection Constructs</li>
+<li>Iteration Constructs</li>
+<li>Introduction to Sequential files</li>
+<li>Processing Sequential files</li>
+<li>Print files and variable length records</li>
+<li>Sorting and Merging files</li>
+<li>Using Tables</li>
+</ul>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
## Summary
- Several course pages still used a stack of `<p>` tags (or a single `<p>` with `<br/>` separators on Subprograms) for their Prerequisites sections — clearly lists of items, but not marked up as such.
- Converted each to a semantic `<ul>` with one `<li>` per prerequisite.
- Matches the pattern from prior cleanups (Iteration, Search, SequentialFiles2, EditedPics, Copy prerequisites).

## Files changed
- `course/COBOLcommands.html`
- `course/Selection.html`
- `course/SequentialFiles1.html`
- `course/SequentialFiles3.html`
- `course/Subprograms.html`
- `course/Tables1.html`
- `course/Tables2.html`

## Test plan
- [ ] Open each updated page and confirm the Prerequisites section renders as a bulleted list.
- [ ] Confirm no visual regressions on desktop and mobile widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)