### PR TITLE
Fix invalid <p> tags wrapping block elements on course pages

### DIFF
--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -929,7 +929,6 @@ The time is 14:41
               precedence rules shown below can change the order of evaluation. 
             </p>
 <title></title>
-<p align="LEFT">
 <table align="center" bgcolor="#E1FFE1" border="" cellpadding="7" cellspacing="1" width="259">
 <tr>
 <td bgcolor="#FFFFCC" valign="TOP" width="32%">
@@ -998,11 +997,11 @@ The time is 14:41
               the ** expression symbol to represent raising to a power.</p>
 <hr width="50%"/>
 <div align="center"> </div>
-</p></td>
+</td>
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#FFFFCC" valign="TOP" width="175">
-<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Arithmetic 
+<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Arithmetic
               examples </font></h4>
 </td>
 <td valign="top" width="525">

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -344,8 +344,7 @@
               literal but unlike literals, when a Figurative Constant is assigned 
               to a data-item it fills the whole item overwriting everything in 
               it.</p>
-<p>The Figurative Constants are: 
-            <p align="CENTER">
+<p>The Figurative Constants are:</p>
 <table align="center" bgcolor="#E1FFE1" border="1" cellpadding="5" cellspacing="0" width="439">
 <tr>
 <td valign="TOP" width="47%"> <font size="-1"><b>SPACE</b></font> 
@@ -393,7 +392,7 @@
                 and <font size="-1">LOW-VALUES</font>. </li>
 </ul>
 <hr width="50%"/>
-</p></p></td>
+</td>
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#FFFFCC" valign="TOP" width="175">

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -311,14 +311,14 @@ Begin.
               clause they default to - <font size="-1">USAGE IS DISPLAY</font>. 
               This means that the values in the variables Num1, Num2 and Num3 
               are stored as ASCII digits. How does this effect calculations?</p>
-<p>If you examine the ASCII table below you will see that the digit 
-              4 (the value in Num1) is encoded as <b><font color="#FF0000">00110100 
-              </font></b> and the digit 1 is encoded as <font color="#FF0000"><b>00110001</b></font>. 
-            <p>When these these binary numbers are added together the result is 
-              <b><font color="#FF0000">01100101</font></b> which is the ASCII 
-              code for the lower case letter "e". 
-            <p>The sum <b>4 + 1 = e</b> does not compute. 
-            <p align="center"><img height="202" src="Resources/pics/Usage2.gif" width="439"/>
+<p>If you examine the ASCII table below you will see that the digit
+              4 (the value in Num1) is encoded as <b><font color="#FF0000">00110100
+              </font></b> and the digit 1 is encoded as <font color="#FF0000"><b>00110001</b></font>.</p>
+<p>When these these binary numbers are added together the result is
+              <b><font color="#FF0000">01100101</font></b> which is the ASCII
+              code for the lower case letter "e".</p>
+<p>The sum <b>4 + 1 = e</b> does not compute.</p>
+<p align="center"><img height="202" src="Resources/pics/Usage2.gif" width="439"/></p>
 
 <p>When calculations are done with numeric data items whose <font size="-1">USAGE 
               IS DISPLAY,</font> the computer has to convert the numeric values 
@@ -2143,7 +2143,7 @@ Begin.
 
 </div>
 <hr align="center" size="1" width="100%"/>
-</p></p></p></p></td>
+</td>
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#FFFFCC" valign="TOP" width="175">


### PR DESCRIPTION
## Summary

Three course pages had `<p>` tags wrapping block-level content (`<table>`, `<ul>`, `<hr>`, `<div>`, nested `<p>`). HTML doesn't allow this — the parser auto-closes the paragraph as soon as it hits the block element, leaving the trailing `</p>` orphaned (sometimes stacked four-deep) and producing semantically invalid markup.

## Changes

- **course/COBOLcommands.html** — removed `<p align="LEFT">` wrapping the operator-precedence `<table>`, plus its orphan `</p>`.
- **course/DataDeclaration.html** — closed the "The Figurative Constants are:" paragraph properly and dropped the `<p align="CENTER">` that wrapped the figurative-constants `<table>`, `<ul>`, and `<hr>`. Removed the resulting `</p></p>` tail.
- **course/Usage.html** — closed four unclosed `<p>` tags inline (the `4 + 1 = e` explanation block) instead of leaving them to be implicitly closed and dumped as `</p></p></p></p>` ~1800 lines later.

No visual changes — browsers were already auto-closing these paragraphs on parse.

## Test plan

- [ ] Spot-check the three pages render identically to before
- [ ] Validate with an HTML linter to confirm the orphan `</p>` tags are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)