### PR TITLE
Use <ol> instead of <blockquote> for PERFORM purposes list

### DIFF
--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -326,11 +326,10 @@
                 in a COBOL program. The <font size="-1">PERFORM</font> verb can 
                 be used for two major purposes;</p>
 </div>
-<blockquote>
-<div align="left">1. To transfer control to a designated block of 
-                code.<br/>
-                2. To execute a block of code iteratively. </div>
-</blockquote>
+<ol>
+<li>To transfer control to a designated block of code.</li>
+<li>To execute a block of code iteratively.</li>
+</ol>
 <div align="center">
 <p align="left">While the other formats of the <font size="-1">PERFORM</font> 
                 verb implement various types of iteration, the format shown here 


### PR DESCRIPTION
## Summary

In [course/Iteration.html](course/Iteration.html), the two purposes of the `PERFORM` verb were rendered as a `<blockquote>` containing a `<div>` with manually-typed `1.` / `2.` prefixes separated by `<br/>`. This is a list, not a quotation, so the markup was misleading both visually-trained reviewers and assistive tech.

Replaced with a proper `<ol>`/`<li>` structure — the rendered output stays a numbered list, but the document now actually says "ordered list of two items" instead of "quoted block of run-on text."

## Test plan

- [ ] Open `course/Iteration.html` in a browser, scroll to the "PERFORM..Proc" section, and confirm the two-item list still renders with numbers
- [ ] Confirm no surrounding layout (the centered intro paragraph above, the centered "While the other formats..." paragraph below) shifted

🤖 Generated with [Claude Code](https://claude.com/claude-code)