### PR TITLE
Wrap course HTML metadata in proper <head> elements

### DIFF
--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Basic Procedure Division commands</title>
@@ -74,6 +75,7 @@
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
+</head>
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
 <table border="1" width="715">
 <tr>

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>The COPY verb</title>
@@ -74,6 +75,7 @@
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
+</head>
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
 <table border="1" height="100%" width="715">
 <tr>

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Declaring Data in COBOL</title>
@@ -74,6 +75,7 @@
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
+</head>
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
 <table border="1" width="715">
 <tr>

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Edited Pictures</title>
@@ -74,6 +75,7 @@
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
+</head>
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000"><table border="1" width="715">
 <tr>
 <td>

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Indexed Files</title>
@@ -76,6 +77,7 @@
     }
   }
 </style>
+</head>
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000"><table border="1" width="715"><tbody><tr><td>
 <center>
 </center>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>The INSPECT verb</title>
@@ -77,6 +78,7 @@
     }
   }
 </style>
+</head>
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000"><table border="1" width="715"><tbody><tr><td>
 <center>
 </center>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Introduction to Direct Access Files</title>
@@ -76,6 +77,7 @@
     }
   }
 </style>
+</head>
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000"><table border="1" width="715"><tbody><tr><td><center>
 <div align="LEFT">
 <table border="0" width="710">

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>COBOL Interation Constructs</title>
@@ -79,6 +80,7 @@
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
+</head>
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
 <table border="1" width="715">
 <tr>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Reference Modification</title>
@@ -74,6 +75,7 @@
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
+</head>
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
 <table border="1" width="715">
 <tr>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Relative Files</title>
@@ -76,6 +77,7 @@
     }
   }
 </style>
+</head>
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000"><table border="1" width="715"><tbody><tr><td>
 <center>
 <div align="LEFT">

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>COBOL Report Writer</title>
@@ -74,6 +75,7 @@
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
+</head>
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
 <table border="1" width="715">
 <tr>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>COBOL Report Writer - Syntax and Semantics</title>
@@ -74,6 +75,7 @@
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
+</head>
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
 <table border="1" width="715">
 <tr>

--- a/course/Search.html
+++ b/course/Search.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Searching Tables</title>
@@ -76,6 +77,7 @@
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
+</head>
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
 <table border="1" width="715">
 <tr>

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>COBOL Selection Constructs</title>
@@ -74,6 +75,7 @@
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
+</head>
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
 <table border="1" width="715">
 <tr>

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Introduction to Sequential Files</title>
@@ -74,6 +75,7 @@
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
+</head>
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
 <table border="1" width="715">
 <tr>

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Processing Sequential Files</title>
@@ -79,6 +80,7 @@
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
+</head>
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
 <table border="1" width="715">
 <tr>

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Print files and variable-length records</title>
@@ -74,6 +75,7 @@
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
+</head>
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
 <table border="1" width="715">
 <tr>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Sorting and Merging files</title>
@@ -74,6 +75,7 @@
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
+</head>
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
 <table border="1" width="715">
 <tr>

--- a/course/String.html
+++ b/course/String.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>The STRING verb</title>
@@ -76,6 +77,7 @@
     }
   }
 </style>
+</head>
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000"><table border="1" width="715"><tbody><tr><td>
 <center>
 </center>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Contained and external sub-programs</title>
@@ -74,6 +75,7 @@
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
+</head>
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
 <table border="1" width="715">
 <tr>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Using Tables</title>
@@ -74,6 +75,7 @@
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
+</head>
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
 <table border="1" width="715">
 <tr>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>Creating tables - syntax and semantics</title>
@@ -78,6 +79,7 @@
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
+</head>
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
 <table border="1" width="715">
 <tr>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>The UNSTRING verb</title>
@@ -76,6 +77,7 @@
     }
   }
 </style>
+</head>
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000"><table border="1" width="715"><tbody><tr><td>
 <center>
 </center>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <meta content="Mozilla/4.0 [en] (WinNT; I) [Netscape]" name="GENERATOR"/>
 <title>The USAGE clause</title>
@@ -74,6 +75,7 @@
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
 </style>
 
+</head>
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
 <table border="1" height="100%" width="715">
 <tr>

--- a/course/index.html
+++ b/course/index.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>COBOL Programming Course</title>


### PR DESCRIPTION
## Summary
- Most pages under `course/` placed `<meta>`, `<title>`, `<link>`, `<script>`, and `<style>` as direct children of `<html>` with no enclosing `<head>`. Browsers infer the head, but it's invalid HTML and risks inconsistent parsing.
- Adds a proper `<head>...</head>` wrapper around the metadata block (just before `<body>`) across all 26 `course/*.html` pages.
- One file (`course/index.html`) already had a stray `</head>` with no matching opener; it's now balanced too.

## Test plan
- [ ] Spot-check a few pages render the same as before (e.g., `course/SequentialFiles2.html`, `course/index.html`).
- [ ] Validate one of the touched pages with an HTML validator to confirm the head/body structure is now well-formed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)