### PR TITLE
Give each Prg-*.html listing a descriptive <title>

### DIFF
--- a/exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html
+++ b/exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<title>Reading an Indexed file directly by key</title>
+<title>AcmeStockReorder &ndash; ACME Stock Reorder 1999 (COBOL source)</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style type="text/css">

--- a/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html
+++ b/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<title>Reading an Indexed file directly by key</title>
+<title>AromaOilFileMainRpt &ndash; Aromamora Oil Stock Maintenance and Report (COBOL source)</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style type="text/css">

--- a/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html
+++ b/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<title>Reading an Indexed file directly by key</title>
+<title>AromaSalesSummaryRpt &ndash; Aromamora Summary Sales Report (COBOL source)</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style type="text/css">

--- a/exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html
+++ b/exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" type="text/css" href="https://web-static.archive.org/_static/css/iconochive.css?v=3PDvdIFv" />
 <!-- End Wayback Rewrite JS Include -->
 
-<title>Reading an Indexed file directly by key</title>
+<title>FolioBestSellersRpt &ndash; Folio Society Best Sellers List Report (COBOL source)</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style type="text/css">

--- a/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html
+++ b/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<title>Reading an Indexed file directly by key</title>
+<title>BookshopLectReqRpt &ndash; Campus Bookshop Purchase Requirements Report (COBOL source)</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style type="text/css">

--- a/exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html
+++ b/exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" type="text/css" href="https://web-static.archive.org/_static/css/iconochive.css?v=3PDvdIFv" />
 <!-- End Wayback Rewrite JS Include -->
 
-<title>Reading an Indexed file directly by key</title>
+<title>CSISEmailDomain &ndash; CSIS Web Site Email Domain File (COBOL source)</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style type="text/css">

--- a/exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html
+++ b/exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<title>Reading an Indexed file directly by key</title>
+<title>DueSubsRpt &ndash; NetNews Due Subscriptions Report (COBOL source)</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style type="text/css">

--- a/exercises/Exm-FileConversion/Prg-FileConversion.html
+++ b/exercises/Exm-FileConversion/Prg-FileConversion.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<title>Reading an Indexed file directly by key</title>
+<title>FileConversion &ndash; File Conversion Program (COBOL source)</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style type="text/css">

--- a/exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html
+++ b/exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<title>Reading an Indexed file directly by key</title>
+<title>FlyByNight &ndash; Travel Agency Sorted Summary File (COBOL source)</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style type="text/css">

--- a/exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html
+++ b/exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<title>Reading an Indexed file directly by key</title>
+<title>LibRoyaltyRpt &ndash; Library Royalty Payment Report (COBOL source)</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style type="text/css">

--- a/exercises/Exm-SFbyMail/Prg-SFbyMail.html
+++ b/exercises/Exm-SFbyMail/Prg-SFbyMail.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" type="text/css" href="https://web-static.archive.org/_static/css/iconochive.css?v=3PDvdIFv" />
 <!-- End Wayback Rewrite JS Include -->
 
-<title>Reading an Indexed file directly by key</title>
+<title>SFbyMail &ndash; Science Fiction by Mail Order Processing (COBOL source)</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style type="text/css">

--- a/exercises/Exm-StudFeesRpt/Prg-StudPay.html
+++ b/exercises/Exm-StudFeesRpt/Prg-StudPay.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<title>Reading an Indexed file directly by key</title>
+<title>StudPay &ndash; Student Fee Payment Update and Report (COBOL source)</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style type="text/css">

--- a/exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html
+++ b/exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<title>Reading an Indexed file directly by key</title>
+<title>TopSupplierRpt &ndash; Top Video Supplier Report (COBOL source)</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style type="text/css">

--- a/exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html
+++ b/exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<title>Reading an Indexed file directly by key</title>
+<title>USSRshipRpt &ndash; USSR Naval Vessel Inventory Report (COBOL source)</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style type="text/css">


### PR DESCRIPTION
## Summary

- All 14 exercise program-listing pages (`exercises/Exm-*/Prg-*.html`) shared the placeholder title `Reading an Indexed file directly by key` — a copy-paste artifact from the `DirectReadIdx` example template.
- The `<title>` element is the document's primary semantic label (browser tabs, history, screen readers, search results, link previews), so each listing now names its program and the exercise it implements, e.g. `LibRoyaltyRpt – Library Royalty Payment Report (COBOL source)`.
- The original `examples/Indexed/DirectReadIdx.html` is left alone — that's the page where the title genuinely fits.

## Test plan

- [ ] Open any of the modified pages in a browser and confirm the tab title now describes the program rather than reading "Reading an Indexed file directly by key".
- [ ] Confirm `examples/Indexed/DirectReadIdx.html` still has its original title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)