### PR TITLE
Replace presentational <b> wrappers on TOC links with CSS font-weight

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -52,6 +52,7 @@
   }
   ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
+  ul.toc a { font-weight: bold; }
 </style>
 </head>
 <body text="#000000" bgcolor="#FFFFFF" link="#0000FF" vlink="#FF0000" alink="#009B00">
@@ -69,32 +70,32 @@
               <hr>
             </center>
             <ul class="toc">
-<li><b><a href="#intro">Introduction</a><br>
-                  </b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
-<li><b><a href="#part1">What is COBOL?</a><br>
-                    </b><font size="-1">A brief introduction to the COBOL programming 
-                    language. A historical overview. COBOL's dominance in the 
-                    business computing domain. Characteristics of COBOL applications. 
+<li><a href="#intro">Introduction</a><br>
+                  <font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><a href="#part1">What is COBOL?</a><br>
+                    <font size="-1">A brief introduction to the COBOL programming
+                    language. A historical overview. COBOL's dominance in the
+                    business computing domain. Characteristics of COBOL applications.
                     Some reasons for COBOL's success.</font></li>
-<li> 
-                    <b><a href="#part2">Introduction to Programming 
+<li>
+                    <a href="#part2">Introduction to Programming
                       </a><br>
-                      </b><font size="-1">This section provides a gentle introduction 
-                      to programing in general and to programming in COBOL in 
-                      particular by means of writing some simple COBOL programs.</font> 
+                      <font size="-1">This section provides a gentle introduction
+                      to programing in general and to programming in COBOL in
+                      particular by means of writing some simple COBOL programs.</font>
                   </li>
-<li> 
-                    <b><a href="#part3">COBOL basics</a><br>
-                      </b><font size="-1">This section presents the fundamentals 
-                      of constructing COBOL programs. It explains the notation 
-                      used in COBOL syntax diagrams, enumerates the COBOL coding 
-                      rules, and examines the hierarchical structure of COBOL 
+<li>
+                    <a href="#part3">COBOL basics</a><br>
+                      <font size="-1">This section presents the fundamentals
+                      of constructing COBOL programs. It explains the notation
+                      used in COBOL syntax diagrams, enumerates the COBOL coding
+                      rules, and examines the hierarchical structure of COBOL
                       programs.</font>
                   </li>
-<li> 
-                    <b><a href="#part4">The Four Divisions</a><br>
-                      </b><font size="-1">Provides an introduction to the structure 
-                      and purpose of the four COBOL divisions.</font> 
+<li>
+                    <a href="#part4">The Four Divisions</a><br>
+                      <font size="-1">Provides an introduction to the structure
+                      and purpose of the four COBOL divisions.</font>
                   </li>
 </ul>
             <hr>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -73,6 +73,7 @@
   }
   ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
+  ul.toc a { font-weight: bold; }
 </style>
 
 </head>
@@ -91,20 +92,20 @@
 <hr/>
 </center>
 <ul class="toc">
-<li><b><a href="#intro">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
-<li><b><a href="#part1">Basic User Input 
+<li><a href="#intro">Introduction</a><br/>
+<font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><a href="#part1">Basic User Input
                   and Output</a><br/>
-</b><font size="-1">This section introduces the ACCEPT and DISPLAY 
-                  verbs and shows how the ACCEPT may be used to get the system 
+<font size="-1">This section introduces the ACCEPT and DISPLAY
+                  verbs and shows how the ACCEPT may be used to get the system
                   date and time.</font></li>
-<li><b><a href="#part2">Assignment using 
+<li><a href="#part2">Assignment using
                     the MOVE verb</a><br/>
-</b><font size="-1">This section demonstrates how assignment 
+<font size="-1">This section demonstrates how assignment
                     is achieved in COBOL.</font></li>
-<li><b><a href="#part3">Arithmetic in 
+<li><a href="#part3">Arithmetic in
                     COBOL</a><br/>
-</b><font size="-1">This section introduces the ADD, SUBTRACT, 
+<font size="-1">This section introduces the ADD, SUBTRACT,
                     MULTIPLY, DIVIDE and COMPUTE verbs.</font></li>
 </ul>
 <hr width="100%"/>

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -73,6 +73,7 @@
   }
   ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
+  ul.toc a { font-weight: bold; }
 </style>
 
 </head>
@@ -91,20 +92,20 @@
 <hr/>
 </center>
 <ul class="toc">
-<li><b><a href="#intro">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
-<li><b><a href="#part1">Using COPY statements</a><br/>
-</b><font size="-1">Introduction to the COPY verb. Using the 
+<li><a href="#intro">Introduction</a><br/>
+<font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><a href="#part1">Using COPY statements</a><br/>
+<font size="-1">Introduction to the COPY verb. Using the
                     COPY verb when creating large software systems</font></li>
-<li><b><a href="#part2">The 
+<li><a href="#part2">The
                   COPY verb - Syntax and Semantics</a><br/>
-</b><font size="-1">The COPY syntax. How the COPY works. How 
+<font size="-1">The COPY syntax. How the COPY works. How
                   the REPLACING phrase works. COPY rules.</font></li>
-<li><b><a href="#part3">COPY 
+<li><a href="#part3">COPY
                   examples </a><br/>
-</b><font size="-1">Four example programs showing the program 
-                  source text before processing the COPY statements, the copy 
-                  library text, and the program source text after processing the 
+<font size="-1">Four example programs showing the program
+                  source text before processing the COPY statements, the copy
+                  library text, and the program source text after processing the
                   COPY statements in the program.</font></li>
 </ul>
 <hr/>

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -73,6 +73,7 @@
   }
   ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
+  ul.toc a { font-weight: bold; }
 </style>
 
 </head>
@@ -91,21 +92,21 @@
 <hr/>
 </center>
 <ul class="toc">
-<li><b><a href="#intro">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites and 
+<li><a href="#intro">Introduction</a><br/>
+<font size="-1">Unit aims, objectives, prerequisites and
                   further reading.</font></li>
-<li><b><a href="#part1">Categories of COBOL 
+<li><a href="#part1">Categories of COBOL
                   data </a><br/>
-</b><font size="-1">This section introduces the three categories 
+<font size="-1">This section introduces the three categories
                   of COBOL data - Literals, Variables and Figurative Constants.</font></li>
-<li><b><a href="#part2">Declaring Data-Items 
+<li><a href="#part2">Declaring Data-Items
                   in COBOL</a><br/>
-</b><font size="-1">In this section we show how variables are 
+<font size="-1">In this section we show how variables are
                   declared in COBOL using the PICTURE clause.</font></li>
-<li><b><a href="#part3">Group and Elementary 
+<li><a href="#part3">Group and Elementary
                     Data-Items </a><br/>
-</b><font size="-1">This section demonstrates how record structures 
-                    can be specified using an appropriate arrangement of level 
+<font size="-1">This section demonstrates how record structures
+                    can be specified using an appropriate arrangement of level
                     numbers.</font></li>
 </ul>
 </td>

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -73,6 +73,7 @@
   }
   ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
+  ul.toc a { font-weight: bold; }
 </style>
 
 </head>
@@ -90,23 +91,23 @@
 <hr/>
 </center>
 <ul class="toc">
-<li><b><a href="#intro">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
-<li><b><a href="#part1">What is an Edited Picture?</a><br/>
-</b><font size="-1">This section introduces Edited Pictures, 
+<li><a href="#intro">Introduction</a><br/>
+<font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><a href="#part1">What is an Edited Picture?</a><br/>
+<font size="-1">This section introduces Edited Pictures,
                     the types of edited pictures, and the edit symbols used.</font></li>
 <li>
-<b><a href="#part2">Insertion Editing</a><br/>
-</b><font size="-1">This section introduces the four types 
-                      of Insertion Editing - Simple Insertion, Special Insertion, 
+<a href="#part2">Insertion Editing</a><br/>
+<font size="-1">This section introduces the four types
+                      of Insertion Editing - Simple Insertion, Special Insertion,
                       Fixed Insertion, and Floating Insertion</font>
 </li>
 <li>
-<b><a href="#part3">Suppression and Replacement 
+<a href="#part3">Suppression and Replacement
                       Editing</a><br/>
-</b><font size="-1">This section introduces the two types 
-                      Suppresion and Replacement Editng - suppression of leading 
-                      zeros and replacement with spaces, and suppresion and replacement 
+<font size="-1">This section introduces the two types
+                      Suppresion and Replacement Editng - suppression of leading
+                      zeros and replacement with spaces, and suppresion and replacement
                       with asterisks.</font>
 </li>
 </ul>

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -11,6 +11,7 @@
 -->
   ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
+  ul.toc a { font-weight: bold; }
 </style><meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -100,24 +101,24 @@
 </table>
 </div>
 </center>
-<ul class="toc"><li> <b><a href="#intro">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives and prerequisites.</font> </li><li> <b><a href="#progs">A look at some programs that 
+<ul class="toc"><li> <a href="#intro">Introduction</a><br/>
+<font size="-1">Unit aims, objectives and prerequisites.</font> </li><li> <a href="#progs">A look at some programs that
       use Indexed files</a><br/>
-</b><font size="-1">We begin with three example programs. The first creates 
-      an Indexed file from a Sequential file, the second reads the Indexed file 
-      sequentially or either the primary or the alternate key, and the third reads 
-      the file directly on either key.</font></li><li> <a href="#org"><b>Indexed file organization</b></a><br/>
-<font size="-1">Explains by means of an animated diagram how the index of 
-      the primary key is organized and shows how it is used to read a record directly. 
-      Explains how the alternate key index is organized and shows how it is used 
-      to read a record directly.</font></li><li><b><a href="#declar">Indexed file - declarations</a><br/>
-</b><font size="-1">Examines the SELECT and ASSIGN clause declarations required 
-      for an Indexed file.</font></li><li> <b><a href="#verbs">Indexed file - file processing verbs</a><br/>
-</b><font size="-1">Examines the Procedure Division verbs used to process 
+<font size="-1">We begin with three example programs. The first creates
+      an Indexed file from a Sequential file, the second reads the Indexed file
+      sequentially or either the primary or the alternate key, and the third reads
+      the file directly on either key.</font></li><li> <a href="#org">Indexed file organization</a><br/>
+<font size="-1">Explains by means of an animated diagram how the index of
+      the primary key is organized and shows how it is used to read a record directly.
+      Explains how the alternate key index is organized and shows how it is used
+      to read a record directly.</font></li><li><a href="#declar">Indexed file - declarations</a><br/>
+<font size="-1">Examines the SELECT and ASSIGN clause declarations required
+      for an Indexed file.</font></li><li> <a href="#verbs">Indexed file - file processing verbs</a><br/>
+<font size="-1">Examines the Procedure Division verbs used to process
       Indexed files - OPEN, CLOSE, READ, WRITE, REWRITE, DELETE, START</font>
 </li><li>
-<a href="#example"><b>A comprehensive example</b></a><br/>
-<font size="-1">We end with a comprehensive problem specification and 
+<a href="#example">A comprehensive example</a><br/>
+<font size="-1">We end with a comprehensive problem specification and
         solution.</font>
 </li></ul>
 <table border="0" cellpadding="4" cellspacing="0" width="710">

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -11,6 +11,7 @@
 -->
   ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
+  ul.toc a { font-weight: bold; }
   ol.spaced > li + li { margin-top: 0.6em; }
 </style><meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
@@ -102,20 +103,20 @@
 </div>
 </center>
 <ul class="toc"><li>
-<b><a href="#intro">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites and a legend for
+<a href="#intro">Introduction</a><br/>
+<font size="-1">Unit aims, objectives, prerequisites and a legend for
       this unit's syntax diagrams.</font>
-</li><li> <b><a href="#inspect">Using the INSPECT</a><br/>
-</b><font size="-1">The INSPECT is introduced by looking at an example program.
-      The way the INSPECT works is explained and its modifying phrases are explored.</font></li><li> <a href="#count"><b>The counting format</b></a><br/>
+</li><li> <a href="#inspect">Using the INSPECT</a><br/>
+<font size="-1">The INSPECT is introduced by looking at an example program.
+      The way the INSPECT works is explained and its modifying phrases are explored.</font></li><li> <a href="#count">The counting format</a><br/>
 <font size="-1">Presents the syntax and rules of the counting format of
-      the INSPECT.</font></li><li><b><a href="#replace">The replacing format</a><br/>
-</b><font size="-1">Presents the syntax and rules of the replacing format
-      of the INSPECT</font></li><li> <b><a href="#combine">The combined format</a><br/>
-</b><font size="-1">This version combines the syntax and rules of the other
+      the INSPECT.</font></li><li><a href="#replace">The replacing format</a><br/>
+<font size="-1">Presents the syntax and rules of the replacing format
+      of the INSPECT</font></li><li> <a href="#combine">The combined format</a><br/>
+<font size="-1">This version combines the syntax and rules of the other
       two formats. The syntax of this combined format is presented.</font></li><li>
-<a href="#convert"><b>The converting format</b></a><br/>
-<font size="-1">Presents the syntax and rules of the converting format 
+<a href="#convert">The converting format</a><br/>
+<font size="-1">Presents the syntax and rules of the converting format
         of the INSPECT.</font>
 </li></ul>
 <table border="0" cellpadding="4" cellspacing="0" width="710">

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -11,6 +11,7 @@
 -->
   ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
+  ul.toc a { font-weight: bold; }
 </style><meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -101,21 +102,21 @@
 </div>
 </center>
 <div align="LEFT">
-<ul class="toc"><li> <b><a href="#intro">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives and prerequisites. </font></li><li> <b><a href="#seq">Organization of Sequential 
+<ul class="toc"><li> <a href="#intro">Introduction</a><br/>
+<font size="-1">Unit aims, objectives and prerequisites. </font></li><li> <a href="#seq">Organization of Sequential
         files</a><br/>
-</b><font size="-1">Provides a recap of Sequential file organization and 
-        the difficulties of adding, removing and updating records in an ordered 
-        Sequential file.</font> </li><li><b><a href="#rel">Organization of Relative files</a><br/>
-</b><font size="-1">Describes how Relative files are organized and shows 
-        how records may be added, deleted or updated.</font></li><li> <b><a href="#idx">Organization of Indexed files</a><br/>
-</b><font size="-1">Describes the organization of Indexed files. Shows 
-        how records may be added, deleted or updated and describes how records 
-        in an Indexed file may be processed directly or sequentially on any key. 
+<font size="-1">Provides a recap of Sequential file organization and
+        the difficulties of adding, removing and updating records in an ordered
+        Sequential file.</font> </li><li><a href="#rel">Organization of Relative files</a><br/>
+<font size="-1">Describes how Relative files are organized and shows
+        how records may be added, deleted or updated.</font></li><li> <a href="#idx">Organization of Indexed files</a><br/>
+<font size="-1">Describes the organization of Indexed files. Shows
+        how records may be added, deleted or updated and describes how records
+        in an Indexed file may be processed directly or sequentially on any key.
         </font></li><li>
-<b><a href="#comp">Comparison of COBOL file organizations</a></b><br/>
-<font size="-1">Summarizes the advantages and disadvantages of each 
-          of the file organizations above.</font> 
+<a href="#comp">Comparison of COBOL file organizations</a><br/>
+<font size="-1">Summarizes the advantages and disadvantages of each
+          of the file organizations above.</font>
 </li></ul>
 </div>
 <table border="0" cellpadding="4" cellspacing="0" width="710">

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -78,6 +78,7 @@
   }
   ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
+  ul.toc a { font-weight: bold; }
 </style>
 
 </head>
@@ -96,25 +97,25 @@
 <hr/>
 </center>
 <ul class="toc">
-<li><b><a href="#intro">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
-<li><b><a href="#part1">PERFORM..Proc</a><br/>
-</b><font size="-1">This section introduces the format of 
-                    the PERFORM that is used to transfer control to a paragraph 
+<li><a href="#intro">Introduction</a><br/>
+<font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><a href="#part1">PERFORM..Proc</a><br/>
+<font size="-1">This section introduces the format of
+                    the PERFORM that is used to transfer control to a paragraph
                     or section.</font></li>
-<li><b><a href="#part2">Using the PERFORM..THRU</a><br/>
-</b><font size="-1">This section demonstrates how the PERFORM..THRU 
+<li><a href="#part2">Using the PERFORM..THRU</a><br/>
+<font size="-1">This section demonstrates how the PERFORM..THRU
                     can be used to implement an emergency exit from a paragraph.</font> </li>
-<li><b><a href="#part3">PERFORM..TIMES</a><br/>
-</b><font size="-1">This section introduces the PERFORM..TIMES 
-                    which allow us to create an iteration that executes x number 
-                    of times. Also discusses the use of in-line versus out-of-line 
+<li><a href="#part3">PERFORM..TIMES</a><br/>
+<font size="-1">This section introduces the PERFORM..TIMES
+                    which allow us to create an iteration that executes x number
+                    of times. Also discusses the use of in-line versus out-of-line
                     PERFORMs</font></li>
-<li><b><a href="#part4">PERFORM..UNTIL </a><br/>
-</b><font size="-1">In this section COBOL's version of of the 
+<li><a href="#part4">PERFORM..UNTIL </a><br/>
+<font size="-1">In this section COBOL's version of of the
                   while and do/repeat loops is introduced.</font></li>
-<li><b><a href="#part5">PERFORM..VARYING</a><br/>
-</b><font size="-1">This section demonstrates COBOL's version 
+<li><a href="#part5">PERFORM..VARYING</a><br/>
+<font size="-1">This section demonstrates COBOL's version
                     of the for loop.</font></li>
 </ul>
 <hr/>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -73,6 +73,7 @@
   }
   ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
+  ul.toc a { font-weight: bold; }
 </style>
 
 </head>
@@ -91,30 +92,30 @@
 <hr/>
 </center>
 <ul class="toc">
-<li><b><a href="#intro">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives and prerequisites.</font></li>
-<li><b><a href="#part1">Reference Modification</a><br/>
-</b><font size="-1">This section examines the syntax and semantics 
-                  of Reference Modification. The section ends with some animated 
+<li><a href="#intro">Introduction</a><br/>
+<font size="-1">Unit aims, objectives and prerequisites.</font></li>
+<li><a href="#part1">Reference Modification</a><br/>
+<font size="-1">This section examines the syntax and semantics
+                  of Reference Modification. The section ends with some animated
                   examples.</font></li>
-<li><b><a href="#part2">Intrinsic Functions 
+<li><a href="#part2">Intrinsic Functions
                     - Introduction</a><br/>
-</b><font size="-1">This section introduces COBOL's predefined 
-                    functions - called Intrinsic Functions. It explains how they 
-                    may be used and introduces the notation used in the Intrinsic 
+<font size="-1">This section introduces COBOL's predefined
+                    functions - called Intrinsic Functions. It explains how they
+                    may be used and introduces the notation used in the Intrinsic
                     Function definitions in the later sections.</font></li>
-<li><a href="#part3"><b>String Functions</b></a><br/>
-<font size="-1">This section presents the definitions of the 
-                    Intrinsic Functions used for string handling . The section 
+<li><a href="#part3">String Functions</a><br/>
+<font size="-1">This section presents the definitions of the
+                    Intrinsic Functions used for string handling . The section
                     ends with some examples.</font></li>
-<li><a href="#part4"><b>Date Functions</b></a><br/>
-<font size="-1">This section presents the definitions of the 
-                    Intrinsic Functions used for date manipulations . The section 
+<li><a href="#part4">Date Functions</a><br/>
+<font size="-1">This section presents the definitions of the
+                    Intrinsic Functions used for date manipulations . The section
                     ends with a set of comprehensive examples.</font></li>
-<li><a href="#part5"><b>Miscellaneous Functions</b></a><br/>
-<font size="-1">This section presents the definitions of the 
-                    other (mainly maths) Intrinsic Functions including used for 
-                    string handling . The section ends with an example using the 
+<li><a href="#part5">Miscellaneous Functions</a><br/>
+<font size="-1">This section presents the definitions of the
+                    other (mainly maths) Intrinsic Functions including used for
+                    string handling . The section ends with an example using the
                     RANDOM Intrinsic Function..</font></li>
 </ul>
 </td>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -11,6 +11,7 @@
 -->
   ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
+  ul.toc a { font-weight: bold; }
 </style><meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -103,20 +104,20 @@
 <p>
 </p>
 <div align="LEFT">
-<ul class="toc"><li> <b><a href="#intro">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives and prerequisites. </font></li><li> <b><a href="#progs">A look at some programs that 
+<ul class="toc"><li> <a href="#intro">Introduction</a><br/>
+<font size="-1">Unit aims, objectives and prerequisites. </font></li><li> <a href="#progs">A look at some programs that
         use Relative files</a><br/>
-</b><font size="-1">We begin with two example programs. The first creates 
-        a Relative File from a Sequential file and the second reads and displays 
-        records from the Relative file.</font></li><li><b><a href="#declar">Relative file - declarations</a><br/>
-</b><font size="-1">Examines the declarations required for a Relative 
-        file including the SELECT and ASSIGN clause and the key.</font></li><li> <b><a href="#verbs">Relative file - file processing verbs</a><br/>
-</b><font size="-1">Examines the Procedure Division verbs used to process 
+<font size="-1">We begin with two example programs. The first creates
+        a Relative File from a Sequential file and the second reads and displays
+        records from the Relative file.</font></li><li><a href="#declar">Relative file - declarations</a><br/>
+<font size="-1">Examines the declarations required for a Relative
+        file including the SELECT and ASSIGN clause and the key.</font></li><li> <a href="#verbs">Relative file - file processing verbs</a><br/>
+<font size="-1">Examines the Procedure Division verbs used to process
         Relative files - OPEN, CLOSE, READ, WRITE, REWRITE, DELETE, START</font>
 </li><li>
-<b><a href="#declaratives">Introduction to Declaratives</a></b><br/>
-<font size="-1">Introduces Declaratives, showing when and how to use 
-          them.</font> 
+<a href="#declaratives">Introduction to Declaratives</a><br/>
+<font size="-1">Introduces Declaratives, showing when and how to use
+          them.</font>
 </li></ul>
 </div>
 <table border="0" cellpadding="4" cellspacing="0" width="710">

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -73,6 +73,7 @@
   }
   ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
+  ul.toc a { font-weight: bold; }
 </style>
 
 </head>
@@ -91,33 +92,33 @@
 <hr/>
 </center>
 <ul class="toc">
-<li><b><a href="#intro">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives and prerequisites.</font></li>
-<li><b><a href="#part1">The Report Writer 
+<li><a href="#intro">Introduction</a><br/>
+<font size="-1">Unit aims, objectives and prerequisites.</font></li>
+<li><a href="#part1">The Report Writer
                   in action</a><br/>
-</b><font size="-1">This section examines a report produced 
-                  by a Report Writer program and then examines the Procedure Division 
+<font size="-1">This section examines a report produced
+                  by a Report Writer program and then examines the Procedure Division
                   of the program that produced the report.</font></li>
-<li><b><a href="#part1b">How the Report 
+<li><a href="#part1b">How the Report
                   Writer works</a><br/>
-</b><font size="-1">This section explains how the Report Writer 
-                  works. It examines the seven report groups a report produced 
-                  by a Report Writer program and then examines the Procedure Division 
+<font size="-1">This section explains how the Report Writer
+                  works. It examines the seven report groups a report produced
+                  by a Report Writer program and then examines the Procedure Division
                   of the program that produced the report.</font></li>
 <li>
-<b><a href="#part2">Let's write a Report Writer 
-                      p</a></b><b><a href="#part2">rogram</a><br/>
-</b><font size="-1">This section uses learning by doing 
-                      as its mode of instruction. We learn how to write a simple 
+<a href="#part2">Let's write a Report Writer
+                      p</a><a href="#part2">rogram</a><br/>
+<font size="-1">This section uses learning by doing
+                      as its mode of instruction. We learn how to write a simple
                       version of the report program shown in the previous section.</font>
 </li>
-<li><a href="#part3"><b>Let's add some features to 
-                    our Report Program</b></a><br/>
-<font size="-1">In this section we amend the report program 
+<li><a href="#part3">Let's add some features to
+                    our Report Program</a><br/>
+<font size="-1">In this section we amend the report program
                     to include more functionality</font><font size="-1">.</font></li>
-<li><a href="#part4"><b>Report Writer Declaratives</b></a><br/>
-<font size="-1">When the requirements of the report do not 
-                    coincide with the way the Report Writer works Declaratives 
+<li><a href="#part4">Report Writer Declaratives</a><br/>
+<font size="-1">When the requirements of the report do not
+                    coincide with the way the Report Writer works Declaratives
                     can be used to extend the functionality of the Report Writer.</font></li>
 </ul>
 </td>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -73,6 +73,7 @@
   }
   ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
+  ul.toc a { font-weight: bold; }
 </style>
 
 </head>
@@ -91,42 +92,41 @@
 <hr/>
 </center>
 <ul class="toc">
-<li><b><a href="#intro">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives and prerequisites.</font></li>
-<li><b><a href="#part1">Defining the Report - Report 
+<li><a href="#intro">Introduction</a><br/>
+<font size="-1">Unit aims, objectives and prerequisites.</font></li>
+<li><a href="#part1">Defining the Report - Report
                     File entries</a><br/>
-</b><font size="-1">This section examines the Environment 
-                    Division and File Section entries required when we create 
+<font size="-1">This section examines the Environment
+                    Division and File Section entries required when we create
                     <br/>
                     a Report Writer program.</font></li>
-<li><b><a href="#part2">Defining the Report - Report 
+<li><a href="#part2">Defining the Report - Report
                     Description (RD) entries </a><br/>
-</b><font size="-1">In this section we examine the Report 
-                    Section and the Report Description (RD) entries required to 
+<font size="-1">In this section we examine the Report
+                    Section and the Report Description (RD) entries required to
                     <br/>
                     define a report.</font></li>
-<li><b><a href="#part3">Defining the Report - Report 
+<li><a href="#part3">Defining the Report - Report
                     Group entries</a><br/>
-</b><font size="-1">This section examines the entries required 
+<font size="-1">This section examines the entries required
                     to define a report group record.</font></li>
-<li><b><a href="#part4">Defining the Report - Lines 
+<li><a href="#part4">Defining the Report - Lines
                     and Columns</a><br/>
-</b><font size="-1">This section examines the entries the 
-                    vertical and horizontal placement of print items. </font><font size="-1">It 
+<font size="-1">This section examines the entries the
+                    vertical and horizontal placement of print items. </font><font size="-1">It
                     examines <br/>
-                    clauses such as - </font><font size="-1">LINE NUMBER, COLUMN 
+                    clauses such as - </font><font size="-1">LINE NUMBER, COLUMN
                     NUMBER, GROUP INDICATE , SOURCE and SUM</font><font size="-1">.</font></li>
-<li><a href="#part5"><b>Special Report Writer registers</b></a><br/>
-<font size="-1">In this section the LINE-COUNTER and PAGE-COUNTER 
+<li><a href="#part5">Special Report Writer registers</a><br/>
+<font size="-1">In this section the LINE-COUNTER and PAGE-COUNTER
                     registers are examined.</font></li>
-<li><b><a href="#part6">The Procedure Division Verbs 
+<li><a href="#part6">The Procedure Division Verbs
                     </a><br/>
-</b><font size="-1">This section introduces the INITIATE, 
+<font size="-1">This section introduces the INITIATE,
                     GENERATE and TERMINATE verbs.</font></li>
 <li>
-<b><a href="#part7">Report Writer Declaratives</a></b><b>
-<br/>
-</b><font size="-1">In this section elements of the Declaratives, 
+<a href="#part7">Report Writer Declaratives</a><br/>
+<font size="-1">In this section elements of the Declaratives,
                       such as USE BEFORE REPORTING, SUPPRESS PRINTING and <br/>
                       control break registers, are examined.</font>
 </li>

--- a/course/Search.html
+++ b/course/Search.html
@@ -75,6 +75,7 @@
   }
   ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
+  ul.toc a { font-weight: bold; }
 </style>
 
 </head>
@@ -93,33 +94,33 @@
 <hr/>
 </center>
 <ul class="toc">
-<li><b><a href="#intro">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
-<li><b><a href="#part1">OCCURS clause extensions</a><br/>
-</b><font size="-1">The SEARCH and SEARCH ALL require that 
-                    the description of the table to be searched contain a number 
-                    of new extensions to the OCCURS clause. In this section the 
+<li><a href="#intro">Introduction</a><br/>
+<font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><a href="#part1">OCCURS clause extensions</a><br/>
+<font size="-1">The SEARCH and SEARCH ALL require that
+                    the description of the table to be searched contain a number
+                    of new extensions to the OCCURS clause. In this section the
                     syntax of these new extensions is introduced</font></li>
 <li>
-<b><a href="#part2">The SEARCH verb</a><br/>
-</b><font size="-1">This section demonstrates how the SEARCH 
+<a href="#part2">The SEARCH verb</a><br/>
+<font size="-1">This section demonstrates how the SEARCH
                       verb may be used to search through a table sequentially.</font>
 </li>
 <li>
-<b><a href="#part3">Searching multi-dimension 
+<a href="#part3">Searching multi-dimension
                       tables </a><br/>
-</b><font size="-1">The SEARCH cannot be applied directly 
-                      to search a multi-dimension table. This section demonstrates 
-                      how to overcome this restriction by treating the multi-dimension 
-                      table as a collection of single dimension tables and applying 
+<font size="-1">The SEARCH cannot be applied directly
+                      to search a multi-dimension table. This section demonstrates
+                      how to overcome this restriction by treating the multi-dimension
+                      table as a collection of single dimension tables and applying
                       the SEARCH to each single dimension table.</font><font size="-1">.</font>
 </li>
 <li>
-<b><a href="#part4">The SEARCH ALL verb</a><br/>
-</b><font size="-1">The SEARCH ALL is used when a binary 
-                      search is required. This section introduces the syntax of 
-                      the SEARCH ALL, demonstrates how a binary search works and 
-                      shows how the SEARCH ALL can be used to search an ordered 
+<a href="#part4">The SEARCH ALL verb</a><br/>
+<font size="-1">The SEARCH ALL is used when a binary
+                      search is required. This section introduces the syntax of
+                      the SEARCH ALL, demonstrates how a binary search works and
+                      shows how the SEARCH ALL can be used to search an ordered
                       table.</font>
 </li>
 </ul>

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -73,6 +73,7 @@
   }
   ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
+  ul.toc a { font-weight: bold; }
 </style>
 
 </head>
@@ -91,23 +92,23 @@
 <hr/>
 </center>
 <ul class="toc">
-<li><b><a href="#intro">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
-<li><b><a href="#part1">Selection using IF</a><br/>
-</b><font size="-1">This section demonstrates selection using 
-                    the IF statement. It introduces Relation Conditions, Class 
-                    Condition, Sign Condition and Complex Conditions. It also 
+<li><a href="#intro">Introduction</a><br/>
+<font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><a href="#part1">Selection using IF</a><br/>
+<font size="-1">This section demonstrates selection using
+                    the IF statement. It introduces Relation Conditions, Class
+                    Condition, Sign Condition and Complex Conditions. It also
                     covers Implied Subjects and Nested IFs.</font></li>
-<li><b><a href="#part2">Condition Names</a><br/>
-</b><font size="-1">In this section the concept of a Condition 
+<li><a href="#part2">Condition Names</a><br/>
+<font size="-1">In this section the concept of a Condition
                     Name is explained.</font> </li>
-<li><b><a href="#part3">Using the SET 
+<li><a href="#part3">Using the SET
                     verb with Condition Names</a><br/>
-</b><font size="-1">This section demonstrates how the SET 
+<font size="-1">This section demonstrates how the SET
                     verb may be used to set a Condition Name to true.</font></li>
-<li><b><a href="#part4">The EVALUATE 
+<li><a href="#part4">The EVALUATE
                     verb </a><br/>
-</b><font size="-1">In this section COBOL's version of Case/Switch 
+<font size="-1">In this section COBOL's version of Case/Switch
                     is introduced.</font></li>
 </ul>
 <hr/>

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -73,6 +73,7 @@
   }
   ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
+  ul.toc a { font-weight: bold; }
 </style>
 
 </head>
@@ -91,24 +92,24 @@
 <hr/>
 </center>
 <ul class="toc">
-<li><b><a href="#intro">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
-<li><b><a href="#part1">Introduction to record-based 
+<li><a href="#intro">Introduction</a><br/>
+<font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><a href="#part1">Introduction to record-based
                     files </a><br/>
-</b><font size="-1">This section introduces record-based files, 
-                    the concept of the record buffer and defines terminology such 
+<font size="-1">This section introduces record-based files,
+                    the concept of the record buffer and defines terminology such
                     as file, record and field.</font></li>
 <li>
-<b><a href="#part2">Declaring records and files</a><br/>
-</b><font size="-1">This section demonstrates how the FD 
-                      entry is used to describe a files record buffer and show 
-                      how to use the SELECT and ASSIGN clause to connect an internal 
+<a href="#part2">Declaring records and files</a><br/>
+<font size="-1">This section demonstrates how the FD
+                      entry is used to describe a files record buffer and show
+                      how to use the SELECT and ASSIGN clause to connect an internal
                       file name to an external data repository.</font>
 </li>
-<li><b><a href="#part3">COBOL file handling 
+<li><a href="#part3">COBOL file handling
                     verbs </a><br/>
-</b><font size="-1">The COBOL verbs for processing Sequential 
-                    Files are introduced in this section. The section ends with 
+<font size="-1">The COBOL verbs for processing Sequential
+                    Files are introduced in this section. The section ends with
                     a full example program.</font></li>
 </ul>
 <hr/>

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -78,6 +78,7 @@
   }
   ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
+  ul.toc a { font-weight: bold; }
 </style>
 
 </head>
@@ -96,25 +97,25 @@
 <hr/>
 </center>
 <ul class="toc">
-<li><b><a href="#intro">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
-<li><b><a href="#part1">Organization and Access</a><br/>
-</b><font size="-1">This section introduces the concepts of 
-                    file organization and access. It describes how Sequential 
-                    files are organized and introduces the idea of ordered and 
+<li><a href="#intro">Introduction</a><br/>
+<font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><a href="#part1">Organization and Access</a><br/>
+<font size="-1">This section introduces the concepts of
+                    file organization and access. It describes how Sequential
+                    files are organized and introduces the idea of ordered and
                     unordered Sequential files.</font></li>
 <li>
-<b><a href="#part2">Processing unordered Sequential 
+<a href="#part2">Processing unordered Sequential
                       files </a><br/>
-</b><font size="-1">This section explores the processing 
-                      restrictions of unordered Sequential files. It demonstrates 
-                      that, while records can be easily added to unordered files, 
+<font size="-1">This section explores the processing
+                      restrictions of unordered Sequential files. It demonstrates
+                      that, while records can be easily added to unordered files,
                       deleting and updating records is not really feasible.</font>
 </li>
-<li><b><a href="#part3">Processing ordered 
+<li><a href="#part3">Processing ordered
                     Sequential files</a><br/>
-</b><font size="-1">This section demonstrates how to use a 
-                    file of batched transactions to insert (add), delete and update 
+<font size="-1">This section demonstrates how to use a
+                    file of batched transactions to insert (add), delete and update
                     records in an ordered Sequential file..</font></li>
 </ul>
 <hr/>

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -73,6 +73,7 @@
   }
   ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
+  ul.toc a { font-weight: bold; }
 </style>
 
 </head>
@@ -91,24 +92,24 @@
 <hr/>
 </center>
 <ul class="toc">
-<li><b><a href="#intro">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
-<li><b><a href="#part1">Multiple record-type files</a><br/>
-</b><font size="-1">This section demonstrates how to declare 
+<li><a href="#intro">Introduction</a><br/>
+<font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><a href="#part1">Multiple record-type files</a><br/>
+<font size="-1">This section demonstrates how to declare
                     and use files that contain multiple types of record.</font></li>
 <li>
-<b><a href="#part2">COBOL print files </a><br/>
-</b><font size="-1">This section introduces COBOL print 
-                      files, demonstrates how a print file may be set up and shows 
+<a href="#part2">COBOL print files </a><br/>
+<font size="-1">This section introduces COBOL print
+                      files, demonstrates how a print file may be set up and shows
                       how a print file is used to print a report.</font>
 </li>
-<li><b><a href="#part3">Variable length 
+<li><a href="#part3">Variable length
                     records </a><br/>
-</b><font size="-1">This section introduces variable length 
-                    records, demonstrates how variable length records may be declared 
-                    and shows how variable length records with the DEPENDING ON 
-                    phrase may be processed. In addition, this section demonstrates 
-                    how a file name may be assigned to a file at run-time rather 
+<font size="-1">This section introduces variable length
+                    records, demonstrates how variable length records may be declared
+                    and shows how variable length records with the DEPENDING ON
+                    phrase may be processed. In addition, this section demonstrates
+                    how a file name may be assigned to a file at run-time rather
                     than at compile-time.</font></li>
 </ul>
 <hr/>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -73,6 +73,7 @@
   }
   ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
+  ul.toc a { font-weight: bold; }
 </style>
 
 </head>
@@ -91,30 +92,30 @@
 <hr/>
 </center>
 <ul class="toc">
-<li><b><a href="#intro">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
-<li><b><a href="#part1">Simple SORTing</a><br/>
-</b><font size="-1">This section introduces a simplified version 
-                    of SORT verb syntax, and discusses why we might need to sort 
+<li><a href="#intro">Introduction</a><br/>
+<font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><a href="#part1">Simple SORTing</a><br/>
+<font size="-1">This section introduces a simplified version
+                    of SORT verb syntax, and discusses why we might need to sort
                     a file as part of a solution to a programming problem..</font></li>
 <li>
-<b><a href="#part2">Sorting with an INPUT PROCEDURE 
+<a href="#part2">Sorting with an INPUT PROCEDURE
                       </a><br/>
-</b><font size="-1">This section introduces a SORT with 
-                      an INPUT PROCEDURE and demonstrates how an INPUT PROCEDURE 
-                      may be used to filter, or alter, records before they are 
+<font size="-1">This section introduces a SORT with
+                      an INPUT PROCEDURE and demonstrates how an INPUT PROCEDURE
+                      may be used to filter, or alter, records before they are
                       supplied to the sort process.</font>
 </li>
 <li>
-<b><a href="#part3">Sorting with an OUTPUT PROCEDURE</a><br/>
-</b><font size="-1">This section shows how an OUTPUT PROCEDURE 
-                      may be used to filter, or alter, records after they have 
+<a href="#part3">Sorting with an OUTPUT PROCEDURE</a><br/>
+<font size="-1">This section shows how an OUTPUT PROCEDURE
+                      may be used to filter, or alter, records after they have
                       been sorted.</font>
 </li>
 <li>
-<b><a href="#part4">MERGEing files</a><br/>
-</b><font size="-1">In this section the MERGE verb is introduced. 
-                      The MERGE verb may be used to merge two or more ordered 
+<a href="#part4">MERGEing files</a><br/>
+<font size="-1">In this section the MERGE verb is introduced.
+                      The MERGE verb may be used to merge two or more ordered
                       files.</font>
 </li>
 </ul>

--- a/course/String.html
+++ b/course/String.html
@@ -11,6 +11,7 @@
 -->
   ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
+  ul.toc a { font-weight: bold; }
 </style><meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -101,13 +102,13 @@
 </div>
 </center>
 <ul class="toc"><li>
-<b><a href="#intro">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives and prerequisites.</font>
-</li><li> <b><a href="#verb">The STRING verb</a><br/>
-</b><font size="-1">This section examines the syntax, functioning and rules 
+<a href="#intro">Introduction</a><br/>
+<font size="-1">Unit aims, objectives and prerequisites.</font>
+</li><li> <a href="#verb">The STRING verb</a><br/>
+<font size="-1">This section examines the syntax, functioning and rules
       of the STRING verb</font></li><li>
-<a href="#examples"><b>STRING examples</b></a><br/>
-<font size="-1">This section starts with some animated examples and ends 
+<a href="#examples">STRING examples</a><br/>
+<font size="-1">This section starts with some animated examples and ends
         with some examples that take the form of Self Assessment Questions (SAQ).</font>
 </li></ul>
 <table border="0" cellpadding="4" cellspacing="0" width="710">

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -73,6 +73,7 @@
   }
   ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
+  ul.toc a { font-weight: bold; }
 </style>
 
 </head>
@@ -91,18 +92,18 @@
 <hr/>
 </center>
 <ul class="toc">
-<li><b><a href="#intro">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
-<li><b><a href="#part1">The CALL verb</a><br/>
-</b><font size="-1">Subprograms, the syntax and semantics 
-                    of the CALL verb and parameter passing mechanisms. State memory, 
+<li><a href="#intro">Introduction</a><br/>
+<font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><a href="#part1">The CALL verb</a><br/>
+<font size="-1">Subprograms, the syntax and semantics
+                    of the CALL verb and parameter passing mechanisms. State memory,
                     the IS INITIAL clause and the CANCEL command.</font></li>
 <li>
-<b><a href="#part2">Contained Subprograms</a><br/>
-</b><font size="-1">C</font><font size="-1">ontained subprogram 
-                      defined. Sharing data with the IS GLOBAL and IS EXTERNAL 
-                      clause. Using the IS COMMON PROGRAM clause. Measuring the 
-                      quality of subprograms.</font> 
+<a href="#part2">Contained Subprograms</a><br/>
+<font size="-1">C</font><font size="-1">ontained subprogram
+                      defined. Sharing data with the IS GLOBAL and IS EXTERNAL
+                      clause. Using the IS COMMON PROGRAM clause. Measuring the
+                      quality of subprograms.</font>
 </li>
 </ul>
 <hr/>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -73,6 +73,7 @@
   }
   ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
+  ul.toc a { font-weight: bold; }
 </style>
 
 </head>
@@ -91,28 +92,28 @@
 <hr/>
 </center>
 <ul class="toc">
-<li><b><a href="#intro">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
-<li><b><a href="#part1">Why use tables?</a><br/>
-</b><font size="-1">This section starts with a problem specification, 
-                    explores possible solutions and ends with the realisation 
+<li><a href="#intro">Introduction</a><br/>
+<font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><a href="#part1">Why use tables?</a><br/>
+<font size="-1">This section starts with a problem specification,
+                    explores possible solutions and ends with the realisation
                     that a table-based solution is probably best.</font></li>
 <li>
-<b><a href="#part2">Using a CountyTax table</a><br/>
-</b><font size="-1">This section explores how the table-based 
-                      solution may be implemented. </font> 
+<a href="#part2">Using a CountyTax table</a><br/>
+<font size="-1">This section explores how the table-based
+                      solution may be implemented. </font>
 </li>
 <li>
-<b><a href="#part3">Displaying the CountyName</a><br/>
-</b><font size="-1">In this section we explore how we might 
-                      deal with an extension to the problem specification that 
-                      requires us to display a county name instead of a county 
+<a href="#part3">Displaying the CountyName</a><br/>
+<font size="-1">In this section we explore how we might
+                      deal with an extension to the problem specification that
+                      requires us to display a county name instead of a county
                       code.</font>
 </li>
 <li>
-<b><a href="#part4">Using one table to index
+<a href="#part4">Using one table to index
                       into another</a><br/>
-</b><font size="-1">In this section we show how the subscript 
+<font size="-1">In this section we show how the subscript
                       of one table may be used to index into another. </font>
 </li>
 </ul>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -77,6 +77,7 @@
   }
   ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
+  ul.toc a { font-weight: bold; }
 </style>
 
 </head>
@@ -95,34 +96,34 @@
 <hr/>
 </center>
 <ul class="toc">
-<li><b><a href="#intro">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
-<li><b><a href="#part1">Declaring a single dimension 
+<li><a href="#intro">Introduction</a><br/>
+<font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><a href="#part1">Declaring a single dimension
                     table </a><br/>
-</b><font size="-1">In this section we demonstrate how the 
-                    OCCURS clause is used to declare a single dimension table. 
-                    We also show how it may be used to declare a variable length 
+<font size="-1">In this section we demonstrate how the
+                    OCCURS clause is used to declare a single dimension table.
+                    We also show how it may be used to declare a variable length
                     table.</font></li>
 <li>
-<b><a href="#part2">Group items as elements</a><br/>
-</b><font size="-1">The elements of a table do not have 
-                      to be elementary items - they can be group items. This section 
-                      demonstrates how to create a table, the elements of which, 
+<a href="#part2">Group items as elements</a><br/>
+<font size="-1">The elements of a table do not have
+                      to be elementary items - they can be group items. This section
+                      demonstrates how to create a table, the elements of which,
                       are group items.</font>
 </li>
 <li>
-<b><a href="#part3">Declaring multi-dimension 
+<a href="#part3">Declaring multi-dimension
                       tables </a><br/>
-</b><font size="-1">This section demonstrates how nested 
+<font size="-1">This section demonstrates how nested
                       OCCURS clauses are used to create multi-dimension tables</font><font size="-1">.</font>
 </li>
 <li>
-<b><a href="#part4">Creating pre-filled tables 
+<a href="#part4">Creating pre-filled tables
                       with the REDEFINES clause.</a><br/>
-</b><font size="-1">This section first demonstrates non-table 
-                      related uses for the REDEFINES clause and then shows how 
-                      it may be used to create pre-filled tables. The new COBOL'85 
-                      approaches to creating pre-filled tables and to initialising 
+<font size="-1">This section first demonstrates non-table
+                      related uses for the REDEFINES clause and then shows how
+                      it may be used to create pre-filled tables. The new COBOL'85
+                      approaches to creating pre-filled tables and to initialising
                       tables are also demonstrated.</font>
 </li>
 </ul>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -11,6 +11,7 @@
 -->
   ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
+  ul.toc a { font-weight: bold; }
 </style><meta content="width=device-width, initial-scale=1" name="viewport"/>
 <style type="text/css">
   img { max-width: 100%; height: auto; }
@@ -100,14 +101,14 @@
 </table>
 </div>
 </center>
-<ul class="toc"><li> <b><a href="#intro">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives and prerequisites.</font></li><li><b><a href="#verb">The UNSTRING verb</a><br/>
-</b><font size="-1">This section examines the syntax, functioning and rules 
-      of the UNSTRING.</font></li><li> <b><a href="#examples">UNSTRING examples</a><br/>
-</b><font size="-1">This section starts with some abstract examples, goes 
+<ul class="toc"><li> <a href="#intro">Introduction</a><br/>
+<font size="-1">Unit aims, objectives and prerequisites.</font></li><li><a href="#verb">The UNSTRING verb</a><br/>
+<font size="-1">This section examines the syntax, functioning and rules
+      of the UNSTRING.</font></li><li> <a href="#examples">UNSTRING examples</a><br/>
+<font size="-1">This section starts with some abstract examples, goes
       on to a more practical example and ends with a example program</font></li><li>
-<a href="#combined"><b>A combined example</b></a><br/>
-<font size="-1">The unit ends with a practical example that uses the STRING 
+<a href="#combined">A combined example</a><br/>
+<font size="-1">The unit ends with a practical example that uses the STRING
         and UNSTRING verbs in combination.</font>
 </li></ul>
 <table border="0" cellpadding="4" cellspacing="0" width="710">

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -73,6 +73,7 @@
   }
   ul.toc { list-style-image: url(Resources/pics/BallGreenG.gif); padding-left: 2.5em; margin: 1em 0; }
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
+  ul.toc a { font-weight: bold; }
 </style>
 
 </head>
@@ -91,11 +92,11 @@
 <hr/>
 </center>
 <ul class="toc">
-<li><b><a href="#intro">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives, prerequisites.</font></li>
-<li><b><a href="#part1">The USAGE clause</a><br/>
-</b><font size="-1">Subprograms, the syntax and semantics 
-                    of the CALL verb and parameter passing mechanisms. State memory, 
+<li><a href="#intro">Introduction</a><br/>
+<font size="-1">Unit aims, objectives, prerequisites.</font></li>
+<li><a href="#part1">The USAGE clause</a><br/>
+<font size="-1">Subprograms, the syntax and semantics
+                    of the CALL verb and parameter passing mechanisms. State memory,
                     the IS INITIAL clause and the CANCEL command.</font></li>
 </ul>
 <hr/>

--- a/lectures/ReportWriterSSWeb.html
+++ b/lectures/ReportWriterSSWeb.html
@@ -66,6 +66,7 @@
   }
   ul.toc { list-style-image: url(Ballgreeng.gif); padding-left: 2.5em; margin: 1em 0; }
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
+  ul.toc a { font-weight: bold; }
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
@@ -83,42 +84,41 @@
 <hr/>
 </center>
 <ul class="toc">
-<li><b><a href="#intro">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives and prerequisites.</font></li>
-<li><b><a href="#part1">Defining the Report - Report 
+<li><a href="#intro">Introduction</a><br/>
+<font size="-1">Unit aims, objectives and prerequisites.</font></li>
+<li><a href="#part1">Defining the Report - Report
                     File entries</a><br/>
-</b><font size="-1">This section examines the Environment 
-                    Division and File Section entries required when we create 
+<font size="-1">This section examines the Environment
+                    Division and File Section entries required when we create
                     <br/>
                     a Report Writer program.</font></li>
-<li><b><a href="#part2">Defining the Report - Report 
+<li><a href="#part2">Defining the Report - Report
                     Description (RD) entries </a><br/>
-</b><font size="-1">In this section we examine the Report 
-                    Section and the Report Description (RD) entries required to 
+<font size="-1">In this section we examine the Report
+                    Section and the Report Description (RD) entries required to
                     <br/>
                     define a report.</font></li>
-<li><b><a href="#part3">Defining the Report - Report 
+<li><a href="#part3">Defining the Report - Report
                     Group entries</a><br/>
-</b><font size="-1">This section examines the entries required 
+<font size="-1">This section examines the entries required
                     to define a report group record.</font></li>
-<li><b><a href="#part4">Defining the Report - Lines 
+<li><a href="#part4">Defining the Report - Lines
                     and Columns</a><br/>
-</b><font size="-1">This section examines the entries the 
-                    vertical and horizontal placement of print items. </font><font size="-1">It 
+<font size="-1">This section examines the entries the
+                    vertical and horizontal placement of print items. </font><font size="-1">It
                     examines <br/>
-                    clauses such as - </font><font size="-1">LINE NUMBER, COLUMN 
+                    clauses such as - </font><font size="-1">LINE NUMBER, COLUMN
                     NUMBER, GROUP INDICATE , SOURCE and SUM</font><font size="-1">.</font></li>
-<li><a href="#part5"><b>Special Report Writer registers</b></a><br/>
-<font size="-1">In this section the LINE-COUNTER and PAGE-COUNTER 
+<li><a href="#part5">Special Report Writer registers</a><br/>
+<font size="-1">In this section the LINE-COUNTER and PAGE-COUNTER
                     registers are examined.</font></li>
-<li><b><a href="#part6">The Procedure Division Verbs 
+<li><a href="#part6">The Procedure Division Verbs
                     </a><br/>
-</b><font size="-1">This section introduces the INITIATE, 
+<font size="-1">This section introduces the INITIATE,
                     GENERATE and TERMINATE verbs.</font></li>
 <li>
-<b><a href="#part7">Report Writer Declaratives</a></b><b>
-<br/>
-</b><font size="-1">In this section elements of the Declaratives, 
+<a href="#part7">Report Writer Declaratives</a><br/>
+<font size="-1">In this section elements of the Declaratives,
                       such as USE BEFORE REPORTING, SUPPRESS PRINTING and <br/>
                       control break registers, are examined.</font>
 </li>

--- a/lectures/ReportWriterWeb.html
+++ b/lectures/ReportWriterWeb.html
@@ -66,6 +66,7 @@
   }
   ul.toc { list-style-image: url(Ballgreeng.gif); padding-left: 2.5em; margin: 1em 0; }
   ul.toc > li { padding-left: 0.4em; margin-bottom: 0.6em; }
+  ul.toc a { font-weight: bold; }
 </style>
 
 <body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
@@ -83,33 +84,33 @@
 <hr/>
 </center>
 <ul class="toc">
-<li><b><a href="#intro">Introduction</a><br/>
-</b><font size="-1">Unit aims, objectives and prerequisites.</font></li>
-<li><b><a href="#part1">The Report Writer 
+<li><a href="#intro">Introduction</a><br/>
+<font size="-1">Unit aims, objectives and prerequisites.</font></li>
+<li><a href="#part1">The Report Writer
                   in action</a><br/>
-</b><font size="-1">This section examines a report produced 
-                  by a Report Writer program and then examines the Procedure Division 
+<font size="-1">This section examines a report produced
+                  by a Report Writer program and then examines the Procedure Division
                   of the program that produced the report.</font></li>
-<li><b><a href="#part1b">How the Report 
+<li><a href="#part1b">How the Report
                   Writer works</a><br/>
-</b><font size="-1">This section explains how the Report Writer 
-                  works. It examines the seven report groups a report produced 
-                  by a Report Writer program and then examines the Procedure Division 
+<font size="-1">This section explains how the Report Writer
+                  works. It examines the seven report groups a report produced
+                  by a Report Writer program and then examines the Procedure Division
                   of the program that produced the report.</font></li>
 <li>
-<b><a href="#part2">Let's write a Report Writer 
-                      p</a></b><b><a href="#part2">rogram</a><br/>
-</b><font size="-1">This section uses learning by doing 
-                      as its mode of instruction. We learn how to write a simple 
+<a href="#part2">Let's write a Report Writer
+                      p</a><a href="#part2">rogram</a><br/>
+<font size="-1">This section uses learning by doing
+                      as its mode of instruction. We learn how to write a simple
                       version of the report program shown in the previous section.</font>
 </li>
-<li><a href="#part3"><b>Let's add some features to 
-                    our Report Program</b></a><br/>
-<font size="-1">In this section we amend the report program 
+<li><a href="#part3">Let's add some features to
+                    our Report Program</a><br/>
+<font size="-1">In this section we amend the report program
                     to include more functionality</font><font size="-1">.</font></li>
-<li><a href="#part4"><b>Report Writer Declaratives</b></a><br/>
-<font size="-1">When the requirements of the report do not 
-                    coincide with the way the Report Writer works Declaratives 
+<li><a href="#part4">Report Writer Declaratives</a><br/>
+<font size="-1">When the requirements of the report do not
+                    coincide with the way the Report Writer works Declaratives
                     can be used to extend the functionality of the Report Writer.</font></li>
 </ul>
 </td>


### PR DESCRIPTION
## Summary

- Removed `<b>` tags that wrapped `<a>` elements in the `<ul class="toc">` table of contents on every course/lecture page
- Added `ul.toc a { font-weight: bold; }` to each page's stylesheet to preserve the visual appearance
- Handled all three forms that appeared across pages: `<b><a>…</a></b>`, `<b><a>…</a><br/></b>`, and `<a><b>…</b></a>`

## Why

`<b>` used solely to make link text bold is presentational markup. Styling belongs in CSS; the HTML should only carry structure and semantics. This is consistent with the recent run of semantic cleanup PRs on this repo.

## Reviewer notes

Visual output is unchanged — the TOC links remain bold. The diff is large (27 files) but mechanical: each file gains one CSS line and loses a few `<b>`/`</b>` tags in the TOC block only. No other content was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)