### PR TITLE
Fix more invalid <p> tags wrapping block-level elements

### DIFF
--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -955,8 +955,7 @@ The time is 14:41
 <tr>
 <td rowspan="2" valign="TOP" width="32%">
 <p align="center">2. 
-                  <div align="center"></div>
-</p></td>
+                </p></td>
 <td valign="TOP" width="29%">
 <p align="center"><b>*</b>
 </p></td>
@@ -975,8 +974,7 @@ The time is 14:41
 <tr>
 <td rowspan="2" valign="TOP" width="32%">
 <p align="center">3. 
-                  <div align="center"></div>
-</p></td>
+                </p></td>
 <td valign="TOP" width="29%">
 <p align="center"><b>+</b>
 </p></td>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -145,9 +145,8 @@
 </div>
 <div align="center">
 
-<p align="CENTER"><b><font face="TIMES">Iteration constructs and 
+<p align="CENTER"><b><font face="TIMES">Iteration constructs and
                 their COBOL equivalents</font></b></p>
-<p align="CENTER">
 <center>
 <table bgcolor="#E1FFE1" border="" cellpadding="7" cellspacing="1" width="411">
 <tr bgcolor="#FFFFCC">
@@ -199,7 +198,7 @@
                   is used to transfer control to an open subroutine.</p>
 </center>
 <hr width="50%"/>
-</p></div>
+</div>
 
 </td>
 </tr>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -428,22 +428,12 @@ END-UNSTRING.</code></pre>
         to review the material above for this). </p>
 <p>When you are happy with your prediction step through the example and 
         see if you were correct. </p>
-<p>If your prediction is not correct try to discover what misunderstanding 
+<p>If your prediction is not correct try to discover what misunderstanding
         has led to your error.</p>
-<p>
 <center>
-<iframe height="416" src="Resources/pdf-viewer.html?src=ppz/Unstring2.pdf" style="border:1px solid #ccc; width:100%; aspect-ratio: 520/416;" width="520"></iframe> <font size="2">Left click or PageDown to go to the next frame 
+<iframe height="416" src="Resources/pdf-viewer.html?src=ppz/Unstring2.pdf" style="border:1px solid #ccc; width:100%; aspect-ratio: 520/416;" width="520"></iframe> <font size="2">Left click or PageDown to go to the next frame
           and right click or press PageUp to go to the previous frame. </font>
 </center>
-</p>
-<p>
-</p>
-<p>
-</p>
-<p>
-</p>
-<p>
-</p>
 <hr/>
 </td>
 </tr>
@@ -456,15 +446,13 @@ END-UNSTRING.</code></pre>
 <p>The <font size="2">WITH POINTER</font> phrase is often very useful because 
         it means that we don't have to unpack the whole source string in one go.. 
       </p>
-<p>In this example, we unpack a full name, any number of Christian names 
+<p>In this example, we unpack a full name, any number of Christian names
         followed by a surname, and display the names one after another.</p>
-<p>
 <center>
-<iframe height="416" src="Resources/pdf-viewer.html?src=ppz/Unstring1.pdf" style="border:1px solid #ccc; width:100%; aspect-ratio: 520/416;" width="520"></iframe> <font size="2">Click on the diagram below to step through 
-          the animation. Left click or PageDown to go to the next step and right 
+<iframe height="416" src="Resources/pdf-viewer.html?src=ppz/Unstring1.pdf" style="border:1px solid #ccc; width:100%; aspect-ratio: 520/416;" width="520"></iframe> <font size="2">Click on the diagram below to step through
+          the animation. Left click or PageDown to go to the next step and right
           click or press PageUp to go to the previous step. </font>
 </center>
-</p>
 <hr/>
 </td>
 </tr>

--- a/examples/default.html
+++ b/examples/default.html
@@ -72,6 +72,8 @@
       margin: 0.2em 0;
     }
   }
+  ul.toc { list-style-image: url(../pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
+  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.4em; }
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
@@ -104,32 +106,32 @@
 </table>
 <hr/>
 <a id="pagetop"></a>
-<ul>
-<li><img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13"/><a href="#SimplePrograms">Beginners
+<ul class="toc">
+<li><a href="#SimplePrograms">Beginners
     Programs </a> - <font size="-1"> Simple programs using ACCEPT, DISPLAY and
     some arithmetic verbs.</font></li>
-<li><img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13"/><a href="#Selection">Selection
+<li><a href="#Selection">Selection
     and Iteration</a> <font size="-1">- Selection (IF, EVALUATE) and Iteration
     (PERFORM) example programs. </font></li>
-<li><img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13"/><a href="#SequentialFiles">Sequential
+<li><a href="#SequentialFiles">Sequential
     Files</a>  - <font size="-1">Programs that demonstrate how to process sequential
     files.</font></li>
-<li><img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13"/><a href="#Sort">Sorting
+<li><a href="#Sort">Sorting
     and Merging</a> - <font size="-1">Examples that use INPUT PROCEDURE's and the
     SORT and MERGE verbs</font></li>
-<li><img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13"/><a href="#Direct">Direct
+<li><a href="#Direct">Direct
     Access Files</a> - <font size="-1">Example programs that show how to process
     Indexed and Relative files.</font></li>
-<li><img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13"/><a href="#Call">CALLing
+<li><a href="#Call">CALLing
     sub-programs</a> - <font size="-1">Example programs that Demonstrate contained,
     and external, sub-programs.</font></li>
-<li><img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13"/><a href="#Strings">String
+<li><a href="#Strings">String
     handling </a> - <font size="-1">Example programs that show how to use Reference
     Modification, INSPECT and UNSTRING.</font></li>
-<li><img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13"/><a href="#Reports">The
+<li><a href="#Reports">The
     COBOL Report Writer</a> - <font size="-1">Example programs using the COBOL Report
     Writer.</font></li>
-<li><img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13"/><a href="#Tables">COBOL
+<li><a href="#Tables">COBOL
     Tables </a> - <font size="-1">Example programs using tables.</font></li>
 </ul>
 <table border="0" bordercolordark="#000000" bordercolorlight="#FFFFFF" width="725">

--- a/examples/default.html
+++ b/examples/default.html
@@ -105,33 +105,33 @@
 <hr/>
 <a id="pagetop"></a>
 <ul>
-<p><img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13"/><a href="#SimplePrograms">Beginners 
-    Programs </a> - <font size="-1"> Simple programs using ACCEPT, DISPLAY and 
-    some arithmetic verbs.</font></p>
-<p><img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13"/><a href="#Selection">Selection 
-    and Iteration</a> <font size="-1">- Selection (IF, EVALUATE) and Iteration 
-    (PERFORM) example programs. </font> </p>
-<p><img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13"/><a href="#SequentialFiles">Sequential 
-    Files</a>  - <font size="-1">Programs that demonstrate how to process sequential 
-    files.</font></p>
-<p><img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13"/><a href="#Sort">Sorting 
-    and Merging</a> - <font size="-1">Examples that use INPUT PROCEDURE's and the 
-    SORT and MERGE verbs</font>
-<p><img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13"/><a href="#Direct">Direct 
-    Access Files</a> - <font size="-1">Example programs that show how to process 
-    Indexed and Relative files.</font>
-<p><img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13"/><a href="#Call">CALLing 
-    sub-programs</a> - <font size="-1">Example programs that Demonstrate contained, 
-    and external, sub-programs.</font>
-<p><img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13"/><a href="#Strings">String 
-    handling </a> - <font size="-1">Example programs that show how to use Reference 
-    Modification, INSPECT and UNSTRING.</font>
-<p><img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13"/><a href="#Reports">The 
-    COBOL Report Writer</a> - <font size="-1">Example programs using the COBOL Report 
-    Writer.</font>
-<p><img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13"/><a href="#Tables">COBOL 
-    Tables </a> - <font size="-1">Example programs using tables.</font>
-</p></p></p></p></p></p></ul>
+<li><img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13"/><a href="#SimplePrograms">Beginners
+    Programs </a> - <font size="-1"> Simple programs using ACCEPT, DISPLAY and
+    some arithmetic verbs.</font></li>
+<li><img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13"/><a href="#Selection">Selection
+    and Iteration</a> <font size="-1">- Selection (IF, EVALUATE) and Iteration
+    (PERFORM) example programs. </font></li>
+<li><img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13"/><a href="#SequentialFiles">Sequential
+    Files</a>  - <font size="-1">Programs that demonstrate how to process sequential
+    files.</font></li>
+<li><img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13"/><a href="#Sort">Sorting
+    and Merging</a> - <font size="-1">Examples that use INPUT PROCEDURE's and the
+    SORT and MERGE verbs</font></li>
+<li><img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13"/><a href="#Direct">Direct
+    Access Files</a> - <font size="-1">Example programs that show how to process
+    Indexed and Relative files.</font></li>
+<li><img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13"/><a href="#Call">CALLing
+    sub-programs</a> - <font size="-1">Example programs that Demonstrate contained,
+    and external, sub-programs.</font></li>
+<li><img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13"/><a href="#Strings">String
+    handling </a> - <font size="-1">Example programs that show how to use Reference
+    Modification, INSPECT and UNSTRING.</font></li>
+<li><img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13"/><a href="#Reports">The
+    COBOL Report Writer</a> - <font size="-1">Example programs using the COBOL Report
+    Writer.</font></li>
+<li><img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13"/><a href="#Tables">COBOL
+    Tables </a> - <font size="-1">Example programs using tables.</font></li>
+</ul>
 <table border="0" bordercolordark="#000000" bordercolorlight="#FFFFFF" width="725">
 <tr bgcolor="#990000" valign="top">
 <td colspan="4">

--- a/exercises/MonthTable.html
+++ b/exercises/MonthTable.html
@@ -300,7 +300,6 @@ order.
 </ul>
 Use Edited picture clauses and the zero suppression symbol to produce the
 output as shown.<tt></tt>
-<p> 
 <h2>
 <b>Suggested Approaches.</b></h2>
 The main problem that we face here is that the results must be displayed
@@ -325,5 +324,5 @@ Sample Solution</h2>
 <font size="-2">To COBOL Exercises</font></td>
 </tr>
 </table>
-</p></p></body>
+</body>
 </html>

--- a/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html
+++ b/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html
@@ -1067,7 +1067,7 @@ uppercase">Sum Of Results</span> by <span style="text-transform:uppercase">Modul
         copyright property of Michael Coughlan. You have permission to use this 
         material for your own personal use but you may not reproduce it in any 
         published work without written permission from the author.</font></p>
-</p></p></p></p></p></p></p></td>
+</td>
 </tr>
 </table></body>
 </html>

--- a/exercises/index.html
+++ b/exercises/index.html
@@ -72,6 +72,8 @@
       margin: 0.2em 0;
     }
   }
+  ul.toc { list-style-image: url(../pics/BallRedG.gif); padding-left: 2.5em; margin: 1em 0; }
+  ul.toc > li { padding-left: 0.4em; margin-bottom: 0.4em; }
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
@@ -117,28 +119,28 @@
 </div>
 <hr align="left" width="800"/>
 <h3>Simple Programming Exercises</h3>
-<ul>
-<li><img height="13" hspace="4" src="../pics/BallRedG.gif" width="13"/><a href="GettingStarted.html">Getting
+<ul class="toc">
+<li><a href="GettingStarted.html">Getting
   Started</a> - Exercise to load, compile, run and alter an existing program.</li>
-<li><img height="13" hspace="4" src="../pics/BallRedG.gif" width="13"/><a href="CountDown.html">CountDown</a>
+<li><a href="CountDown.html">CountDown</a>
     - Exercise using the <font size="-1">ACCEPT</font>, <font size="-1">DISPLAY</font>,
     <font size="-1">PERFORM</font> ... <font size="-1">TIMES, COMPUTE</font> and <font size="-1">IF</font>.</li>
-<li><img height="13" hspace="4" src="../pics/BallRedG.gif" width="13"/><a href="SeqRead.html">Reading
+<li><a href="SeqRead.html">Reading
     Sequential Files</a>  - <font size="-1">READ, PERFORM.. UNTIL, DISPLAY</font></li>
-<li><img height="13" hspace="4" src="../pics/BallRedG.gif" width="13"/><a href="SeqReadIf.html">Counting
+<li><a href="SeqReadIf.html">Counting
     records in a Sequential File</a> - <font size="-1">READ, PERFORM..UNTIL, DISPLAY,
     IF, COMPUTE</font></li>
-<li><img height="13" hspace="4" src="../pics/BallRedG.gif" width="13"/><a href="SeqWrite.html">Writing
+<li><a href="SeqWrite.html">Writing
     to a Sequential File</a> - <font size="-1">ACCEPT, DISPLAY, WRITE, PERFORM..UNTIL,</font></li>
-<li><img height="13" hspace="4" src="../pics/BallRedG.gif" width="13"/><a href="SeqInsert.html">Inserting
+<li><a href="SeqInsert.html">Inserting
     records into a Sequential File</a> - <font size="-1">READ</font>, <font size="-1">WRITE,
     PERFORM.. UNTIL.</font></li>
-<li><img height="14" hspace="4" src="../pics/BallRedG.gif" width="14"/><a href="SeqUpdate.html">Updating
+<li><a href="SeqUpdate.html">Updating
     records in a Sequential File</a> - <font size="-1">READ</font>, <font size="-1">WRITE.</font></li>
-<li><img height="14" hspace="4" src="../pics/BallRedG.gif" width="14"/><a href="SortIP.html">Sorting
+<li><a href="SortIP.html">Sorting
     a Sequential File</a> - <font size="-1">SORT</font>, <font size="-1">READ</font>,
     <font size="-1">RELEASE, </font>Input Procedure.</li>
-<li><img height="14" hspace="4" src="../pics/BallRedG.gif" width="14"/><a href="MonthTable.html">Using
+<li><a href="MonthTable.html">Using
     Tables</a> - <font size="-1">READ</font>, pre-defined Tables, Tables.</li>
 </ul>
 <hr/>

--- a/exercises/index.html
+++ b/exercises/index.html
@@ -118,30 +118,29 @@
 <hr align="left" width="800"/>
 <h3>Simple Programming Exercises</h3>
 <ul>
-<img height="13" hspace="4" src="../pics/BallRedG.gif" width="13"/><a href="GettingStarted.html">Getting 
-  Started</a> - Exercise to load, compile, run and alter an existing program. 
-  <p><img height="13" hspace="4" src="../pics/BallRedG.gif" width="13"/><a href="CountDown.html">CountDown</a> 
-    - Exercise using the <font size="-1">ACCEPT</font>, <font size="-1">DISPLAY</font>, 
-    <font size="-1">PERFORM</font> ... <font size="-1">TIMES, COMPUTE</font> and <font size="-1">IF</font>. 
-  <p><img height="13" hspace="4" src="../pics/BallRedG.gif" width="13"/><a href="SeqRead.html">Reading 
-    Sequential Files</a>  - <font size="-1">READ, PERFORM.. UNTIL, DISPLAY</font>
-<p><img height="13" hspace="4" src="../pics/BallRedG.gif" width="13"/><a href="SeqReadIf.html">Counting 
-    records in a Sequential File</a> - <font size="-1">READ, PERFORM..UNTIL, DISPLAY, 
-    IF, COMPUTE</font>
-<p><img height="13" hspace="4" src="../pics/BallRedG.gif" width="13"/><a href="SeqWrite.html">Writing 
-    to a Sequential File</a> - <font size="-1">ACCEPT, DISPLAY, WRITE, PERFORM..UNTIL,</font>
-<p><img height="13" hspace="4" src="../pics/BallRedG.gif" width="13"/><a href="SeqInsert.html">Inserting 
-    records into a Sequential File</a> - <font size="-1">READ</font>, <font size="-1">WRITE, 
-    PERFORM.. UNTIL.</font>
-<p><img height="14" hspace="4" src="../pics/BallRedG.gif" width="14"/><a href="SeqUpdate.html">Updating 
-    records in a Sequential File</a> - <font size="-1">READ</font>, <font size="-1">WRITE.</font>
-<p><img height="14" hspace="4" src="../pics/BallRedG.gif" width="14"/><a href="SortIP.html">Sorting 
-    a Sequential File</a> - <font size="-1">SORT</font>, <font size="-1">READ</font>, 
-    <font size="-1">RELEASE, </font>Input Procedure. 
-  <p><img height="14" hspace="4" src="../pics/BallRedG.gif" width="14"/><a href="MonthTable.html">Using 
-    Tables</a> - <font size="-1">READ</font>, pre-defined Tables, Tables. <br/>
-     
-</p></p></p></p></p></p></p></p></ul>
+<li><img height="13" hspace="4" src="../pics/BallRedG.gif" width="13"/><a href="GettingStarted.html">Getting
+  Started</a> - Exercise to load, compile, run and alter an existing program.</li>
+<li><img height="13" hspace="4" src="../pics/BallRedG.gif" width="13"/><a href="CountDown.html">CountDown</a>
+    - Exercise using the <font size="-1">ACCEPT</font>, <font size="-1">DISPLAY</font>,
+    <font size="-1">PERFORM</font> ... <font size="-1">TIMES, COMPUTE</font> and <font size="-1">IF</font>.</li>
+<li><img height="13" hspace="4" src="../pics/BallRedG.gif" width="13"/><a href="SeqRead.html">Reading
+    Sequential Files</a>  - <font size="-1">READ, PERFORM.. UNTIL, DISPLAY</font></li>
+<li><img height="13" hspace="4" src="../pics/BallRedG.gif" width="13"/><a href="SeqReadIf.html">Counting
+    records in a Sequential File</a> - <font size="-1">READ, PERFORM..UNTIL, DISPLAY,
+    IF, COMPUTE</font></li>
+<li><img height="13" hspace="4" src="../pics/BallRedG.gif" width="13"/><a href="SeqWrite.html">Writing
+    to a Sequential File</a> - <font size="-1">ACCEPT, DISPLAY, WRITE, PERFORM..UNTIL,</font></li>
+<li><img height="13" hspace="4" src="../pics/BallRedG.gif" width="13"/><a href="SeqInsert.html">Inserting
+    records into a Sequential File</a> - <font size="-1">READ</font>, <font size="-1">WRITE,
+    PERFORM.. UNTIL.</font></li>
+<li><img height="14" hspace="4" src="../pics/BallRedG.gif" width="14"/><a href="SeqUpdate.html">Updating
+    records in a Sequential File</a> - <font size="-1">READ</font>, <font size="-1">WRITE.</font></li>
+<li><img height="14" hspace="4" src="../pics/BallRedG.gif" width="14"/><a href="SortIP.html">Sorting
+    a Sequential File</a> - <font size="-1">SORT</font>, <font size="-1">READ</font>,
+    <font size="-1">RELEASE, </font>Input Procedure.</li>
+<li><img height="14" hspace="4" src="../pics/BallRedG.gif" width="14"/><a href="MonthTable.html">Using
+    Tables</a> - <font size="-1">READ</font>, pre-defined Tables, Tables.</li>
+</ul>
 <hr/>
 <h3>Programming Exam Specifications</h3>
 <blockquote>

--- a/lectures/index.html
+++ b/lectures/index.html
@@ -78,9 +78,9 @@
 <p>These pages contain the COBOL programming lectures and tutorials for CS4312
   - Software Engineering 2. For COBOL programming exercises, COBOL example programs,
   links to other COBOL sites or information about the Year2000 problem please
-  connect to the <a href="../index.html">main COBOL page</a>.
+  connect to the <a href="../index.html">main COBOL page</a>.</p>
 <p>The COBOL programming lectures are delivered using Microsoft PowerPoint slides.
-  Each topic links to a downloadable .pptx file alongside the in-browser HTML rendering.
+  Each topic links to a downloadable .pptx file alongside the in-browser HTML rendering.</p>
 <p>Each lecture topic in the module outline is followed by these two clickable
   buttons - </p>
 <ul>
@@ -175,11 +175,11 @@ USAGE clause</a></h4>
 <p>The copyright for these presentations belongs to the author - Michael
 Coughlan. Permission is given to use these presentations, in part or whole,
 in your own lectures but you may not use the material in any published
-work without written permission from the author.
+work without written permission from the author.</p>
 
 <p>If you find any errors in these presentations or wish to make some comment
 concerning them please email the author <a href="mailto:michael.coughlan@ul.ie">Michael
-Coughlan</a>.
+Coughlan</a>.</p>
 
 
 <hr/>
@@ -193,5 +193,5 @@ Coughlan</a>.
 <font size="-2">Evaluation Form</font></td>
 </tr>
 </table>
-</p></p></p></p></body>
+</body>
 </html>


### PR DESCRIPTION
## Summary

Extends [#96](https://github.com/bushidocodes/limerick-cobol/pull/96) to the rest of the repo. Found seven more pages where `<p>` was illegally wrapping block-level content (`<table>`, `<ul>`, `<hr>`, `<center>`, `<div>`, or other `<p>`), leaving orphaned `</p>` stacks after browsers auto-closed the paragraph at parse.

- `course/Iteration.html`, `course/Unstring.html`, `course/COBOLcommands.html` — removed `<p>` wrappers around `<center>`/`<iframe>`/`<table>`/`<hr>` blocks and the empty `<div>`/`<p></p>` artifacts they left behind.
- `lectures/index.html`, `exercises/MonthTable.html`, `exercises/Prj-NewtronicsFileMaint.html` — closed unterminated `<p>` paragraphs and removed trailing orphan `</p>` stacks before `</body>`/`</td>`.
- `exercises/index.html`, `examples/default.html` — `<ul>` contained `<p>` children (invalid — only `<li>` is permitted); converted each entry into a proper `<li>`.

After this change, three diagnostic searches across all `*.html` (`<p>`-then-block, block-then-`</p>`, stacked `</p></p>`) all return no matches.

## Test plan

- [ ] Spot-check rendered pages in a browser — list/copyright sections on `exercises/index.html`, `examples/default.html`, `lectures/index.html`
- [ ] Spot-check `course/Iteration.html` "Iteration constructs and their COBOL equivalents" table area
- [ ] Spot-check `course/Unstring.html` Example 6/7 PDF iframes
- [ ] Run an HTML validator (or `tidy`) on at least one changed page and confirm no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)