### PR TITLE
Wrap Detail/BugAlert/LightBulbTip callouts in semantic <aside>

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -623,11 +623,13 @@
           <td valign="TOP" align="LEFT" width="175" bgcolor="#FFFFCC"> 
             <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Selection 
               Program Specification</font></h4>
+            <aside>
             <p align="center"><img src="Resources/pics/i-Detail.gif" width="30" height="37"><br>
-              <font size="-1">Note that these example programs are not meant to 
-              be realistic. For instance, at the very least, a program operating 
-              in the real world would have to ensure that the input data was validated 
+              <font size="-1">Note that these example programs are not meant to
+              be realistic. For instance, at the very least, a program operating
+              in the real world would have to ensure that the input data was validated
               before it was used.</font></p>
+            </aside>
           </td>
           <td width="525" valign="top"> 
             <p>Write a program that accepts two numbers and an operator from the 
@@ -789,10 +791,12 @@
           <td valign="TOP" align="LEFT" width="175" bgcolor="#FFFFCC"> 
             <h4><font color="#800000" face="Arial, Helvetica, sans-serif">An example 
               syntax diagram</font></h4>
-            <div align="center"><img src="Resources/pics/i-Detail.gif" width="30" height="37"><br>
-              <font size="-1">Note that for clarity data items may be separated 
+            <aside>
+            <p align="center"><img src="Resources/pics/i-Detail.gif" width="30" height="37"><br>
+              <font size="-1">Note that for clarity data items may be separated
               from one another by means of an optional comma. <br>
-              This has been done in the COMPUTE statement opposite</font></div>
+              This has been done in the COMPUTE statement opposite</font></p>
+            </aside>
           </td>
           <td width="525" valign="top"> 
             <p>In COBOL, evaluating an arithmetic expression and assigning the 

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -201,21 +201,23 @@
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif">The 
               DISPLAY verb</font></h4>
 
-<h4 align="center"><img height="44" src="Resources/pics/i-LightBulbTip.gif" width="42"/></h4>
-<p align="left"><font size="-1">In the COBOL syntax diagrams ( the 
-              COBOL metalanguage) upper case words are keywords. If underlined, 
+<aside>
+<p align="center"><img height="44" src="Resources/pics/i-LightBulbTip.gif" width="42"/></p>
+<p align="left"><font size="-1">In the COBOL syntax diagrams ( the
+              COBOL metalanguage) upper case words are keywords. If underlined,
               they are mandatory.<br/>
-</font><font size="-1">{ } brackets mean that one of the options 
+</font><font size="-1">{ } brackets mean that one of the options
               must be selected<br/>
 </font><font size="-1">[ ] brackets mean that the item is optional<br/>
-</font><font size="-1">ellipses (...) mean that the item may be 
+</font><font size="-1">ellipses (...) mean that the item may be
               repeated at the programmer's discretion.</font></p>
-<p align="left"><font size="-1">The symbols used in the syntax diagram 
+<p align="left"><font size="-1">The symbols used in the syntax diagram
               identifiers have the following significance:-</font><br/>
 <font size="-1"><b>$</b> signifies a string item,<br/>
 <b>#</b> is numeric item, <br/>
 <b>i</b> indicates that the item can be a variable identifier<br/>
 <b>l</b> indicates that the item can be a literal.</font></p>
+</aside>
 
 </td>
 <td valign="top" width="525">

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -299,11 +299,13 @@
 <td bgcolor="#FFFFCC" valign="top" width="175">
 <h4><font color="#993300" face="Arial, Helvetica, sans-serif">COPY 
               Syntax</font></h4>
-<div align="center"><img height="37" src="Resources/pics/aa%20i-Detail.gif" width="30"/><br/>
-<font size="-1">The syntax diagram shown opposite has been simplified 
-              for the sake of completeness and clarity. It is the author's opinion 
-              that the standard syntax diagram does not clearly identify all the 
-              replaceable objects.</font> </div>
+<aside>
+<p align="center"><img height="37" src="Resources/pics/aa%20i-Detail.gif" width="30"/><br/>
+<font size="-1">The syntax diagram shown opposite has been simplified
+              for the sake of completeness and clarity. It is the author's opinion
+              that the standard syntax diagram does not clearly identify all the
+              replaceable objects.</font> </p>
+</aside>
 <h4><img height="1" src="Resources/pics/PanelLine.gif" width="175"/></h4>
 </td>
 <td valign="top" width="525">
@@ -622,34 +624,36 @@ BeginProg.
 
 
 
+<aside>
 <p align="center"><img height="37" src="Resources/pics/aa%20i-Detail.gif" width="30"/></p>
 <p align="left"><font size="-1"><b>Note1</b><br/>
               The TextWord XYZ in the library text is replaced by 120. </font></p>
 <p align="left"><font size="-1"><b>Note2</b><br/>
-              The PseudoText symbols tell us that we are looking for the text 
-              word R in the library text. Other R's in the text which might be 
-              part of a word are not matched because they are not text words. 
-              The replaced R is a text word because it is bounded by two other 
+              The PseudoText symbols tell us that we are looking for the text
+              word R in the library text. Other R's in the text which might be
+              part of a word are not matched because they are not text words.
+              The replaced R is a text word because it is bounded by two other
               text words i.e. the parentheses ( and ).</font></p>
 <p align="left"><font size="-1"><b>Note3</b><br/>
-              The PseudoText ==V99== is replaced by nothing; effectively deleting 
+              The PseudoText ==V99== is replaced by nothing; effectively deleting
               it.</font></p>
 <p align="left"><font size="-1"><b>Note4</b><br/>
               The literal "KEY" in the library text is replaced by "ABC"</font></p>
 <p align="left"><font size="-1"><b>Note5</b><br/>
-              In this case the library text is copied without change because the 
-              literal "KEY" in the library text is not the same as the 
+              In this case the library text is copied without change because the
+              literal "KEY" in the library text is not the same as the
               word <i>KEY</i> in TextWord2.</font></p>
 <p align="left"><font size="-1"><b>Note6</b><br/>
-              Similar to the previous example demonstrates the difference between 
-              CustKey and the literal "CustKey". A literal text word 
+              Similar to the previous example demonstrates the difference between
+              CustKey and the literal "CustKey". A literal text word
               includes the opening and closing quotes.</font></p>
 <p align="left"><font size="-1"><b>Note7</b><br/>
-              Replaces "KEY" by two lines of text. Note that we are 
-              only replacing the literal "KEY" in the library text. 
-              So the full stop after "KEY" is not replaced and that 
-              is why there is no full stop after the PIC 9(8) in the TextWord2 
+              Replaces "KEY" by two lines of text. Note that we are
+              only replacing the literal "KEY" in the library text.
+              So the full stop after "KEY" is not replaced and that
+              is why there is no full stop after the PIC 9(8) in the TextWord2
               replacement text.</font></p>
+</aside>
 <p align="left"><img height="1" src="Resources/pics/PanelLine.gif" width="175"/></p>
 </td>
 <td valign="top" width="525">
@@ -819,36 +823,38 @@ STOP RUN.
 
 
 
+<aside>
 <p align="center"><img height="37" src="Resources/pics/aa%20i-Detail.gif" width="30"/></p>
-<p align="left"><font size="-1">Note that these COPY statements, which 
-              are themselves syntactically correct, result in statements which 
-              cause syntax errors. This is a clear indication that COPY statements 
+<p align="left"><font size="-1">Note that these COPY statements, which
+              are themselves syntactically correct, result in statements which
+              cause syntax errors. This is a clear indication that COPY statements
               are processed before the resulting program is compiled.</font></p>
 <p align="left"><font size="-1"><b>Note1</b><br/>
-              The text word ( in the library text is replaced by @. Demonstrates 
+              The text word ( in the library text is replaced by @. Demonstrates
               that ( is a text word.</font></p>
 <p align="left"><font size="-1"><b>Note2</b><br/>
               Demonstrates that the 3 between ( and ) is a text word.</font></p>
 <p align="left"><font size="-1">Note3<br/>
               Demonstrates that ) is a textword.</font></p>
 <p align="left"><font size="-1"><b>Note4</b><br/>
-              Demonstrates that the X before (3) is a textword and is replaced 
+              Demonstrates that the X before (3) is a textword and is replaced
               by the PseudoText "Replace the X" </font></p>
 <p><font size="-1"><b>Note5</b><br/>
               The PseudoText X(3) is replaced by X(19) </font></p>
 <p><font size="-1"><b>Note6</b><br/>
-              This looks the same as number 5 but what is actually happening is 
+              This looks the same as number 5 but what is actually happening is
               that the series of textwords<br/>
-</font><font size="-1"> <b>X</b> and<b> (</b> and<b> 3 </b>and<b> 
+</font><font size="-1"> <b>X</b> and<b> (</b> and<b> 3 </b>and<b>
               ) </b>is replaced by the series <b>X ( 19 ) </b></font></p>
 <p><font size="-1"><b>Note7</b><br/>
-              The textword PIC (bounded by separator spaces) is replaced by the 
+              The textword PIC (bounded by separator spaces) is replaced by the
               PseudoText <i>Pic is Replaced </i></font></p>
 <p><font size="-1"><b>Note8</b><br/>
-              But the letter P in PIC is not a textword by itself and so is not 
+              But the letter P in PIC is not a textword by itself and so is not
               replaced.</font></p>
 <p align="left"><font size="-1"><br/>
 </font></p>
+</aside>
 </td>
 <td valign="top" width="525">
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="500">
@@ -986,12 +992,14 @@ BeginProg.
 
 
 
+<aside>
 <p align="center"><img height="37" src="Resources/pics/aa%20i-Detail.gif" width="30"/></p>
 <p align="left"><font size="-1"><b>Note1</b><br/>
-              This example demonstrates that a single COPY statement can be used 
+              This example demonstrates that a single COPY statement can be used
               to replace more than one set of items.</font></p>
 <p align="left"><font size="-1"><b>Note2</b><br/>
               As above. </font></p>
+</aside>
 
 </td>
 <td valign="top" width="525">

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -317,18 +317,20 @@
 <h4 align="left"><font color="#800000" face="Arial, Helvetica, sans-serif">Figurative 
               Constants</font></h4>
 
-<h4 align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/></h4>
-<p align="center"><font size="-1">Actually <font size="-2">COBOL</font> 
-              does allow you to set up single character user-defined Figurative 
-              Constants. These can be useful if you need to use the non-printable 
-              <font size="-2">ASCII</font> characters such as <font size="-2">ESC</font> 
+<aside>
+<p align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/></p>
+<p align="center"><font size="-1">Actually <font size="-2">COBOL</font>
+              does allow you to set up single character user-defined Figurative
+              Constants. These can be useful if you need to use the non-printable
+              <font size="-2">ASCII</font> characters such as <font size="-2">ESC</font>
               or FormFeed.</font></p>
-<p align="center"><font size="-1">User-defined Figurative Constants 
-              are declared in the <font size="-2">SYMBOLIC CHARACTERS </font>clause 
+<p align="center"><font size="-1">User-defined Figurative Constants
+              are declared in the <font size="-2">SYMBOLIC CHARACTERS </font>clause
               of the <font size="-2">ENVIRONMENT DIVISION</font>.</font></p>
-<p align="center"><font size="-1">In an extension that previews the 
-              new <font size="-2">COBOL</font> specification, NetExpress does 
+<p align="center"><font size="-1">In an extension that previews the
+              new <font size="-2">COBOL</font> specification, NetExpress does
               allow user-defined constants. It uses the level 78 for this purpose.</font></p>
+</aside>
 
 
 </td>
@@ -447,10 +449,12 @@
               picture clauses</font></h4>
 
 
-<h4 align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/></h4>
-<p align="center"><font size="-1">There are actually many more picture 
-              symbols than these. Most of these will be introduced when we cover 
+<aside>
+<p align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/><br/>
+<font size="-1">There are actually many more picture
+              symbols than these. Most of these will be introduced when we cover
               Edited Pictures.</font></p>
+</aside>
 
 </td>
 <td valign="top" width="525">
@@ -571,10 +575,12 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
               items </font></h4>
 
 
-<h4 align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/></h4>
-<p align="center"><font size="-1">A variable declaration may also 
-              have a number of other clauses such as <font size="-2">USAGE</font> 
+<aside>
+<p align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/><br/>
+<font size="-1">A variable declaration may also
+              have a number of other clauses such as <font size="-2">USAGE</font>
               or <font size="-2">BLANK WHEN ZERO</font></font></p>
+</aside>
 
 </td>
 <td valign="top" width="525">
@@ -653,13 +659,15 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Level 
               Numbers </font></h4>
 
-<h4 align="center"><img height="44" src="Resources/pics/i-LightBulbTip.gif" width="42"/></h4>
-<p align="center"><font size="-1">Although level numbers specify the 
-              actual data hierarchy you should use indentation to provide a graphic 
-              representation of it.</font><font size="-1"> This will make your 
-              programs easier to read. For instance, indentation makes it obvious 
-              that DayOfBirth, MonthOfBirth and YearOfBirth are subordinate items 
+<aside>
+<p align="center"><img height="44" src="Resources/pics/i-LightBulbTip.gif" width="42"/><br/>
+<font size="-1">Although level numbers specify the
+              actual data hierarchy you should use indentation to provide a graphic
+              representation of it.</font><font size="-1"> This will make your
+              programs easier to read. For instance, indentation makes it obvious
+              that DayOfBirth, MonthOfBirth and YearOfBirth are subordinate items
               of DateOfBirth, while CourseCode is not.</font></p>
+</aside>
 
 </td>
 <td valign="top" width="525">

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -803,13 +803,15 @@
 <h4 align="left"><font color="#800000" face="Arial, Helvetica, sans-serif">Fixed 
               Insertion </font></h4>
 
-<h4 align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/></h4>
-<p align="left"><font size="-1">The default currency symbol is the 
-              dollar sign ($) but it may be changed to a different symbol by the 
-              <font size="-2">CURRENCY SIGN IS</font> clause, in the<font size="-2"> 
-              SPECIAL-NAMES </font>paragraph, of the <font size="-2">CONFIGURATION 
-              SECTION</font>, in the <font size="-2">ENVIRONMENT DIVISION</font>. 
+<aside>
+<p align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/></p>
+<p align="left"><font size="-1">The default currency symbol is the
+              dollar sign ($) but it may be changed to a different symbol by the
+              <font size="-2">CURRENCY SIGN IS</font> clause, in the<font size="-2">
+              SPECIAL-NAMES </font>paragraph, of the <font size="-2">CONFIGURATION
+              SECTION</font>, in the <font size="-2">ENVIRONMENT DIVISION</font>.
               </font></p>
+</aside>
 </td>
 <td height="135" valign="top" width="525">
 <p> Fixed Insertion editing inserts the symbol at the beginning or 

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -305,14 +305,16 @@
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif">PERFORM 
               format 1 syntax</font></h4>
 
-<h4 align="center"><img height="44" src="Resources/pics/i-LightBulbTip.gif" width="42"/></h4>
-<p align="left"><font size="-1">A paragraph is a block of code that 
-              starts at the paragraph name and extends to the next paragraph name, 
+<aside>
+<p align="center"><img height="44" src="Resources/pics/i-LightBulbTip.gif" width="42"/></p>
+<p align="left"><font size="-1">A paragraph is a block of code that
+              starts at the paragraph name and extends to the next paragraph name,
               the next section name or the end of the program text.</font></p>
-<p align="left"><font size="-1">A section is a block of code that 
-              starts at the section name and extends to the next section name 
-              or the end of the program text. A section must contain at least 
+<p align="left"><font size="-1">A section is a block of code that
+              starts at the section name and extends to the next section name
+              or the end of the program text. A section must contain at least
               one paragraph. </font></p>
+</aside>
 </td>
 <td valign="top" width="525">
 <div align="center">
@@ -346,24 +348,26 @@
 <td align="LEFT" bgcolor="#FFFFCC" valign="TOP" width="175">
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif">How 
               this format works</font></h4>
-<h4 align="center"><img height="62" src="Resources/pics/i-BugAlert.gif" width="56"/></h4>
-<p align="left"><font size="-1">The <font size="-2">PERFORM..THRU<font size="-1"> 
-              should be used sparingly and then only to<font size="-2"> PERFORM</font> 
+<aside>
+<p align="center"><img height="62" src="Resources/pics/i-BugAlert.gif" width="56"/></p>
+<p align="left"><font size="-1">The <font size="-2">PERFORM..THRU<font size="-1">
+              should be used sparingly and then only to<font size="-2"> PERFORM</font>
               a paragraph and its immediately succeeding paragraph.</font></font></font></p>
-<p align="left"><font size="-1"><font size="-2"><font size="-1">The 
-              problem with using the <font size="-2">PERFORM..THRU<font size="-1"></font></font> 
-              to execute an number of paragraphs as one unit is that, in the maintenance 
-              phase of your program's life, another programmer may insert a paragraph 
-              in the middle of your <font size="-2"><font size="-1"><font size="-2">PERFORM..THRU</font></font></font> 
-              block. Suddenly your block won't work correctly because now its 
+<p align="left"><font size="-1"><font size="-2"><font size="-1">The
+              problem with using the <font size="-2">PERFORM..THRU<font size="-1"></font></font>
+              to execute an number of paragraphs as one unit is that, in the maintenance
+              phase of your program's life, another programmer may insert a paragraph
+              in the middle of your <font size="-2"><font size="-1"><font size="-2">PERFORM..THRU</font></font></font>
+              block. Suddenly your block won't work correctly because now its
               executing an additional, unintentional paragraph.</font></font></font></p>
+</aside>
 
-
-
+<aside>
 <p align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/></p>
-<p align="left"><font size="-1"><font size="-2"><font size="-1">Although 
-              Netexpress does allow recursive Performs, this is a nonstandard 
+<p align="left"><font size="-1"><font size="-2"><font size="-1">Although
+              Netexpress does allow recursive Performs, this is a nonstandard
               extension. Please do not take advantage of it..</font></font></font></p>
+</aside>
 </td>
 <td valign="top" width="525">
 <div align="center">
@@ -667,11 +671,13 @@ SumSales.
 <h4 align="left"><font color="#800000" face="Arial, Helvetica, sans-serif">Using 
               the PERFORM..THRU</font></h4>
 
-<h4 align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/></h4>
-<p align="left"><font size="-1">Actually this approach will soon be 
-              unnecessary on the way out, because the coming COBOL standard solves 
-              the problem by having an<font size="-2"> EXIT PARAGRAPH</font> statement, 
+<aside>
+<p align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/><br/>
+<font size="-1">Actually this approach will soon be
+              unnecessary on the way out, because the coming COBOL standard solves
+              the problem by having an<font size="-2"> EXIT PARAGRAPH</font> statement,
               that can be used to exit a paragraph prematurely.</font></p>
+</aside>
 
 
 

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -348,17 +348,19 @@ Statement6.</code></pre>
 <td align="LEFT" bgcolor="#FFFFCC" valign="TOP" width="175">
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Class 
               Conditions </font></h4>
-<h4 align="center"><img height="44" src="Resources/pics/i-LightBulbTip.gif" width="42"/></h4>
-<p align="left"><font size="-1">Although this course will not cover 
-              the <font size="-2">SPECIAL-NAMES </font>paragraph in detail it 
+<aside>
+<p align="center"><img height="44" src="Resources/pics/i-LightBulbTip.gif" width="42"/></p>
+<p align="left"><font size="-1">Although this course will not cover
+              the <font size="-2">SPECIAL-NAMES </font>paragraph in detail it
               is useful to acquaint yourself with its clauses. </font></p>
-<p align="left"><font size="-1">As well as setting up a class name, 
-              the<font size="-2"> SPECIAL-NAMES </font>paragraph allows you to 
+<p align="left"><font size="-1">As well as setting up a class name,
+              the<font size="-2"> SPECIAL-NAMES </font>paragraph allows you to
               do such things as;<br/>
-</font><font size="-1">Specify the collating sequence - e.g. <font size="-2">ASCII</font> 
+</font><font size="-1">Specify the collating sequence - e.g. <font size="-2">ASCII</font>
               or <font size="-2">EBCDIC</font><br/>
               Specify the currency sign <br/>
               Create User Defined Figurative constants.</font></p>
+</aside>
 
 
 </td>
@@ -426,12 +428,14 @@ END-IF
 
 
 
-<h4 align="center"><img height="44" src="Resources/pics/i-LightBulbTip.gif" width="42"/></h4>
-<p align="left"><font size="-1">You can see from the IF Amnt1 example, 
-              that figuring out how a complex condition will be evaluated is not 
+<aside>
+<p align="center"><img height="44" src="Resources/pics/i-LightBulbTip.gif" width="42"/></p>
+<p align="left"><font size="-1">You can see from the IF Amnt1 example,
+              that figuring out how a complex condition will be evaluated is not
               straightfoward.<br/>
-</font><font size="-1">Always use brackets to make the order of 
+</font><font size="-1">Always use brackets to make the order of
               evaluation explicit.</font></p>
+</aside>
 
 
 

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -360,10 +360,12 @@
 <h4 align="left"><font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font></h4>
 
 
-<h4 align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/></h4>
-<p align="left"><font size="-1">This is for demonstration only. In 
-              reality we would need to include far more items and some of the 
+<aside>
+<p align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/><br/>
+<font size="-1">This is for demonstration only. In
+              reality we would need to include far more items and some of the
               fields would have to be considerably larger.</font></p>
+</aside>
 
 </td>
 <td valign="top" width="525">
@@ -554,18 +556,19 @@ FD StudentFile.
 <td align="LEFT" bgcolor="#FFFFCC" height="551" valign="TOP" width="175">
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif">SELECT 
               and ASSIGN syntax for Sequential files</font></h4>
-<h4 align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/></h4>
-<p><font size="-1">The Select and Assign clause has far more entries 
-              (even for Sequential files) than those we show here; but we will 
+<aside>
+<p align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/><br/>
+<font size="-1">The Select and Assign clause has far more entries
+              (even for Sequential files) than those we show here; but we will
               examine the other entries in later tutorials.</font></p>
+</aside>
 
-
-
-
-<h4 align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/></h4>
-<p><font size="-1">We are only going to deal with statically assigned 
-              file names for the moment, but it is possible to assign a file name 
+<aside>
+<p align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/><br/>
+<font size="-1">We are only going to deal with statically assigned
+              file names for the moment, but it is possible to assign a file name
               to a file at run-time.</font></p>
+</aside>
 
 </td>
 <td height="551" valign="top" width="525">
@@ -657,14 +660,16 @@ SELECT StudentFile
               OPEN verb</font></h4>
 
 
-<h4 align="center"><img height="44" src="Resources/pics/i-LightBulbTip.gif" width="42"/></h4>
-<p align="left"><font size="-1">Although, as you can see from the 
-              ellipses in the syntax diagram, it is possible to open a number 
-              of files with one OPEN statement it not advisable to do so. If an 
-              error is detected on opening a file and you have used only one statement 
-              to open all the files, the system probably won't be able to show 
-              you which particular file is causing the problem. If you open all 
+<aside>
+<p align="center"><img height="44" src="Resources/pics/i-LightBulbTip.gif" width="42"/><br/>
+<font size="-1">Although, as you can see from the
+              ellipses in the syntax diagram, it is possible to open a number
+              of files with one OPEN statement it not advisable to do so. If an
+              error is detected on opening a file and you have used only one statement
+              to open all the files, the system probably won't be able to show
+              you which particular file is causing the problem. If you open all
               the files separately, it will.</font></p>
+</aside>
 </td>
 <td valign="top" width="525">
 <p align="left"><img height="78" src="Resources/pics/FileSeq4.gif" width="277"/></p>
@@ -779,10 +784,12 @@ SELECT StudentFile
 <td align="LEFT" bgcolor="#FFFFCC" valign="top" width="175">
 <h4 align="left"><font color="#800000" face="Arial, Helvetica, sans-serif">The 
               WRITE verb</font></h4>
-<h4 align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/></h4>
-<p align="left"><font size="-1">The WRITE format actually contains 
-              a number of other entries but these relate to writing to print files 
+<aside>
+<p align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/><br/>
+<font size="-1">The WRITE format actually contains
+              a number of other entries but these relate to writing to print files
               and will be covered in subsequent tutorials.</font></p>
+</aside>
 
 
 </td>

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -364,12 +364,14 @@
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#FFFFCC" height="173" valign="top" width="175">
-<h4 align="left"><font color="#800000" face="Arial, Helvetica, sans-serif">Problems 
+<h4 align="left"><font color="#800000" face="Arial, Helvetica, sans-serif">Problems
               with unordered Sequential files</font></h4>
-<h4 align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/></h4>
-<p><font size="-1">Although it is true that in standard COBOL, Sequential 
-              files cannot be deleted or updated "in situ", many vendors, 
+<aside>
+<p align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/><br/>
+<font size="-1">Although it is true that in standard COBOL, Sequential
+              files cannot be deleted or updated "in situ", many vendors,
               including Microfocus, allow this for disk based files.</font></p>
+</aside>
 
 </td>
 <td height="173" valign="top" width="525">

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -334,11 +334,13 @@ FD TransFile.
 <td align="LEFT" bgcolor="#FFFFCC" valign="TOP" width="175">
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Implications 
               of record mappings</font></h4>
-<h4 align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/></h4>
-<p align="left"><font size="-1">Actually, in the NetExpress version 
-              of COBOL, when a record is smaller than the record buffer the rest 
-              of the buffer is filled with spaces. So in the example opposite, 
+<aside>
+<p align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/><br/>
+<font size="-1">Actually, in the NetExpress version
+              of COBOL, when a record is smaller than the record buffer the rest
+              of the buffer is filled with spaces. So in the example opposite,
               the NewCourseCode would display spaces. </font></p>
+</aside>
 </td>
 <td valign="top" width="525">
 <div align="center">
@@ -934,11 +936,13 @@ PrintPageHeadings.
 <h4 align="left"><font color="#800000" face="Arial, Helvetica, sans-serif">FD 
               entries for variable length records</font></h4>
 
-<h4 align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/></h4>
-<p align="left"><font size="-1">The<font size="-2"> RECORD CONTAINS 
-              </font>clause does much the same as the <font size="-2">RECORD..VARYING</font> 
-              clause without the <font size="-2">DEPENDING ON </font>phrase, but 
+<aside>
+<p align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/><br/>
+<font size="-1">The<font size="-2"> RECORD CONTAINS
+              </font>clause does much the same as the <font size="-2">RECORD..VARYING</font>
+              clause without the <font size="-2">DEPENDING ON </font>phrase, but
               the <font size="-2">RECORD..VARYING</font> clause is the more versatile.</font></p>
+</aside>
 
 </td>
 <td valign="top" width="525">

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -352,11 +352,13 @@ END-IF</code></pre>
 
 
 
-<h4 align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/></h4>
-<p><font size="-1">Records in <font size="-2">LINE SEQUENTIAL</font> 
-              files are followed by the carriage return and line feed characters, 
-              but <font size="-2">RECORD SEQUENTIAL</font> files are organized 
+<aside>
+<p align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/><br/>
+<font size="-1">Records in <font size="-2">LINE SEQUENTIAL</font>
+              files are followed by the carriage return and line feed characters,
+              but <font size="-2">RECORD SEQUENTIAL</font> files are organized
               as a simple stream of bytes.</font></p>
+</aside>
 
 
 
@@ -863,10 +865,12 @@ CLOSE InFileName</code></pre>
 <h4 align="left"><font color="#800000" face="Arial, Helvetica, sans-serif">The 
               Foreign Guests Report - example program </font></h4>
 
-<h4 align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/></h4>
-<p><font size="-1">In this instance, since the number of countries 
-              in the world is fairly static, a table-based solution might also 
+<aside>
+<p align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/><br/>
+<font size="-1">In this instance, since the number of countries
+              in the world is fairly static, a table-based solution might also
               be viable.</font></p>
+</aside>
 
 
 

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -220,15 +220,12 @@
 <td align="LEFT" bgcolor="#FFFFCC" valign="TOP" width="175">
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif"><b>Introduction</b></font></h4>
 
-<div align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/>
-</div>
-<div align="center">
-<p><font size="-1"><br/>
-</font><font size="-1">Your vendor will have supplied a Linker 
-                with your COBOL development system. You will have to read the 
-                vendor manual for the specifics of how it works.</font><br/>
-</p>
-</div>
+<aside>
+<p align="center"><img height="37" src="Resources/pics/i-Detail.gif" width="30"/><br/>
+<font size="-1">Your vendor will have supplied a Linker
+                with your COBOL development system. You will have to read the
+                vendor manual for the specifics of how it works.</font></p>
+</aside>
 </td>
 <td valign="top" width="525">
 <p>A large software system is not usually written as a single monolithic 
@@ -284,13 +281,15 @@
 
 
 
+<aside>
 <p align="center"><img height="62" src="Resources/pics/i-BugAlert.gif" width="56"/></p>
-<p align="center"><font size="-1">Passing parameters of incorrect 
-              types to a called program is a frequent source of program failure 
+<p align="center"><font size="-1">Passing parameters of incorrect
+              types to a called program is a frequent source of program failure
               (crashes).<br/>
-</font><font size="-1">Always double check to make sure that the 
-              types of the parameters passed by the caller program are in agreement 
+</font><font size="-1">Always double check to make sure that the
+              types of the parameters passed by the caller program are in agreement
               with those declared in the LINKAGE SECTION of the called program.</font></p>
+</aside>
 
 
 </td>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -257,18 +257,20 @@
 
 
 
-<h4 align="center"><img height="44" src="Resources/pics/aai-LightBulbTip.gif" width="42"/></h4>
-<p><font size="-1">The speed of modern computers means that it is 
-              hardly worth the effort of using the USAGE clause unless the data 
+<aside>
+<p align="center"><img height="44" src="Resources/pics/aai-LightBulbTip.gif" width="42"/></p>
+<p><font size="-1">The speed of modern computers means that it is
+              hardly worth the effort of using the USAGE clause unless the data
               item is going to be used in thousands of computations.</font></p>
-<p> <font size="-1">For reasons of portability the USAGE clause should 
+<p> <font size="-1">For reasons of portability the USAGE clause should
               never be used in record descriptions.<br/>
-              If the file is read on a different make of computer we have no guarantee 
+              If the file is read on a different make of computer we have no guarantee
               that the data will be interpreted correctly.</font></p>
-<p><font size="-1">Even on the same make of computer, using the USAGE 
-              clause in record descriptions means that the data in the file will 
-              probably not be understood by other programming languages or by 
+<p><font size="-1">Even on the same make of computer, using the USAGE
+              clause in record descriptions means that the data in the file will
+              probably not be understood by other programming languages or by
               utility programs or by text editors. </font> </p>
+</aside>
 
 
 
@@ -2166,22 +2168,24 @@ Begin.
 
 
 <p align="center"><img height="44" src="Resources/pics/aa-ProgFrag.gif" width="48"/></p>
+<aside>
 <p align="center"><img height="62" src="Resources/pics/aai-BugAlert.gif" width="56"/></p>
-<p align="center"><font size="-1">Group items are always treated as 
-              alphanumeric and this can cause problems when there are subordinate 
+<p align="center"><font size="-1">Group items are always treated as
+              alphanumeric and this can cause problems when there are subordinate
               COMP items.</font></p>
-<p align="center"><font size="-1">For instance, suppose we had a statement 
+<p align="center"><font size="-1">For instance, suppose we had a statement
               like - <br/>
               MOVE ZEROS TO GROUP2.<br/>
               in the program opposite.</font><font size="-1"><br/>
 <br/>
-              On the surface it looks as if this statement is moving the numeric 
-              value 0 to NumItem1 and NumItem2 but what is actually moved into 
+              On the surface it looks as if this statement is moving the numeric
+              value 0 to NumItem1 and NumItem2 but what is actually moved into
               these items is the ASCII digit "0".<br/>
 <br/>
-              When an attempt is made to use NumItem1 or NumItem2 in a calculation 
-              the program will crash because these data-items contain non-numeric 
+              When an attempt is made to use NumItem1 or NumItem2 in a calculation
+              the program will crash because these data-items contain non-numeric
               data. </font></p>
+</aside>
 </td>
 <td valign="top" width="525">
 <p align="center"><img height="118" src="Resources/pics/UsageSyn1.gif" width="214"/></p>


### PR DESCRIPTION
## Summary

Across 13 course pages, the leftmost narrow column of the layout table held small marginalia callouts — a Detail / BugAlert / LightBulbTip icon plus a `<font size="-1">` note — with no semantic wrapper. In most cases the icon was held inside an `<h4 align="center">`, a heading element used purely to position a decorative image.

This PR wraps each callout in `<aside>` and replaces the icon-only `<h4>` with a centered `<p>`, extending the pattern established by the Bug Alert conversion in [DataDeclaration.html](course/DataDeclaration.html) (commit 0362a30).

**30 callouts converted across 13 files:**
- COBOLIntro.html (2), COBOLcommands.html (1), Copy.html (4), DataDeclaration.html (3 remaining), EditedPics.html (1), Iteration.html (4), Selection.html (2), SequentialFiles1.html (5), SequentialFiles2.html (1), SequentialFiles3.html (2), SortMerge.html (2), Subprograms.html (2), Usage.html (2).

## Skipped (flagged as follow-on)

- **`Usage.html:194`** — the Detail icon introduces an ASCII/EBCDIC abbreviation glossary. Semantically a `<dl>` more than an `<aside>`.
- **`<h4><img PanelLine.gif></h4>` separators in Copy.html** — heading misuse for a horizontal rule. Better as `<hr>`, separate semantic issue.

## Test plan

- [ ] Spot-check rendering of a converted callout on each page (visual layout should be unchanged — `<aside>` is unstyled by default and the existing layout-table CSS is unaffected).
- [ ] Confirm no broken HTML by loading each modified page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)