### PR TITLE
Remove presentational <br/><br/> spacers from Objectives list

### DIFF
--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -145,21 +145,13 @@
 <td width="550">
 <p>By the end of this unit you should:</p>
 <ol>
-<li>Be able to write the Environment Division and Data Division declarations 
-          required for a Relative file. <br/>
-<br/>
-</li>
-<li>Understand the difference between a file's access mode and its organization.<br/>
-<br/>
-</li>
-<li>Be able to used the use the <font size="-1"> <font size="-1">START, 
+<li>Be able to write the Environment Division and Data Division declarations
+          required for a Relative file.</li>
+<li>Understand the difference between a file's access mode and its organization.</li>
+<li>Be able to used the use the <font size="-1"> <font size="-1">START,
           OPEN, CLOSE, READ, WRITE, REWRITE</font> and <font size="-1">DELETE</font>
-</font>Procedure Division verbs required to process Relative files.<br/>
-<br/>
-</li>
-<li>Be able to process a Relative file directly or sequentially. <br/>
-<br/>
-</li>
+</font>Procedure Division verbs required to process Relative files.</li>
+<li>Be able to process a Relative file directly or sequentially.</li>
 <li>Understand when, and how, to use Declaratives.</li>
 </ol>
 </td>


### PR DESCRIPTION
## Summary
- In `course/RelativeFiles.html`, the Objectives ordered list used `<br/><br/>` inside each `<li>` to fake spacing between items.
- Removed the line breaks so the markup carries only semantic content; visual spacing should be handled by CSS on `li`.

## Why
- `<br/>` inside a list item is a presentational hack — it adds no semantic meaning and can produce awkward output for screen readers.
- Cleaner markup makes future styling and accessibility changes simpler.

## Test plan
- [ ] Open `course/RelativeFiles.html` and confirm the Objectives list still renders as a numbered list with readable spacing.
- [ ] Verify no other content shifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)