### PR TITLE
Disable COBOL highlighting on Relative file program output

### DIFF
--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -253,7 +253,7 @@
 <td>
 <p><iframe height="541" src="Resources/pdf-viewer.html?src=ppz/RelFile2.pdf" style="border:1px solid #ccc; width:100%; aspect-ratio: 520/541;" width="520"></iframe></p>
 <p>Below we see the results produced by two runs of the program.</p>
-<pre class="language-cobol"><code class="language-cobol">RUN USING SEQUENTIAL READING
+<pre class="language-none"><code class="language-none">RUN USING SEQUENTIAL READING
 Enter Read type (Direct=1, Seq=2)-&gt; 2
   01  VESTRON VIDEOS        OVER THE SEA SOMEWHERE IN LONDON
   02  EMI STUDIOS           HOLLYWOOD, CALIFORNIA, USA 


### PR DESCRIPTION
## Summary
- The sample-run block on `course/RelativeFiles.html` was tagged with `class="language-cobol"`, so Prism was syntax-highlighting plain program output (prompts and supplier records) as COBOL.
- Switched the `<pre>`/`<code>` classes to `language-none` so the block retains its preformatted column alignment but is no longer highlighted as source code.

## Test plan
- [ ] Open `course/RelativeFiles.html` in the preview and confirm the "RUN USING SEQUENTIAL READING" block renders as plain monospace text with no COBOL keyword highlighting.
- [ ] Confirm column alignment of the supplier records is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)