### PR TITLE
Replace deprecated <a name> anchors with id attributes

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -102,7 +102,7 @@
         </tr>
         <tr> 
           <td valign="top" align="LEFT" bgcolor="#993300" colspan="2"> 
-            <h2 align="CENTER"><font color="#FFFF00"><a name="intro"></a><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
+            <h2 align="CENTER" id="intro"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
           </td>
         </tr>
         <tr> 
@@ -159,7 +159,7 @@
         </tr>
         <tr> 
           <td valign="top" align="LEFT" bgcolor="#993300" colspan="2"> 
-            <h2 align="CENTER"><font color="#FFFF00"><a name="part1"></a> <font face="Arial, Helvetica, sans-serif">What 
+            <h2 align="CENTER" id="part1"><font color="#FFFF00"> <font face="Arial, Helvetica, sans-serif">What 
               is COBOL?</font></font></h2>
           </td>
         </tr>
@@ -425,10 +425,10 @@
             <p><a href="https://web.archive.org/web/20020326093554/http://www.cobolwebler.com/new_cobol.htm">Arranga,Edmund C. - The Viagrazation of COBOL - COBOLwebler.com</a></p>
             <p><a href="https://ieeexplore.ieee.org/document/841599">Arranga, Edmund C. &amp; Price, Wilson - Fresh from Y2K, What's
               next for COBOL? (March/April 2000) - IEEE Software</a></p>
-            <p><a name="arranga"></a><a href="https://www.computer.org/csdl/magazine/so/2000/02/s2070/13rRUxBrGey">Arranga et al - In COBOL's Defense : Roundtable
+            <p id="arranga"><a href="https://www.computer.org/csdl/magazine/so/2000/02/s2070/13rRUxBrGey">Arranga et al - In COBOL's Defense : Roundtable
               Discussion (March/April 2000) - IEEE Software</a></p>
             <p>Badower, Justin - COBOL: Foundation of the future - COBOLwebler.com</p>
-            <p><a name="brown"></a>Brown, Gary DeWard - COBOL: The failure that 
+            <p id="brown">Brown, Gary DeWard - COBOL: The failure that 
               wasn't - COBOLReport.com</p>
             <p>Burger,Thomas Wolfgang - COBOL in an open source future (May 2000) 
               - IBM developerWorks : Linux : Linux articles</p>
@@ -438,9 +438,9 @@
               - Gartner Advisory</p>
             <p><a href="https://dl.acm.org/doi/10.1145/260750.260752">Glass, Robert L. - Cobol - A Contradiction and an Enigma - COMMUNICATIONS
               OF THE ACM September 1997/Vol. 40, No. 9</a></p>
-            <p><a name="capers"></a>Jones, Capers - The global economic impact 
+            <p id="capers">Jones, Capers - The global economic impact 
               of the year 2000 software problem (Jan, 1997) </p>
-            <p><a name="kapple"></a>Kappelman, Leon A. - Some Strategic Y2K Blessings 
+            <p id="kapple">Kappelman, Leon A. - Some Strategic Y2K Blessings 
               (March/April 2000) - IEEE Software</p>
             <p>Kizior, Dr. Ronald J. &amp; Carr, Donald &amp; Halpern, Dr. Paul 
               - What Professionals think of the Future of COBOL? </p>
@@ -454,7 +454,7 @@
               Programming Legacy - MicroFocus Ltd.</p>
             <p>Silverberg, Fred, COBOL and the Business Programming Paradigm (1996)</p>
             <p>Sneed, Harry M.- The Evolution of COBOL - COBOLReport.com</p>
-            <p><a name="uppermohawk"></a><a href="https://web.archive.org/web/20030206082345/http://www.uppermohawkinc.com/corporate_capabilities.htm">Upper Mohawk, Inc. - Corporate Capabilities - uppermohawkinc.com</a></p>
+            <p id="uppermohawk"><a href="https://web.archive.org/web/20030206082345/http://www.uppermohawkinc.com/corporate_capabilities.htm">Upper Mohawk, Inc. - Corporate Capabilities - uppermohawkinc.com</a></p>
             <p>Wilkinson,Stephanie - From the Dustbin, Cobol Rises (May, 2001)-
               eWeek</p>
             </td>
@@ -470,7 +470,7 @@
         </tr>
         <tr> 
           <td valign="top" align="LEFT" bgcolor="#993300" colspan="2"> 
-            <h2 align="CENTER"><font color="#FFFF00"><a name="part2"></a><font face="Arial, Helvetica, sans-serif">Introduction 
+            <h2 align="CENTER" id="part2"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Introduction 
               to Programming </font></font></h2>
           </td>
         </tr>
@@ -670,7 +670,7 @@
         </tr>
         <tr> 
           <td valign="top" align="LEFT" bgcolor="#993300" colspan="2"> 
-            <h2 align="CENTER"><font color="#FFFF00"><a name="part3"></a><font face="Arial, Helvetica, sans-serif">COBOL 
+            <h2 align="CENTER" id="part3"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">COBOL 
               basics </font></font></h2>
           </td>
         </tr>
@@ -953,7 +953,7 @@ PROGRAM-ID.</code></pre>
         </tr>
         <tr> 
           <td valign="top" align="LEFT" bgcolor="#993300" colspan="2"> 
-            <h2 align="CENTER"><font color="#FFFF00"><a name="part4"></a><font face="Arial, Helvetica, sans-serif">The 
+            <h2 align="CENTER" id="part4"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">The 
               Four Divisions</font></font></h2>
           </td>
         </tr>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -112,7 +112,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="intro"></a><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
+<h2 align="CENTER" id="intro"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
 </td>
 </tr>
 <tr>
@@ -168,7 +168,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part1"></a><font face="Arial, Helvetica, sans-serif">Basic 
+<h2 align="CENTER" id="part1"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Basic 
               User Input and Output</font></font></h2>
 </td>
 </tr>
@@ -465,7 +465,7 @@ The time is 14:41
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part2"></a><font face="Arial, Helvetica, sans-serif">Assignment 
+<h2 align="CENTER" id="part2"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Assignment 
               using the MOVE verb</font></font></h2>
 </td>
 </tr>
@@ -553,7 +553,7 @@ The time is 14:41
 
 </td>
 <td valign="top" width="525">
-<p><a name="com1"></a>Examine the examples in the animation below 
+<p id="com1">Examine the examples in the animation below 
               in combination with the <font color="#000000" size="-1">MOVE</font> 
               rules above. Make sure you understand the why the moves produce 
               the results shown.</p>
@@ -571,7 +571,7 @@ The time is 14:41
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part3"></a><font face="Arial, Helvetica, sans-serif">Arithmetic 
+<h2 align="CENTER" id="part3"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Arithmetic 
               in COBOL</font></font></h2>
 </td>
 </tr>
@@ -1009,7 +1009,7 @@ The time is 14:41
               examples </font></h4>
 </td>
 <td valign="top" width="525">
-<p><a name="com2"></a>The animation below contains examples of each 
+<p id="com2">The animation below contains examples of each 
               of the arithmetic verbs. The arithmetic statement shows the contents 
               of the variables before the statement executes. Initially the contents 
               of the variables after execution are hidden; but you can display 

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -112,7 +112,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top">
-<h2 align="CENTER"><font color="#FFFF00"><a name="intro"></a><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
+<h2 align="CENTER" id="intro"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
 </td>
 </tr>
 <tr>
@@ -201,7 +201,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part1"></a><font face="Arial, Helvetica, sans-serif">Using 
+<h2 align="CENTER" id="part1"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Using 
               the COPY verb</font></font></h2>
 </td>
 </tr>
@@ -290,7 +290,7 @@
 </td>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part2"></a><font color="#FFFF00" face="Arial, Helvetica, sans-serif"><b>The 
+<h2 align="CENTER" id="part2"><font color="#FFFF00"><font color="#FFFF00" face="Arial, Helvetica, sans-serif"><b>The 
               COPY verb <br/>
               Syntax and Semantics</b></font></font></h2>
 </td>
@@ -472,7 +472,7 @@ COPY CopyFile4 IN EGLIB.</code></pre>
 </td>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part3"></a> <font face="Arial, Helvetica, sans-serif">COPY 
+<h2 align="CENTER" id="part3"><font color="#FFFF00"> <font face="Arial, Helvetica, sans-serif">COPY 
               examples </font></font></h2>
 </td>
 </tr>

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -112,7 +112,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="intro"></a><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
+<h2 align="CENTER" id="intro"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
 </td>
 </tr>
 <tr>
@@ -186,7 +186,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part1"></a><font face="Arial, Helvetica, sans-serif">Categories 
+<h2 align="CENTER" id="part1"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Categories 
               of COBOL data </font></font></h2>
 </td>
 </tr>
@@ -400,7 +400,7 @@
 <h4 align="left"><font color="#800000" face="Arial, Helvetica, sans-serif">Using COBOL data &mdash; examples</font></h4>
 </td>
 <td valign="top" width="525">
-<p><font color="#800000" face="Arial, Helvetica, sans-serif"><a name="data1"></a></font>The 
+<p id="data1"><font color="#800000" face="Arial, Helvetica, sans-serif"></font>The 
               animated program fragments below demonstrate how variables, literals 
               and Figurative Constants may be created and used. </p>
 
@@ -418,7 +418,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP">
-<h2 align="CENTER"><font color="#FFFF00" face="Arial, Helvetica, sans-serif"><a name="part2"></a>Declaring 
+<h2 align="CENTER" id="part2"><font color="#FFFF00" face="Arial, Helvetica, sans-serif">Declaring 
               Data-Items in COBOL</font></h2>
 </td>
 </tr>
@@ -552,7 +552,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part3"></a><font face="Arial, Helvetica, sans-serif">Group 
+<h2 align="CENTER" id="part3"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Group 
               and Elementary data-items</font></font></h2>
 </td>
 </tr>

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -115,7 +115,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="intro"></a><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
+<h2 align="CENTER" id="intro"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
 </td>
 </tr>
 <tr>
@@ -184,7 +184,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part1"></a><font face="Arial, Helvetica, sans-serif">What 
+<h2 align="CENTER" id="part1"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">What 
               is an Edited Picture? </font></font></h2>
 </td>
 </tr>
@@ -378,7 +378,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part2"></a><font face="Arial, Helvetica, sans-serif">Insertion 
+<h2 align="CENTER" id="part2"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Insertion 
               Editing </font></font></h2>
 </td>
 </tr>
@@ -1336,7 +1336,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part3"></a><font face="Arial, Helvetica, sans-serif">Suppression 
+<h2 align="CENTER" id="part3"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Suppression 
               and Replacement Editing</font></font></h2>
 </td>
 </tr>

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -91,7 +91,7 @@
 <tr>
 <td>
 <center>
-<h2><a name="top"></a> <img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<h2 id="top"> <img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
 <h2> <b>Indexed Files</b></h2>
@@ -125,7 +125,7 @@
 <table border="0" cellpadding="4" cellspacing="0" width="710">
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP" width="175">
-<h2 align="CENTER"><font color="#FFFF00">Introd<a name="intro"></a>uction</font></h2>
+<h2 align="CENTER" id="intro"><font color="#FFFF00">Introduction</font></h2>
 </td>
 </tr>
 <tr>
@@ -187,7 +187,7 @@
 <table border="0" cellpadding="4" cellspacing="0" width="710">
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP" width="100%">
-<h2 align="CENTER"><font color="#FFFF00"><a name="progs"></a>A look at some 
+<h2 align="CENTER" id="progs"><font color="#FFFF00">A look at some 
         programs that use Indexed files</font></h2>
 </td>
 </tr>
@@ -410,7 +410,7 @@ VIDEO STATUS :- 23</code></pre>
 <table border="0" cellpadding="4" cellspacing="0" width="710">
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP" width="175">
-<h2 align="CENTER"><font color="#FFFF00"><a name="org"></a>Indexed file 
+<h2 align="CENTER" id="org"><font color="#FFFF00">Indexed file 
         organization</font></h2>
 </td>
 </tr>
@@ -527,7 +527,7 @@ END-IF</code></pre>
 <table border="0" cellpadding="4" cellspacing="0" width="710">
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP" width="175">
-<h2 align="CENTER"><font color="#FFFF00"><a name="declar"></a>Indexed file 
+<h2 align="CENTER" id="declar"><font color="#FFFF00">Indexed file 
         - Declarations</font></h2>
 </td>
 </tr>
@@ -604,7 +604,7 @@ END-IF</code></pre>
 <table border="0" cellpadding="4" cellspacing="0" width="710">
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP" width="100%">
-<h2 align="CENTER"><font color="#FFFF00"><a name="verbs"></a>Indexed file 
+<h2 align="CENTER" id="verbs"><font color="#FFFF00">Indexed file 
         - file processing verbs </font></h2>
 </td>
 </tr>
@@ -811,7 +811,7 @@ END-IF</code></pre>
 <table border="0" cellpadding="4" cellspacing="0" width="710">
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP" width="100%">
-<h2 align="CENTER"><font color="#FFFF00"><a name="example"></a>An Comprehensive 
+<h2 align="CENTER" id="example"><font color="#FFFF00">An Comprehensive 
         Example Program</font></h2>
 </td>
 </tr>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -89,7 +89,7 @@
 <tr>
 <td>
 <center>
-<h2><a name="top"></a> <img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<h2 id="top"> <img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
 <h2> <b>Introduction to Direct Access Files</b></h2>
@@ -121,7 +121,7 @@
 <table border="0" cellpadding="4" cellspacing="0" width="710">
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP" width="175">
-<h2 align="CENTER"><font color="#FFFF00">Introd<a name="intro"></a>uction</font></h2>
+<h2 align="CENTER" id="intro"><font color="#FFFF00">Introduction</font></h2>
 </td>
 </tr>
 <tr>
@@ -185,7 +185,7 @@
 <table border="0" cellpadding="4" cellspacing="0" width="710">
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP" width="175">
-<h2 align="CENTER"><font color="#FFFF00">Sequential<a name="seq"></a> files</font></h2>
+<h2 align="CENTER" id="seq"><font color="#FFFF00">Sequential files</font></h2>
 </td>
 </tr>
 <tr>
@@ -342,7 +342,7 @@
 <table border="0" cellpadding="4" cellspacing="0" width="710">
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP" width="175">
-<h2 align="CENTER"><font color="#FFFF00">Relative<a name="rel"></a> Files</font></h2>
+<h2 align="CENTER" id="rel"><font color="#FFFF00">Relative Files</font></h2>
 </td>
 </tr>
 <tr>
@@ -476,7 +476,7 @@
 <table border="0" cellpadding="4" cellspacing="0" width="710">
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP" width="175">
-<h2 align="CENTER"><font color="#FFFF00">Indexed <a name="idx"></a>Files</font></h2>
+<h2 align="CENTER" id="idx"><font color="#FFFF00">Indexed Files</font></h2>
 </td>
 </tr>
 <tr>
@@ -591,7 +591,7 @@ END-IF</code></pre>
 <table border="0" cellpadding="4" cellspacing="0" width="710">
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP" width="175">
-<h2 align="CENTER"><font color="#FFFF00">Comparison<a name="comp"></a> of 
+<h2 align="CENTER" id="comp"><font color="#FFFF00">Comparison of 
         COBOL file organizations</font></h2>
 </td>
 </tr>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -122,7 +122,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="intro"></a><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
+<h2 align="CENTER" id="intro"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
 </td>
 </tr>
 <tr>
@@ -251,7 +251,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part1"></a><font face="Arial, Helvetica, sans-serif">PERFORM..Proc</font></font></h2>
+<h2 align="CENTER" id="part1"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">PERFORM..Proc</font></font></h2>
 </td>
 </tr>
 <tr>
@@ -604,7 +604,7 @@ ThreeLevelsDown.
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part2"></a><font face="Arial, Helvetica, sans-serif">Using 
+<h2 align="CENTER" id="part2"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Using 
               the PERFORM..THRU</font></font></h2>
 </td>
 </tr>
@@ -764,7 +764,7 @@ SumSalesExit.
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part3"></a><font face="Arial, Helvetica, sans-serif">PERFORM..TIMES 
+<h2 align="CENTER" id="part3"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">PERFORM..TIMES 
               </font></font></h2>
 </td>
 </tr>
@@ -926,7 +926,7 @@ OutOfLineEG.
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part4"></a><font face="Arial, Helvetica, sans-serif">PERFORM..UNTIL 
+<h2 align="CENTER" id="part4"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">PERFORM..UNTIL 
               </font></font></h2>
 </td>
 </tr>
@@ -1096,7 +1096,7 @@ END-PERFORM</code></pre>
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part5"></a><font face="Arial, Helvetica, sans-serif">PERFORM..VARYING 
+<h2 align="CENTER" id="part5"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">PERFORM..VARYING 
               </font></font></h2>
 </td>
 </tr>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -121,7 +121,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="intro"></a><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
+<h2 align="CENTER" id="intro"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
 </td>
 </tr>
 <tr>
@@ -182,7 +182,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part1"></a><font face="Arial, Helvetica, sans-serif">Reference 
+<h2 align="CENTER" id="part1"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Reference 
               Modification</font></font></h2>
 </td>
 </tr>
@@ -236,7 +236,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part2"></a><font face="Arial, Helvetica, sans-serif">Intrinsic 
+<h2 align="CENTER" id="part2"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Intrinsic 
               Functions </font></font></h2>
 </td>
 </tr>
@@ -362,7 +362,7 @@ MOVE FUNCTION ORD-MAX(IntElement(ALL)) TO OrdPos             </code></pre>
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part3"></a><font face="Arial, Helvetica, sans-serif">String 
+<h2 align="CENTER" id="part3"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">String 
               Functions </font></font></h2>
 </td>
 </tr>
@@ -570,7 +570,7 @@ Begin.
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part4"></a><font face="Arial, Helvetica, sans-serif">Date 
+<h2 align="CENTER" id="part4"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Date 
               Functions </font></font></h2>
 </td>
 </tr>
@@ -786,7 +786,7 @@ Begin.
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part5"></a><font face="Arial, Helvetica, sans-serif">Miscellaneous 
+<h2 align="CENTER" id="part5"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Miscellaneous 
               Functions </font></font></h2>
 </td>
 </tr>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -89,7 +89,7 @@
 <tr>
 <td>
 <center>
-<h2><a name="top"></a> <img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<h2 id="top"> <img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
 <h2> <b>Relative Files</b></h2>
@@ -128,7 +128,7 @@
 <table border="0" cellpadding="4" cellspacing="0" width="710">
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP" width="100%">
-<h2 align="CENTER"><font color="#FFFF00">Introd<a name="intro"></a>uction</font></h2>
+<h2 align="CENTER" id="intro"><font color="#FFFF00">Introduction</font></h2>
 </td>
 </tr>
 <tr>
@@ -195,7 +195,7 @@
 <table border="0" cellpadding="4" cellspacing="0" width="710">
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP" width="100%">
-<h2 align="CENTER"><font color="#FFFF00"><a name="progs"></a>A look at some 
+<h2 align="CENTER" id="progs"><font color="#FFFF00">A look at some 
         programs that use Relative files</font></h2>
 </td>
 </tr>
@@ -309,7 +309,7 @@ Enter supplier key (2 digits)-&gt; 05
 <table border="0" cellpadding="4" cellspacing="0" width="710">
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP" width="100%">
-<h2 align="CENTER"><font color="#FFFF00"><a name="declar"></a>Relative file 
+<h2 align="CENTER" id="declar"><font color="#FFFF00">Relative file 
         - Declarations</font></h2>
 </td>
 </tr>
@@ -442,7 +442,7 @@ Enter supplier key (2 digits)-&gt; 05
 <table border="0" cellpadding="4" cellspacing="0" width="710">
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP" width="100%">
-<h2 align="CENTER"><font color="#FFFF00"><a name="verbs"></a>Relative file 
+<h2 align="CENTER" id="verbs"><font color="#FFFF00">Relative file 
         - file processing verbs </font></h2>
 </td>
 </tr>
@@ -730,7 +730,7 @@ Enter supplier key (2 digits)-&gt; 05
 <table border="0" cellpadding="4" cellspacing="0" width="710">
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP" width="100%">
-<h2 align="CENTER"><font color="#FFFF00"><a name="declaratives"></a>Introduction 
+<h2 align="CENTER" id="declaratives"><font color="#FFFF00">Introduction 
         to Declaratives</font></h2>
 </td>
 </tr>

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -124,7 +124,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="intro"></a><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
+<h2 align="CENTER" id="intro"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
 </td>
 </tr>
 <tr>
@@ -205,7 +205,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part1"></a><font face="Arial, Helvetica, sans-serif">The 
+<h2 align="CENTER" id="part1"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">The 
               Report Writer in Action</font></font></h2>
 </td>
 </tr>
@@ -318,7 +318,7 @@ PrintSalaryReport.
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP">
-<h2 align="CENTER"><font color="#FFFF00" face="Arial, Helvetica, sans-serif"><a name="part1b"></a>How 
+<h2 align="CENTER" id="part1b"><font color="#FFFF00" face="Arial, Helvetica, sans-serif">How 
               the Report Writer works</font></h2>
 </td>
 </tr>
@@ -423,7 +423,7 @@ PrintSalaryReport.
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part2"></a><font face="Arial, Helvetica, sans-serif">Let's 
+<h2 align="CENTER" id="part2"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Let's 
               write a Report Writer program!</font></font></h2>
 </td>
 </tr>
@@ -566,7 +566,7 @@ Programmer - Michael Coughlan               Page :  1
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part3"></a>Let's 
+<h2 align="CENTER" id="part3"><font color="#FFFF00">Let's 
               add some features to our Report Program</font></h2>
 </td>
 </tr>
@@ -738,7 +738,7 @@ RD  SalesReport
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP">
-<h2 align="CENTER"><font color="#FFFF00" face="Arial, Helvetica, sans-serif"><a name="part4"></a>Report 
+<h2 align="CENTER" id="part4"><font color="#FFFF00" face="Arial, Helvetica, sans-serif">Report 
               Writer Declaratives</font></h2>
 </td>
 </tr>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -135,7 +135,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="intro"></a><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
+<h2 align="CENTER" id="intro"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
 </td>
 </tr>
 <tr>
@@ -194,7 +194,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part1"></a><font face="Arial, Helvetica, sans-serif">Defining 
+<h2 align="CENTER" id="part1"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Defining 
               the Report - Report File entries</font></font></h2>
 </td>
 </tr>
@@ -283,7 +283,7 @@ RD  SalesReport
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP">
-<h2 align="CENTER"><font color="#FFFF00" face="Arial, Helvetica, sans-serif"><a name="part2"></a>Defining 
+<h2 align="CENTER" id="part2"><font color="#FFFF00" face="Arial, Helvetica, sans-serif">Defining 
               the Report - Report Description (RD) Entries</font></h2>
 </td>
 </tr>
@@ -377,7 +377,7 @@ RD  SalesReport
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP">
-<h2 align="CENTER"><font color="#FFFF00" face="Arial, Helvetica, sans-serif"><a name="part3"></a></font><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Defining 
+<h2 align="CENTER" id="part3"><font color="#FFFF00" face="Arial, Helvetica, sans-serif"></font><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Defining 
               the Report - Report Group entries</font></font></h2>
 </td>
 </tr>
@@ -528,7 +528,7 @@ RD  SalesReport
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP">
-<h2 align="CENTER"><font color="#FFFF00" face="Arial, Helvetica, sans-serif"><a name="part4"></a></font><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Defining 
+<h2 align="CENTER" id="part4"><font color="#FFFF00" face="Arial, Helvetica, sans-serif"></font><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Defining 
               the Report - Lines and Columns</font></font></h2>
 </td>
 </tr>
@@ -764,7 +764,7 @@ RD  SalesReport
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part5"></a><font face="Arial, Helvetica, sans-serif">Special 
+<h2 align="CENTER" id="part5"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Special 
               Report Writer registers</font></font></h2>
 </td>
 </tr>
@@ -852,7 +852,7 @@ RD  SalesReport
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part6"></a>Procedure 
+<h2 align="CENTER" id="part6"><font color="#FFFF00">Procedure 
               Division verbs</font></h2>
 </td>
 </tr>
@@ -1041,7 +1041,7 @@ Programmer - Michael Coughlan               Page :  1
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP">
-<h2 align="CENTER"><font color="#FFFF00" face="Arial, Helvetica, sans-serif"><a name="part7"></a>Report 
+<h2 align="CENTER" id="part7"><font color="#FFFF00" face="Arial, Helvetica, sans-serif">Report 
               Writer Declaratives</font></h2>
 </td>
 </tr>

--- a/course/Search.html
+++ b/course/Search.html
@@ -128,7 +128,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top">
-<h2 align="CENTER"><font color="#FFFF00"><a name="intro"></a><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
+<h2 align="CENTER" id="intro"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
 </td>
 </tr>
 <tr>
@@ -217,7 +217,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part1"></a><font face="Arial, Helvetica, sans-serif">Occurs 
+<h2 align="CENTER" id="part1"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Occurs 
               clause extensions</font></font></h2>
 </td>
 </tr>
@@ -311,7 +311,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part2"></a><font face="Arial, Helvetica, sans-serif">The 
+<h2 align="CENTER" id="part2"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">The 
               SEARCH verb</font></font></h2>
 </td>
 </tr>
@@ -657,7 +657,7 @@ DisplayCountyTaxes.
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part3"></a><font face="Arial, Helvetica, sans-serif">Searching 
+<h2 align="CENTER" id="part3"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Searching 
               multi-dimension tables</font></font></h2>
 </td>
 </tr>
@@ -928,7 +928,7 @@ END-SEARCH</code></pre>
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part4"></a> <font face="Arial, Helvetica, sans-serif">The 
+<h2 align="CENTER" id="part4"><font color="#FFFF00"> <font face="Arial, Helvetica, sans-serif">The 
               SEARCH ALL verb</font></font></h2>
 </td>
 </tr>

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -115,7 +115,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="intro"></a><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
+<h2 align="CENTER" id="intro"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
 </td>
 </tr>
 <tr>
@@ -182,7 +182,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part1"></a><font face="Arial, Helvetica, sans-serif">Selection 
+<h2 align="CENTER" id="part1"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Selection 
               using IF</font></font></h2>
 </td>
 </tr>
@@ -825,7 +825,7 @@ END-IF
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part2"></a><font face="Arial, Helvetica, sans-serif">Condition 
+<h2 align="CENTER" id="part2"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Condition 
               Names </font></font></h2>
 </td>
 </tr>
@@ -1013,7 +1013,7 @@ END-IF
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part3"></a><font face="Arial, Helvetica, sans-serif">Using
+<h2 align="CENTER" id="part3"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Using
               the SET verb with Condition Names </font></font></h2>
 </td>
 </tr>
@@ -1162,7 +1162,7 @@ Begin.
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part4"></a><font face="Arial, Helvetica, sans-serif">The 
+<h2 align="CENTER" id="part4"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">The 
               EVALUATE verb</font></font></h2>
 </td>
 </tr>

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -116,7 +116,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="intro"></a><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
+<h2 align="CENTER" id="intro"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
 </td>
 </tr>
 <tr>
@@ -208,7 +208,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part1"></a><font face="Arial, Helvetica, sans-serif">Introduction 
+<h2 align="CENTER" id="part1"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Introduction 
               to record-based files</font></font></h2>
 </td>
 </tr>
@@ -362,7 +362,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part2"></a><font face="Arial, Helvetica, sans-serif">Declaring 
+<h2 align="CENTER" id="part2"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Declaring 
               Records and Files</font></font></h2>
 </td>
 </tr>
@@ -650,7 +650,7 @@ SELECT StudentFile
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part3"></a><font face="Arial, Helvetica, sans-serif">COBOL 
+<h2 align="CENTER" id="part3"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">COBOL 
               file handling verbs</font></font></h2>
 </td>
 </tr>

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -122,7 +122,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="intro"></a><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
+<h2 align="CENTER" id="intro"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
 </td>
 </tr>
 <tr>
@@ -191,7 +191,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part1"></a><font face="Arial, Helvetica, sans-serif">Organization 
+<h2 align="CENTER" id="part1"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Organization 
               and Access</font></font></h2>
 </td>
 </tr>
@@ -325,7 +325,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part2"></a><font face="Arial, Helvetica, sans-serif">Processing 
+<h2 align="CENTER" id="part2"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Processing 
               unordered Sequential Files</font></font></h2>
 </td>
 </tr>
@@ -468,7 +468,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part3"></a><font face="Arial, Helvetica, sans-serif">Processing 
+<h2 align="CENTER" id="part3"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Processing 
               Ordered Sequential Files</font></font></h2>
 </td>
 </tr>

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -116,7 +116,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="intro"></a><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
+<h2 align="CENTER" id="intro"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
 </td>
 </tr>
 <tr>
@@ -185,7 +185,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part1"></a><font face="Arial, Helvetica, sans-serif">Multiple 
+<h2 align="CENTER" id="part1"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Multiple 
               record-type files</font></font></h2>
 </td>
 </tr>
@@ -566,7 +566,7 @@ FD TransFile.
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part2"></a>COBOL 
+<h2 align="CENTER" id="part2"><font color="#FFFF00">COBOL 
               print files </font></h2>
 </td>
 </tr>
@@ -927,7 +927,7 @@ PrintPageHeadings.
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part3"></a><font face="Arial, Helvetica, sans-serif">Variable 
+<h2 align="CENTER" id="part3"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Variable 
               length records</font></font></h2>
 </td>
 </tr>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -123,7 +123,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="intro"></a><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
+<h2 align="CENTER" id="intro"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
 </td>
 </tr>
 <tr>
@@ -206,7 +206,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part1"></a><font face="Arial, Helvetica, sans-serif">Simple 
+<h2 align="CENTER" id="part1"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Simple
               Sorting </font></font></h2>
 </td>
 </tr>
@@ -705,7 +705,7 @@ etc.</code></pre>
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part2"></a><font face="Arial, Helvetica, sans-serif">SORTing 
+<h2 align="CENTER" id="part2"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">SORTing
               with an INPUT PROCEDURE</font></font></h2>
 </td>
 </tr>
@@ -1158,7 +1158,7 @@ GetStudentDetails.
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part3"></a><font face="Arial, Helvetica, sans-serif">Sorting 
+<h2 align="CENTER" id="part3"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Sorting
               with an OUTPUT PROCEDURE</font></font></h2>
 </td>
 </tr>
@@ -1536,7 +1536,7 @@ PrintReportBody.
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part4"></a><font face="Arial, Helvetica, sans-serif">MERGEing 
+<h2 align="CENTER" id="part4"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">MERGEing
               files</font></font></h2>
 </td>
 </tr>

--- a/course/String.html
+++ b/course/String.html
@@ -91,7 +91,7 @@
 <tr>
 <td>
 <center>
-<h2><a name="top"></a> <img alt="Cobol Tutorial" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<h2 id="top"> <img alt="Cobol Tutorial" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
 <h2> <b>The STRING verb</b></h2>
@@ -115,7 +115,7 @@
 <table border="0" cellpadding="4" cellspacing="0" width="710">
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP" width="100%">
-<h2 align="CENTER"><font color="#FFFF00">Introd<a name="intro"></a>uction</font></h2>
+<h2 align="CENTER" id="intro"><font color="#FFFF00">Introduction</font></h2>
 </td>
 </tr>
 <tr>
@@ -171,7 +171,7 @@
 <table border="0" cellpadding="4" cellspacing="0" width="710">
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP" width="100%">
-<h2 align="CENTER"><font color="#FFFF00"><a name="verb"></a>The STRING verb 
+<h2 align="CENTER" id="verb"><font color="#FFFF00">The STRING verb 
         </font></h2>
 </td>
 </tr>
@@ -346,7 +346,7 @@ END-STRING.</code></pre>
 <table border="0" cellpadding="4" cellspacing="0" width="710">
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP" width="100%">
-<h2 align="CENTER"><font color="#FFFF00"><a name="examples"></a>STRING examples</font></h2>
+<h2 align="CENTER" id="examples"><font color="#FFFF00">STRING examples</font></h2>
 </td>
 </tr>
 <tr>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -110,7 +110,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top">
-<h2 align="CENTER"><font color="#FFFF00"><a name="intro"></a><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
+<h2 align="CENTER" id="intro"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
 </td>
 </tr>
 <tr>
@@ -212,7 +212,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part1"></a> <font face="Arial, Helvetica, sans-serif">The 
+<h2 align="CENTER" id="part1"><font color="#FFFF00"> <font face="Arial, Helvetica, sans-serif">The 
               CALL verb</font></font></h2>
 </td>
 </tr>
@@ -728,7 +728,7 @@ CALL "Fickle" USING BY CONTENT IncValue.</code></pre>
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part2"></a><font face="Arial, Helvetica, sans-serif">Contained 
+<h2 align="CENTER" id="part2"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Contained 
               Subprograms</font></font></h2>
 </td>
 </tr>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -121,7 +121,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" height="27" valign="top">
-<h2 align="CENTER"><font color="#FFFF00"><a name="intro"></a><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
+<h2 align="CENTER" id="intro"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
 </td>
 </tr>
 <tr>
@@ -185,7 +185,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part1"></a><font face="Arial, Helvetica, sans-serif">Why 
+<h2 align="CENTER" id="part1"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Why 
               use tables? </font></font></h2>
 </td>
 </tr>
@@ -349,7 +349,7 @@ DISPLAY "County 3 total is ", County3TaxTotal
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part2"></a><font face="Arial, Helvetica, sans-serif">Using 
+<h2 align="CENTER" id="part2"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Using 
               a CountyTax table</font></font></h2>
 </td>
 </tr>
@@ -483,7 +483,7 @@ Begin.
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part3"></a><font face="Arial, Helvetica, sans-serif">Displaying
+<h2 align="CENTER" id="part3"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Displaying
               the County Name</font></font></h2>
 </td>
 </tr>
@@ -601,7 +601,7 @@ Begin.
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part4"></a><font face="Arial, Helvetica, sans-serif">Using
+<h2 align="CENTER" id="part4"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Using
               one table to index into another</font></font></h2>
 </td>
 </tr>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -131,7 +131,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top">
-<h2 align="CENTER"><font color="#FFFF00"><a name="intro"></a><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
+<h2 align="CENTER" id="intro"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
 </td>
 </tr>
 <tr>
@@ -203,7 +203,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part1"></a><font face="Arial, Helvetica, sans-serif">Declaring 
+<h2 align="CENTER" id="part1"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Declaring 
               a single dimension table</font></font></h2>
 </td>
 </tr>
@@ -493,7 +493,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part2"></a><font face="Arial, Helvetica, sans-serif">Group 
+<h2 align="CENTER" id="part2"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Group 
               items as elements</font></font></h2>
 </td>
 </tr>
@@ -736,7 +736,7 @@ DisplayCountyTaxes.
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part3"></a><font face="Arial, Helvetica, sans-serif">Declaring 
+<h2 align="CENTER" id="part3"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Declaring 
               multi-dimension tables</font></font></h2>
 </td>
 </tr>
@@ -1091,7 +1091,7 @@ ADD 56 TO PopTotal(12,3,2)</code></pre>
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part4"></a> <font face="Arial, Helvetica, sans-serif">Creating 
+<h2 align="CENTER" id="part4"><font color="#FFFF00"> <font face="Arial, Helvetica, sans-serif">Creating 
               pre-filled tables with the REDEFINES clause</font></font></h2>
 </td>
 </tr>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -91,7 +91,7 @@
 <tr>
 <td>
 <center>
-<h2><a name="top"></a> <img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<h2 id="top"> <img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
 <h2> <b>The UNSTRING verb</b></h2>
@@ -115,7 +115,7 @@
 <table border="0" cellpadding="4" cellspacing="0" width="710">
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP" width="100%">
-<h2 align="CENTER"><font color="#FFFF00">Introd<a name="intro"></a>uction</font></h2>
+<h2 align="CENTER" id="intro"><font color="#FFFF00">Introduction</font></h2>
 </td>
 </tr>
 <tr>
@@ -172,7 +172,7 @@
 <table border="0" cellpadding="4" cellspacing="0" width="710">
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP" width="100%">
-<h2 align="CENTER"><font color="#FFFF00"><a name="verb"></a>The UNSTRING 
+<h2 align="CENTER" id="verb"><font color="#FFFF00">The UNSTRING 
         verb </font></h2>
 </td>
 </tr>
@@ -403,7 +403,7 @@ END-UNSTRING.</code></pre>
 <table border="0" cellpadding="4" cellspacing="0" width="710">
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP" width="100%">
-<h2 align="CENTER"><font color="#FFFF00"><a name="examples"></a>UNSTRING 
+<h2 align="CENTER" id="examples"><font color="#FFFF00">UNSTRING 
         examples</font></h2>
 </td>
 </tr>
@@ -576,7 +576,7 @@ Begin.
 <table border="0" cellpadding="4" cellspacing="0" width="710">
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP" width="100%">
-<h2 align="CENTER"><font color="#FFFF00"><a name="combined"></a>Combined 
+<h2 align="CENTER" id="combined"><font color="#FFFF00">Combined 
         example</font></h2>
 </td>
 </tr>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -103,7 +103,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top">
-<h2 align="CENTER"><font color="#FFFF00"><a name="intro"></a><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
+<h2 align="CENTER" id="intro"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
 </td>
 </tr>
 <tr>
@@ -183,7 +183,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part1"></a> <font face="Arial, Helvetica, sans-serif">The 
+<h2 align="CENTER" id="part1"><font color="#FFFF00"> <font face="Arial, Helvetica, sans-serif">The 
               USAGE clause</font></font></h2>
 </td>
 </tr>

--- a/examples/default.html
+++ b/examples/default.html
@@ -103,7 +103,7 @@
 </tr>
 </table>
 <hr/>
-<a name="pagetop"></a>
+<a id="pagetop"></a>
 <ul>
 <p><img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13"/><a href="#SimplePrograms">Beginners 
     Programs </a> - <font size="-1"> Simple programs using ACCEPT, DISPLAY and 
@@ -135,7 +135,7 @@
 <table border="0" bordercolordark="#000000" bordercolorlight="#FFFFFF" width="725">
 <tr bgcolor="#990000" valign="top">
 <td colspan="4">
-<h2 align="center"><b><font color="#FFFF00">Beginners programs<a name="SimplePrograms"></a></font></b></h2>
+<h2 align="center" id="SimplePrograms"><b><font color="#FFFF00">Beginners programs</font></b></h2>
 </td>
 </tr>
 <tr valign="top">
@@ -210,7 +210,7 @@
 <table border="0" bordercolordark="#999999" bordercolorlight="#FFFFFF" width="725">
 <tr bgcolor="#990000" valign="top">
 <td colspan="4">
-<h2 align="center"><b><font color="#FFFF00">Selection and Interation<a name="Selection"></a></font></b></h2>
+<h2 align="center" id="Selection"><b><font color="#FFFF00">Selection and Interation</font></b></h2>
 </td>
 </tr>
 <tr valign="top">
@@ -354,7 +354,7 @@
 <table bordercolorlight="#FFFFFF" width="725">
 <tr bgcolor="#990000" valign="top">
 <td colspan="4">
-<h2 align="center"><b><font color="#FFFF00">Sequential Files<a name="SequentialFiles"></a></font></b></h2>
+<h2 align="center" id="SequentialFiles"><b><font color="#FFFF00">Sequential Files</font></b></h2>
 </td>
 </tr>
 <tr valign="top">
@@ -479,7 +479,7 @@
 <table border="0" bordercolorlight="#FFFFFF" width="725">
 <tr bgcolor="#990000" valign="top">
 <td colspan="4">
-<h2 align="center"><b><font color="#FFFF00">Sorting and Merging <a name="Sort"></a></font></b></h2>
+<h2 align="center" id="Sort"><b><font color="#FFFF00">Sorting and Merging </font></b></h2>
 </td>
 </tr>
 <tr valign="top">
@@ -640,7 +640,7 @@
 <table border="0" bordercolorlight="#FFFFFF" width="725">
 <tr bgcolor="#990000" valign="top">
 <td colspan="4">
-<h2 align="center"><b><font color="#FFFF00">Direct Access Files<a name="Direct"></a></font></b></h2>
+<h2 align="center" id="Direct"><b><font color="#FFFF00">Direct Access Files</font></b></h2>
 </td>
 </tr>
 <tr valign="top">
@@ -873,7 +873,7 @@
 <table border="0" bordercolorlight="#FFFFFF" width="725">
 <tr bgcolor="#990000" valign="top">
 <td colspan="4">
-<h2 align="center"><b><font color="#FFFF00">CALLing sub-programs <a name="Call"></a></font></b></h2>
+<h2 align="center" id="Call"><b><font color="#FFFF00">CALLing sub-programs </font></b></h2>
 </td>
 </tr>
 <tr valign="top">
@@ -1079,7 +1079,7 @@
 <table border="0" bordercolorlight="#FFFFFF" width="725">
 <tr bgcolor="#990000" valign="top">
 <td colspan="4">
-<h2 align="center"><b><font color="#FFFF00">String handling<a name="Strings"></a></font></b></h2>
+<h2 align="center" id="Strings"><b><font color="#FFFF00">String handling</font></b></h2>
 </td>
 </tr>
 <tr valign="top">
@@ -1172,7 +1172,7 @@
 <table border="0" bordercolorlight="#FFFFFF" width="725">
 <tr bgcolor="#990000" valign="top">
 <td colspan="4">
-<h2 align="center"><b><font color="#FFFF00">The COBOL Report Writer<a name="Reports"></a></font></b></h2>
+<h2 align="center" id="Reports"><b><font color="#FFFF00">The COBOL Report Writer</font></b></h2>
 </td>
 </tr>
 <tr valign="top">
@@ -1274,7 +1274,7 @@
 <table border="0" bordercolorlight="#FFFFFF" width="725">
 <tr bgcolor="#990000" valign="top">
 <td colspan="4">
-<h2 align="center"><b><font color="#FFFF00">COBOL Tables<a name="Tables"></a></font></b></h2>
+<h2 align="center" id="Tables"><b><font color="#FFFF00">COBOL Tables</font></b></h2>
 </td>
 </tr>
 <tr valign="top">

--- a/lectures/CS4312Topics.html
+++ b/lectures/CS4312Topics.html
@@ -70,8 +70,8 @@
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
 <h2><img align="ABSCENTER" height="36" src="../pics/T-Dept.gif" width="297"/><br/>
  Software Engineering 2 - Module Outline</h2>
-<h3>
-<hr width="100%"/><a name="General"></a>General Introduction</h3>
+<h3 id="General">
+<hr width="100%"/>General Introduction</h3>
 <ul>
 <li>What is a program? </li>
 <li>What is an Algorithm? </li>
@@ -94,8 +94,8 @@
 </td>
 </tr>
 </table>
-<h3>
-<hr width="100%"/><a name="Introduction"></a>Introduction to COBOL</h3>
+<h3 id="Introduction">
+<hr width="100%"/>Introduction to COBOL</h3>
 <ul>
 <li>COBOL design goals. </li>
 <li>COBOL Metalanguage. </li>
@@ -121,9 +121,9 @@
 </td>
 </tr>
 </table>
-<h3>
+<h3 id="Basics1">
 <hr width="100%"/>
-<a name="Basics1"></a>COBOL Basics 1</h3>
+COBOL Basics 1</h3>
 <ul>
 <li>The COBOL coding rules. </li>
 <li>Name construction. </li>
@@ -151,9 +151,9 @@
 </td>
 </tr>
 </table>
-<h3>
+<h3 id="Basics2">
 <hr width="100%"/>
-<a name="Basics2"></a>COBOL Basics 2</h3>
+COBOL Basics 2</h3>
 <ul>
 <li>Level Numbers. </li>
 <li>Group and elementary data items. </li>
@@ -177,9 +177,9 @@
 </td>
 </tr>
 </table>
-<h3>
+<h3 id="IntroSeqFiles">
 <hr width="100%"/>
-<a name="IntroSeqFiles"></a>Introduction to Sequential Files</h3>
+Introduction to Sequential Files</h3>
 <ul>
 <li>Files, records, fields. </li>
 <li>The record buffer concept. </li>
@@ -202,9 +202,9 @@
 </td>
 </tr>
 </table>
-<h3>
+<h3 id="ProcessingSeqFiles">
 <hr width="100%"/>
-<a name="ProcessingSeqFiles"></a>Processing Sequential Files</h3>
+Processing Sequential Files</h3>
 <ul>
 <li>File organization and access methods. </li>
 <li>Ordered and unordered Sequential Files. </li>
@@ -227,9 +227,9 @@
 </td>
 </tr>
 </table>
-<h3>
+<h3 id="PERFORM">
 <hr width="100%"/>
-<a name="PERFORM"></a>Simple iteration with the PERFORM verb</h3>
+Simple iteration with the PERFORM verb</h3>
 <ul>
 <li>Non-Iteration PERFORM. </li>
 <li>GO TO and PERFORM....THRU. </li>
@@ -254,9 +254,9 @@
 </td>
 </tr>
 </table>
-<h3>
+<h3 id="Arithmetic">
 <hr width="100%"/>
-<a name="Arithmetic"></a>Arithmetic and Edited Pictures</h3>
+Arithmetic and Edited Pictures</h3>
 <ul>
 <li>ROUNDED option. </li>
 <li>ON SIZE ERROR option. </li>
@@ -287,9 +287,9 @@
 </td>
 </tr>
 </table>
-<h3>
+<h3 id="Conditions">
 <hr width="100%"/>
-<a name="Conditions"></a>Conditions</h3>
+Conditions</h3>
 <ul>
 <li>IF..THEN...ELSE. </li>
 <li>Relation conditions. </li>
@@ -317,9 +317,9 @@
 </td>
 </tr>
 </table>
-<h3>
+<h3 id="Designing">
 <hr width="100%"/>
-<a name="Designing"></a>Designing Programs</h3>
+Designing Programs</h3>
 <ul>
 <li>Why we use COBOL. </li>
 <li>The problem of program maintenance. </li>
@@ -345,9 +345,9 @@
 </td>
 </tr>
 </table>
-<h3>
+<h3 id="DSR1">
 <hr width="100%"/>
-<a name="DSR1"></a>Introduction to Diagrammatic Stepwise Refinement</h3>
+Introduction to Diagrammatic Stepwise Refinement</h3>
 <ul>
 <li>Steps in the DSR approach </li>
 <li>Stepwise Refinement </li>
@@ -373,9 +373,9 @@
 </td>
 </tr>
 </table>
-<h3>
+<h3 id="SORT">
 <hr width="100%"/>
-<a name="SORT"></a>SORT and MERGE</h3>
+SORT and MERGE</h3>
 <ul>
 <li>Simple SORTing. </li>
 <li>The SD entry. </li>
@@ -399,9 +399,9 @@
 </td>
 </tr>
 </table>
-<h3>
+<h3 id="Tables">
 <hr width="100%"/>
-<a name="Tables"></a>Tables and the PERFORM ... VARYING</h3>
+Tables and the PERFORM ... VARYING</h3>
 <ul>
 <li>Introduction to tables. </li>
 <li>Declaring tables. </li>
@@ -423,9 +423,9 @@
 </td>
 </tr>
 </table>
-<h3>
+<h3 id="AdvancedTables">
 <hr width="100%"/>
-<a name="AdvancedTables"></a>Advanced Tables</h3>
+Advanced Tables</h3>
 <ul>
 <li>Defining and processing multi-dimension tables. </li>
 <li>The REDEFINES clause. </li>
@@ -450,9 +450,9 @@
 </td>
 </tr>
 </table>
-<h3>
+<h3 id="SearchingTAbles">
 <hr width="100%"/>
-<a name="SearchingTAbles"></a>Searching Tables</h3>
+Searching Tables</h3>
 <ul>
 <li>The SEARCH </li>
 <li>The SEARCH ALL. verbs.</li>
@@ -473,9 +473,9 @@
 </td>
 </tr>
 </table>
-<h3>
+<h3 id="AdvancedSeqFiles">
 <hr width="100%"/>
-<a name="AdvancedSeqFiles"></a>Advanced Sequential Files</h3>
+Advanced Sequential Files</h3>
 <ul>
 <li>Multiple record type files. </li>
 <li>Variable length records.</li>
@@ -496,9 +496,9 @@
 </td>
 </tr>
 </table>
-<h3>
+<h3 id="IntroDirectAccessFiles">
 <hr width="100%"/>
-<a name="IntroDirectAccessFiles"></a>Introduction to Direct Access Files</h3>
+Introduction to Direct Access Files</h3>
 <ul>
 <li>Introduction to Relative Files. </li>
 <li>Introduction to Indexed files. </li>
@@ -520,9 +520,9 @@
 </td>
 </tr>
 </table>
-<h3>
+<h3 id="RelativeFiles">
 <hr width="100%"/>
-<a name="RelativeFiles"></a>Relative Files</h3>
+Relative Files</h3>
 <ul>
 <li>Creating and reading a Relative file. </li>
 <li>SELECT and ASSIGN entries for Relative Files. </li>
@@ -545,9 +545,9 @@
 </td>
 </tr>
 </table>
-<h3>
+<h3 id="IndexedFiles">
 <hr width="100%"/>
-<a name="IndexedFiles"></a>Indexed Files</h3>
+Indexed Files</h3>
 <ul>
 <li>Creating and Reading an Indexed file. </li>
 <li>SELECT and ASSIGN entries for Indexed files. </li>
@@ -570,9 +570,9 @@
 </td>
 </tr>
 </table>
-<h3>
+<h3 id="Calling">
 <hr width="100%"/>
-<a name="Calling"></a>Calling Subprograms</h3>
+Calling Subprograms</h3>
 <ul>
 <li>The CALL verb. </li>
 <li>COBOL Subprograms. </li>
@@ -600,9 +600,9 @@
 </td>
 </tr>
 </table>
-<h3>
+<h3 id="Inspect">
 <hr width="100%"/>
-<a name="Inspect"></a>The INSPECT</h3>
+The INSPECT</h3>
 <table border="0" width="25%">
 <tr>
 <td width="32%">
@@ -619,9 +619,9 @@
 </td>
 </tr>
 </table>
-<h3>
+<h3 id="String">
 <hr width="100%"/>
-<a name="String"></a>The STRING </h3>
+The STRING </h3>
 <table border="0" width="25%">
 <tr>
 <td width="32%">
@@ -638,9 +638,9 @@
 </td>
 </tr>
 </table>
-<h3>
+<h3 id="Unstring">
 <hr width="100%"/>
-<a name="Unstring"></a>The UNSTRING</h3>
+The UNSTRING</h3>
 <table border="0" width="25%">
 <tr>
 <td width="32%">
@@ -657,9 +657,9 @@
 </td>
 </tr>
 </table>
-<h3>
+<h3 id="Usage">
 <hr width="100%"/>
-<a name="Usage"></a>The USAGE clause</h3>
+The USAGE clause</h3>
 <table border="0" width="25%">
 <tr>
 <td width="32%">
@@ -676,9 +676,9 @@
 </td>
 </tr>
 </table>
-<h3>
+<h3 id="ReportWriter1">
 <hr width="100%"/>
-<a name="ReportWriter1"></a>The COBOL Report Writer - A worked example</h3>
+The COBOL Report Writer - A worked example</h3>
 <blockquote>
 <p>Unlike the other topics here, which contain only the slides from my COBOL 
     lectures, the Report Writer units contain a full tutorials. I am rewriting 
@@ -705,9 +705,9 @@
 </td>
 </tr>
 </table>
-<h3>
+<h3 id="ReportWriter2">
 <hr width="100%"/>
-<a name="ReportWriter2"></a>The COBOL Report Writer - Syntax and Semantics</h3>
+The COBOL Report Writer - Syntax and Semantics</h3>
 <blockquote>
 <p>This tutorial provides a Report Writer reference. The syntactic elements 
     of the Report Writer are presented and the semantics of their operation discussed.</p>
@@ -729,7 +729,7 @@
 </tr>
 </table>
 <hr width="100%"/>
-<h3><a name="Copy"></a>The COPY</h3>
+<h3 id="Copy">The COPY</h3>
 <ul>
 <li>The COPY verb </li>
 <li>Why use COPY Libraries. </li>

--- a/lectures/ReportWriterSSWeb.html
+++ b/lectures/ReportWriterSSWeb.html
@@ -127,7 +127,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="intro"></a><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
+<h2 align="CENTER" id="intro"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
 </td>
 </tr>
 <tr>
@@ -186,7 +186,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part1"></a><font face="Arial, Helvetica, sans-serif">Defining 
+<h2 align="CENTER" id="part1"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Defining 
               the Report - Report File entries</font></font></h2>
 </td>
 </tr>
@@ -275,7 +275,7 @@ FD  SalesFile.
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP">
-<h2 align="CENTER"><font color="#FFFF00" face="Arial, Helvetica, sans-serif"><a name="part2"></a>Defining 
+<h2 align="CENTER" id="part2"><font color="#FFFF00" face="Arial, Helvetica, sans-serif">Defining 
               the Report - Report Description (RD) Entries</font></h2>
 </td>
 </tr>
@@ -369,7 +369,7 @@ FD  SalesFile.
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP">
-<h2 align="CENTER"><font color="#FFFF00" face="Arial, Helvetica, sans-serif"><a name="part3"></a></font><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Defining 
+<h2 align="CENTER" id="part3"><font color="#FFFF00" face="Arial, Helvetica, sans-serif"></font><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Defining 
               the Report - Report Group entries</font></font></h2>
 </td>
 </tr>
@@ -520,7 +520,7 @@ FD  SalesFile.
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP">
-<h2 align="CENTER"><font color="#FFFF00" face="Arial, Helvetica, sans-serif"><a name="part4"></a></font><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Defining 
+<h2 align="CENTER" id="part4"><font color="#FFFF00" face="Arial, Helvetica, sans-serif"></font><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Defining 
               the Report - Lines and Columns</font></font></h2>
 </td>
 </tr>
@@ -756,7 +756,7 @@ FD  SalesFile.
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part5"></a><font face="Arial, Helvetica, sans-serif">Special 
+<h2 align="CENTER" id="part5"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Special 
               Report Writer registers</font></font></h2>
 </td>
 </tr>
@@ -844,7 +844,7 @@ FD  SalesFile.
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part6"></a>Procedure 
+<h2 align="CENTER" id="part6"><font color="#FFFF00">Procedure 
               Division verbs</font></h2>
 </td>
 </tr>
@@ -1041,7 +1041,7 @@ Programmer - Michael Coughlan               Page :  1
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP">
-<h2 align="CENTER"><font color="#FFFF00" face="Arial, Helvetica, sans-serif"><a name="part7"></a>Report 
+<h2 align="CENTER" id="part7"><font color="#FFFF00" face="Arial, Helvetica, sans-serif">Report 
               Writer Declaratives</font></h2>
 </td>
 </tr>

--- a/lectures/ReportWriterWeb.html
+++ b/lectures/ReportWriterWeb.html
@@ -116,7 +116,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="intro"></a><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
+<h2 align="CENTER" id="intro"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Introduction</font></font></h2>
 </td>
 </tr>
 <tr>
@@ -197,7 +197,7 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part1"></a><font face="Arial, Helvetica, sans-serif">The 
+<h2 align="CENTER" id="part1"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">The 
               Report Writer in Action</font></font></h2>
 </td>
 </tr>
@@ -310,7 +310,7 @@ PrintSalaryReport.
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP">
-<h2 align="CENTER"><font color="#FFFF00" face="Arial, Helvetica, sans-serif"><a name="part1b"></a>How 
+<h2 align="CENTER" id="part1b"><font color="#FFFF00" face="Arial, Helvetica, sans-serif">How 
               the Report Writer works</font></h2>
 </td>
 </tr>
@@ -415,7 +415,7 @@ PrintSalaryReport.
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part2"></a><font face="Arial, Helvetica, sans-serif">Let's 
+<h2 align="CENTER" id="part2"><font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Let's 
               write a Report Writer program!</font></font></h2>
 </td>
 </tr>
@@ -558,7 +558,7 @@ Programmer - Michael Coughlan               Page :  1
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="top" width="700">
-<h2 align="CENTER"><font color="#FFFF00"><a name="part3"></a>Let's 
+<h2 align="CENTER" id="part3"><font color="#FFFF00">Let's 
               add some features to our Report Program</font></h2>
 </td>
 </tr>
@@ -730,7 +730,7 @@ RD  SalesReport
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#993300" colspan="2" valign="TOP">
-<h2 align="CENTER"><font color="#FFFF00" face="Arial, Helvetica, sans-serif"><a name="part4"></a>Report 
+<h2 align="CENTER" id="part4"><font color="#FFFF00" face="Arial, Helvetica, sans-serif">Report 
               Writer Declaratives</font></h2>
 </td>
 </tr>

--- a/lectures/index.html
+++ b/lectures/index.html
@@ -92,8 +92,8 @@
 </ul>
 
 <hr width="100%"/>
-<h2>
-<a name="Contents"></a>Module Contents</h2>
+<h2 id="Contents">
+Module Contents</h2>
 <h4><img height="13" hspace="5" src="../pics/BallBlueG.gif" width="13"/><a href="CS4312Topics.html#General">General
   Introduction</a></h4>
 <h4>


### PR DESCRIPTION
## Summary

- Migrates 172 empty `<a name="X"></a>` anchors to modern `id` attributes across 29 HTML pages.
- The deprecated `name` attribute on `<a>` was removed in HTML5; promoting the anchor to an `id` on the enclosing section heading (or `<p>`) is the semantic equivalent and eliminates 171 of the empty `<a>` wrappers entirely.
- All existing intra-page TOC links (`#intro`, `#part1`, `#General`, etc.) continue to resolve to the same targets — only the mechanism changes.

## What changed

For each empty `<a name="X"></a>`, the migration picks the most natural enclosing block element and lifts the anchor's name onto it as an `id`. Patterns covered:

- `<h2><font color="#FFFF00"><a name="X"></a>...</h2>` → `<h2 id="X"><font color="#FFFF00">...</h2>` (most common — 118 cases)
- `<h3>\n<a name="X"></a>Title</h3>` → `<h3 id="X">\nTitle</h3>` (lecture pages)
- `<h2>...Introd<a name="X"></a>uction</h2>` → `<h2 id="X">...Introduction</h2>` (split-word case — text rejoins seamlessly)
- `<p><a name="X"></a>...` → `<p id="X">...`
- One outlier (`#pagetop` in [examples/default.html](examples/default.html)) had no natural parent and is kept as `<a id="pagetop"></a>` — still a strict semantic upgrade (deprecated `name` → modern `id`).

## Out of scope

[faq/COBOLFAQ.html](faq/COBOLFAQ.html) is deliberately excluded. It is Word-exported HTML with paired MSO bookmark machinery (`<?if !supportNestedAnchors?>`, `mso-bookmark` spans) where the empty anchors are part of a tightly coupled bookmark system. It deserves a separate, more careful pass.

## Test plan

- [ ] Spot-check [course/Iteration.html](course/Iteration.html) — verify TOC links `#intro`, `#part1`–`#part5` still jump to the correct sections
- [ ] Spot-check [course/IndexedFiles.html](course/IndexedFiles.html) — anchors that used to be wedged mid-word (`Introd<a></a>uction`); confirm headings now read cleanly and links still work
- [ ] Spot-check [lectures/CS4312Topics.html](lectures/CS4312Topics.html) — 27 lecture-section anchors (`#General`, `#Basics1`, `#IntroSeqFiles`, ...)
- [ ] Spot-check [examples/default.html](examples/default.html) — including the `#pagetop` fallback
- [ ] Verify line endings preserved (CRLF on the original files stays CRLF)