### PR TITLE
Remove <blockquote> wrappers around <pre><code> samples

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -909,10 +909,8 @@
               by the language. A section name is followed by the word <font size="-1">SECTION</font> 
               and a period. <br>
               See the two example names below -</p>
-            <blockquote>
-<pre class="language-cobol"><code class="language-cobol">SelectUnpaidBills SECTION.
+            <pre class="language-cobol"><code class="language-cobol">SelectUnpaidBills SECTION.
 FILE SECTION.</code></pre>
-            </blockquote>
             <p><font face="Arial, Helvetica, sans-serif"><b>Paragraphs</b></font><br>
               A paragraph is a block of code made up of one or more sentences. 
               A paragraph begins with the paragraph name and ends with the next 
@@ -920,26 +918,20 @@ FILE SECTION.</code></pre>
             <p>A paragraph name is devised by the programmer or defined by the 
               language, and is followed by a period. <br>
               See the two example names below -</p>
-            <blockquote>
-<pre class="language-cobol"><code class="language-cobol">PrintFinalTotals.
+            <pre class="language-cobol"><code class="language-cobol">PrintFinalTotals.
 PROGRAM-ID.</code></pre>
-            </blockquote>
             <p><font face="Arial, Helvetica, sans-serif"><b>Sentences and statements</b></font><br>
               A sentence consists of one or more statements and is terminated 
               by a period.<br>
               For example:</p>
-            <blockquote>
-<pre class="language-cobol"><code class="language-cobol">MOVE .21 TO VatRate
+            <pre class="language-cobol"><code class="language-cobol">MOVE .21 TO VatRate
    MOVE 1235.76 TO ProductCost
    COMPUTE VatAmount = ProductCost * VatRate.</code></pre>
-            </blockquote>
             <p><br>
               A statement consists of a COBOL verb and an operand or operands.
               <br>
               For example:</p>
-            <blockquote>
-<pre class="language-cobol"><code class="language-cobol">SUBTRACT Tax FROM GrossPay GIVING NetPay</code></pre>
-            </blockquote>
+            <pre class="language-cobol"><code class="language-cobol">SUBTRACT Tax FROM GrossPay GIVING NetPay</code></pre>
           </td>
         </tr>
         <tr> 
@@ -1003,12 +995,10 @@ PROGRAM-ID.</code></pre>
               to a subprogram.</p>
             <p>The <font size="-1">IDENTIFICATION DIVISION </font>has the following 
               structure:</p>
-            <blockquote>
-<pre class="language-cobol"><code class="language-cobol">IDENTIFICATION DIVISION
+            <pre class="language-cobol"><code class="language-cobol">IDENTIFICATION DIVISION
 PROGRAM-ID. NameOfProgram.
 [AUTHOR. YourName.]
 other entries here</code></pre>
-            </blockquote>
             <p>The keywords - <font size="-1">IDENTIFICATION DIVISION</font> - 
               represent the division header, and signal the commencement of the 
               program text.</p>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -245,13 +245,11 @@
               </p>
 <p align="left"><b><font size="-1">DISPLAY</font> examples</b></p>
 </div>
-<blockquote>
 <pre class="language-cobol" align="left"><code class="language-cobol">DISPLAY "My name is " ProgrammerName.
 DISPLAY "The vat rate is " VatRate. 
 DISPLAY PrinterSetupCodes UPON PrinterPort1.
 </code></pre>
 <hr width="50%"/>
-</blockquote>
 </td>
 </tr>
 <tr>
@@ -340,13 +338,11 @@ DISPLAY PrinterSetupCodes UPON PrinterPort1.
 </blockquote>
 <p>When the new formatting instructions are used, the receiving fields 
               must be defined as; </p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">*&gt; Y2KDate is the date in YYYYMMDD format
 01 Y2KDate PIC 9(8).
 
 *&gt; Y2KDayOfYear is current day in YYYYDDD format
 01 Y2KDayOfYear PIC 9(7).</code></pre>
-</blockquote>
 <hr width="50%"/>
 </td>
 </tr>

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -385,13 +385,11 @@
               in the library text is replaced by the corresponding <i>TextWord2</i> 
               in the <font size="-1">REPLACING</font> phrase.</p>
 <h4>Some example COPY statements</h4>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">COPY CopyFile2 REPLACING XYZ BY 120. 
 COPY CopyFile5 REPLACING X(3) BY X(19).
 COPY CopyFile3 IN EGLIB.
 COPY CopyFile5 REPLACING ==X(3)== BY ==X(19)==.
 COPY CopyFile4 IN EGLIB.</code></pre>
-</blockquote>
 <hr align="center" size="1" width="100%"/>
 </td>
 </tr>

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -529,13 +529,11 @@
               defining a picture clause it is normal to use the abbreviation <font size="-1">PIC.</font></p>
 <p>Recurring symbols may be specified by using a 'repeat' factor inside 
               brackets. For instance: </p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">PIC 9(6)       is equivalent to PICTURE 999999
 PIC 9(6)V99    is equivalent to PIC 999999V99
 PICTURE X(10)  is equivalent to PIC XXXXXXXXXX
 PIC S9(4)V9(4) is equivalent to PIC S9999V9999
 PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
-</blockquote>
 <p>Numeric values can have a maximum of 18 (eighteen) digits. </p>
 <p>The limit on string values is usually system dependent. </p>
 </td>
@@ -601,7 +599,6 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
               means of an extension to the <font size="-1">PICTURE</font> clause 
               called the <font size="-1">VALUE</font> clause. </p>
 <p align="left"><b>Some examples:</b></p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">01 GrossPay       PIC 9(5)V99 VALUE ZEROS.
 
 01 NetPay         PIC 9(5)V99 VALUE ZEROS.
@@ -609,7 +606,6 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 01 CustomerName   PIC X(20) VALUE SPACES.
 
 01 CustDiscount   PIC V99 VALUE .25.</code></pre>
-</blockquote>
 <hr width="50%"/>
 </td>
 </tr>

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -473,13 +473,11 @@ VIDEO STATUS :- 23</code></pre>
 <p>The animation also shows how an alternate key index is organized 
               and how this index is used to read a record directly.</p>
 <p>The algorithm used for traversing both indexes is -</p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">IF RecordKeyValue &gt; RequiredKeyValue 
    take this branch
 ELSE
    go to next index record
 END-IF</code></pre>
-</blockquote>
 
 </td>
 </tr>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -540,13 +540,11 @@
                 In the animation we see how the index is used to find the required 
                 record we.</p>
 <p>The algorithm used for traversing the index is -</p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">IF RecordKeyValue &gt; RequiredKeyValue 
    take this branch
 ELSE
    go to next index record
 END-IF</code></pre>
-</blockquote>
 
 </td>
 </tr>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -1143,10 +1143,8 @@ END-PERFORM</code></pre>
 <p>Though the condition would normally involve some evaluation of 
               the counter, it is not mandatory. For instance, the statement that 
               follows is perfectly valid: </p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">PERFORM CountRecords
         VARYING RecCount FROM 1 BY 1 UNTIL EndOfFile </code></pre>
-</blockquote>
 
 <hr width="50%"/>
 </td>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -314,10 +314,8 @@
 <p><i>FunctionName</i> is the name of the function and <i>Parameters</i> 
               is one or more parameters supplied to the function.</p>
 <p>Example declarations.</p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">MOVE FUNCTION RANDOM(99) TO RandNum. </code></pre>
 <pre class="language-cobol"><code class="language-cobol">DISPLAY FUNCTION UPPER-CASE("this will be in upper case").</code></pre>
-</blockquote>
 <hr/>
 </td>
 </tr>
@@ -350,11 +348,9 @@
               indicate all the elements of the array.</p>
 <p>For instance the ORD-MAX function may take a parameter list or 
               an array may be used: </p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">MOVE FUNCTION ORD-MAX(12 23 03 78 65) TO OrdPos
                      or
 MOVE FUNCTION ORD-MAX(IntElement(ALL)) TO OrdPos             </code></pre>
-</blockquote>
 <hr/>
 </td>
 </tr>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -1132,7 +1132,6 @@ Begin.
 <table background="Resources/pics/code.gif" border="1" width="91%">
 <tr>
 <td>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">PROCEDURE DIVISION.
 DECLARATIVES.
 CheckShopSales SECTION.
@@ -1142,7 +1141,6 @@ PrintMajorShopsOnly.
        SUPPRESS PRINTING
     END-IF.
 END DECLARATIVES.</code></pre>
-</blockquote>
 </td>
 </tr>
 </table>

--- a/course/Search.html
+++ b/course/Search.html
@@ -440,12 +440,10 @@
               value as the index and we can display it without the complications 
               we might encounter with the index item. For instance, to display 
               the value of the index item we would require following code - </p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">SET LetterPos TO LetterIdx
 MOVE LetterPos TO PrnPos
 DISPLAY LetterIn, " is in position ", PrnPos
 </code></pre>
-</blockquote>
 <p>The example below is not meant to be a practical example of how 
               to find the position of a letter in the alphabet. Nowadays, this 
               task would be accomplished in much the same way as it would in C 
@@ -1033,14 +1031,12 @@ END-PERFORM</code></pre>
 </code></pre>
 <p>When the table description contains a KEY IS phrase we can search 
               it using the following statement - </p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">SEARCH ALL Letter
   AT END DISPLAY "Letter " SearchLetter " was not found!"
   WHEN Letter(LetterIdx) = SearchLetter
        SET LetterPos TO LetterIdx
        DISPLAY SearchLetter " is in position " LetterPos
 END-SEARCH.</code></pre>
-</blockquote>
 <p align="center"><a href="Resources/ppz/TC-Search2.html"><img border="0" height="62" src="Resources/pics/i-Animation.gif" width="62"/></a>
 </p>
 <p align="left">The full program for searching the letter table is 

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -494,7 +494,6 @@ END-IF
 </tr>
 </table>
 <p><b>Example</b></p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">IF Row &gt; 0 AND Row &lt; 26 THEN
    DISPLAY "On Screen" 
 END-IF 
@@ -503,7 +502,6 @@ IF NOT Amnt1 &lt; 10 OR Amnt2 = 50 AND Amnt3 &gt; 150 THEN
    DISPLAY "Done"
 END-IF
 </code></pre>
-</blockquote>
 <p><b>The effect of bracketing<br/>
 </b>Let's examine the last example above to see what difference 
               bracketing makes to the order of evaluation.</p>
@@ -629,9 +627,7 @@ END-IF
 <p>For instance, in the first example in Complex Conditions above, 
               we check to see if Row is greater than 0 and Row is less than 26. 
               We could rewrite this statement using Implied Subjects as-</p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">IF Row &gt; 0 AND &lt; 26 THEN etc</code></pre>
-</blockquote>
 <p>the Implied Subject here is Row.</p>
 <p><b>Examples</b><br/>
               In these examples the full condition is shown first and is followed 
@@ -674,7 +670,6 @@ END-IF
 <td valign="top" width="525">
 <p> COBOL allows nested <font size="-1">IF</font> statements.</p>
 <p> For example: </p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">IF ( VarA &lt; 10 ) AND ( VarB NOT &gt; VarC ) THEN 
    IF VarG = 14 THEN 
         DISPLAY "First"
@@ -684,7 +679,6 @@ END-IF
  ELSE DISPLAY "Third" 
 END-IF 
 </code></pre>
-</blockquote>
 <p>The table below contains representations of the variables used 
               in the nested <font size="-1">Ifs</font> above. In each instance, 
               see if you can figure out which of the messages will be displayed. 
@@ -869,26 +863,22 @@ END-IF
 </blockquote>
 <p align="left">Several Condition Names may be associated with a single 
               data item, </p>
-<blockquote>
 <pre class="language-cobol" align="left"><code class="language-cobol">e.g. 02 AgeInYears  PIC 9(3). 
         88 Child    VALUE 0  THRU 12. 
         88 Teenager VALUE 13 THRU 19. 
         88 Adult    VALUE 21 THRU 999. 
 </code></pre>
-</blockquote>
 <blockquote>
 </blockquote>
 <p align="left">More than one Condition Names may be true at the same 
               time. For instance, if AgeInYears contains the value 20 both Teenager 
               and Voter will be true.</p>
-<blockquote>
 <pre class="language-cobol" align="left"><code class="language-cobol">E.g. 02 AgeInYears  PIC 9(3). 
         88 Child    VALUE 0  THRU 12. 
         88 Teenager VALUE 13 THRU 19. 
         88 Adult    VALUE 21 THRU 999.
         88 Voter    VALUE 18 THRU 999. 
 </code></pre>
-</blockquote>
 
 <p align="left"><b>Condition Name notes</b></p>
 <ul>

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -592,14 +592,12 @@ FD StudentFile.
                 to the file. For instance, we could associate the StudentFile 
                 with an actual file using statements like:</p>
 </div>
-<blockquote>
 <pre class="language-cobol" align="left"><code class="language-cobol">SELECT StudentFile 
        ASSIGN TO "D:\Cobol\ExampleProgs\Students.Dat"
 
 SELECT StudentFile 
        ASSIGN TO "A:\Students.Dat"
 </code></pre>
-</blockquote>
 <div align="center">
 <hr width="50%"/>
 </div>

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -964,7 +964,6 @@ PrintPageHeadings.
               ON</font> phase must be an elementary unsigned integer data-item 
               declared in the <font size="-1">WORKING-STORAGE SECTION</font>.</p>
 <p align="left"><b>Examples</b></p>
-<blockquote>
 <pre class="language-cobol" align="left"><code class="language-cobol">FD TransFile
    RECORD IS VARYING IN SIZE 
    FROM 8 TO 31 CHARACTERS.
@@ -974,7 +973,6 @@ FD Stringfile
    RECORD IS VARYING IN SIZE
    FROM 1 TO 80 CHARACTERS
    DEPENDING ON StringSize.</code></pre>
-</blockquote>
 <hr align="center" width="50%"/>
 
 </td>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -263,14 +263,11 @@
                       The cost per unit is 0.10.</p>
 <p>The calls file in an unordered Sequential file. The record 
                       description is as follows; </p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">FIELD          TYPE   LENGTH        VALUE
 SubscriberNum    9      8    00000001 - 99999999
 UnitsUsed        9      5       00001 - 99999</code></pre>
-</blockquote>
 <p>The report must be printed on ascending subscriber number 
                       and has the following format;</p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">Telephone Analysis Monthly Report</code></pre>
 <pre class="language-cobol"><code class="language-cobol">
 SubscriberNum      ValueOfCalls
@@ -280,7 +277,6 @@ SubscriberNum      ValueOfCalls
   99999999         999,999.99
 -------------------------------
 Total value =  999,999,999.99</code></pre>
-</blockquote>
 </td>
 </tr>
 </table>
@@ -317,7 +313,6 @@ Total value =  999,999,999.99</code></pre>
                   not as easy as the control break solution) there would be serious 
                   performance implications. For each of the millions of records 
                   in the file we would have to;</p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">Read the Sequential File
 IF the record already exists THEN
    Read the Relative Record
@@ -326,7 +321,6 @@ IF the record already exists THEN
 ELSE
    Write a new Relative Record to the file
 END-IF</code></pre>
-</blockquote>
 <p align="left">And when the calls file ended we would have to 
                   read through the entire Relative file again to create the report.</p>
 <p align="left">We can arrive at the most viable solution by using 
@@ -549,12 +543,10 @@ Begin.
               will fail.</p>
 <p align="center"><img height="270" src="Resources/pics/Sort2.gif" width="470"/>
 </p>
-<blockquote>
 <pre class="language-cobol" align="center"><code class="language-cobol">SORT WorkFile ON ASCENDING SubscriberNumWF
      USING  CallsFile
      GIVING SortedCallsFile.
 </code></pre>
-</blockquote>
 <hr align="center" size="1" width="100%"/>
 </td>
 </tr>
@@ -572,12 +564,10 @@ Begin.
               below. The table contains a sales file that has been sorted into 
               descending VendorNumber, within ascending ProvinceCode, by the following 
               <font size="-1">SORT</font> statement; </p>
-<blockquote>
 <pre class="language-cobol" align="left"><code class="language-cobol">SORT WorkFile ON ASCENDING ProvinceCode 
                  DESCENDING VendorNumber
                  USING SalesFile
                  GIVING SortedSalesFile</code></pre>
-</blockquote>
 <p align="left">Notice that ProvinceCode is the major key, and that 
               VendorNumber is only in descending sequence, <i>within</i> ProvinceCode. 
               The first key named in a <font size="-1">SORT</font> statement is 
@@ -822,12 +812,10 @@ SORT WorkFile ON ASCENDING CountryNameWF, CustomerNameWF
               the records.</p>
 
 <p align="center"><img height="240" src="Resources/pics/Sort5.gif" width="435"/></p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">SORT WorkFile ON ASCENDING CountryNameWF
               INPUT PROCEDURE IS SelectForeignGuests
               GIVING SortedGuestsFile.
 </code></pre>
-</blockquote>
 <hr align="center" size="1" width="100%"/>
 </td>
 </tr>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -664,11 +664,9 @@ Begin.
               closed and the data-items initialized to their <font size="-1">VALUE</font> 
               clauses).</p>
 <p>By using the following statements in our main program</p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">CALL "Fickle" USING BY CONTENT IncValue.
 CANCEL "Fickle"
 CALL "Fickle" USING BY CONTENT IncValue.</code></pre>
-</blockquote>
 <p>we can force "Fickle" to act like "Steadfast".<br/>
 </p>
 <hr align="center" size="1" width="100%"/>
@@ -1093,7 +1091,6 @@ END PROGRAM Counter.</code></pre>
                       shown in <font color="#0000FF">blue </font>and values output 
                       by the computer are shown in <font color="#FF0000">red</font>.</font></p>
 </div>
-<blockquote>
 <pre class="language-cobol" align="left"><code class="language-cobol">Enter value - 13
 Fickle total    = 13
 Steadfast total = 13
@@ -1121,7 +1118,6 @@ Fickle total =  3
 Fickle total =  6
 Fickle total =  9
 Value - 0</code></pre>
-</blockquote>
 </td>
 </tr>
 </table>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -408,12 +408,10 @@ DISPLAY "County 3 total is ", County3TaxTotal
               numeric value between 1 and the size of the table; even a simple 
               arithmetic expression.</p>
 <p align="left"><a href="Resources/ppz/TC-Tables1.html"><img border="0" height="71" src="Resources/pics/Tables1.gif" width="456"/></a></p>
-<blockquote>
 <pre class="language-cobol" align="left"><code class="language-cobol">MOVE 10 TO CountyTax(3)
 ADD TaxPaid TO CountyTax(CountyCode)
 ADD TaxPaid TO CountyTax(CountyCode + 1)
 ADD TaxPaid TO CountyTax(CountyCode - 2)</code></pre>
-</blockquote>
 <hr align="center" size="1" width="100%"/>
 </td>
 </tr>
@@ -533,10 +531,8 @@ END-EVALUATE.</code></pre>
 <p>If we declare a CountyName table and fill its elements with the 
               names of the counties, we can replace the <font size="-1">EVALUATE</font> 
               solution above, with one simple statement -</p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">DISPLAY CountyName(Idx) " tax total is " CountyTax(Idx).
 </code></pre>
-</blockquote>
 <p>We can incorporate this statement into the County Tax Report program 
               as follows - </p>
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="475">
@@ -650,14 +646,12 @@ Begin.
               1, the second into the value 2 and so on. </p>
 <p align="left">One approach we might try, is the now discredited<font size="-1"> 
               EVALUATE</font> based solution. For example -</p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">EVALUATE County
    WHEN "Carlow" MOVE 1 TO CountyNum
    WHEN "Cavan"  MOVE 2 TO CountyNum
    ..... 24 more WHEN branches
 END-EVALUATE
 ADD TaxPaid TO CountyTax(CountyNum)</code></pre>
-</blockquote>
 <p align="left">But by now we realise that there must be a more elegant 
               solution. The question is - what is it?</p>
 

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -270,14 +270,12 @@
               after, the <font size="-1">PICTURE</font> clause that defines the 
               element. For instance, we might declare the <i>CountyTaxTable</i> 
               as - </p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">01 CountyTax   PIC 9(8)V99  OCCURS 26 TIMES.</code></pre>
 <blockquote>
 <p>or as</p>
 </blockquote>
 <pre class="language-cobol"><code class="language-cobol">01 CountyTax   OCCURS 26 TIMES PIC 9(8)V99.
 </code></pre>
-</blockquote>
 <div align="left">
 <p>We can represent the county tax table diagrammatically as follows;</p>
 <p align="center"><a href="Resources/ppz/TC-Tables1.html"><img border="0" height="71" src="Resources/pics/Tables1.gif" width="456"/></a>
@@ -565,20 +563,17 @@
 <td valign="top" width="525">
 <p>Q1. Examine the CountyTaxTable described above. Suppose that in 
               our program we have the following statements;</p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">MOVE ZEROS TO CountyTax(3)
 MOVE 67 TO PayerCount(6)
 MOVE 1234.45 TO CountyTax(4)
 MOVE ZEROS TO CountyTaxDetails(4)
 MOVE ZEROS TO CountyTaxTable</code></pre>
-</blockquote>
             What effect on the table will each of these statements have? Copy 
             the table diagram above, fill in your answer and then click on the 
             animation icon below to see the animated solution. 
             <p align="center"><a href="Resources/ppz/TC-Tables3.html"><img border="0" height="62" src="Resources/pics/i-Animation.gif" width="62"/></a></p>
 
 <p>Q2. What is the difference between the following data descriptions;</p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">01 CountyTaxTable1.
    02 CountyTaxDetails OCCURS 26 TIMES.
       03 CountyTax   PIC 9(8)V99.  
@@ -591,7 +586,6 @@ MOVE ZEROS TO CountyTaxTable</code></pre>
       03 CountyTax   PIC 9(8)V99 OCCURS 26 TIMES.  
       03 PayerCount  PIC 9(7)OCCURS 26 TIMES. 
 </code></pre>
-</blockquote>
 <form action="Tables2.html" method="post">
 <div align="center">
 <select name="select" size="1">
@@ -834,17 +828,14 @@ DisplayCountyTaxes.
               of a table might we require? We can see that six totals are needed, 
               so we might think that the six element, single-dimension, table 
               shown below might do the trick.</p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">01 PopulationTable.
    02 PopTotal PIC 9(6) OCCURS 6 TIMES.</code></pre>
-</blockquote>
 <p align="left">The problem with this is - what can we use as an index 
               into the table? No single item in the record will do. The index 
               must be a combination of the <i>AgeCategory</i> and the <i>Gender</i>. 
               Of course, we could use an <font size="-1">EVALUATE</font>, as shown 
               below, to map the <i>AgeCategory</i> and <i>Gender</i> to a combined 
               index value.</p>
-<blockquote>
 <pre class="language-cobol" align="left"><code class="language-cobol">EVALUATE AgeCategory ALSO Gender
   WHEN        1      ALSO    1      MOVE 1 TO Idx
   WHEN        1      ALSO    2      MOVE 2 TO Idx
@@ -852,7 +843,6 @@ DisplayCountyTaxes.
           etc...
 END-EVALUATE.
 </code></pre>
-</blockquote>
 <p align="left">Or we could manipulate the values arithmetically to 
               map them to the index value. For instance <i>COMPUTE Idx = ((AgeCategory 
               -1) * 2) + Gender</i></p>
@@ -912,13 +902,11 @@ END-EVALUATE.
 <p>Sketch the diagram above on a piece of paper and then show how 
               the contents of the table are effected when the following statements 
               are executed.</p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">MOVE ZEROS TO PopulationTable
 MOVE 123 TO PopTotal(3,1)
 MOVE 456 TO Gender(3,2)
 ADD 1255 TO PopTotal(2,2)
 MOVE ZEROS TO Age(3)</code></pre>
-</blockquote>
 <p>Click on the animation icon below to see an animated answer.</p>
 <p align="center"><a href="Resources/ppz/TC-Tables4.html"><img border="0" height="62" src="Resources/pics/i-Animation.gif" width="62"/></a></p>
 <hr size="1" width="100%"/>
@@ -993,14 +981,12 @@ MOVE ZEROS TO Age(3)</code></pre>
 <p>Sketch the diagram above on a piece of paper and then show how 
               the contents of the table are effected when the following statements 
               are executed.</p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">MOVE ZEROS TO County(1)
 MOVE ZEROS TO Age(2,3)
 MOVE ZEROS TO PopTotal(2,1,2)
 MOVE 56 TO PopTotal(1,3,2)
 MOVE 12 TO PopTotal(2,1,1) 
 MOVE ZEROS TO PopulationTable</code></pre>
-</blockquote>
 <p>Click on the animation icon below to see an animated answer.</p>
 <p align="center"><a href="Resources/ppz/TC-Tables5.html"><img border="0" height="62" src="Resources/pics/i-Animation.gif" width="62"/></a></p>
 <hr size="1" width="100%"/>
@@ -1070,13 +1056,11 @@ MOVE ZEROS TO PopulationTable</code></pre>
               and <i>PopTotal</i> requires three subscripts (three superordinate 
               <font size="-1">OCCURS</font> clauses).</p>
 <p><b>Examples of use</b></p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">MOVE ZEROS TO County(23)
 ADD 1643 TO CarOwnersTotal(15)
 MOVE ZEROS TO Age(17,3)
 MOVE ZEROS TO Gender(18,3,2)
 ADD 56 TO PopTotal(12,3,2)</code></pre>
-</blockquote>
 
 </td>
 </tr>
@@ -1143,10 +1127,8 @@ ADD 56 TO PopTotal(12,3,2)</code></pre>
               us to solve this problem neatly because we can <font size="-1">UNSTRING</font> 
               the number into <i>TextValue</i> and then treat <i>TextValue </i>as 
               if it were described as PIC 9(5)V99. For instance - </p>
-<blockquote>
 <pre class="language-cobol" align="left"><code class="language-cobol">01  TextValue    PIC X(7).
 01  NumericValue REDEFINES TextValue PIC 9(5)V99.</code></pre>
-</blockquote>
 <p align="left"><b>Example 2<br/>
 </b>The<font size="-1"> REDEFINES</font> clause is not just used 
               to create pre-filled tables. It is used whenever a programmer needs 
@@ -1170,7 +1152,6 @@ ADD 56 TO PopTotal(12,3,2)</code></pre>
               of storage holding the date so that we can access the correct day, 
               month and year fields without recourse to special programming. For 
               instance, if define the <i>InputDate</i> as - </p>
-<blockquote>
 <pre class="language-cobol" align="left"><code class="language-cobol">01 InputDate.
    02 DateType         PIC 9.
       88 DateIsSort    VALUE 1.
@@ -1189,9 +1170,7 @@ ADD 56 TO PopTotal(12,3,2)</code></pre>
       03 USDay         PIC 99.
       03 USYear        PIC 9(4).
 </code></pre>
-</blockquote>
 <p>we can use statements like -</p>
-<blockquote>
 <pre class="language-cobol" align="left"><code class="language-cobol">EVALUATE TRUE
     WHEN DateIsSort
            DISPLAY "SortDate format is yyyy-mm-dd "
@@ -1203,7 +1182,6 @@ ADD 56 TO PopTotal(12,3,2)</code></pre>
            DISPLAY "USDate format is mm-dd-yyyy "
            DISPLAY  USMonth "-" USDay "-" USYear
 END-EVALUATE </code></pre>
-</blockquote>
 <p>- and still get the correct values displayed.</p>
 <p align="left"><b>Example 3<br/>
 </b>The <font size="-1">REDEFINES</font> clause is also useful when 
@@ -1211,12 +1189,10 @@ END-EVALUATE </code></pre>
               different places. For instance the value 12345 is treated as if 
               it were 12.345 if we refer to <i>10Rate</i>, 123.45 if we refer 
               to <i>100Rate</i>, and 1234.5 if we refer to <i>1000Rate</i>.</p>
-<blockquote>
 <pre class="language-cobol" align="left"><code class="language-cobol">01 Rates.
    02 10Rate                    PIC 99V999.
    02 100Rate  REDEFINES 10Rate PIC 999V99.
    02 1000Rate REDEFINES 10Rate PIC 9999V9.</code></pre>
-</blockquote>
 
 <p align="left"><b>Animated versions of the examples above</b></p>
 <p align="center"><a href="Resources/ppz/TC-Tables7.html"><img border="0" height="62" src="Resources/pics/i-Animation.gif" width="62"/></a></p>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -192,7 +192,6 @@
         The address lines are stored in a six element table. </p>
 <p>Since not all addresses will have six parts exactly, we use the <font size="2">TALLYING</font> 
         clause to discover how many parts there are.</p>
-<blockquote>
 <pre class="language-cobol"><code class="language-cobol">UNSTRING FullName DELIMITED BY ALL SPACES
     INTO FirstName, SecondName, Surname
 END-UNSTRING.
@@ -202,7 +201,6 @@ UNSTRING CustAddress DELIMITED BY ","
         AdrLine(4), AdrLine(5), AdrLine(6) 
    TALLYING IN AdrLinesUsed
 END-UNSTRING.</code></pre>
-</blockquote>
 <hr/>
 </td>
 </tr>

--- a/exercises/Exm-FileConversion/Exm-FileConversion.html
+++ b/exercises/Exm-FileConversion/Exm-FileConversion.html
@@ -126,11 +126,8 @@
         The fields may be upper case or lower case or a mixture of these. In the 
         Address field the County Name will always be the last part of the address.</p>
 <p>Some example records are;</p>
-<blockquote>
 <pre>Michael Terence Ryan,34 Winchester Drive Dublin 3 Co. Dublin,0123
 MARY TYLER MOORE,THIS IS AN INVALID ADDRESS,1432<br/>Fred James Hoyle,17 Starry Lane Cork Co. Cork,0012</pre>
-
-</blockquote>
 <h4>The Sorted-Clients File (output)</h4>
 <p>The Sorted-Clients file is produced from the unsorted Client-Names file. 
         The records of the file must be fixed length records held in ascending 
@@ -216,12 +213,10 @@ MARY TYLER MOORE,THIS IS AN INVALID ADDRESS,1432<br/>Fred James Hoyle,17 Starry 
 <p>The Client-Name in the sorted file must have the surname first so that 
         the sorting will be done correctly.</p>
 <p>Some sample records are;</p>
-<blockquote>
 <pre>
 Hoyle Fred James              17 Starry Lane Cork Co. CORK                060012
 Ryan Michael Terence          34 Winchester Drive Dubline 7 Co. Dublin    090123
      </pre>
-</blockquote>
 <h4>The Error File</h4>
 <p>Any records that are found to contain invalid county names are sent to 
         an Error File. This fle has the same format as the input file</p>

--- a/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html
+++ b/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html
@@ -1024,7 +1024,6 @@ always"/>
         your student number is calculated in exactly the same way so any valid 
         student number will be a valid StockNumber.</p>
 <p class="in5">Here is an example:-</p>
-<blockquote>
 <pre>
 StockNumber    = 7944454
 Real  Number    = 794445
@@ -1035,7 +1034,6 @@ Check Digit       =            4</pre>
 <pre class="in1"><span style="text-transform:uppercase">Digit</span>                      7          9          4          4          4          5<br/>    <span>         </span>                *          *           *          *           *          *<br/><span style="text-transform:uppercase">Weight</span>                  7          6          5          4          3          2<br/>                           ----        ----        ----       ----        ----        ----<br/><span style="text-transform:uppercase">Result</span>                  49  +    54  +     20   +   16  +    12   +   10    =  161
 
 </pre>
-</blockquote>
 <table border="0" cellpadding="0" cellspacing="0" width="613">
 <tr valign="top">
 <td width="99">161/11 = 7   </td>

--- a/lectures/ReportWriterSSWeb.html
+++ b/lectures/ReportWriterSSWeb.html
@@ -1150,7 +1150,6 @@ Begin.
 <table background="lectures/cobol\pics\code.gif" border="1" width="91%">
 <tr>
 <td>
-<blockquote>
 <pre><font color="#000000">PROCEDURE DIVISION.
 DECLARATIVES.
 CheckShopSales SECTION.
@@ -1160,7 +1159,6 @@ PrintMajorShopsOnly.
        <font color="#FF3300">SUPPRESS PRINTING</font>
 </b>    END-IF.
 END DECLARATIVES.</font></pre>
-</blockquote>
 </td>
 </tr>
 </table>


### PR DESCRIPTION
## Summary
- `<blockquote>` is for extended quotations, not visual indentation, but 21 course/exercise/lecture pages were wrapping `<pre><code>` COBOL samples in `<blockquote>` purely to indent them
- Removed 51 such wrappers across 21 files (`course/`, `exercises/`, `lectures/`); the inner `<pre><code>` blocks are preserved verbatim
- One case in `course/COBOLcommands.html` also wrapped a trailing `<hr width="50%"/>` inside the blockquote — kept the `<hr>`, just stripped the `<blockquote>` shell

Complements the earlier nested-blockquote cleanup in e965909 by addressing the top-level cases it missed. No content changes — only structural.

## Test plan
- [ ] Spot-check a few of the modified pages render the code samples correctly (no missing blocks, code still readable)
- [ ] Confirm `grep -P '<blockquote>\s*\n\s*<pre'` returns zero matches across the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)