### PR TITLE
Use semantic <aside> for Bug Alert callout in DataDeclaration

### DIFF
--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -230,16 +230,12 @@
 
 
 
-<table 0="" width="100%">
-<tr>
-<td height="85">
+<aside>
 <p align="center"><img height="62" src="Resources/pics/i-BugAlert.gif" width="56"/><br/>
-<font size="-1">Attempting to perform computations on numeric 
-                    data items that contain non-numeric data is a frequent cause 
+<font size="-1">Attempting to perform computations on numeric
+                    data items that contain non-numeric data is a frequent cause
                     of program crashes for beginning COBOL programmers.</font></p>
-</td>
-</tr>
-</table>
+</aside>
 
 </td>
 <td valign="top" width="525">


### PR DESCRIPTION
## Summary
- Replace a single-cell layout `<table>` (with an invalid `0=""` attribute) wrapping the Bug Alert callout in `course/DataDeclaration.html` with a semantic `<aside>`.

## Test plan
- [ ] Open `course/DataDeclaration.html` and confirm the Bug Alert image and warning text still render in the right-hand sidebar of the "Variable Data types" row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)