### PR TITLE
Scope ol spacing rule to INSPECT lists and fix stringwith typo

### DIFF
--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -10,7 +10,7 @@
 -->
   ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
-  ol > li + li { margin-top: 0.6em; }
+  ol.spaced > li + li { margin-top: 0.6em; }
 </style><meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -226,9 +226,9 @@
 </td>
 <td width="525">
 <p>The <font size="2">INSPECT</font> has four formats;</p>
-<ol>
+<ol class="spaced">
 <li>The first format is used for counting characters in a string.</li>
-<li>The second replaces a group of characters in a stringwith another
+<li>The second replaces a group of characters in a string with another
           group of characters.</li>
 <li>The third combines both operations in one statement.</li>
 <li>The fourth format converts each of a set of characters to its corresponding
@@ -570,7 +570,7 @@ END-PERFORM</code></pre>
 <h3><font color="#800000">Rules</font> </h3>
 </td>
 <td width="525">
-<ol>
+<ol class="spaced">
 <li>Compare$il and Convert$il must be equal in size.</li>
 <li>When Convert$il is a figurative constant its size equals that of Compare$il.</li>
 <li>The same character cannot appear more than once in the Compare$il


### PR DESCRIPTION
## Summary
- Follow-up to [#64](https://github.com/bushidocodes/limerick-cobol/pull/64) addressing review feedback.
- Scopes the `ol > li + li { margin-top: 0.6em; }` rule to a new `ol.spaced` class so it only affects the two INSPECT-related ordered lists, not the unrelated "Objectives" list higher up the page.
- Fixes the "stringwith" -> "string with" typo in the format-2 list item.

## Test plan
- [ ] Open `course/Inspect.html` and confirm the "Objectives" list renders with its original tight spacing.
- [ ] Confirm the "INSPECT has four formats" list and the "Rules" list still render with the 0.6em gap between items.
- [ ] Confirm the format-2 list item now reads "a string with another group of characters".

🤖 Generated with [Claude Code](https://claude.com/claude-code)