### PR TITLE
Promote Search page title to h1

### DIFF
--- a/course/Search.html
+++ b/course/Search.html
@@ -89,7 +89,7 @@
 <h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
-<h2> Searching Tables</h2>
+<h1> Searching Tables</h1>
 <hr/>
 </center>
 <ul class="toc">


### PR DESCRIPTION
## Summary
- Promotes the "Searching Tables" page title in [course/Search.html](course/Search.html) from `<h2>` to `<h1>` so the page has a single top-level heading and a cleaner document outline.
- Follows the same semantic cleanup applied to the Inspect page in 4b3a43e ("Promote Inspect page title to h1").

## Test plan
- [ ] Visually confirm the "Searching Tables" heading still renders prominently.
- [ ] Verify no other styling regressions on [course/Search.html](course/Search.html).

🤖 Generated with [Claude Code](https://claude.com/claude-code)