### PR TITLE
Replace <h2> wrappers around decorative logo image with <p>

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -62,7 +62,7 @@
         <tr> 
           <td valign="top" align="left" bgcolor="#FFFFFF" colspan="2"> 
             <center>
-              <h2><img src="Resources/pics/t-CobolTut.gif" width="173" height="59"></h2>
+              <p><img src="Resources/pics/t-CobolTut.gif" width="173" height="59"></p>
             </center>
             <center>
               <h1>Introduction to COBOL</h1>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -84,7 +84,7 @@
 <tr>
 <td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
 <center>
-<h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<p><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></p>
 </center>
 <center>
 <h1>Basic Procedure Division Commands</h1>

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -84,7 +84,7 @@
 <tr>
 <td align="left" bgcolor="#FFFFFF" colspan="2" valign="top">
 <center>
-<h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<p><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></p>
 </center>
 <center>
 <h1>The COPY verb</h1>

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -84,7 +84,7 @@
 <tr>
 <td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
 <center>
-<h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<p><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></p>
 </center>
 <center>
 <h1>Declaring Data in COBOL</h1>

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -83,7 +83,7 @@
 <tr>
 <td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
 <center>
-<h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<p><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></p>
 </center>
 <center>
 <h1>Edited Pictures</h1>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -89,7 +89,7 @@
 <tr>
 <td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
 <center>
-<h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<p><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></p>
 </center>
 <center>
 <h1>COBOL Iteration Constructs</h1>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -84,7 +84,7 @@
 <tr>
 <td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
 <center>
-<h2><img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<p><img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></p>
 </center>
 <center>
 <h1>Reference Modification and Intrinsic Functions</h1>

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -84,7 +84,7 @@
 <tr>
 <td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
 <center>
-<h2><img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<p><img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></p>
 </center>
 <center>
 <h1>The COBOL Report Writer</h1>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -84,7 +84,7 @@
 <tr>
 <td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
 <center>
-<h2><img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<p><img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></p>
 </center>
 <center>
 <h1>The COBOL Report Writer - Syntax and Semantics</h1>

--- a/course/Search.html
+++ b/course/Search.html
@@ -86,7 +86,7 @@
 <tr>
 <td align="left" bgcolor="#FFFFFF" colspan="2" valign="top">
 <center>
-<h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<p><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></p>
 </center>
 <center>
 <h1> Searching Tables</h1>

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -84,7 +84,7 @@
 <tr>
 <td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
 <center>
-<h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<p><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></p>
 </center>
 <center>
 <h1>COBOL Selection Constructs</h1>

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -84,7 +84,7 @@
 <tr>
 <td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
 <center>
-<h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<p><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></p>
 </center>
 <center>
 <h1>Introduction to Sequential Files</h1>

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -89,7 +89,7 @@
 <tr>
 <td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
 <center>
-<h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<p><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></p>
 </center>
 <center>
 <h1>Processing Sequential Files</h1>

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -84,7 +84,7 @@
 <tr>
 <td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
 <center>
-<h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<p><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></p>
 </center>
 <center>
 <h1>Print files and variable-length records</h1>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -84,7 +84,7 @@
 <tr>
 <td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
 <center>
-<h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<p><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></p>
 </center>
 <center>
 <h1>Sorting and Merging files</h1>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -84,7 +84,7 @@
 <tr>
 <td align="left" bgcolor="#FFFFFF" colspan="2" valign="top">
 <center>
-<h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<p><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></p>
 </center>
 <center>
 <h1>Subprograms</h1>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -84,7 +84,7 @@
 <tr>
 <td align="left" bgcolor="#FFFFFF" colspan="2" valign="top">
 <center>
-<h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<p><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></p>
 </center>
 <center>
 <h1> Using Tables </h1>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -88,7 +88,7 @@
 <tr>
 <td align="left" bgcolor="#FFFFFF" colspan="2" valign="top">
 <center>
-<h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<p><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></p>
 </center>
 <center>
 <h1>Creating Tables - syntax and semantics</h1>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -84,7 +84,7 @@
 <tr>
 <td align="left" bgcolor="#FFFFFF" colspan="2" valign="top">
 <center>
-<h2><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<p><img height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></p>
 </center>
 <center>
 <h1>The USAGE clause</h1>


### PR DESCRIPTION
## Summary

- The COBOL Tutorial banner image (`t-CobolTut.gif`) was wrapped in `<h2>` across all 19 course pages
- A heading element that contains only a decorative/presentational image misrepresents document structure — the actual page title is the `<h1>` that immediately follows
- Replaced all 19 instances with `<p>`, consistent with the fix already applied to decorative icon `<h4>` wrappers (PR #108)

## Test plan

- [ ] Spot-check a few course pages in a browser — the banner image should appear unchanged visually
- [ ] Confirm heading outline (e.g. via browser accessibility tree) no longer includes the logo image as an `<h2>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)