### PR TITLE
Drop empty center wrapper at top of String.html

### DIFF
--- a/course/String.html
+++ b/course/String.html
@@ -84,8 +84,6 @@
 <tr>
 <td>
 <center>
-</center>
-<center>
 <div align="LEFT">
 <table border="0" width="710">
 <tr>


### PR DESCRIPTION
## Summary
- Removes a stray empty `<center></center>` followed immediately by a redundant `<center>` reopen near the top of [course/String.html](course/String.html) — dead markup using a deprecated element with no content.

## Test plan
- [ ] Open [course/String.html](course/String.html) in a browser and confirm the page header/layout is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)