### PR TITLE
Unwrap converting INSPECT syntax diagram from h3

### DIFF
--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -551,7 +551,7 @@ END-PERFORM</code></pre>
 <tr>
 <td align="LEFT" colspan="2" valign="TOP" width="175">
 <h3><font color="#800000">Syntax</font></h3>
-<h3><img src="Resources/pics/ConvInspect.gif"/></h3>
+<p><img src="Resources/pics/ConvInspect.gif"/></p>
 <hr/>
 </td>
 </tr>


### PR DESCRIPTION
## Summary
- The converting INSPECT syntax diagram image in [course/Inspect.html](course/Inspect.html) was wrapped in `<h3>` tags, polluting the document outline with a heading that contained no text — just an image.
- Changed to `<p>` to match the wrapper used by the other three syntax diagrams on the same page (counting, replacing, combined).

## Test plan
- [ ] Open [course/Inspect.html](course/Inspect.html) and visually confirm the converting INSPECT syntax diagram still renders in place under the "Syntax" heading.
- [ ] Confirm the document outline no longer shows an empty h3 entry for the diagram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)