### PR TITLE
Remove empty <tr> elements from Report Writer pages

### DIFF
--- a/lectures/ReportWriterSSWeb.html
+++ b/lectures/ReportWriterSSWeb.html
@@ -807,10 +807,9 @@ FD  SalesFile.
 <hr/>
 </td>
 </tr>
-<tr> </tr>
 <tr>
 <td align="LEFT" bgcolor="#FFFFCC" valign="TOP" width="175">
-<h4><font color="#800000" face="Arial, Helvetica, sans-serif">The 
+<h4><font color="#800000" face="Arial, Helvetica, sans-serif">The
               PAGE-COUNTER register</font></h4>
 </td>
 <td valign="top" width="525">

--- a/lectures/ReportWriterWeb.html
+++ b/lectures/ReportWriterWeb.html
@@ -459,7 +459,6 @@ PrintSalaryReport.
 <hr/>
 </td>
 </tr>
-<tr> </tr>
 <tr>
 <td align="LEFT" bgcolor="#FFFFCC" valign="TOP" width="175">
 <h4><font color="#800000" face="Arial, Helvetica, sans-serif">A simple 


### PR DESCRIPTION
## Summary

Removed unnecessary empty table rows (`<tr> </tr>`) that had no semantic value from two Report Writer lecture pages. These empty rows clutter the DOM without contributing to the document structure or accessibility.

## Pages modified
- lectures/ReportWriterWeb.html
- lectures/ReportWriterSSWeb.html

## Test plan
- [x] Visually verify pages still render correctly
- [x] Search codebase confirms no remaining empty `<tr>` elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)