### PR TITLE
Remove empty <pre><code> blocks from course pages

### DIFF
--- a/course/Search.html
+++ b/course/Search.html
@@ -693,9 +693,7 @@ DisplayCountyTaxes.
 <div align="center">
 <img alt="Diagram of the hotel occupancy table showing floors and rooms" height="170" src="Resources/pics/Search5.gif" width="411"/>
 </div>
-<pre class="language-cobol" align="left"><code class="language-cobol"> 
-</code></pre>
-<p align="left"> Suppose we want to search the table to discover which 
+<p align="left"> Suppose we want to search the table to discover which
               room is occupied by customer 126789. We can't use the <font size="-1">SEARCH</font> 
               to search the whole two-dimension table directly but we can use 
               the <font size="-1">SEARCH</font> to search the table floor by floor. 

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -340,9 +340,6 @@ Statement6.</code></pre>
                   statement that says </p>
 <pre class="language-cobol" align="left"><code class="language-cobol">IF "mike" IS EQUAL TO 123 THEN etc
                   </code></pre>
-<div align="left">
-<pre class="language-cobol" align="left"><code class="language-cobol">  </code></pre>
-</div>
 </div>
 </div>
 </td>
@@ -807,11 +804,6 @@ END-IF
 </tr>
 </table>
 </form>
-
-<blockquote>
-<pre class="language-cobol"><code class="language-cobol"> 
-</code></pre>
-</blockquote>
 </td>
 </tr>
 <tr>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -2255,10 +2255,6 @@ Begin.
 </td>
 </tr>
 </table>
-<div align="center"></div>
-<pre class="language-cobol"><code class="language-cobol"> 
-
-</code></pre>
 <p><b>COMP/COMPUTATIONAL/BINARY</b><br/>
 <font size="-1">COMP</font> items are held in memory as pure binary 
               two's complement numbers. The storage requirements for fields described 


### PR DESCRIPTION
## Summary

- Removed four whitespace-only `<pre><code>` blocks that rendered as empty styled code boxes on three course pages
- Also dropped the empty `<div>`/`<blockquote>` wrappers whose only child was the removed block

## Changes

- [course/Selection.html](course/Selection.html) — removed two empty code blocks (one in the Relation Conditions section under the `IF "mike"...` example, and one in an empty `<blockquote>` after the EVALUATE form)
- [course/Search.html](course/Search.html) — removed the empty code block between the hotel-occupancy diagram and the following paragraph
- [course/Usage.html](course/Usage.html) — removed the empty code block (and a sibling empty `<div align="center">`) between the COMP example table and the COMP/COMPUTATIONAL/BINARY heading

## Why

These blocks contained only whitespace, so they had no semantic value but Prism styling made them visible as empty boxes. Skipped a similar `<pre>     </pre>` in `exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html` because it sits between two real `<pre>` calculation steps and removing it would visually merge them.

## Test plan

- [ ] Open each affected page in a browser and verify the empty code box no longer appears
- [ ] Confirm surrounding content (examples, diagram, COMP table) still flows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)