### PR TITLE
Promote course page titles to h1

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -65,7 +65,7 @@
               <h2><img src="Resources/pics/t-CobolTut.gif" width="173" height="59"></h2>
             </center>
             <center>
-              <h2> Introduction to COBOL</h2>
+              <h1>Introduction to COBOL</h1>
               <hr>
             </center>
             <ul class="toc">

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -87,7 +87,7 @@
 <h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
-<h2> <b>Basic Procedure Division Commands</b></h2>
+<h1>Basic Procedure Division Commands</h1>
 <hr/>
 </center>
 <ul class="toc">

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -87,7 +87,7 @@
 <h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
-<h2> The COPY verb</h2>
+<h1>The COPY verb</h1>
 <hr/>
 </center>
 <ul class="toc">

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -87,7 +87,7 @@
 <h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
-<h2> <b>Declaring Data in COBOL</b></h2>
+<h1>Declaring Data in COBOL</h1>
 <hr/>
 </center>
 <ul class="toc">

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -86,7 +86,7 @@
 <h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
-<h2> <b>Edited Pictures</b></h2>
+<h1>Edited Pictures</h1>
 <hr/>
 </center>
 <ul class="toc">

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -94,7 +94,7 @@
 <h2 id="top"> <img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
-<h2> <b>Indexed Files</b></h2>
+<h1>Indexed Files</h1>
 <hr align="LEFT"/>
 </center>
 </td>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -92,7 +92,7 @@
 <h2 id="top"> <img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
-<h2> <b>Introduction to Direct Access Files</b></h2>
+<h1>Introduction to Direct Access Files</h1>
 <hr/>
 </center>
 </td>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -92,7 +92,7 @@
 <h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
-<h2> <b>COBOL Iteration Constructs</b></h2>
+<h1>COBOL Iteration Constructs</h1>
 <hr/>
 </center>
 <ul class="toc">

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -87,7 +87,7 @@
 <h2><img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
-<h2> <b>Reference Modification and Intrinsic Functions</b></h2>
+<h1>Reference Modification and Intrinsic Functions</h1>
 <hr/>
 </center>
 <ul class="toc">

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -92,7 +92,7 @@
 <h2 id="top"> <img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
-<h2> <b>Relative Files</b></h2>
+<h1>Relative Files</h1>
 </center>
 <hr/>
 </td>

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -87,7 +87,7 @@
 <h2><img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
-<h2> <b>The COBOL Report Writer</b></h2>
+<h1>The COBOL Report Writer</h1>
 <hr/>
 </center>
 <ul class="toc">

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -87,7 +87,7 @@
 <h2><img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
-<h2> <b>The COBOL Report Writer - Syntax and Semantics</b></h2>
+<h1>The COBOL Report Writer - Syntax and Semantics</h1>
 <hr/>
 </center>
 <ul class="toc">

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -87,7 +87,7 @@
 <h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
-<h2> <b>COBOL Selection Constructs</b></h2>
+<h1>COBOL Selection Constructs</h1>
 <hr/>
 </center>
 <ul class="toc">

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -87,7 +87,7 @@
 <h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
-<h2> <b>Introduction to Sequential Files</b></h2>
+<h1>Introduction to Sequential Files</h1>
 <hr/>
 </center>
 <ul class="toc">

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -92,7 +92,7 @@
 <h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
-<h2> <b>Processing Sequential Files</b></h2>
+<h1>Processing Sequential Files</h1>
 <hr/>
 </center>
 <ul class="toc">

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -87,7 +87,7 @@
 <h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
-<h2> Print files and variable-length records</h2>
+<h1>Print files and variable-length records</h1>
 <hr/>
 </center>
 <ul class="toc">

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -87,7 +87,7 @@
 <h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
-<h2> Sorting and Merging files</h2>
+<h1>Sorting and Merging files</h1>
 <hr/>
 </center>
 <ul class="toc">

--- a/course/String.html
+++ b/course/String.html
@@ -92,7 +92,7 @@
 <h2 id="top"> <img alt="Cobol Tutorial" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
-<h2> <b>The STRING verb</b></h2>
+<h1>The STRING verb</h1>
 <hr align="LEFT"/>
 </center>
 </td>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -87,7 +87,7 @@
 <h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
-<h2> Subprograms</h2>
+<h1>Subprograms</h1>
 <hr/>
 </center>
 <ul class="toc">

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -87,7 +87,7 @@
 <h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
-<h2> Using Tables </h2>
+<h1> Using Tables </h1>
 <hr/>
 </center>
 <ul class="toc">

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -91,7 +91,7 @@
 <h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
-<h2> Creating Tables - syntax and semantics</h2>
+<h1>Creating Tables - syntax and semantics</h1>
 <hr/>
 </center>
 <ul class="toc">

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -94,7 +94,7 @@
 <h2 id="top"> <img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
-<h2> <b>The UNSTRING verb</b></h2>
+<h1>The UNSTRING verb</h1>
 <hr align="LEFT"/>
 </center>
 </td>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -87,7 +87,7 @@
 <h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
 </center>
 <center>
-<h2> The USAGE clause</h2>
+<h1>The USAGE clause</h1>
 <hr/>
 </center>
 <ul class="toc">


### PR DESCRIPTION
## Summary
Most pages under `course/` marked their main page title as `<h2>` (often wrapped in a redundant `<b>`), leaving each document with no top-level heading and conflating the page title with the section-level `<h2>`s ("Introduction", etc.). This PR promotes the title on each affected page to `<h1>` and drops the redundant `<b>` where present.

This continues the pattern from the prior fixes to:
- `course/Inspect.html` (4b3a43e)
- `course/Search.html` (bda35d1)

## Pages updated
- Tables1.html (initial commit)
- COBOLIntro.html, COBOLcommands.html, Copy.html, DataDeclaration.html, EditedPics.html, IndexedFiles.html, Intro2DirectAccess.html, Iteration.html, RefMod.html, RelativeFiles.html, ReportWriter.html, ReportWriterSS.html, Selection.html, SequentialFiles1.html, SequentialFiles2.html, SequentialFiles3.html, SortMerge.html, String.html, Subprograms.html, Tables2.html, Unstring.html, Usage.html

## Test plan
- [ ] Spot-check a few pages and confirm the title still renders as the visual page heading and the rest of the page is unchanged.
- [ ] Confirm no page now has more than one `<h1>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)