### PR TITLE
Promote Inspect page title to h1

### DIFF
--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -95,7 +95,7 @@
 <h2 id="top"> <img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
-<h2> <b>The INSPECT verb</b></h2>
+<h1>The INSPECT verb</h1>
 <hr align="LEFT"/>
 </center>
 </td>


### PR DESCRIPTION
## Summary
- On `course/Inspect.html`, the page's main title was `<h2><b>The INSPECT verb</b></h2>`. The `<b>` is redundant inside a heading, and the page had no top-level `<h1>`.
- Promote it to `<h1>The INSPECT verb</h1>` so the page title is the document's top-level heading and distinct from the section `<h2>`s.

## Test plan
- [ ] Open `course/Inspect.html` and confirm the title still renders as the most prominent heading.
- [ ] Confirm the document outline now has a single `<h1>` with section `<h2>`s beneath it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)