### PR TITLE
Fix misplaced <font> opening tags in course/Inspect.html

### DIFF
--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -108,7 +108,7 @@
 </b><font size="-1">Unit aims, objectives, prerequisites and a legend for
       this unit's syntax diagrams.</font>
 </li><li> <b><a href="#inspect">Using the INSPECT</a><br/>
-</b>T<font size="-1">he INSPECT is introduced by looking at an example program.
+</b><font size="-1">The INSPECT is introduced by looking at an example program.
       The way the INSPECT works is explained and its modifying phrases are explored.</font></li><li> <a href="#count"><b>The counting format</b></a><br/>
 <font size="-1">Presents the syntax and rules of the counting format of
       the INSPECT.</font></li><li><b><a href="#replace">The replacing format</a><br/>
@@ -310,7 +310,7 @@ Begin.
 <h3><font color="#800000">How the INSPECT works.</font></h3>
 </td>
 <td width="525">
-<p>The I<font size="2">NSPECT</font> scans the source string from left to 
+<p>The <font size="2">INSPECT</font> scans the source string from left to
         right counting, replacing or converting characters under the control of 
         the <font size="2">TALLYING</font>, <font size="2">REPLACING</font> or 
         <font size="2">CONVERTING</font> phrases.</p>


### PR DESCRIPTION
## Summary
- Two spots in [course/Inspect.html](course/Inspect.html) had the opening `<font>` tag placed one character too far right, orphaning the first letter of a word outside the styled span.
- Line 111 (table of contents): `</b>T<font size="-1">he INSPECT...` — the "T" of "The" rendered at default size while the rest of the sentence rendered at `size="-1"`.
- Line 313 (body): `<p>The I<font size="2">NSPECT</font>...` — the "I" of "INSPECT" rendered at default size, splitting the word visually and semantically from "NSPECT".
- Both are now `<font ...>The...</font>` / `<font size="2">INSPECT</font>`, matching how `INSPECT` is wrapped consistently elsewhere on the same page.

## Test plan
- [ ] Visually inspect [course/Inspect.html](course/Inspect.html) — the introductory TOC bullet for "Using the INSPECT" reads as one uniform-size sentence.
- [ ] In the "How the INSPECT works" section, the word `INSPECT` is rendered as a single styled token rather than `I` + `NSPECT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)