### PR TITLE
Format wrapper table tags onto separate lines in 6 course pages

### DIFF
--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -78,7 +78,11 @@
   }
 </style>
 </head>
-<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000"><table border="1" width="715"><tbody><tr><td>
+<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+<table border="1" width="715">
+<tbody>
+<tr>
+<td>
 <center>
 </center>
 <center>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -79,7 +79,11 @@
   }
 </style>
 </head>
-<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000"><table border="1" width="715"><tbody><tr><td>
+<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+<table border="1" width="715">
+<tbody>
+<tr>
+<td>
 <center>
 </center>
 <center>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -78,7 +78,12 @@
   }
 </style>
 </head>
-<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000"><table border="1" width="715"><tbody><tr><td><center>
+<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+<table border="1" width="715">
+<tbody>
+<tr>
+<td>
+<center>
 <div align="LEFT">
 <table border="0" width="710">
 <tr>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -78,7 +78,11 @@
   }
 </style>
 </head>
-<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000"><table border="1" width="715"><tbody><tr><td>
+<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+<table border="1" width="715">
+<tbody>
+<tr>
+<td>
 <center>
 <div align="LEFT">
 <table border="0" width="710">

--- a/course/String.html
+++ b/course/String.html
@@ -78,7 +78,11 @@
   }
 </style>
 </head>
-<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000"><table border="1" width="715"><tbody><tr><td>
+<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+<table border="1" width="715">
+<tbody>
+<tr>
+<td>
 <center>
 </center>
 <center>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -78,7 +78,11 @@
   }
 </style>
 </head>
-<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000"><table border="1" width="715"><tbody><tr><td>
+<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+<table border="1" width="715">
+<tbody>
+<tr>
+<td>
 <center>
 </center>
 <center>


### PR DESCRIPTION
## Summary
- Addresses review feedback on 6 course pages where the outer wrapper table markup (`<table>`, `<tbody>`, `<tr>`, `<td>`) was inlined on the same line as the `<body>` tag.
- Splits each wrapper tag onto its own line to improve readability and reduce the risk of mismatched tag edits in the future, matching the formatting style used in other course pages (e.g. `course/DataDeclaration.html`).

## Files changed
- `course/Inspect.html`
- `course/String.html`
- `course/Unstring.html`
- `course/IndexedFiles.html`
- `course/RelativeFiles.html`
- `course/Intro2DirectAccess.html` (also splits the existing `<center>` onto its own line)

## Test plan
- [ ] Open each of the 6 pages in a browser and verify the layout is unchanged
- [ ] Confirm no tag mismatches were introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)