### PR TITLE
Close stacked <p> tags in Subprograms IS COMMON PROGRAM section

### DIFF
--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -901,27 +901,26 @@ END-PROGRAM ContainerProgram.</code></pre>
               an external program to make direct calls to the subprograms contained 
               within a container might be excited to come across the <font size="-1">IS 
               COMMON PROGRAM </font>clause. He might be forgiven for thinking 
-              for a moment that this clause was the solution to his problem. Sadly 
-              this is not the case. 
-            <p>The <b>only use</b> of the <font size="-1">IS COMMON PROGRAM </font>clause 
-              is to allow a subprogram to call one of its sibling subprograms. 
-              (i.e. a subprogram at the same level). 
-            <p>Contained subprograms can only call a subprogram at the same level 
+              for a moment that this clause was the solution to his problem. Sadly
+              this is not the case.</p>
+<p>The <b>only use</b> of the <font size="-1">IS COMMON PROGRAM </font>clause
+              is to allow a subprogram to call one of its sibling subprograms.
+              (i.e. a subprogram at the same level).</p>
+<p>Contained subprograms can only call a subprogram at the same level
               if the called program uses the <font size="-1">IS COMMON PROGRAM</font> 
               phrase in its <font size="-1">PROGRAM-ID</font>. For instance in 
               the example below <i>DisplayData</i> is called by the main program 
-              and by its sibling <i>InsertData</i> but <i>InsertData</i> cannot 
-              call <i>DisplayData</i>. 
-            <p>The syntax diagram for the <font size="-1">IS INITIAL</font> and 
+              and by its sibling <i>InsertData</i> but <i>InsertData</i> cannot
+              call <i>DisplayData</i>.</p>
+<p>The syntax diagram for the <font size="-1">IS INITIAL</font> and
               <font size="-1">IS COMMON</font> clauses is shown below. As you 
               can see from the diagram both the <font size="-1">COMMON</font> 
               and <font size="-1">INITIAL</font> clauses may be used in combination. 
               The words<font size="-1"> IS</font> and <font size="-1">PROGRAM</font> 
-              are noise words which may be omitted. 
-            <p align="center"><img height="23" src="Resources/pics/call8.gif" width="495"/>
-<p>  
-            <hr size="1" width="100%"/>
-</p></p></p></p></p></p></td>
+              are noise words which may be omitted.</p>
+<p align="center"><img height="23" src="Resources/pics/call8.gif" width="495"/></p>
+<hr size="1" width="100%"/>
+</td>
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#FFFFCC" valign="TOP" width="175">


### PR DESCRIPTION
## Summary
- The "IS COMMON PROGRAM clause" cell in [course/Subprograms.html](course/Subprograms.html) had five `<p>` elements that opened without closing, with the resulting closures stacked as `</p></p></p></p></p></p>` at the end of the cell.
- `<p>` elements cannot nest, so browsers were silently auto-closing each open `<p>` when the next began — the rendered output was fine, but the markup was invalid.
- Made each paragraph a proper sibling and lifted the `<hr>` out of the empty `<p>` that wrapped it.

## Test plan
- [ ] Visually compare the "IS COMMON PROGRAM clause" section before/after — rendering should be unchanged.
- [ ] Validate the page (e.g. via the W3C validator) and confirm the nested-`<p>` warnings on this section are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)