### PR TITLE
Mark PDF viewer status div as ARIA live region

### DIFF
--- a/course/Resources/pdf-viewer.html
+++ b/course/Resources/pdf-viewer.html
@@ -26,7 +26,7 @@
 <body>
 <div id="stage">
   <canvas id="canvas"></canvas>
-  <div id="status">Loading…</div>
+  <div id="status" role="status">Loading…</div>
 </div>
 <div id="controls">
   <button id="prev" type="button" aria-label="Previous slide">&#9664; Prev</button>


### PR DESCRIPTION
## Summary
- Add `role="status"` to the `#status` div in `course/Resources/pdf-viewer.html` so screen readers announce its dynamic state changes.

## Why
The viewer swaps `#status` text between "Loading…", "Missing ?src= parameter", "PDF library failed to load", and "Failed to load PDF: …". Without an ARIA live role, assistive tech never picks up these transitions. `role="status"` carries an implicit `aria-live="polite"`, which announces updates without interrupting the user.

## Test plan
- [ ] Open `course/Resources/pdf-viewer.html?src=…` and confirm the viewer still loads and renders pages.
- [ ] With a screen reader active, navigate to the page and verify "Loading…" (and any failure message) is announced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)