### PR TITLE
Remove empty <tr> rows from Report Writer pages

### DIFF
--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -467,10 +467,9 @@ PrintSalaryReport.
 <hr/>
 </td>
 </tr>
-<tr> </tr>
 <tr>
 <td align="LEFT" bgcolor="#FFFFCC" valign="TOP" width="175">
-<h4><font color="#800000" face="Arial, Helvetica, sans-serif">A simple 
+<h4><font color="#800000" face="Arial, Helvetica, sans-serif">A simple
               report </font></h4>
 </td>
 <td valign="top" width="525">

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -807,10 +807,9 @@ RD  SalesReport
 <hr/>
 </td>
 </tr>
-<tr> </tr>
 <tr>
 <td align="LEFT" bgcolor="#FFFFCC" valign="TOP" width="175">
-<h4><font color="#800000" face="Arial, Helvetica, sans-serif">The 
+<h4><font color="#800000" face="Arial, Helvetica, sans-serif">The
               PAGE-COUNTER register</font></h4>
 </td>
 <td valign="top" width="525">


### PR DESCRIPTION
## Summary
- Remove two empty `<tr> </tr>` rows in the Report Writer course pages.
- A `<tr>` must contain at least one `<td>` or `<th>` — these stray rows are invalid markup left over from the original Netscape editor and rendered nothing.

## Files
- `course/ReportWriter.html` (line 470)
- `course/ReportWriterSS.html` (line 810)

## Test plan
- [ ] Open both pages and confirm the surrounding tables render identically (no visible spacing change)
- [ ] HTML validates without the empty-row warnings on these lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)