### PR TITLE
Fix duplicate in-page anchors breaking TOC navigation

### DIFF
--- a/course/Selection.html
+++ b/course/Selection.html
@@ -1011,7 +1011,7 @@ END-IF
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part2"></a><font face="Arial, Helvetica, sans-serif">Using 
+<h2 align="CENTER"><font color="#FFFF00"><a name="part3"></a><font face="Arial, Helvetica, sans-serif">Using
               the SET verb with Condition Names </font></font></h2>
 </td>
 </tr>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -108,7 +108,7 @@
                       code.</font>
 </li>
 <li>
-<b><a href="#part3">Using one table to index 
+<b><a href="#part4">Using one table to index
                       into another</a><br/>
 </b><font size="-1">In this section we show how the subscript 
                       of one table may be used to index into another. </font>
@@ -481,7 +481,7 @@ Begin.
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part2"></a><font face="Arial, Helvetica, sans-serif">Displaying 
+<h2 align="CENTER"><font color="#FFFF00"><a name="part3"></a><font face="Arial, Helvetica, sans-serif">Displaying
               the County Name</font></font></h2>
 </td>
 </tr>
@@ -599,7 +599,7 @@ Begin.
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part2"></a><font face="Arial, Helvetica, sans-serif">Using 
+<h2 align="CENTER"><font color="#FFFF00"><a name="part4"></a><font face="Arial, Helvetica, sans-serif">Using
               one table to index into another</font></font></h2>
 </td>
 </tr>

--- a/lectures/CS4312Topics.html
+++ b/lectures/CS4312Topics.html
@@ -707,7 +707,7 @@
 </table>
 <h3>
 <hr width="100%"/>
-<a name="ReportWriter1"></a>The COBOL Report Writer - Syntax and Semantics</h3>
+<a name="ReportWriter2"></a>The COBOL Report Writer - Syntax and Semantics</h3>
 <blockquote>
 <p>This tutorial provides a Report Writer reference. The syntactic elements 
     of the Report Writer are presented and the semantics of their operation discussed.</p>


### PR DESCRIPTION
## Summary
Addresses the three broken-anchor issues Copilot flagged on [#76](https://github.com/bushidocodes/limerick-cobol/pull/76), plus one matching duplicate found by sweeping the rest of the course/lecture pages.

- `course/Tables1.html`: three section headings were all named `part2` while the TOC linked to `part2`/`part3`/`part3`. Renamed the headings to `part2`/`part3`/`part4` and fixed the final TOC `href` to `#part4`.
- `course/Selection.html`: the third section anchor was mislabeled `part2` instead of `part3`, leaving the TOC entry stranded. Renamed to `part3`.
- `lectures/CS4312Topics.html`: `name="ReportWriter1"` was defined twice for two distinct sections (worked example vs. syntax/semantics). Renamed the second to `ReportWriter2`.

## Test plan
- [ ] Open each page and confirm every TOC entry scrolls to the correct heading
- [ ] Confirm no other in-page `href="#fragment"` is broken (audit script run; only the above were flagged)