### PR TITLE
Remove nested <blockquote> indentation hacks from course pages

### DIFF
--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -316,9 +316,6 @@ DISPLAY PrinterSetupCodes UPON PrinterPort1.
 </code></pre>
 </div>
 </div>
-<blockquote>
-<blockquote> </blockquote>
-</blockquote>
 </td>
 </tr>
 <tr>

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -218,16 +218,10 @@
 <td width="525">
 <p> You can download both the program and the sequential data file 
               it uses. </p>
-<blockquote>
-<blockquote>
-<blockquote>
-<p><a href="Resources/progs/INX-EG1.CBL">Download the 
+<p><a href="Resources/progs/INX-EG1.CBL">Download the
                     Indexed file example program 1</a></p>
-<p><a href="Resources/progs/INVIDEO.DAT">Download the 
+<p><a href="Resources/progs/INVIDEO.DAT">Download the
                     Sequential data file </a></p>
-</blockquote>
-</blockquote>
-</blockquote>
 </td>
 </tr>
 </table>
@@ -320,14 +314,8 @@ Enter key : 1=VideoCode, 2=VideoTitle -&gt;2
               should already have the Indexed file (it was produced when you ran 
               the first example program). You can use this file with the second 
               Indexed file example program.  </p>
-<blockquote>
-<blockquote>
-<blockquote>
-<p><a href="Resources/progs/INX-EG2.CBL">Download Indexed 
+<p><a href="Resources/progs/INX-EG2.CBL">Download Indexed
                     file example program 2</a></p>
-</blockquote>
-</blockquote>
-</blockquote>
 </td>
 </tr>
 </table>
@@ -383,15 +371,8 @@ VIDEO STATUS :- 23</code></pre>
 <p>You can use the Indexed file that is created when you run the first 
               sexample program with this third Indexed example program.  
             </p>
-<blockquote>
-<blockquote>
-<blockquote>
-<p><a href="Resources/progs/INX-EG3.CBL">Download Indexed 
+<p><a href="Resources/progs/INX-EG3.CBL">Download Indexed
                     file example program 3</a></p>
-
-</blockquote>
-</blockquote>
-</blockquote>
 </td>
 </tr>
 </table>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -309,9 +309,7 @@
 </ol>
 <p align="left">The template for Intrinsic Functions is shown below:</p>
 <blockquote>
-<blockquote>
 <p>FUNCTION FunctionName(<i>Parameters</i>)</p>
-</blockquote>
 </blockquote>
 <p><i>FunctionName</i> is the name of the function and <i>Parameters</i> 
               is one or more parameters supplied to the function.</p>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -226,16 +226,10 @@
 <p>It is a good idea to download the program and use the animator 
               to watch how the Relative file is created. You can download both 
               the program and the sequential data file it uses. </p>
-<blockquote>
-<blockquote>
-<blockquote>
-<p><a href="Resources/progs/REL-EG1.CBL">Download Relative 
+<p><a href="Resources/progs/REL-EG1.CBL">Download Relative
                     file example program 1</a></p>
-<p><a href="Resources/progs/INSUPP.DAT">Download the Sequential 
+<p><a href="Resources/progs/INSUPP.DAT">Download the Sequential
                     data file </a></p>
-</blockquote>
-</blockquote>
-</blockquote>
 </td>
 </tr>
 </table>
@@ -282,15 +276,8 @@ Enter supplier key (2 digits)-&gt; 05
               should already have the Relative file (it was produced when you 
               ran the first example program). You can use this file with the second 
               Relative file example program.  </p>
-<blockquote>
-<blockquote>
-<blockquote>
-<p><a href="Resources/progs/REL-EG2.CBL">Download Relative 
+<p><a href="Resources/progs/REL-EG2.CBL">Download Relative
                     file example program 2</a></p>
-
-</blockquote>
-</blockquote>
-</blockquote>
 </td>
 </tr>
 </table>
@@ -411,13 +398,9 @@ Enter supplier key (2 digits)-&gt; 05
         </div>
 </div>
 <blockquote>
-<blockquote>
-<div align="LEFT">
-            00 = Operation successful. 
-          </div>
-<p> 22 = Duplicate key. i.e. The record already exists. </p>
-<p> 23 = Record not found</p>
-</blockquote>
+<p>00 = Operation successful.</p>
+<p>22 = Duplicate key. i.e. The record already exists.</p>
+<p>23 = Record not found</p>
 </blockquote>
 <div align="CENTER">
 <div align="LEFT">

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -778,17 +778,9 @@ RD  SalesReport
                 for each report declared in the Report Section. The two registers 
                 are -</p>
 </div>
-<div align="left">
-<blockquote>
-<blockquote>
-<blockquote>
 <p align="center"> the LINE-COUNTER<br/>
                       and<br/>
                       the PAGE-COUNTER</p>
-</blockquote>
-</blockquote>
-</blockquote>
-</div>
 </td>
 </tr>
 <tr>
@@ -937,19 +929,9 @@ RD  SalesReport
               we have to to is to change the <font size="-1">GENERATE </font>statement 
               from -</p>
 <blockquote>
-<blockquote>
-<blockquote>
-<blockquote>
 <p>GENERATE DetailLine.</p>
-<blockquote>
-<blockquote>
-<p>to </p>
-</blockquote>
-</blockquote>
+<p>to</p>
 <p>GENERATE SalesReport.</p>
-</blockquote>
-</blockquote>
-</blockquote>
 </blockquote>
 
 <p>If we specify <font size="-1">GENERATE</font> SalesReport then 

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -606,11 +606,6 @@ END-IF
 </td>
 </tr>
 </table>
-<blockquote>
-<blockquote>
-
-</blockquote>
-</blockquote>
 <p>Now, consider the condition below and create a table similar to 
               the ones above. Is this Complex Condition true if all the Simple 
               Conditions are true?</p>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -318,7 +318,6 @@ Total value =  999,999,999.99</code></pre>
                   performance implications. For each of the millions of records 
                   in the file we would have to;</p>
 <blockquote>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">Read the Sequential File
 IF the record already exists THEN
    Read the Relative Record
@@ -327,7 +326,6 @@ IF the record already exists THEN
 ELSE
    Write a new Relative Record to the file
 END-IF</code></pre>
-</blockquote>
 </blockquote>
 <p align="left">And when the calls file ended we would have to 
                   read through the entire Relative file again to create the report.</p>


### PR DESCRIPTION
## Summary
- `<blockquote>` is for quotations, not visual indentation. Several course pages stacked two, three, even four `<blockquote>` elements purely to indent download links, code fragments, and short inline notes. A couple of wrappers contained nothing but a non-breaking space.
- Collapsed each nest to a single `<blockquote>` where the content was a real callout, and removed the wrappers entirely where they were either pure indentation around already-contained content (table cells, `<p align="center">`) or empty.
- After this change there are no remaining `<blockquote>` immediately nested inside another `<blockquote>` in `course/`.

Files touched:
- `course/IndexedFiles.html` — 3 triple-nests around download links
- `course/RelativeFiles.html` — 2 triple-nests around download links, 1 two-nest around file-status definitions
- `course/ReportWriterSS.html` — 1 triple-nest around the LINE-COUNTER/PAGE-COUNTER block, 1 tangled four-deep + two-deep nest around the `GENERATE` example
- `course/COBOLcommands.html` — empty NBSP-only nested wrapper deleted
- `course/Selection.html` — empty nested wrapper deleted
- `course/RefMod.html` — two-nest around the `FUNCTION FunctionName(...)` template collapsed
- `course/SortMerge.html` — two-nest around a pseudocode `<pre>` block collapsed

## Test plan
- [ ] Visually spot-check each affected page renders without the indentation looking obviously broken
- [ ] Confirm `rg -U '<blockquote>\s*<blockquote>' course/` returns nothing