### PR TITLE
Replace <td> header cells with semantic <th> in Selection.html

### DIFF
--- a/course/Selection.html
+++ b/course/Selection.html
@@ -290,9 +290,9 @@ Statement6.</code></pre>
               shown in the table below.</p>
 <table align="center" border="1" cellpadding="7" cellspacing="0" height="180" width="241">
 <tr bgcolor="#FFFFCC">
-<td valign="TOP">
+<th valign="TOP">
 <div align="center"><b><font color="#FF0000">Condition Types</font></b></div>
-</td>
+</th>
 </tr>
 <tr bgcolor="#E1FFE1">
 <td valign="TOP">
@@ -453,15 +453,15 @@ END-IF
               below) or by bracketing.</p>
 <table align="center" bgcolor="#E1FFE1" border="" cellpadding="7" cellspacing="1" width="275">
 <tr bgcolor="#FFFFCC">
-<td valign="TOP" width="23%">
+<th valign="TOP" width="23%">
 <p align="CENTER"><font color="#FF0000"><b>Precedence</b></font>
-</p></td>
-<td valign="TOP" width="35%">
+</p></th>
+<th valign="TOP" width="35%">
 <p align="CENTER"><font color="#FF0000"><b>Condition Value</b></font>
-</p></td>
-<td valign="TOP" width="42%">
+</p></th>
+<th valign="TOP" width="42%">
 <p align="CENTER"><font color="#FF0000"><b>Arithmetic Equivalent</b></font>
-</p></td>
+</p></th>
 </tr>
 <tr>
 <td valign="TOP" width="23%">
@@ -528,9 +528,9 @@ END-IF
               be true? Let's check.</p>
 <table align="center" border="1" width="94%">
 <tr>
-<td bgcolor="#FFFFCC" width="16%">
+<th scope="row" bgcolor="#FFFFCC" width="16%">
 <p align="center"><font size="-1">Condition</font></p>
-</td>
+</th>
 <td bgcolor="#E1FFE1" width="84%">
 <p align="center"> (<font size="-1">NOT </font>(Amnt1 &lt; 
                     10)) <font size="-1">OR </font>((Amnt2 = 50) <font size="-1">AND</font> 
@@ -538,25 +538,25 @@ END-IF
 </td>
 </tr>
 <tr>
-<td bgcolor="#FFFFCC" width="16%">
+<th scope="row" bgcolor="#FFFFCC" width="16%">
 <p align="center"><font size="-1">Expressed as</font></p>
-</td>
+</th>
 <td bgcolor="#E1FFE1" width="84%">
 <pre class="language-cobol"><code class="language-cobol">   (NOT    (T))   OR      ((T)   AND      (T)) </code></pre>
 </td>
 </tr>
 <tr>
-<td bgcolor="#FFFFCC" height="17" width="16%">
+<th scope="row" bgcolor="#FFFFCC" height="17" width="16%">
 <div align="center"><font size="-1">Evaluates to</font></div>
-</td>
+</th>
 <td bgcolor="#E1FFE1" height="17" width="84%">
 <pre class="language-cobol"><code class="language-cobol">      (F)         OR             (T) </code></pre>
 </td>
 </tr>
 <tr>
-<td bgcolor="#FFFFCC" width="16%">
+<th scope="row" bgcolor="#FFFFCC" width="16%">
 <div align="center"><font size="-1">Evaluates to</font></div>
-</td>
+</th>
 <td bgcolor="#E1FFE1" width="84%">
 <pre class="language-cobol"><code class="language-cobol">                 True </code></pre>
 </td>
@@ -567,42 +567,42 @@ END-IF
                    </p>
 <table align="center" border="1" width="93%">
 <tr>
-<td bgcolor="#FFFFCC" width="16%">
+<th scope="row" bgcolor="#FFFFCC" width="16%">
 <p align="center"><font size="-1">Condition</font></p>
-</td>
+</th>
 <td bgcolor="#E1FFE1" width="84%">
 <p align="center"><font size="-1">NOT </font>((Amnt1 &lt; 10) <font size="-1">OR</font> 
                     (Amnt2 = 50)) <font size="-1">AND</font> (Amnt3 &gt; 150)</p>
 </td>
 </tr>
 <tr>
-<td bgcolor="#FFFFCC" width="16%">
+<th scope="row" bgcolor="#FFFFCC" width="16%">
 <p align="center"><font size="-1">Expressed as</font></p>
-</td>
+</th>
 <td bgcolor="#E1FFE1" width="84%">
 <pre class="language-cobol"><code class="language-cobol">   NOT     ((T)   OR      (T))   AND      (T)</code></pre>
 </td>
 </tr>
 <tr>
-<td bgcolor="#FFFFCC" height="17" width="16%">
+<th scope="row" bgcolor="#FFFFCC" height="17" width="16%">
 <div align="center"><font size="-1">Evaluates to</font></div>
-</td>
+</th>
 <td bgcolor="#E1FFE1" height="17" width="84%">
 <pre class="language-cobol"><code class="language-cobol">   NOT            (T)            AND      (T)</code></pre>
 </td>
 </tr>
 <tr>
-<td bgcolor="#FFFFCC" width="16%">
+<th scope="row" bgcolor="#FFFFCC" width="16%">
 <div align="center"><font size="-1">Evaluates to</font></div>
-</td>
+</th>
 <td bgcolor="#E1FFE1" width="84%">
 <pre class="language-cobol"><code class="language-cobol">          (F)                    AND      (T)</code></pre>
 </td>
 </tr>
 <tr>
-<td bgcolor="#FFFFCC" width="16%">
+<th scope="row" bgcolor="#FFFFCC" width="16%">
 <div align="center"><font size="-1">Evaluates to</font></div>
-</td>
+</th>
 <td bgcolor="#E1FFE1" width="84%">
 <pre class="language-cobol"><code class="language-cobol">                 False</code></pre>
 </td>
@@ -691,21 +691,21 @@ END-IF
 <form action="Selection.html" method="post">
 <table align="center" bgcolor="#E1FFE1" border="1" width="50%">
 <tr bgcolor="#FFFFCC">
-<td width="13%">
+<th width="13%">
 <div align="center"><font color="#FF0000"><b>VarA</b></font></div>
-</td>
-<td width="13%">
+</th>
+<th width="13%">
 <div align="center"><font color="#FF0000"><b>VarB</b></font></div>
-</td>
-<td width="13%">
+</th>
+<th width="13%">
 <div align="center"><font color="#FF0000"><b>VarC</b></font></div>
-</td>
-<td width="12%">
+</th>
+<th width="12%">
 <div align="center"><font color="#FF0000"><b>VarG</b></font></div>
-</td>
-<td bgcolor="#FFFFCC" width="49%">
+</th>
+<th bgcolor="#FFFFCC" width="49%">
 <div align="center"><font color="#FF0000"><b><font size="-1">DISPLAY</font></b></font></div>
-</td>
+</th>
 </tr>
 <tr>
 <td width="13%">
@@ -1279,20 +1279,20 @@ END-EVALUATE
               which implements it are shown below.</p>
 <table align="center" bgcolor="#E1FFE1" border="1" width="83%">
 <tr bgcolor="#FFFFCC" valign="top">
-<td height="10" width="20%">
+<th height="10" width="20%">
 <div align="center">
 <p>QtyOfBooks </p>
 </div>
-</td>
-<td bgcolor="#FFFFCC" height="10" width="43%">
+</th>
+<th bgcolor="#FFFFCC" height="10" width="43%">
 <div align="center">ValueOfPurchases (VOP) </div>
-</td>
-<td height="10" width="14%">
+</th>
+<th height="10" width="14%">
 <div align="center">ClubMember</div>
-</td>
-<td height="10" width="23%">
+</th>
+<th height="10" width="23%">
 <div align="center">% Discount</div>
-</td>
+</th>
 </tr>
 <tr>
 <td width="20%">


### PR DESCRIPTION
## Summary
- In `course/Selection.html`, five data tables used `<td>` (with `<b>` or plain text) for header cells instead of the semantic `<th>` element
- Column headers replaced: Condition Types table, Condition Precedence table, Nested IFs variable table, and the Jupiter Books discount decision table
- Row headers in the two condition-evaluation tables replaced with `<th scope="row">` for correct axis semantics

## Test plan
- [ ] Open `course/Selection.html` and verify all tables render correctly
- [ ] Confirm table headers appear visually unchanged (bold/styled as before)
- [ ] Check with a screen reader or accessibility tool that header cells are correctly announced

🤖 Generated with [Claude Code](https://claude.com/claude-code)