### PR TITLE
Replace <h4> wrappers around decorative icons with <p>

### DIFF
--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -353,7 +353,7 @@ DISPLAY PrinterSetupCodes UPON PrinterPort1.
 <h4 align="left"><font color="#800000" face="Arial, Helvetica, sans-serif">ACCEPT 
               and DISPLAY example program</font></h4>
 
-<h4 align="center"><img height="44" src="Resources/pics/program.gif" width="42"/></h4>
+<p align="center"><img height="44" src="Resources/pics/program.gif" width="42"/></p>
 
 
 

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -438,7 +438,7 @@
               Insertion examples </font></h4>
 
 
-<h4 align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32"/></h4>
+<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32"/></p>
 </td>
 <td height="413" valign="top" width="525">
 <p>In the examples/questions below, see if you can figure out what 
@@ -667,7 +667,7 @@
               Insertion examples</font></h4>
 
 
-<h4 align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32"/></h4>
+<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32"/></p>
 </td>
 <td height="177" valign="top" width="525">
 <div align="center">
@@ -856,7 +856,7 @@
 <h4 align="left"><font color="#800000" face="Arial, Helvetica, sans-serif">Fixed 
               Insertion examples</font></h4>
 
-<h4 align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32"/></h4>
+<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32"/></p>
 </td>
 <td height="135" valign="top" width="525">
 <p>Like the previous examples/questions above, see if you can figure 
@@ -1369,7 +1369,7 @@
 <h4 align="left"><font color="#800000" face="Arial, Helvetica, sans-serif">Suppression 
               and Replacement editing examples</font></h4>
 
-<h4 align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32"/></h4>
+<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32"/></p>
 </td>
 <td height="389" valign="top" width="525">
 

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -446,7 +446,7 @@
 <td align="LEFT" bgcolor="#FFFFCC" valign="TOP" width="175">
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif">PERFORM..PROC 
               example </font></h4>
-<h4 align="center"><img height="44" src="Resources/pics/program.gif" width="42"/></h4>
+<p align="center"><img height="44" src="Resources/pics/program.gif" width="42"/></p>
 </td>
 <td valign="top" width="525">
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="83%">
@@ -491,7 +491,7 @@ ThreeLevelsDown.
 <td align="LEFT" bgcolor="#FFFFCC" valign="TOP" width="175">
 <h4 align="left"><font color="#800000" face="Arial, Helvetica, sans-serif">Self 
               Assessment Questions</font></h4>
-<h4 align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32"/></h4>
+<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32"/></p>
 </td>
 <td valign="top" width="525">
 <div align="center">
@@ -627,7 +627,7 @@ ThreeLevelsDown.
 
 
 
-<h4 align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48"/></h4>
+<p align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48"/></p>
 </td>
 <td height="355" valign="top" width="525">
 <p>In the program fragment below, the programmer does not want to 
@@ -681,7 +681,7 @@ SumSales.
 
 
 
-<h4 align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48"/></h4>
+<p align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48"/></p>
 </td>
 <td height="355" valign="top" width="525">
 <p>In the program fragment below, the <font size="-1">PERFORM..THRU</font> 
@@ -887,7 +887,7 @@ OutOfLineEG.
 <td align="LEFT" bgcolor="#FFFFCC" valign="top" width="175">
 <h4 align="left"><font color="#800000" face="Arial, Helvetica, sans-serif">Self 
               Assessment Questions</font></h4>
-<h4 align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32"/></h4>
+<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32"/></p>
 </td>
 <td valign="top" width="525">
 <p>Examine the program above and write out what it will display on 
@@ -1199,7 +1199,7 @@ END-PERFORM</code></pre>
               </font><font color="#800000" face="Arial, Helvetica, sans-serif">Example 
               Program</font></h4>
 
-<h4 align="center"><img height="44" src="Resources/pics/program.gif" width="42"/></h4>
+<p align="center"><img height="44" src="Resources/pics/program.gif" width="42"/></p>
 
 
 
@@ -1223,7 +1223,7 @@ END-PERFORM</code></pre>
 
 
 
-<h4 align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32"/></h4>
+<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32"/></p>
 
 </td>
 <td valign="top" width="525">

--- a/course/Search.html
+++ b/course/Search.html
@@ -420,7 +420,7 @@
 
 
 
-<h4 align="center"><img height="44" src="Resources/pics/program.gif" width="42"/></h4>
+<p align="center"><img height="44" src="Resources/pics/program.gif" width="42"/></p>
 
 
 
@@ -513,7 +513,7 @@ Begin.
 
 
 
-<h4 align="center"><img height="44" src="Resources/pics/program.gif" width="42"/></h4>
+<p align="center"><img height="44" src="Resources/pics/program.gif" width="42"/></p>
 
 
 
@@ -704,7 +704,7 @@ DisplayCountyTaxes.
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#FFFFCC" valign="TOP" width="175">
-<h4 align="center"><font color="#800000" face="Arial, Helvetica, sans-serif"><img height="44" src="Resources/pics/program.gif" width="42"/></font></h4>
+<p align="center"><img height="44" src="Resources/pics/program.gif" width="42"/></p>
 </td>
 <td valign="top" width="525">
 <table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="475">
@@ -814,7 +814,7 @@ LoadTable.
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#FFFFCC" valign="TOP" width="175">
-<h4 align="center"><font color="#800000" face="Arial, Helvetica, sans-serif"><img height="44" src="Resources/pics/program.gif" width="42"/></font></h4>
+<p align="center"><img height="44" src="Resources/pics/program.gif" width="42"/></p>
 
 </td>
 <td valign="top" width="525">
@@ -1045,7 +1045,7 @@ END-SEARCH.</code></pre>
 </tr>
 <tr>
 <td align="LEFT" bgcolor="#FFFFCC" valign="TOP" width="175">
-<h4 align="center"><font color="#800000" face="Arial, Helvetica, sans-serif"><img height="44" src="Resources/pics/program.gif" width="42"/></font></h4>
+<p align="center"><img height="44" src="Resources/pics/program.gif" width="42"/></p>
 
 </td>
 <td valign="top" width="525">
@@ -1108,7 +1108,7 @@ Begin.
 
 
 
-<h4 align="center"><img height="44" src="Resources/pics/program.gif" width="42"/></h4>
+<p align="center"><img height="44" src="Resources/pics/program.gif" width="42"/></p>
 </td>
 <td valign="top" width="525">
 <p>In this example, we revisit the County Tax Report program once 

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -669,7 +669,7 @@ END-IF
 
 
 
-<h4 align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32"/></h4>
+<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32"/></p>
 </td>
 <td valign="top" width="525">
 <p> COBOL allows nested <font size="-1">IF</font> statements.</p>
@@ -1062,7 +1062,7 @@ END-IF
 
 
 
-<h4 align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48"/></h4>
+<p align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48"/></p>
 </td>
 <td height="355" valign="top" width="525">
 <p>The animation above demonstrated a simplified version of how the 

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -321,7 +321,7 @@
 <td align="LEFT" bgcolor="#FFFFCC" valign="TOP" width="175">
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Some 
               implications of "buffers"</font></h4>
-<h4 align="center"><img height="44" src="Resources/pics/program.gif" width="42"/></h4>
+<p align="center"><img height="44" src="Resources/pics/program.gif" width="42"/></p>
 </td>
 <td valign="top" width="525">
 <p>If a program processes more than one file, a record buffer must 
@@ -466,7 +466,7 @@
 
 
 
-<h4 align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48"/></h4>
+<p align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48"/></p>
 </td>
 <td height="355" valign="top" width="525">
 <p>The record type/template/buffer of every file used in a program 
@@ -509,7 +509,7 @@ FD StudentFile.
 
 
 
-<h4 align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48"/></h4>
+<p align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48"/></p>
 </td>
 <td valign="top" width="525">
 <p>Although the name of the students file on disk is <i>Students.Dat</i> 
@@ -843,7 +843,7 @@ SELECT StudentFile
               Program </font></h4>
 
 
-<h4 align="center"><img height="44" src="Resources/pics/program.gif" width="42"/></h4>
+<p align="center"><img height="44" src="Resources/pics/program.gif" width="42"/></p>
 </td>
 <td valign="top" width="525">
 <p>The example program below demonstrates the items discussed above. 

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -500,13 +500,13 @@
 <h4 align="left"><font color="#800000" face="Arial, Helvetica, sans-serif">Self 
               Assessment questions</font></h4>
 
-<h4 align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48"/></h4>
+<p align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48"/></p>
 
 
 
 
 
-<h4 align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32"/></h4>
+<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32"/></p>
 </td>
 <td height="536" valign="top" width="525">
 <p>The main processing loop from the animation is shown below. Examine 

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -243,7 +243,7 @@
 
 
 
-<h4 align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48"/></h4>
+<p align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48"/></p>
 </td>
 <td valign="top" width="525">
 <div align="center">
@@ -309,7 +309,7 @@ FD TransFile.
 
 
 
-<h4 align="center"><img height="62" src="Resources/pics/i-Animation.gif" width="62"/></h4>
+<p align="center"><img height="62" src="Resources/pics/i-Animation.gif" width="62"/></p>
 <p align="left"><font size="-1">Click on the diagram opposite to see 
               how the records map on to the buffer</font></p>
 </td>
@@ -747,7 +747,7 @@ FD TransFile.
 <h4 align="left"><font color="#800000" face="Arial, Helvetica, sans-serif">Bringing 
               it all together.</font></h4>
 
-<h4 align="center"><img height="44" src="Resources/pics/program.gif" width="42"/></h4>
+<p align="center"><img height="44" src="Resources/pics/program.gif" width="42"/></p>
 </td>
 <td valign="top" width="525">
 <p>The example program below implements the Student Details Report 

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -1301,7 +1301,7 @@ CLOSE OutFile
 
 
 
-<h4 align="center"><img height="44" src="Resources/pics/program.gif" width="42"/></h4>
+<p align="center"><img height="44" src="Resources/pics/program.gif" width="42"/></p>
 </td>
 <td valign="top" width="525">
 <p>The example below creates a sorted SalesSummaryFile from an unsorted 
@@ -1385,7 +1385,7 @@ SummariseSales.
               Foreign Guests Report - example program</font></h4>
 
 
-<h4 align="center"><img height="44" src="Resources/pics/program.gif" width="42"/></h4>
+<p align="center"><img height="44" src="Resources/pics/program.gif" width="42"/></p>
 </td>
 <td valign="top" width="525">
 <p>This example program is a revised version of the Foreign Guest 

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -201,7 +201,7 @@
 
 
 
-<h4 align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48"/></h4>
+<p align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48"/></p>
 </td>
 <td height="195" valign="top" width="525">
 <div align="center">
@@ -425,7 +425,7 @@ ADD TaxPaid TO CountyTax(CountyCode - 2)</code></pre>
 
 
 
-<h4 align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48"/></h4>
+<p align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48"/></p>
 </td>
 <td height="551" valign="top" width="525">
 <p>The solution to the problem of producing the County Tax 
@@ -513,7 +513,7 @@ Begin.
 
 
 
-<h4 align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48"/></h4>
+<p align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48"/></p>
 </td>
 <td height="679" valign="top" width="525">
 <p>One solution might be to use an <font size="-1">EVALUATE</font> 
@@ -672,7 +672,7 @@ ADD TaxPaid TO CountyTax(CountyNum)</code></pre>
 
 
 
-<h4 align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48"/></h4>
+<p align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48"/></p>
 </td>
 <td height="206" valign="top" width="525">
 <p align="left">To convert the county name to a numeric value, we 

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -356,7 +356,7 @@
 
 
 
-<h4 align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32"/></h4>
+<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32"/></p>
 </td>
 <td valign="top" width="525">
 <p>Examine the example table declarations below and then attempt to 
@@ -552,7 +552,7 @@
 <td align="LEFT" bgcolor="#FFFFCC" valign="TOP" width="175">
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Self 
               Assessment Questions and animated example</font></h4>
-<h4 align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32"/></h4>
+<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32"/></p>
 
 
 
@@ -621,7 +621,7 @@ MOVE ZEROS TO CountyTaxTable</code></pre>
 
 
 
-<h4 align="center"><img height="44" src="Resources/pics/program.gif" width="42"/></h4>
+<p align="center"><img height="44" src="Resources/pics/program.gif" width="42"/></p>
 
 
 
@@ -895,7 +895,7 @@ END-EVALUATE.
 <td align="LEFT" bgcolor="#FFFFCC" valign="TOP" width="175">
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif">Self 
               Assessment Questions and examples</font></h4>
-<h4 align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32"/></h4>
+<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32"/></p>
 
 </td>
 <td valign="top" width="525">
@@ -1277,7 +1277,7 @@ END-EVALUATE </code></pre>
 
 
 
-<h4 align="center"><img height="44" src="Resources/pics/program.gif" width="42"/></h4>
+<p align="center"><img height="44" src="Resources/pics/program.gif" width="42"/></p>
 </td>
 <td valign="top" width="525">
 <p>In this example, we revisit the County Tax Report program. In the 

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -243,7 +243,7 @@
 
 
 
-<h4 align="center"><img height="44" src="Resources/pics/aa-ProgFrag.gif" width="48"/></h4>
+<p align="center"><img height="44" src="Resources/pics/aa-ProgFrag.gif" width="48"/></p>
 
 
 


### PR DESCRIPTION
## Summary

- Decorative badge icons (`program.gif`, `ProgFrag.gif`, `aa-ProgFrag.gif`, `i-SAQ2.gif`, `i-Animation.gif`) were wrapped in `<h4 align="center">` purely so they'd render centered. These aren't headings — they're visual markers — so the wrapping polluted the document outline and would be announced as level-4 sections by screen readers.
- Switched all 41 instances across 12 course pages to `<p align="center">`, matching the convention already used for centered figure images elsewhere on the same pages.
- `PanelLine.gif` instances (5 of them) are intentionally left inside `<h4>` because the mobile CSS targets them via `h4:has(> img[src*="PanelLine"])` to hide on small screens.

## Test plan

- [ ] Visually spot-check a couple of the affected pages (e.g. Search.html, EditedPics.html) — the icons should still appear centered in their sidebar cells, with no visible change.
- [ ] Confirm `PanelLine.gif` dividers still hide correctly on mobile widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)