### PR TITLE
Replace <td>+<b> header cells with semantic <th> in data tables

### DIFF
--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -655,18 +655,10 @@ The time is 14:41
 </td>
 </tr>
 <tr>
-<td>
-<div align="center"><b>Receiving Field</b></div>
-</td>
-<td>
-<div align="center"><b>Actual Result</b></div>
-</td>
-<td>
-<div align="center"><b>Truncated Result</b></div>
-</td>
-<td>
-<div align="center"><b>Rounded Result</b></div>
-</td>
+<th scope="col">Receiving Field</th>
+<th scope="col">Actual Result</th>
+<th scope="col">Truncated Result</th>
+<th scope="col">Rounded Result</th>
 </tr>
 <tr>
 <td>

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -449,26 +449,14 @@
 <form action="" method="post">
 <table align="center" bgcolor="#FFFFCC" border="1" cellpadding="0" cellspacing="0" width="94%">
 <tr bgcolor="#FFFFCC">
-<td colspan="2" height="24">
-<div align="center"><b>Sending item</b></div>
-</td>
-<td colspan="2" height="24">
-<div align="center"><b>Receiving item</b></div>
-</td>
+<th colspan="2" scope="colgroup">Sending item</th>
+<th colspan="2" scope="colgroup">Receiving item</th>
 </tr>
 <tr bgcolor="#FFFFCC">
-<td width="20%">
-<div align="center"><b>Picture </b></div>
-</td>
-<td width="15%">
-<div align="center"><b>Data</b></div>
-</td>
-<td width="24%">
-<div align="center"><b>Picture    </b></div>
-</td>
-<td width="41%">
-<div align="center"><b>Result</b></div>
-</td>
+<th scope="col" width="20%">Picture</th>
+<th scope="col" width="15%">Data</th>
+<th scope="col" width="24%">Picture</th>
+<th scope="col" width="41%">Result</th>
 </tr>
 <tr bgcolor="#E1FFE1">
 <td width="20%">
@@ -680,26 +668,14 @@
 <form action="" method="post">
 <table align="center" bgcolor="#FFFFCC" border="1" bordercolorlight="#FFFFFF" cellpadding="0" cellspacing="0" width="88%">
 <tr bgcolor="#FFFFCC">
-<td colspan="2" height="24">
-<div align="center"><b>Sending item</b></div>
-</td>
-<td colspan="2" height="24">
-<div align="center"><b>Receiving item</b></div>
-</td>
+<th colspan="2" scope="colgroup">Sending item</th>
+<th colspan="2" scope="colgroup">Receiving item</th>
 </tr>
 <tr bgcolor="#FFFFCC">
-<td width="23%">
-<div align="center"><b>Picture </b></div>
-</td>
-<td width="11%">
-<div align="center"><b>Data</b></div>
-</td>
-<td width="22%">
-<div align="center"><b>Picture    </b></div>
-</td>
-<td width="44%">
-<div align="center"><b>Result</b></div>
-</td>
+<th scope="col" width="23%">Picture</th>
+<th scope="col" width="11%">Data</th>
+<th scope="col" width="22%">Picture</th>
+<th scope="col" width="44%">Result</th>
 </tr>
 <tr bgcolor="#E1FFE1">
 <td height="13" width="23%">
@@ -865,26 +841,14 @@
 <form action="" method="post">
 <table align="center" bgcolor="#FFFFCC" border="1" cellpadding="0" cellspacing="0" width="87%">
 <tr bgcolor="#FFFFCC">
-<td colspan="2" height="24">
-<div align="center"><b>Sending item</b></div>
-</td>
-<td colspan="2" height="24">
-<div align="center"><b>Receiving item</b></div>
-</td>
+<th colspan="2" scope="colgroup">Sending item</th>
+<th colspan="2" scope="colgroup">Receiving item</th>
 </tr>
 <tr bgcolor="#FFFFCC">
-<td width="18%">
-<div align="center"><b>Picture </b></div>
-</td>
-<td width="16%">
-<div align="center"><b>Data</b></div>
-</td>
-<td width="20%">
-<div align="center"><b>Picture    </b></div>
-</td>
-<td width="46%">
-<div align="center"><b>Result</b></div>
-</td>
+<th scope="col" width="18%">Picture</th>
+<th scope="col" width="16%">Data</th>
+<th scope="col" width="20%">Picture</th>
+<th scope="col" width="46%">Result</th>
 </tr>
 <tr bgcolor="#E1FFE1">
 <td height="15" width="18%">
@@ -1142,26 +1106,14 @@
 <form action="" method="post">
 <table align="center" bgcolor="#FFFFCC" border="1" cellpadding="0" cellspacing="0" width="83%">
 <tr bgcolor="#FFFFCC">
-<td colspan="2" height="24">
-<div align="center"><b>Sending item</b></div>
-</td>
-<td colspan="2" height="24">
-<div align="center"><b>Receiving item</b></div>
-</td>
+<th colspan="2" scope="colgroup">Sending item</th>
+<th colspan="2" scope="colgroup">Receiving item</th>
 </tr>
 <tr bgcolor="#FFFFCC">
-<td width="18%">
-<div align="center"><b>Picture </b></div>
-</td>
-<td width="16%">
-<div align="center"><b>Data</b></div>
-</td>
-<td width="23%">
-<div align="center"><b>Picture    </b></div>
-</td>
-<td width="43%">
-<div align="center"><b>Result</b></div>
-</td>
+<th scope="col" width="18%">Picture</th>
+<th scope="col" width="16%">Data</th>
+<th scope="col" width="23%">Picture</th>
+<th scope="col" width="43%">Result</th>
 </tr>
 <tr bgcolor="#E1FFE1">
 <td height="15" width="18%">
@@ -1376,26 +1328,14 @@
 <form>
 <table align="center" bgcolor="#FFFFCC" border="1" cellpadding="0" cellspacing="0" width="93%">
 <tr bgcolor="#FFFFCC">
-<td colspan="2" height="24">
-<div align="center"><b>Sending item</b></div>
-</td>
-<td colspan="2" height="24">
-<div align="center"><b>Receiving item</b></div>
-</td>
+<th colspan="2" scope="colgroup">Sending item</th>
+<th colspan="2" scope="colgroup">Receiving item</th>
 </tr>
 <tr bgcolor="#FFFFCC">
-<td width="21%">
-<div align="center"><b>Picture </b></div>
-</td>
-<td width="13%">
-<div align="center"><b>Data</b></div>
-</td>
-<td width="25%">
-<div align="center"><b>Picture    </b></div>
-</td>
-<td width="41%">
-<div align="center"><b>Result</b></div>
-</td>
+<th scope="col" width="21%">Picture</th>
+<th scope="col" width="13%">Data</th>
+<th scope="col" width="25%">Picture</th>
+<th scope="col" width="41%">Result</th>
 </tr>
 <tr bgcolor="#E1FFE1">
 <td height="15" width="21%">
@@ -1562,12 +1502,8 @@
               below shows the combination of symbols that is allowed.</p>
 <table align="center" bgcolor="#E1FFE1" border="1" cellpadding="5" height="69" width="47%">
 <tr bgcolor="#FFFFCC">
-<td bgcolor="#FFFFCC" width="15%">
-<div align="center"><b>Character</b></div>
-</td>
-<td width="85%">
-<div align="center"><b>May be followed by</b></div>
-</td>
+<th scope="col" width="15%">Character</th>
+<th scope="col" width="85%">May be followed by</th>
 </tr>
 <tr>
 <td bgcolor="#FFFFCC" height="192" valign="top" width="15%">

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -150,15 +150,9 @@
 <center>
 <table bgcolor="#E1FFE1" border="" cellpadding="7" cellspacing="1" width="411">
 <tr bgcolor="#FFFFCC">
-<td valign="TOP" width="18%">
-<div align="center"><b>C</b></div>
-</td>
-<td valign="TOP" width="23%">
-<div align="center"><b>Modula-2</b></div>
-</td>
-<td valign="TOP" width="59%">
-<div align="center"><b>COBOL</b></div>
-</td>
+<th scope="col" width="18%">C</th>
+<th scope="col" width="23%">Modula-2</th>
+<th scope="col" width="59%">COBOL</th>
 </tr>
 <tr>
 <td valign="TOP" width="18%">

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -368,15 +368,9 @@ MOVE FUNCTION ORD-MAX(IntElement(ALL)) TO OrdPos             </code></pre>
 <div align="center">
 <table bgcolor="#E1FFE1" border="2" cellpadding="7" cellspacing="0" width="502">
 <tr>
-<td valign="top" width="34%">
-<div align="center"><b>Function Name</b></div>
-</td>
-<td valign="top" width="20%">
-<div align="center"><b>Result Type</b></div>
-</td>
-<td valign="TOP" width="46%">
-<div align="center"><b>Comment</b></div>
-</td>
+<th scope="col" width="34%">Function Name</th>
+<th scope="col" width="20%">Result Type</th>
+<th scope="col" width="46%">Comment</th>
 </tr>
 <tr>
 <td valign="top" width="34%"> <font face="TIMES" size="2">
@@ -575,13 +569,9 @@ Begin.
 <div align="center">
 <table bgcolor="#E1FFE1" border="2" cellpadding="7" cellspacing="0" width="502">
 <tr>
-<td valign="TOP" width="36%"><b>Function Name</b></td>
-<td valign="TOP" width="20%">
-<div align="center"><b>Result Type</b></div>
-</td>
-<td valign="TOP" width="44%">
-<div align="center"><b>Comment</b></div>
-</td>
+<th scope="col" width="36%">Function Name</th>
+<th scope="col" width="20%">Result Type</th>
+<th scope="col" width="44%">Comment</th>
 </tr>
 <tr>
 <td valign="TOP" width="36%">
@@ -792,13 +782,9 @@ Begin.
 <div align="center">
 <table bgcolor="#E1FFE1" border="2" cellpadding="7" cellspacing="0" width="502">
 <tr>
-<td valign="TOP" width="36%"><b>Function Name</b></td>
-<td valign="TOP" width="21%">
-<div align="center"><b>Result Type</b></div>
-</td>
-<td valign="TOP" width="43%">
-<div align="center"><b>Comment</b></div>
-</td>
+<th scope="col" width="36%">Function Name</th>
+<th scope="col" width="21%">Result Type</th>
+<th scope="col" width="43%">Comment</th>
 </tr>
 <tr>
 <td valign="TOP" width="36%">

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -273,12 +273,8 @@
 
 <table bgcolor="#E1FFE1" border="1" width="53%">
 <tr bgcolor="#FFFFCC">
-<td width="39%">
-<div align="center"><b>Ordered File</b></div>
-</td>
-<td width="40%">
-<div align="center"><b>Unordered File</b></div>
-</td>
+<th scope="col" width="39%">Ordered File</th>
+<th scope="col" width="40%">Unordered File</th>
 </tr>
 <tr>
 <td width="39%">

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -746,15 +746,9 @@ DisplayCountyTaxes.
 <div align="center">
 <table bgcolor="#E1FFE1" border="1" cellpadding="5" width="56%">
 <tr bgcolor="#FFFFCC">
-<td width="32%">
-<div align="center"><b>Name</b></div>
-</td>
-<td width="26%">
-<div align="center"><b>Description</b></div>
-</td>
-<td width="42%">
-<div align="center"><b>Value</b></div>
-</td>
+<th scope="col" width="32%">Name</th>
+<th scope="col" width="26%">Description</th>
+<th scope="col" width="42%">Value</th>
 </tr>
 <tr>
 <td width="32%">CountyCode</td>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -333,18 +333,10 @@ Begin.
 <p><b>ASCII Table</b> </p>
 <table align="center" border="1" cellpadding="0" cellspacing="0">
 <tr bgcolor="#FFFFCC">
-<td width="114">
-<p align="center"><b><a>Char</a></b></p>
-</td>
-<td width="66">
-<p align="center"><b>Dec</b></p>
-</td>
-<td width="60">
-<p align="center"><b>Hex</b></p>
-</td>
-<td width="108">
-<p align="center"><b>Binary</b></p>
-</td>
+<th scope="col" width="114">Char</th>
+<th scope="col" width="66">Dec</th>
+<th scope="col" width="60">Hex</th>
+<th scope="col" width="108">Binary</th>
 </tr>
 <tr>
 <td width="114">
@@ -2262,12 +2254,8 @@ Begin.
               as <font size="-1">COMP</font> are as follows:</p>
 <table align="center" border="1" cellpadding="1" cellspacing="1" width="293">
 <tr bgcolor="#FFFFCC">
-<td width="133">
-<div align="center"><b>Number of Digits</b></div>
-</td>
-<td width="166">
-<div align="center"><b>Storage Required.</b></div>
-</td>
+<th scope="col" width="133">Number of Digits</th>
+<th scope="col" width="166">Storage Required.</th>
 </tr>
 <tr>
 <td width="133">PIC 9(1 to 4) </td>


### PR DESCRIPTION
## Summary

- Across 7 course pages, table header rows were using `<td>` cells styled with `<b>` tags to visually fake column headers without semantic meaning
- Replaced all such cells with proper `<th scope="col">` elements (and `scope="colgroup"` for spanning group-headers in EditedPics)
- Redundant `<b>`, `<div align="center">`, and `<p align="center">` wrappers removed from the converted cells — `<th>` is bold and centered by default in browsers

## Files changed

| File | Tables fixed |
|---|---|
| `course/Usage.html` | ASCII character table + COMP storage requirements table |
| `course/COBOLcommands.html` | ROUNDED examples table |
| `course/RefMod.html` | 3× intrinsic function reference tables |
| `course/Iteration.html` | C / Modula-2 / COBOL loop construct comparison table |
| `course/EditedPics.html` | 5× Sending/Receiving item tables (two-level headers) + Character/May-be-followed-by table |
| `course/Tables2.html` | Field name/description/value reference table |
| `course/SequentialFiles2.html` | Ordered/Unordered file comparison table |

## Reviewer notes

- Visual appearance is unchanged — `<th>` renders bold and centered, same as the `<td><b>` pattern it replaces
- The EditedPics tables had a two-level header structure; the top row (Sending item / Receiving item spanning 2 cols each) uses `scope="colgroup"` and the sub-row uses `scope="col"`
- The `Picture` cells in EditedPics originally contained non-breaking spaces (`&nbsp;`) as padding — those were stripped in the conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)