### PR TITLE
Replace <h2> wrappers around decorative logo image with <p> in remaining 6 pages

### DIFF
--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -89,7 +89,7 @@
 <tr>
 <td>
 <center>
-<h2 id="top"> <img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<p id="top"><img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></p>
 </center>
 <center>
 <h1>Indexed Files</h1>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -90,7 +90,7 @@
 <tr>
 <td>
 <center>
-<h2 id="top"> <img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<p id="top"><img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></p>
 </center>
 <center>
 <h1>The INSPECT verb</h1>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -89,7 +89,7 @@
 <tr>
 <td>
 <center>
-<h2 id="top"> <img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<p id="top"><img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></p>
 </center>
 <center>
 <h1>Introduction to Direct Access Files</h1>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -89,7 +89,7 @@
 <tr>
 <td>
 <center>
-<h2 id="top"> <img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<p id="top"><img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></p>
 </center>
 <center>
 <h1>Relative Files</h1>

--- a/course/String.html
+++ b/course/String.html
@@ -89,7 +89,7 @@
 <tr>
 <td>
 <center>
-<h2 id="top"> <img alt="Cobol Tutorial" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<p id="top"><img alt="Cobol Tutorial" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></p>
 </center>
 <center>
 <h1>The STRING verb</h1>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -89,7 +89,7 @@
 <tr>
 <td>
 <center>
-<h2 id="top"> <img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></h2>
+<p id="top"><img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173"/></p>
 </center>
 <center>
 <h1>The UNSTRING verb</h1>


### PR DESCRIPTION
## Summary

- PR #110 applied this fix to 19 course pages but missed 6: `IndexedFiles.html`, `Inspect.html`, `Intro2DirectAccess.html`, `RelativeFiles.html`, `String.html`, and `Unstring.html`.
- This PR applies the same change to those remaining pages: replaces `<h2 id="top">` wrapping the `t-CobolTut.gif` banner image with `<p id="top">`.
- A heading element containing only a decorative/presentational image misrepresents document structure — the real page title is the `<h1>` immediately below it.

## Test plan

- [ ] Visually verify the banner image still renders correctly on the 6 affected pages
- [ ] Confirm the `#top` anchor still works (used by "back to top" links throughout each page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)