### PR TITLE
Remove empty presentational div and blockquote wrappers

### DIFF
--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -641,7 +641,6 @@ The time is 14:41
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif"> The 
               ROUNDED option</font></h4>
 
-<div align="right"></div>
 </td>
 <td valign="top" width="525">
 <p align="left">All the arithmetic verbs allow the <font size="-1">ROUNDED</font> 
@@ -861,7 +860,6 @@ The time is 14:41
                 from <b>each</b> of the ValueResult#i items after the word <font size="-1">FROM</font> 
                 in turn.</p>
 </div>
-<div align="left"></div>
 <hr width="50%"/>
 </td>
 </tr>
@@ -881,7 +879,6 @@ The time is 14:41
               by <b>each</b> of the ValueResult#i items. The result of each calculation 
               is placed in the ValueResult#i involved in the calculation.</p>
 <hr width="50%"/>
-<div align="center"> </div>
 </td>
 </tr>
 <tr>
@@ -912,7 +909,6 @@ The time is 14:41
               The quotient part of the computation is assigned to Quot#i and the 
               remainder is assigned to Rem#i.</p>
 <hr width="50%"/>
-<div align="center"> </div>
 </td>
 </tr>
 <tr>
@@ -994,7 +990,6 @@ The time is 14:41
 <p>Note that unlike some other programming languages COBOL provides 
               the ** expression symbol to represent raising to a power.</p>
 <hr width="50%"/>
-<div align="center"> </div>
 </td>
 </tr>
 <tr>
@@ -1013,7 +1008,6 @@ The time is 14:41
               sure you understand why the statement produces the answer shown. 
             </p>
 <p align="center"><a href="Resources/ppz/TC-Commands2.html"><img alt="Click to view the animation" border="0" height="62" src="Resources/pics/i-Animation.gif" width="62"/></a></p>
-<div align="center"> </div>
 </td>
 </tr>
 <tr>

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -347,7 +347,6 @@
 </ul>
 </div>
 <p align="left"><b>Text Word examples</b></p>
-<div align="left"> </div>
 <blockquote>
 <p align="left"><b>MOVE</b> <br/>
                   1 Text Word<br/>

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -618,7 +618,6 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif"> Group 
               items </font></h4>
 
-<div align="right"></div>
 </td>
 <td valign="top" width="525">
 <p align="left">Sometimes when we are manipulating data it is convenient 

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -1538,9 +1538,6 @@
 </tr>
 </table></form>
 
-<blockquote>
-<div align="left"></div>
-</blockquote>
 <hr width="50%"/>
 
 </td>

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -528,8 +528,6 @@ END-IF</code></pre>
 <td width="525">
 <p><img height="245" src="Resources/pics/I-DFidx1.gif" width="474"/></p>
 
-<div align="CENTER">
-</div>
 </td>
 </tr>
 <tr>
@@ -561,10 +559,6 @@ END-IF</code></pre>
 <p>Each alternate key may be unique or may have duplicate values (for 
             this the <font size="2">WITH DUPLICATES</font> clause is required).</p>
 
-</div>
-</div>
-<div align="CENTER">
-<div align="LEFT">
 </div>
 </div>
 </td>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -259,8 +259,6 @@
 <li> Finally, the remaining records must be written to the new file.</li>
 </ol>
 <hr/>
-<div align="CENTER">
-</div>
 </td>
 </tr>
 <tr>
@@ -516,7 +514,6 @@
         of the 254 alternate keys, indexed files may also be processed sequentially. 
         When processed sequentially, the records may be read in ascending order 
         on the primary key or on any of the alternate keys. </p>
-<blockquote></blockquote>
 <p>Since the data records are in held in ascending primary key sequence 
         it is easy to see how the file may be accessed sequentially on the primary 
         key. It is not quite so obvious how sequential on the alternate keys is 

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -585,7 +585,6 @@ ThreeLevelsDown.
 </table>
 </form>
 
-<div align="left"> </div>
 </div>
 </div>
 </td>
@@ -794,9 +793,6 @@ SumSalesExit.
 <li>Out-of-line execution of a block of code</li>
 <li>In-line execution of a block of code. </li>
 </ul>
-<blockquote>
-<div align="left"></div>
-</blockquote>
 <hr width="50%"/>
 </td>
 </tr>
@@ -1140,7 +1136,6 @@ END-PERFORM</code></pre>
               of the counter. This can be negative or positive. If a negative 
               step value is used, the counter should be signed (<font size="-1">PIC 
               S99</font>, etc.).</p>
-<blockquote> </blockquote>
 <p>When the iteration ends, the counters retain their terminating 
               values. </p>
 <p>As before, when no <font size="-1">WITH TEST</font> phrase is used, 

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -486,7 +486,6 @@ MOVE FUNCTION ORD-MAX(IntElement(ALL)) TO OrdPos             </code></pre>
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif"> Examples 
               </font></h4>
 
-<div align="right"></div>
 </td>
 <td valign="top" width="525">
 <p>The statements in the following examples produce the results shown 
@@ -1252,7 +1251,6 @@ Begin.
 </td>
 </tr>
 </table>
-<div align="center"> </div>
 </td>
 </tr>
 <tr>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -100,8 +100,6 @@
 </table>
 </div>
 </center>
-<blockquote>
-</blockquote>
 <p>
 </p>
 <div align="LEFT">
@@ -314,8 +312,6 @@ Enter supplier key (2 digits)-&gt; 05
 <td width="525">
 <p><img height="189" src="Resources/pics/I-DFrel1.gif" width="507"/></p>
 
-<div align="CENTER">
-</div>
 </td>
 </tr>
 <tr>
@@ -363,10 +359,6 @@ Enter supplier key (2 digits)-&gt; 05
             description. It is normally described in the <font size="2">WORKING-STORAGE 
             SECTION</font>.</p>
 
-</div>
-</div>
-<div align="CENTER">
-<div align="LEFT">
 </div>
 </div>
 </td>
@@ -778,8 +770,6 @@ Begin.</code></pre>
 </table>
 
 <hr/>
-<div align="CENTER">
-</div>
 </td>
 </tr>
 <tr>

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -448,7 +448,6 @@ PrintSalaryReport.
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif"> Report 
               Specification </font></h4>
 
-<div align="right"></div>
 </td>
 <td valign="top" width="525">
 <p align="left">Bible salespersons work in each of the cities of Ireland. 
@@ -561,7 +560,6 @@ Programmer - Michael Coughlan               Page :  1
 </table>
 
 
-<div align="center"> </div>
 </td>
 </tr>
 <tr>
@@ -576,7 +574,6 @@ Programmer - Michael Coughlan               Page :  1
               a city and a final total</font></h4>
 </td>
 <td valign="top" width="525">
-<div align="center"> </div>
 <p>Let's add city totals and a final total to the Report. The city 
               total will be the sum of all the salesperson totals for the city 
               and the final total will be the sum of all the city totals. A city 
@@ -610,7 +607,6 @@ Programmer - Michael Coughlan               Page :  1
               This is so that we can refer to it in the final total SUM phrase. 
             </p>
 <hr/>
-<div align="center"></div>
 </td>
 </tr>
 <tr>
@@ -720,7 +716,6 @@ RD  SalesReport
 </table>
 <hr/>
 
-<div align="center"> </div>
 </td>
 </tr>
 <tr>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -268,7 +268,6 @@ RD  SalesReport
               description is replaced by phrase which points to the Report Description 
               (RD) in the Report Section. The syntax of the phrase is - </p>
 <p align="center"><img height="48" src="Resources/pics/rwReportIS.gif" width="222"/></p>
-<div align="center"> </div>
 <p>The <i>ReportName</i> must be the same as the <i>ReportName</i> 
               used in the Report Description (RD) entry.</p>
 <p>You can see this in the program fragment above where the <b>REPORT 
@@ -788,7 +787,6 @@ RD  SalesReport
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif"> The 
               LINE-COUNTER register</font></h4>
 
-<div align="right"></div>
 </td>
 <td valign="top" width="525">
 <p align="left">The reserved word <font size="-1">LINE-COUNTER</font> 

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -866,7 +866,6 @@ END-IF
 <pre class="language-cobol" align="left"><code class="language-cobol">E.g. 02 AgeInYears  PIC 9(3). 
         88 Teenager VALUE 13 THRU 19. </code></pre>
 </div>
-<div align="left"></div>
 </blockquote>
 <p align="left">Several Condition Names may be associated with a single 
               data item, </p>
@@ -878,8 +877,6 @@ END-IF
 </code></pre>
 </blockquote>
 <blockquote>
-<div align="left"></div>
-<div align="left"></div>
 </blockquote>
 <p align="left">More than one Condition Names may be true at the same 
               time. For instance, if AgeInYears contains the value 20 both Teenager 
@@ -1213,7 +1210,6 @@ Begin.
             </p>
 <p align="center"><img align="absmiddle" height="100" src="Resources/pics/eval1.gif" width="450"/>
 </p>
-<div align="center"></div>
 <p>What sort of functionality do we want to implement?</p>
 <ul>
 <li>We want to insert characters typed at the keyboard into the 

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -269,9 +269,6 @@
 </td>
 <td valign="top" width="525">
 <div align="center">
-<div align="center">
-
-</div>
 <div align="left">It is important to distinguish between a record 
                 occurrence (i.e. the values of a record) and the record type or 
                 template (i.e. the structure of the record). </div>
@@ -284,9 +281,6 @@
                 of each record occurrence.</p>
 <p align="center"><img height="388" src="Resources/pics/FileSeq1.gif" width="472"/></p>
 </div>
-<blockquote>
-<div align="left"></div>
-</blockquote>
 <div align="center">
 <hr width="50%"/>
 </div>
@@ -696,9 +690,6 @@ SELECT StudentFile
 <p> When a file is opened for <font size="-1">OUTPUT</font>, it is 
               created if it does not exist, and is overwritten, if it already 
               exists. </p>
-<blockquote>
-<div align="left"></div>
-</blockquote>
 <hr width="50%"/>
 
 </td>

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -205,7 +205,6 @@
                 records of the file are organized on the backing storage device.
                 COBOL recognizes three main file organizations; </p>
 </div>
-<div align="center"></div>
 <ul>
 <li>
 <div align="left">Sequential - Records organized serially. </div>
@@ -304,10 +303,6 @@
 </table>
 
 </div>
-<blockquote>
-<div align="left"></div>
-</blockquote>
-<div align="center"> </div>
 </td>
 </tr>
 <tr>
@@ -441,7 +436,6 @@
                 file.</p>
 <p align="center"><a href="Resources/ppz/TC-SeqFile2b.html"><img border="0" height="62" src="Resources/pics/i-Animation.gif" width="62"/></a></p>
 </div>
-<blockquote> </blockquote>
 <div align="center">
 <hr width="50%"/>
 
@@ -495,9 +489,6 @@
               into an ordered Sequential file.</p>
 <p align="center"><a href="Resources/ppz/TC-SeqFile2c.html"><img border="0" height="62" src="Resources/pics/i-Animation.gif" width="62"/></a></p>
 
-<blockquote>
-<div align="left"></div>
-</blockquote>
 <hr width="50%"/>
 
 </td>

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -360,7 +360,6 @@ FD TransFile.
                 values in StudentName or DateOfBirth but they will not be meaningful.</p>
 <hr align="center" width="50%"/>
 </div>
-<div align="center"></div>
 </td>
 </tr>
 <tr>
@@ -541,8 +540,6 @@ FD TransFile.
               on to the same area of storage as the FILLERs in the other two record 
               types. </p>
 <p align="center"><img height="253" src="Resources/pics/SeqFile2.gif" width="480"/></p>
-<div align="center">
-</div>
 </td>
 </tr>
 <tr>
@@ -977,7 +974,6 @@ FD Stringfile
    RECORD IS VARYING IN SIZE
    FROM 1 TO 80 CHARACTERS
    DEPENDING ON StringSize.</code></pre>
-<div align="left"></div>
 </blockquote>
 <hr align="center" width="50%"/>
 

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -254,8 +254,6 @@ Begin.
                 total for the whole country, we were asked to produce a breakdown 
                 of the tax totals by county. How could we solve that problem?</p>
 </div>
-<div align="center">
-</div>
 </td>
 </tr>
 <tr>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -230,7 +230,6 @@
               - even when no explicit clause is specified. When there is no explicit 
               <font size="-1">USAGE</font> clause, the default - <font size="-1">USAGE 
               IS DISPLAY</font> - is applied. </p>
-<div align="center"> </div>
 <hr align="center" size="1" width="100%"/>
 </td>
 </tr>
@@ -305,8 +304,6 @@ Begin.
 </td>
 </tr>
 </table>
-<div align="center"></div>
-
 <p>Since none of the data items have an explicit <font size="-1">USAGE</font> 
               clause they default to - <font size="-1">USAGE IS DISPLAY</font>. 
               This means that the values in the variables Num1, Num2 and Num3 

--- a/course/index.html
+++ b/course/index.html
@@ -62,7 +62,6 @@
   </tr>
 </table>
 <hr width="605" align="left">
-<div align="center"> </div>
 <table width="605" border="1" cellpadding="1" cellspacing="1">
   <tr>
     <td height="1045"> 

--- a/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html
+++ b/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html
@@ -153,8 +153,6 @@
 <tr>
 <td height="6" rowspan="3" valign="top">
 <div align="left">  AddToStock</div>
-<div align="center"></div>
-<div align="center"></div>
 </td>
 <td height="2" valign="top" width="150">
 <p align="center" class="MsoNormal">Type Code</p>
@@ -200,8 +198,6 @@
 <tr>
 <td height="6" rowspan="3" valign="top">
 <div align="left"> RemoveFromStock</div>
-<div align="center"></div>
-<div align="center"></div>
 </td>
 <td height="2" valign="top" width="150">
 <div align="center">Type Code</div>

--- a/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html
+++ b/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html
@@ -119,8 +119,6 @@
         summarize sales of essential oils only. The report should be printed, 
         sequenced on ascending Customer-Name. <br/>
 </p>
-<div align="center"> </div>
-
 <h3>The Sales File</h3>
 <p>The Sales File contains details of sales to all Aromamora customers. 
         It is a validated, unsorted sequential file. The records in the Sales 

--- a/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html
+++ b/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html
@@ -287,10 +287,6 @@
 <p><span>          </span>See print specification and example report.<br/>
                   The Sales field should be zero suppressed and have commas inserted 
         as appropriate.</p>
-<div align="center">
-
-</div>
-
 <div align="center"><a href="BestSellers.gif"><img border="1" height="199" src="SBestSellers.gif" width="344"/></a><br/>
         Click for full size version </div>
 

--- a/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html
+++ b/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html
@@ -110,7 +110,6 @@
 <p>The unsorted USSR Vessel Master File (UVMF) contains details of all the 
         sea-going vessels of the SOVIET UNION. The following is the record description.<br/>
 </p>
-<div align="center"> </div>
 <table border="1" cellpadding="0" cellspacing="0" height="60" width="459">
 <tr bgcolor="#FFFFCC">
 <td height="23" valign="top" width="150">

--- a/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html
+++ b/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html
@@ -138,8 +138,6 @@
 </blockquote>
 </blockquote>
 </blockquote>
-<div align="center"> </div>
-
 <h3><span style="font-variant:normal;text-transform:uppercase">Processing</span></h3>
 <p>You will need to sort the file on ascending Surname within ascending 
         County name.  Use an Input Procedure to unpack the records and get rid 

--- a/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html
+++ b/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html
@@ -198,9 +198,6 @@
 </div>
 <blockquote>
 <blockquote>
-<blockquote>
-
-</blockquote>
 </blockquote>
 </blockquote>
 <p><b>Transaction Record Descriptions<br/>

--- a/lectures/ReportWriterSSWeb.html
+++ b/lectures/ReportWriterSSWeb.html
@@ -260,7 +260,6 @@ FD  SalesFile.
               description is replaced by phrase which points to the Report Description 
               (RD) in the Report Section. The syntax of the phrase is - </p>
 <p align="center"><img height="48" src="rwReportIS.gif" width="222"/></p>
-<div align="center"> </div>
 <p>The <i>ReportName</i> must be the same as the <i>ReportName</i> 
               used in the Report Description (RD) entry.</p>
 <p>You can see this in the program fragment above where the <b>REPORT 
@@ -788,7 +787,6 @@ FD  SalesFile.
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif"> The 
               LINE-COUNTER register</font></h4>
 
-<div align="right"></div>
 </td>
 <td valign="top" width="525">
 <p align="left">The reserved word <font size="-1">LINE-COUNTER</font> 

--- a/lectures/ReportWriterWeb.html
+++ b/lectures/ReportWriterWeb.html
@@ -440,7 +440,6 @@ PrintSalaryReport.
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif"> Report 
               Specification </font></h4>
 
-<div align="right"></div>
 </td>
 <td valign="top" width="525">
 <p align="left">Bible salespersons work in each of the cities of Ireland. 
@@ -553,7 +552,6 @@ Programmer - Michael Coughlan               Page :  1
 </table>
 
 
-<div align="center"> </div>
 </td>
 </tr>
 <tr>
@@ -568,7 +566,6 @@ Programmer - Michael Coughlan               Page :  1
               a city and a final total</font></h4>
 </td>
 <td valign="top" width="525">
-<div align="center"> </div>
 <p>Let's add city totals and a final total to the Report. The city 
               total will be the sum of all the salesperson totals for the city 
               and the final total will be the sum of all the city totals. A city 
@@ -602,7 +599,6 @@ Programmer - Michael Coughlan               Page :  1
               This is so that we can refer to it in the final total SUM phrase. 
             </p>
 <hr/>
-<div align="center"></div>
 </td>
 </tr>
 <tr>
@@ -712,7 +708,6 @@ RD  SalesReport
 </table>
 <hr/>
 
-<div align="center"> </div>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
## Summary
- Removed 61 empty layout wrappers across 26 HTML pages (99 lines deleted) — leftover artifacts from the original WYSIWYG editor that added DOM noise without rendering anything visible.
- Targets: `<div>`s whose only attribute was `align` (or with no attributes) and `<blockquote>`s containing only whitespace, non-breaking spaces, or an empty `<div>`.
- Preserved any `<div>` carrying `id`, `class`, `style`, or `name` so anchor targets and styled containers remain intact.

## What changed
- 53 empty `<div align="...">` tags removed
- 4 `<blockquote>` wrappers around empty `<div>` removed
- 4 `<blockquote>`s containing only whitespace/`&nbsp;` removed
- Touches 26 files across `course/`, `exercises/`, `lectures/`

## Test plan
- [ ] Spot-check a few pages visually (e.g. course/SequentialFiles2.html, course/ReportWriter.html, lectures/ReportWriterWeb.html) — layout should be unchanged since the removed elements rendered nothing.
- [ ] Confirm in-page anchors (`#intro`, `#part1`, etc.) still scroll to their sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)