### PR TITLE
Add missing <head> opening tag to 55 HTML files

### DIFF
--- a/examples/Accept/ACCEPT.html
+++ b/examples/Accept/ACCEPT.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>ACCEPT and DISPLAY example program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/Accept/Multiplier.html
+++ b/examples/Accept/Multiplier.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>ACCEPT, DISPLAY and MULTIPLY example program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/Accept/Shortest.html
+++ b/examples/Accept/Shortest.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>The Shortest COBOL program we can have</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/Conditn/Conditions.html
+++ b/examples/Conditn/Conditions.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Condition Names (level 88) example program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/Conditn/IterIf.html
+++ b/examples/Conditn/IterIf.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Condition Names (level 88) example program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/Indexed/DirectReadIdx.html
+++ b/examples/Indexed/DirectReadIdx.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Reading an Indexed file directly by key</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/Indexed/Seq2Index.html
+++ b/examples/Indexed/Seq2Index.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Creating an Indexed file from a sequential file</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/Indexed/SeqReadIdx.html
+++ b/examples/Indexed/SeqReadIdx.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Reading an Indexed file sequentially on any of its keys</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/Merge/Merge.html
+++ b/examples/Merge/Merge.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Merge Files - Example Program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/Perform/MileageCount.html
+++ b/examples/Perform/MileageCount.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Mileage counter simulation</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/Perform/Perform1.html
+++ b/examples/Perform/Perform1.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Perform - Format 1 example program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/Perform/Perform2.html
+++ b/examples/Perform/Perform2.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Perform - Format 2 example program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/Perform/Perform3.html
+++ b/examples/Perform/Perform3.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Perform - Format 3 example program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/Perform/Perform4.html
+++ b/examples/Perform/Perform4.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Perform - Format 4 example program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/Relative/ReadRel.html
+++ b/examples/Relative/ReadRel.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Inserting records in a Sequential File </title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/Relative/Seq2Rel.html
+++ b/examples/Relative/Seq2Rel.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Inserting records in a Sequential File </title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/ReportWriter/RepWriteA.html
+++ b/examples/ReportWriter/RepWriteA.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>One control break version of full Report Writer example Program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/ReportWriter/RepWriteB.html
+++ b/examples/ReportWriter/RepWriteB.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>No Declaratives version of full Report Writer example program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/ReportWriter/RepWriteFull.html
+++ b/examples/ReportWriter/RepWriteFull.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Full Report Writer example program - includes Declaratives</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/ReportWriter/RepWriteSumm.html
+++ b/examples/ReportWriter/RepWriteSumm.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Summary version of the full Report Writer program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/SeqIns/SEQINSERT.html
+++ b/examples/SeqIns/SEQINSERT.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Inserting records in a Sequential File </title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/SeqRead/SEQREAD.html
+++ b/examples/SeqRead/SEQREAD.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Reading a Sequential File </title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/SeqRead/SEQREADno88.html
+++ b/examples/SeqRead/SEQREADno88.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Reading a Sequential File</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/SeqRpt/SEQRPT.html
+++ b/examples/SeqRpt/SEQRPT.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Sequential Student Number Report</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/SeqWrite/SEQWRITE.html
+++ b/examples/SeqWrite/SEQWRITE.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Writing to a Sequential File</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/Sort/InputSort.html
+++ b/examples/Sort/InputSort.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>SORT with Input Procedure to get recs from user</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/Sort/MaleSort.html
+++ b/examples/Sort/MaleSort.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>SORT file and select only male records</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/Strings/RefMod.html
+++ b/examples/Strings/RefMod.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>String handling - Reference Modification examples</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/Strings/UnstringFileEg.html
+++ b/examples/Strings/UnstringFileEg.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>String handling - Unpacking and size-validating comma separated records</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/SubProg/DateValid/DateDriver.html
+++ b/examples/SubProg/DateValid/DateDriver.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Driver program for date validation sub-program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/SubProg/DateValid/ValiDate.html
+++ b/examples/SubProg/DateValid/ValiDate.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Date validation sub-program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/SubProg/DayDiff/DayDiffDriver.html
+++ b/examples/SubProg/DayDiff/DayDiffDriver.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Get difference between dates driver program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/SubProg/Multiply/DriverProg.html
+++ b/examples/SubProg/Multiply/DriverProg.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>A driver for the MultiplyNums, Fickle and Steafast sub-programs</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/SubProg/Multiply/Fickle.html
+++ b/examples/SubProg/Multiply/Fickle.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>The Fickle sub-program demonstrates State Memory</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/SubProg/Multiply/MultiplyNums.html
+++ b/examples/SubProg/Multiply/MultiplyNums.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>The MultiplyNums sub-program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/SubProg/Multiply/Steadfast.html
+++ b/examples/SubProg/Multiply/Steadfast.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>The Steadfast sub-program demonstrates the IS INITIAL phrase</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/Tables/MonthTable.html
+++ b/examples/Tables/MonthTable.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Tables - Counts number of students born in each month</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/exercises/CountDown.html
+++ b/exercises/CountDown.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
    <meta name="GENERATOR" content="Mozilla/4.0 [en] (WinNT; I) [Netscape]">
    <title>ACCEPT + DISPLAY Terminal Exercise</title>

--- a/exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html
+++ b/exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Reading an Indexed file directly by key</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html
+++ b/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Reading an Indexed file directly by key</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html
+++ b/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Reading an Indexed file directly by key</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html
+++ b/exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Reading an Indexed file directly by key</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/exercises/Exm-FileConversion/Prg-FileConversion.html
+++ b/exercises/Exm-FileConversion/Prg-FileConversion.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Reading an Indexed file directly by key</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html
+++ b/exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Reading an Indexed file directly by key</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html
+++ b/exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Reading an Indexed file directly by key</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/exercises/Exm-StudFeesRpt/Prg-StudPay.html
+++ b/exercises/Exm-StudFeesRpt/Prg-StudPay.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Reading an Indexed file directly by key</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html
+++ b/exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Reading an Indexed file directly by key</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html
+++ b/exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <title>Reading an Indexed file directly by key</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/exercises/GettingStarted.html
+++ b/exercises/GettingStarted.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
    <meta name="GENERATOR" content="Mozilla/4.0 [en] (WinNT; I) [Netscape]">
    <title>Getting Started with the VISOC Environment</title>

--- a/exercises/SeqInsert.html
+++ b/exercises/SeqInsert.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
    <meta name="GENERATOR" content="Mozilla/4.0 [en] (WinNT; I) [Netscape]">
    <title>Inserting records in a Sequential File</title>

--- a/exercises/SeqRead.html
+++ b/exercises/SeqRead.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
    <meta name="GENERATOR" content="Mozilla/4.0 [en] (WinNT; I) [Netscape]">
    <title>Reading Sequential Files</title>

--- a/exercises/SeqReadIf.html
+++ b/exercises/SeqReadIf.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
    <meta name="GENERATOR" content="Mozilla/4.0 [en] (WinNT; I) [Netscape]">
    <title>Counting records in a sequential file</title>

--- a/exercises/SeqUpdate.html
+++ b/exercises/SeqUpdate.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
    <meta name="GENERATOR" content="Mozilla/4.0 [en] (WinNT; I) [Netscape]">
    <title>Updating a Sequential File</title>

--- a/exercises/SeqWrite.html
+++ b/exercises/SeqWrite.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
    <meta name="GENERATOR" content="Mozilla/4.0 [en] (WinNT; I) [Netscape]">
    <title>Writing records to a Sequential File</title>

--- a/exercises/SortIP.html
+++ b/exercises/SortIP.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
    <meta name="GENERATOR" content="Mozilla/4.0 [en] (WinNT; I) [Netscape]">
    <title>Sorting a Sequential File</title>

--- a/index.html
+++ b/index.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="google-site-verification" content="g9Kb5_0qV7EdRel40vEW48IAmR1DCIYL7oBqiuPNTr8"/>


### PR DESCRIPTION
## Summary
- 55 HTML pages across `examples/`, `exercises/`, and the repo root had a closing `</head>` tag with no matching opening tag — `<title>`, `<meta>`, and `<style>` elements sat as direct children of `<html>`.
- Inserted an opening `<head>` immediately after `<html>` in each affected file, so the head section is now properly delimited.
- Line endings (CRLF/LF) were preserved per file.

## Why
Browsers tolerated the broken structure by auto-creating an implicit head, but the markup was technically invalid. Cleaner, more semantic HTML.

## Test plan
- [ ] Spot-check a few pages render identically to before
- [ ] Confirm `<title>` still appears in the browser tab
- [ ] Confirm responsive `<style>` rules still apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)