### PR TITLE
Add Prism.js COBOL syntax highlighting to example program pages

### DIFF
--- a/examples/Accept/ACCEPT.html
+++ b/examples/Accept/ACCEPT.html
@@ -3,6 +3,9 @@
 <title>ACCEPT and DISPLAY example program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  AcceptAndDisplay.
 AUTHOR.  Michael Coughlan.
@@ -124,6 +127,6 @@ Begin.
     DISPLAY "Today is day " YearDay " of the year".
     DISPLAY "The time is " CurrentHour ":" CurrentMinute.
     STOP RUN.
-</pre>
+</code></pre>
 </body>
 </html>

--- a/examples/Accept/Multiplier.html
+++ b/examples/Accept/Multiplier.html
@@ -3,6 +3,9 @@
 <title>ACCEPT, DISPLAY and MULTIPLY example program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  Multiplier.
 AUTHOR.  Michael Coughlan.
@@ -91,6 +94,6 @@ PROCEDURE DIVISION.
     DISPLAY "Result is = ", Result.
     STOP RUN.
 
-</pre>
+</code></pre>
 </body>
 </html>

--- a/examples/Accept/Shortest.html
+++ b/examples/Accept/Shortest.html
@@ -3,6 +3,9 @@
 <title>The Shortest COBOL program we can have</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  ShortestProgram.
 
@@ -76,6 +79,6 @@ PROCEDURE DIVISION.
 DisplayPrompt.
     DISPLAY "I did it".
     STOP RUN.
-</pre>
+</code></pre>
 </body>
 </html>

--- a/examples/Conditn/Conditions.html
+++ b/examples/Conditn/Conditions.html
@@ -3,6 +3,9 @@
 <title>Condition Names (level 88) example program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  Conditions.
 AUTHOR.  Michael Coughlan.
@@ -98,6 +101,6 @@ Begin.
         END-EVALUATE
     END-PERFORM
     STOP RUN.
-</pre>
+</code></pre>
 </body>
 </html>

--- a/examples/Conditn/IterIf.html
+++ b/examples/Conditn/IterIf.html
@@ -3,6 +3,9 @@
 <title>Condition Names (level 88) example program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  Iteration-If.
 AUTHOR.  Michael Coughlan.
@@ -98,6 +101,6 @@ Calculator.
        DISPLAY "Result is = ", Result
     END-PERFORM.
     STOP RUN.
-</pre>
+</code></pre>
 </body>
 </html>

--- a/examples/Indexed/DirectReadIdx.html
+++ b/examples/Indexed/DirectReadIdx.html
@@ -3,6 +3,9 @@
 <title>Reading an Indexed file directly by key</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  DirectReadIdx.
 AUTHOR.  Michael Coughlan.
@@ -145,6 +148,6 @@ Begin.
 
    CLOSE VideoFile.
    STOP RUN.
-</pre>
+</code></pre>
 </body>
 </html>

--- a/examples/Indexed/Seq2Index.html
+++ b/examples/Indexed/Seq2Index.html
@@ -3,6 +3,9 @@
 <title>Creating an Indexed file from a sequential file</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  Seq2Index.
 AUTHOR.  Michael Coughlan.
@@ -128,6 +131,6 @@ Begin.
    END-PERFORM.
 
    CLOSE VideoFile, SeqVideoFile.
-   STOP RUN.</pre>
+   STOP RUN.</code></pre>
 </body>
 </html>

--- a/examples/Indexed/SeqReadIdx.html
+++ b/examples/Indexed/SeqReadIdx.html
@@ -3,6 +3,9 @@
 <title>Reading an Indexed file sequentially on any of its keys</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  SeqReadIdx.
 AUTHOR.  Michael Coughlan.
@@ -149,6 +152,6 @@ Begin.
 
    CLOSE VideoFile.
    STOP RUN.
-</pre>
+</code></pre>
 </body>
 </html>

--- a/examples/Merge/Merge.html
+++ b/examples/Merge/Merge.html
@@ -3,6 +3,9 @@
 <title>Merge Files - Example Program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. MergeFiles.
 AUTHOR. MICHAEL COUGHLAN.
@@ -117,6 +120,6 @@ Begin.
        USING InsertionsFile,  StudentFile
        GIVING NewStudentFile.
     STOP RUN.
-</pre>
+</code></pre>
 </body>
 </html>

--- a/examples/Perform/MileageCount.html
+++ b/examples/Perform/MileageCount.html
@@ -3,6 +3,9 @@
 <title>Mileage counter simulation</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  MileageCounter.
 AUTHOR.  Michael Coughlan.
@@ -118,6 +121,6 @@ CountMilage.
    MOVE UnitsCount    TO PrnUnits
    DISPLAY PrnHunds "-" PrnTens "-" PrnUnits.
 
- </pre>
+ </code></pre>
 </body>
 </html>

--- a/examples/Perform/Perform1.html
+++ b/examples/Perform/Perform1.html
@@ -3,6 +3,9 @@
 <title>Perform - Format 1 example program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  PerformFormat1.
 AUTHOR.  Michael Coughlan.
@@ -99,6 +102,6 @@ OneLevelDown.
 
 ThreeLevelsDown.
     DISPLAY "&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Now in ThreeLevelsDown".
-</pre>
+</code></pre>
 </body>
 </html>

--- a/examples/Perform/Perform2.html
+++ b/examples/Perform/Perform2.html
@@ -3,6 +3,9 @@
 <title>Perform - Format 2 example program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  PerformFormat2.
 AUTHOR.  Michael Coughlan.
@@ -92,6 +95,6 @@ Begin.
     STOP RUN.
 
 OutOfLineEG.
-    DISPLAY "&gt;&gt;&gt;&gt; This is an out of line Perform".</pre>
+    DISPLAY "&gt;&gt;&gt;&gt; This is an out of line Perform".</code></pre>
 </body>
 </html>

--- a/examples/Perform/Perform3.html
+++ b/examples/Perform/Perform3.html
@@ -3,6 +3,9 @@
 <title>Perform - Format 3 example program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  PerformFormat3.
 AUTHOR.  Michael Coughlan.
@@ -124,6 +127,6 @@ GetUserInput.
     DISPLAY "Total so far is - " RunningTotal
     DISPLAY "Count so far is - " IterCount
     DISPLAY "Enter number :- " WITH NO ADVANCING
-    ACCEPT UserInput.</pre>
+    ACCEPT UserInput.</code></pre>
 </body>
 </html>

--- a/examples/Perform/Perform4.html
+++ b/examples/Perform/Perform4.html
@@ -3,6 +3,9 @@
 <title>Perform - Format 4 example program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  PerformFormat4.
 AUTHOR.  Michael Coughlan.
@@ -121,6 +124,6 @@ Begin.
 LoopBody.
     DISPLAY "LoopBody " WITH NO ADVANCING
     DISPLAY "LoopCount = " LoopCount " LoopCount2 = " LoopCount2.
-</pre>
+</code></pre>
 </body>
 </html>

--- a/examples/Relative/ReadRel.html
+++ b/examples/Relative/ReadRel.html
@@ -3,6 +3,9 @@
 <title>Inserting records in a Sequential File </title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  ReadRelative.
 AUTHOR.  MICHAEL COUGHLAN.
@@ -148,6 +151,6 @@ DisplayRecord.
         MOVE SupplierAddress TO PrnSupplierAddress
         DISPLAY PrnSupplierRecord
     END-IF.
-     </pre>
+     </code></pre>
 </body>
 </html>

--- a/examples/Relative/Seq2Rel.html
+++ b/examples/Relative/Seq2Rel.html
@@ -3,6 +3,9 @@
 <title>Inserting records in a Sequential File </title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  Seq2Rel.
 AUTHOR.  MICHAEL COUGHLAN.
@@ -131,6 +134,6 @@ Begin.
     END-PERFORM.    
 
     CLOSE  SupplierFile, SupplierFileSeq.
-    STOP RUN.</pre>
+    STOP RUN.</code></pre>
 </body>
 </html>

--- a/examples/ReportWriter/RepWriteA.html
+++ b/examples/ReportWriter/RepWriteA.html
@@ -3,6 +3,9 @@
 <title>One control break version of full Report Writer example Program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  ReportExampleA.
 AUTHOR.  Michael Coughlan.
@@ -179,6 +182,6 @@ PrintSalaryReport.
     GENERATE DetailLine.
     READ SalesFile
           AT END SET EndOfFile TO TRUE
-    END-READ.	</pre>
+    END-READ.	</code></pre>
 </body>
 </html>

--- a/examples/ReportWriter/RepWriteB.html
+++ b/examples/ReportWriter/RepWriteB.html
@@ -3,6 +3,9 @@
 <title>No Declaratives version of full Report Writer example program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  ReportExampleB.
 AUTHOR.  Michael Coughlan.
@@ -201,6 +204,6 @@ PrintSalaryReport.
     END-READ.
 
 
-	</pre>
+	</code></pre>
 </body>
 </html>

--- a/examples/ReportWriter/RepWriteFull.html
+++ b/examples/ReportWriter/RepWriteFull.html
@@ -3,6 +3,9 @@
 <title>Full Report Writer example program - includes Declaratives</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  ReportExampleFull.
 AUTHOR.  Michael Coughlan.
@@ -278,6 +281,6 @@ PrintSalaryReport.
     END-READ.
 
 
-	</pre>
+	</code></pre>
 </body>
 </html>

--- a/examples/ReportWriter/RepWriteSumm.html
+++ b/examples/ReportWriter/RepWriteSumm.html
@@ -3,6 +3,9 @@
 <title>Summary version of the full Report Writer program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  ReportExampleSummary.
 AUTHOR.  Michael Coughlan.
@@ -278,6 +281,6 @@ PrintSalaryReport.
     END-READ.
 
 
-	</pre>
+	</code></pre>
 </body>
 </html>

--- a/examples/SeqIns/SEQINSERT.html
+++ b/examples/SeqIns/SEQINSERT.html
@@ -3,6 +3,9 @@
 <title>Inserting records in a Sequential File </title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. InsertRecords.
 AUTHOR. Michael Coughlan.
@@ -152,6 +155,6 @@ BEGIN.
     CLOSE TransRecords
     CLOSE NewStudentRecords
     STOP RUN.
-</pre>
+</code></pre>
 </body>
 </html>

--- a/examples/SeqRead/SEQREAD.html
+++ b/examples/SeqRead/SEQREAD.html
@@ -3,6 +3,9 @@
 <title>Reading a Sequential File </title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  SeqRead.
 AUTHOR.  Michael Coughlan.
@@ -110,6 +113,6 @@ Begin.
       END-READ
    END-PERFORM
    CLOSE StudentFile
-   STOP RUN.</pre>
+   STOP RUN.</code></pre>
 </body>
 </html>

--- a/examples/SeqRead/SEQREADno88.html
+++ b/examples/SeqRead/SEQREADno88.html
@@ -3,6 +3,9 @@
 <title>Reading a Sequential File</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  SeqReadNo88.
 AUTHOR.  Michael Coughlan.
@@ -111,6 +114,6 @@ Begin.
       END-READ
    END-PERFORM
    CLOSE StudentFile
-   STOP RUN.</pre>
+   STOP RUN.</code></pre>
 </body>
 </html>

--- a/examples/SeqRpt/SEQRPT.html
+++ b/examples/SeqRpt/SEQRPT.html
@@ -3,6 +3,9 @@
 <title>Sequential Student Number Report</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION. 
 PROGRAM-ID.  StudentNumbersReport . 
 AUTHOR. Michael Coughlan. 
@@ -169,6 +172,6 @@ PrintReportLines.
             AFTER ADVANCING 2 LINES 
     WRITE PrintLine FROM FemaleTotalLine 
             AFTER ADVANCING 2 LINES. 
-</pre>
+</code></pre>
 </body>
 </html>

--- a/examples/SeqWrite/SEQWRITE.html
+++ b/examples/SeqWrite/SEQWRITE.html
@@ -3,6 +3,9 @@
 <title>Writing to a Sequential File</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  SeqWrite.
 AUTHOR.  Michael Coughlan.
@@ -116,6 +119,6 @@ Begin.
 GetStudentDetails.
     DISPLAY "Enter - StudId, Surname, Initials, YOB, MOB, DOB, Course, Gender"
     DISPLAY "NNNNNNNSSSSSSSSIIYYYYMMDDCCCCG"
-    ACCEPT  StudentDetails.  </pre>
+    ACCEPT  StudentDetails.  </code></pre>
 </body>
 </html>

--- a/examples/Sort/InputSort.html
+++ b/examples/Sort/InputSort.html
@@ -3,6 +3,9 @@
 <title>SORT with Input Procedure to get recs from user</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  InputSort.
 AUTHOR.  Michael Coughlan.
@@ -131,6 +134,6 @@ GetStudentDetails.
     PERFORM UNTIL WorkRec = SPACES
        RELEASE WorkRec
        ACCEPT WorkRec
-    END-PERFORM.</pre>
+    END-PERFORM.</code></pre>
 </body>
 </html>

--- a/examples/Sort/MaleSort.html
+++ b/examples/Sort/MaleSort.html
@@ -3,6 +3,9 @@
 <title>SORT file and select only male records</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  MaleSort.
 AUTHOR.  Michael Coughlan.
@@ -129,6 +132,6 @@ GetMaleStudents.
         AT END SET EndOfFile TO TRUE
       END-READ 
    END-PERFORM
-   CLOSE StudentFile.</pre>
+   CLOSE StudentFile.</code></pre>
 </body>
 </html>

--- a/examples/Strings/RefMod.html
+++ b/examples/Strings/RefMod.html
@@ -3,6 +3,9 @@
 <title>String handling - Reference Modification examples</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  RefModification.
 AUTHOR.  Michael Coughlan.
@@ -175,6 +178,6 @@ Begin.
     DISPLAY "Task7 First occurrence is in char position " EndCount
     DISPLAY "The character is " xStr(EndCount:1)
     STOP RUN.
-</pre>
+</code></pre>
 </body>
 </html>

--- a/examples/Strings/UnstringFileEg.html
+++ b/examples/Strings/UnstringFileEg.html
@@ -3,6 +3,9 @@
 <title>String handling - Unpacking and size-validating comma separated records</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  UnstringFileEg.
 AUTHOR.  Michael Coughlan.
@@ -162,6 +165,6 @@ CheckForErrors.
    IF NOT ValidDate     DISPLAY "Date Size Error"        END-IF
    IF NOT ValidSuppCode DISPLAY "Supplier Code Error"    END-IF
    IF NOT ValidSuppName DISPLAY "Supplier name Error"    END-IF
-   IF NOT ValidSuppAdr  DISPLAY "Supplier address Error" END-IF.</pre>
+   IF NOT ValidSuppAdr  DISPLAY "Supplier address Error" END-IF.</code></pre>
 </body>
 </html>

--- a/examples/SubProg/DateValid/DateDriver.html
+++ b/examples/SubProg/DateValid/DateDriver.html
@@ -3,6 +3,9 @@
 <title>Driver program for date validation sub-program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. DateDriver.
 AUTHOR.  Michael Coughlan.
@@ -114,6 +117,6 @@ Begin.
     STOP RUN.
 
 
-</pre>
+</code></pre>
 </body>
 </html>

--- a/examples/SubProg/DateValid/ValiDate.html
+++ b/examples/SubProg/DateValid/ValiDate.html
@@ -3,6 +3,9 @@
 <title>Date validation sub-program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. Validate IS INITIAL.
 AUTHOR.  Michael Coughlan.
@@ -149,6 +152,6 @@ CheckForValidDay.
    ELSE
      SET DateIsValid TO TRUE
   END-IF.
-</pre>
+</code></pre>
 </body>
 </html>

--- a/examples/SubProg/DayDiff/DayDiffDriver.html
+++ b/examples/SubProg/DayDiff/DayDiffDriver.html
@@ -3,6 +3,9 @@
 <title>Get difference between dates driver program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. DayDiffDriver.
 AUTHOR. Michael Coughlan.
@@ -263,6 +266,6 @@ Begin.
 END PROGRAM GetDayDiff.
 
 END PROGRAM DayDiffDriver.
-</pre>
+</code></pre>
 </body>
 </html>

--- a/examples/SubProg/Multiply/DriverProg.html
+++ b/examples/SubProg/Multiply/DriverProg.html
@@ -3,6 +3,9 @@
 <title>A driver for the MultiplyNums, Fickle and Steafast sub-programs</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. DriverProg.
 AUTHOR.  Michael Coughlan. 
@@ -199,6 +202,6 @@ MakeFickleSteadfast.
     CALL "Fickle" USING BY CONTENT UserNumber.
 *&gt;   We can make Fickle act like Steadfast by using
 *&gt;   the CANCEL verb to set it into its initial state
-*&gt;   each time we call it</pre>
+*&gt;   each time we call it</code></pre>
 </body>
 </html>

--- a/examples/SubProg/Multiply/Fickle.html
+++ b/examples/SubProg/Multiply/Fickle.html
@@ -3,6 +3,9 @@
 <title>The Fickle sub-program demonstrates State Memory</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. Fickle.
 AUTHOR. Michael Coughlan.
@@ -92,6 +95,6 @@ Begin.
     DISPLAY "The total so far is " RunningTotal
 
     EXIT PROGRAM.
-</pre>
+</code></pre>
 </body>
 </html>

--- a/examples/SubProg/Multiply/MultiplyNums.html
+++ b/examples/SubProg/Multiply/MultiplyNums.html
@@ -3,6 +3,9 @@
 <title>The MultiplyNums sub-program</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. MultiplyNums.
 AUTHOR. Michael Coughlan.
@@ -121,6 +124,6 @@ Begin.
 
     DISPLAY "&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt; Leaving sub-program now".
     EXIT PROGRAM.
-</pre>
+</code></pre>
 </body>
 </html>

--- a/examples/SubProg/Multiply/Steadfast.html
+++ b/examples/SubProg/Multiply/Steadfast.html
@@ -3,6 +3,9 @@
 <title>The Steadfast sub-program demonstrates the IS INITIAL phrase</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. Steadfast IS INITIAL.
 AUTHOR. Michael Coughlan.
@@ -92,6 +95,6 @@ Begin.
     DISPLAY "The total so far is " RunningTotal
 
     EXIT PROGRAM.
-</pre>
+</code></pre>
 </body>
 </html>

--- a/examples/Tables/MonthTable.html
+++ b/examples/Tables/MonthTable.html
@@ -3,6 +3,9 @@
 <title>Tables - Counts number of students born in each month</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>       &gt;&gt;SOURCE FORMAT IS FREE
+<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  MonthTable.
 AUTHOR.  Michael Coughlan.
@@ -142,6 +145,6 @@ Begin.
    END-PERFORM.
 
    CLOSE StudentFile
-   STOP RUN.</pre>
+   STOP RUN.</code></pre>
 </body>
 </html>

--- a/exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html
+++ b/exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html
@@ -3,6 +3,9 @@
 <title>Reading an Indexed file directly by key</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  ACME99.
@@ -268,6 +271,6 @@ EXTRACT-ADDRESS-ITEMS.
 *&gt;debugging displays
    DISPLAY "COUNTY = "  COUNTY-WC.
    DISPLAY "COUNTRY = " COUNTRY-WC.
- </pre>
+ </code></pre>
 </body>
 </html>

--- a/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html
+++ b/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html
@@ -3,6 +3,9 @@
 <title>Reading an Indexed file directly by key</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  Aroma96exam.
@@ -247,6 +250,6 @@ Print-Stock-Report.
    READ Oil-Details-File NEXT RECORD
       AT END SET End-Of-ODF TO TRUE
    END-READ.
- </pre>
+ </code></pre>
 </body>
 </html>

--- a/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html
+++ b/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html
@@ -3,6 +3,9 @@
 <title>Reading an Indexed file directly by key</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. CS4321-95-COBOL-EXAM.
@@ -265,6 +268,6 @@ Print-Customer-Lines.
     MOVE Cust-Sales-Value TO Prn-Sales-Value.
 
     WRITE Print-Line FROM Cust-Sales-Line AFTER ADVANCING 2 LINES.
- </pre>
+ </code></pre>
 </body>
 </html>

--- a/exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html
+++ b/exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html
@@ -15,6 +15,9 @@
 <title>Reading an Indexed file directly by key</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -80,7 +83,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  BestSellers.
@@ -254,7 +257,7 @@ CheckBookRank.
         MOVE BookSalesTotal TO BookSales(Rank)
     END-IF.
                       
-</pre>
+</code></pre>
 </body>
 </html>
 <!--

--- a/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html
+++ b/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html
@@ -3,6 +3,9 @@
 <title>Reading an Indexed file directly by key</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. BookshopLectReqRpt.
@@ -273,6 +276,6 @@ Process-Publisher.
 		AT END SET End-Of-Books TO TRUE
 	END-READ.
 	DISPLAY "book rec " Book-Rec.
- </pre>
+ </code></pre>
 </body>
 </html>

--- a/exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html
+++ b/exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html
@@ -15,6 +15,9 @@
 <title>Reading an Indexed file directly by key</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -80,7 +83,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  CSISEmailDomain.
@@ -222,7 +225,7 @@ LoadCountryTable.
         END-READ
     END-PERFORM.
     CLOSE CountryFile.
-</pre>
+</code></pre>
 </body>
 </html>
 <!--

--- a/exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html
+++ b/exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html
@@ -3,6 +3,9 @@
 <title>Reading an Indexed file directly by key</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. DueSubsRpt.
@@ -367,6 +370,6 @@ PrintFinalTotals.
     WRITE PrintLine FROM AccessTotalLine AFTER ADVANCING 1 LINE
     WRITE PrintLine FROM AmExTotalLine   AFTER ADVANCING 1 LINE
     WRITE PrintLine FROM ChequeTotalLine AFTER ADVANCING 1 LINE.
- </pre>
+ </code></pre>
 </body>
 </html>

--- a/exercises/Exm-FileConversion/Prg-FileConversion.html
+++ b/exercises/Exm-FileConversion/Prg-FileConversion.html
@@ -3,6 +3,9 @@
 <title>Reading an Indexed file directly by key</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  TERMINAL-EXAM.
@@ -243,6 +246,6 @@ RESTRUCTURE-NAME.
             INTO CLIENT-NAME
             WITH POINTER STR-PTR
     END-PERFORM.        
- </pre>
+ </code></pre>
 </body>
 </html>

--- a/exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html
+++ b/exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html
@@ -3,6 +3,9 @@
 <title>Reading an Indexed file directly by key</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  DP173EXAM1986.
@@ -230,6 +233,6 @@ BEGIN.
 	END-PERFORM.
 	SET NOT-END-OF-FILE TO TRUE.
 	CLOSE BOOKING-FILE.
- </pre>
+ </code></pre>
 </body>
 </html>

--- a/exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html
+++ b/exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html
@@ -3,6 +3,9 @@
 <title>Reading an Indexed file directly by key</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.   LibRoyaltyRpt.
@@ -282,6 +285,6 @@ PROCEDURE DIVISION.
         INVALID KEY
         DISPLAY "REWRITE 50-PROCESS-ONE-BOOK " BOOK-ERROR-STATUS
     END-REWRITE.
-</pre>
+</code></pre>
 </body>
 </html>

--- a/exercises/Exm-SFbyMail/Prg-SFbyMail.html
+++ b/exercises/Exm-SFbyMail/Prg-SFbyMail.html
@@ -15,6 +15,9 @@
 <title>Reading an Indexed file directly by key</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -80,7 +83,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  SFbyMail.
@@ -207,7 +210,7 @@ GetCopyPostage.
     CALL "GetPostage" USING BY CONTENT Country-Code
                             BY REFERENCE Copy-Postage.
 
- </pre>
+ </code></pre>
 </body>
 </html>
 <!--

--- a/exercises/Exm-StudFeesRpt/Prg-StudPay.html
+++ b/exercises/Exm-StudFeesRpt/Prg-StudPay.html
@@ -3,6 +3,9 @@
 <title>Reading an Indexed file directly by key</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  DP196-93-Repeat-Exam.
@@ -210,6 +213,6 @@ Print-Outstanding-Fees-Rpt.
     READ Student-Master-File NEXT RECORD
          AT END SET End-Of-SMF TO TRUE
     END-READ.
- </pre>
+ </code></pre>
 </body>
 </html>

--- a/exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html
+++ b/exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html
@@ -3,6 +3,9 @@
 <title>Reading an Indexed file directly by key</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  TopSupplierRpt.
@@ -334,6 +337,6 @@ SUM-TITLE-EARNINGS.
     READ VIDEO-DETAILS-FILE NEXT RECORD
         AT END SET VDF-FILE-END TO TRUE
     END-READ.
- </pre>
+ </code></pre>
 </body>
 </html>

--- a/exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html
+++ b/exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html
@@ -3,6 +3,9 @@
 <title>Reading an Indexed file directly by key</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet"/>
+<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -68,7 +71,7 @@
 </head>
 
 <body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-<pre>
+<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  DP173EXAM.
@@ -300,6 +303,6 @@ SELECT-MAJOR-SHIPS SECTION.
 
 30-EXIT-SELECT-MAJOR-SHIPS.
 	EXIT.
- </pre>
+ </code></pre>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Extends the Prism.js COBOL syntax highlighting (already used on `course/` pages) to the program-listing pages under `examples/` and `exercises/`.
- 51 pages total: 37 `examples/` pages and 14 `exercises/Prg-*.html` pages.
- Each page now (a) wraps its `<pre>` listing in `<code class="language-cobol">`, and (b) loads the existing `course/Resources/vendor/prism/` CSS + JS via relative paths (`../../` for top-level dirs, `../../../` for `examples/SubProg/*` subdirs).

## What's left untouched (intentional)
The 3 exercise pages whose `<pre>` blocks contain sample input data, checksum tables, or report mockups — not COBOL — were skipped to avoid mis-highlighting:
- `exercises/Exm-FileConversion/Exm-FileConversion.html`
- `exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html`
- `exercises/Proj-CSISEvalform/CSISEvalForm.html`

`examples/default.html` (directory index, no listing) was also skipped.

## Notes for reviewers
- No new vendor files added — these all reuse the Prism assets already in `course/Resources/vendor/prism/` (added in an earlier PR).
- The change to each file is mechanical and identical: 3 new `<link>`/`<script>` lines in `<head>`, plus `class="language-cobol"` + `<code>` wrapping the existing `<pre>`. The only per-file variable is the relative path prefix.
- Pre-flight script verified single `<pre>` block and presence of `IDENTIFICATION DIVISION` marker before editing.

## Test plan
- [ ] Spot-check a few pages from each group render with COBOL keywords highlighted (e.g. `IDENTIFICATION`, `PERFORM`, `DISPLAY`).
- [ ] Confirm `examples/SubProg/*` pages (deeper nesting) load Prism assets correctly.
- [ ] Confirm the 3 skipped non-COBOL exercise pages still render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)