### PR TITLE
Fix all htmlhint errors across 171 HTML files

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
@@ -1362,18 +1363,14 @@
 									<img src="Resources/pics/CobolStructure.gif" width="467" height="203" /><br />
 								</p>
 								<p align="left">
-									<b>
-										<font face="Arial, Helvetica, sans-serif">Divisions</font> </b
-									><br />
+									<b> <font face="Arial, Helvetica, sans-serif">Divisions</font> </b><br />
 									A division is a block of code, usually containing one or more sections, that starts
 									where the division name is encountered and ends with the beginning of the next
 									division or with the end of the program text.
 								</p>
 								<p align="left">
 									<br />
-									<b>
-										<font face="Arial, Helvetica, sans-serif">Sections</font> </b
-									><br />
+									<b> <font face="Arial, Helvetica, sans-serif">Sections</font> </b><br />
 									A section is a block of code usually containing one or more paragraphs. A section
 									begins with the section name and ends where the next section name is encountered or
 									where the program text ends.

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <head>

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />

--- a/course/Resources/ppz/TC-Call.html
+++ b/course/Resources/ppz/TC-Call.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-Call - COBOL Course Animation</title>

--- a/course/Resources/ppz/TC-CobIntro1.html
+++ b/course/Resources/ppz/TC-CobIntro1.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-CobIntro1 - COBOL Course Animation</title>

--- a/course/Resources/ppz/TC-CobIntro2.html
+++ b/course/Resources/ppz/TC-CobIntro2.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-CobIntro2 - COBOL Course Animation</title>

--- a/course/Resources/ppz/TC-CobIntro3.html
+++ b/course/Resources/ppz/TC-CobIntro3.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-CobIntro3 - COBOL Course Animation</title>

--- a/course/Resources/ppz/TC-CobIntro4.html
+++ b/course/Resources/ppz/TC-CobIntro4.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-CobIntro4 - COBOL Course Animation</title>

--- a/course/Resources/ppz/TC-CobIntro5.html
+++ b/course/Resources/ppz/TC-CobIntro5.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-CobIntro5 - COBOL Course Animation</title>

--- a/course/Resources/ppz/TC-CobIntro6.html
+++ b/course/Resources/ppz/TC-CobIntro6.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-CobIntro6 - COBOL Course Animation</title>

--- a/course/Resources/ppz/TC-Commands1.html
+++ b/course/Resources/ppz/TC-Commands1.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-Commands1 - COBOL Course Animation</title>

--- a/course/Resources/ppz/TC-Commands2.html
+++ b/course/Resources/ppz/TC-Commands2.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-Commands2 - COBOL Course Animation</title>

--- a/course/Resources/ppz/TC-Condition1.html
+++ b/course/Resources/ppz/TC-Condition1.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-Condition1 - COBOL Course Animation</title>

--- a/course/Resources/ppz/TC-Condition2.html
+++ b/course/Resources/ppz/TC-Condition2.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-Condition2 - COBOL Course Animation</title>

--- a/course/Resources/ppz/TC-Data1.html
+++ b/course/Resources/ppz/TC-Data1.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-Data1 - COBOL Course Animation</title>

--- a/course/Resources/ppz/TC-Data2.html
+++ b/course/Resources/ppz/TC-Data2.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-Data2 - COBOL Course Animation</title>

--- a/course/Resources/ppz/TC-Perform1.html
+++ b/course/Resources/ppz/TC-Perform1.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-Perform1 - COBOL Course Animation</title>

--- a/course/Resources/ppz/TC-Perform2.html
+++ b/course/Resources/ppz/TC-Perform2.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-Perform2 - COBOL Course Animation</title>

--- a/course/Resources/ppz/TC-Search2.html
+++ b/course/Resources/ppz/TC-Search2.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-Search2 - COBOL Course Animation</title>

--- a/course/Resources/ppz/TC-SeqFile1.html
+++ b/course/Resources/ppz/TC-SeqFile1.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-SeqFile1 - COBOL Course Animation</title>

--- a/course/Resources/ppz/TC-SeqFile2a.html
+++ b/course/Resources/ppz/TC-SeqFile2a.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-SeqFile2a - COBOL Course Animation</title>

--- a/course/Resources/ppz/TC-SeqFile2b.html
+++ b/course/Resources/ppz/TC-SeqFile2b.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-SeqFile2b - COBOL Course Animation</title>

--- a/course/Resources/ppz/TC-SeqFile2c.html
+++ b/course/Resources/ppz/TC-SeqFile2c.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-SeqFile2c - COBOL Course Animation</title>

--- a/course/Resources/ppz/TC-SeqFile2d.html
+++ b/course/Resources/ppz/TC-SeqFile2d.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-SeqFile2d - COBOL Course Animation</title>

--- a/course/Resources/ppz/TC-SeqFile2e.html
+++ b/course/Resources/ppz/TC-SeqFile2e.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-SeqFile2e - COBOL Course Animation</title>

--- a/course/Resources/ppz/TC-SeqFile3a.html
+++ b/course/Resources/ppz/TC-SeqFile3a.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-SeqFile3a - COBOL Course Animation</title>

--- a/course/Resources/ppz/TC-Tables1.html
+++ b/course/Resources/ppz/TC-Tables1.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-Tables1 - COBOL Course Animation</title>

--- a/course/Resources/ppz/TC-Tables2.html
+++ b/course/Resources/ppz/TC-Tables2.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-Tables2 - COBOL Course Animation</title>

--- a/course/Resources/ppz/TC-Tables3.html
+++ b/course/Resources/ppz/TC-Tables3.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-Tables3 - COBOL Course Animation</title>

--- a/course/Resources/ppz/TC-Tables4.html
+++ b/course/Resources/ppz/TC-Tables4.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-Tables4 - COBOL Course Animation</title>

--- a/course/Resources/ppz/TC-Tables5.html
+++ b/course/Resources/ppz/TC-Tables5.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-Tables5 - COBOL Course Animation</title>

--- a/course/Resources/ppz/TC-Tables7.html
+++ b/course/Resources/ppz/TC-Tables7.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-Tables7 - COBOL Course Animation</title>

--- a/course/Resources/ppz/TC-Tables8.html
+++ b/course/Resources/ppz/TC-Tables8.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TC-Tables8 - COBOL Course Animation</title>

--- a/course/Search.html
+++ b/course/Search.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />

--- a/course/String.html
+++ b/course/String.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />

--- a/course/index.html
+++ b/course/index.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/examples/Accept/ACCEPT.html
+++ b/examples/Accept/ACCEPT.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>ACCEPT and DISPLAY example program</title>

--- a/examples/Accept/Multiplier.html
+++ b/examples/Accept/Multiplier.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>ACCEPT, DISPLAY and MULTIPLY example program</title>

--- a/examples/Accept/Shortest.html
+++ b/examples/Accept/Shortest.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>The Shortest COBOL program we can have</title>

--- a/examples/Conditn/Conditions.html
+++ b/examples/Conditn/Conditions.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Condition Names (level 88) example program</title>

--- a/examples/Conditn/IterIf.html
+++ b/examples/Conditn/IterIf.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Condition Names (level 88) example program</title>

--- a/examples/Indexed/DirectReadIdx.html
+++ b/examples/Indexed/DirectReadIdx.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Reading an Indexed file directly by key</title>

--- a/examples/Indexed/Seq2Index.html
+++ b/examples/Indexed/Seq2Index.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Creating an Indexed file from a sequential file</title>

--- a/examples/Indexed/SeqReadIdx.html
+++ b/examples/Indexed/SeqReadIdx.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Reading an Indexed file sequentially on any of its keys</title>

--- a/examples/Merge/Merge.html
+++ b/examples/Merge/Merge.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Merge Files - Example Program</title>

--- a/examples/Perform/MileageCount.html
+++ b/examples/Perform/MileageCount.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Mileage counter simulation</title>

--- a/examples/Perform/Perform1.html
+++ b/examples/Perform/Perform1.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Perform - Format 1 example program</title>

--- a/examples/Perform/Perform2.html
+++ b/examples/Perform/Perform2.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Perform - Format 2 example program</title>

--- a/examples/Perform/Perform3.html
+++ b/examples/Perform/Perform3.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Perform - Format 3 example program</title>

--- a/examples/Perform/Perform4.html
+++ b/examples/Perform/Perform4.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Perform - Format 4 example program</title>

--- a/examples/Relative/ReadRel.html
+++ b/examples/Relative/ReadRel.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Inserting records in a Sequential File</title>

--- a/examples/Relative/Seq2Rel.html
+++ b/examples/Relative/Seq2Rel.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Inserting records in a Sequential File</title>

--- a/examples/ReportWriter/RepWriteA.html
+++ b/examples/ReportWriter/RepWriteA.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>One control break version of full Report Writer example Program</title>

--- a/examples/ReportWriter/RepWriteB.html
+++ b/examples/ReportWriter/RepWriteB.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>No Declaratives version of full Report Writer example program</title>

--- a/examples/ReportWriter/RepWriteFull.html
+++ b/examples/ReportWriter/RepWriteFull.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Full Report Writer example program - includes Declaratives</title>

--- a/examples/ReportWriter/RepWriteSumm.html
+++ b/examples/ReportWriter/RepWriteSumm.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Summary version of the full Report Writer program</title>

--- a/examples/SeqIns/SEQINSERT.html
+++ b/examples/SeqIns/SEQINSERT.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Inserting records in a Sequential File</title>

--- a/examples/SeqRead/SEQREAD.html
+++ b/examples/SeqRead/SEQREAD.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Reading a Sequential File</title>

--- a/examples/SeqRead/SEQREADno88.html
+++ b/examples/SeqRead/SEQREADno88.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Reading a Sequential File</title>

--- a/examples/SeqRpt/SEQRPT.html
+++ b/examples/SeqRpt/SEQRPT.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Sequential Student Number Report</title>

--- a/examples/SeqWrite/SEQWRITE.html
+++ b/examples/SeqWrite/SEQWRITE.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Writing to a Sequential File</title>

--- a/examples/Sort/InputSort.html
+++ b/examples/Sort/InputSort.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>SORT with Input Procedure to get recs from user</title>

--- a/examples/Sort/MaleSort.html
+++ b/examples/Sort/MaleSort.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>SORT file and select only male records</title>

--- a/examples/Strings/RefMod.html
+++ b/examples/Strings/RefMod.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>String handling - Reference Modification examples</title>

--- a/examples/Strings/UnstringFileEg.html
+++ b/examples/Strings/UnstringFileEg.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>String handling - Unpacking and size-validating comma separated records</title>

--- a/examples/SubProg/DateValid/DateDriver.html
+++ b/examples/SubProg/DateValid/DateDriver.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Driver program for date validation sub-program</title>

--- a/examples/SubProg/DateValid/ValiDate.html
+++ b/examples/SubProg/DateValid/ValiDate.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Date validation sub-program</title>

--- a/examples/SubProg/DayDiff/DayDiffDriver.html
+++ b/examples/SubProg/DayDiff/DayDiffDriver.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Get difference between dates driver program</title>

--- a/examples/SubProg/Multiply/DriverProg.html
+++ b/examples/SubProg/Multiply/DriverProg.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>A driver for the MultiplyNums, Fickle and Steafast sub-programs</title>

--- a/examples/SubProg/Multiply/Fickle.html
+++ b/examples/SubProg/Multiply/Fickle.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>The Fickle sub-program demonstrates State Memory</title>

--- a/examples/SubProg/Multiply/MultiplyNums.html
+++ b/examples/SubProg/Multiply/MultiplyNums.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>The MultiplyNums sub-program</title>

--- a/examples/SubProg/Multiply/Steadfast.html
+++ b/examples/SubProg/Multiply/Steadfast.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>The Steadfast sub-program demonstrates the IS INITIAL phrase</title>

--- a/examples/Tables/MonthTable.html
+++ b/examples/Tables/MonthTable.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Tables - Counts number of students born in each month</title>

--- a/examples/default.html
+++ b/examples/default.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 	<title>COBOL example programs</title>

--- a/exercises/COBOLExams/COBOLExams.html
+++ b/exercises/COBOLExams/COBOLExams.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<title>COBOL Programming Exams</title>
 	<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />

--- a/exercises/CountDown.html
+++ b/exercises/CountDown.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html
+++ b/exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
@@ -134,8 +135,8 @@
 				}
 			}
 		</style>
+		<title>ACME Stock Reorder 1999 (Exam Paper)</title>
 	</head>
-	<title>ACME Stock Reorder 1999 (Exam Paper)</title>
 
 	<body bgcolor="#FFFFFF" class="Normal" lang="EN-GB" link="blue" vlink="purple">
 		<table border="1" cellpadding="5" cellspacing="0" height="72%" width="694">

--- a/exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html
+++ b/exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>AcmeStockReorder &ndash; ACME Stock Reorder 1999 (COBOL source)</title>

--- a/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html
+++ b/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<title>Aromamora Oil Stock Maintenance and Report (Exam Paper)</title>
 	<meta content="width=device-width, initial-scale=1" name="viewport" />

--- a/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html
+++ b/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>AromaOilFileMainRpt &ndash; Aromamora Oil Stock Maintenance and Report (COBOL source)</title>

--- a/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html
+++ b/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<title>Aromamora Summary Sales Report (Exam Paper)</title>
 	<meta content="width=device-width, initial-scale=1" name="viewport" />

--- a/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html
+++ b/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>AromaSalesSummaryRpt &ndash; Aromamora Summary Sales Report (COBOL source)</title>

--- a/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html
+++ b/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta charset="utf-8" />

--- a/exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html
+++ b/exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<script

--- a/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html
+++ b/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<title>Campus Bookshop Purchase Requirements Report (Exam Paper)</title>
 	<meta content="width=device-width, initial-scale=1" name="viewport" />

--- a/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html
+++ b/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>BookshopLectReqRpt &ndash; Campus Bookshop Purchase Requirements Report (COBOL source)</title>

--- a/exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html
+++ b/exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta charset="utf-8" />

--- a/exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html
+++ b/exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<script

--- a/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html
+++ b/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
@@ -134,8 +135,8 @@
 				}
 			}
 		</style>
+		<title>NetNews - Due Subscriptions Report (Exam Paper)</title>
 	</head>
-	<title>NetNews - Due Subscriptions Report (Exam Paper)</title>
 
 	<body bgcolor="#FFFFFF" class="Normal" lang="EN-GB" link="blue" vlink="purple">
 		<table border="1" cellpadding="5" cellspacing="0" height="72%" width="694">

--- a/exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html
+++ b/exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>DueSubsRpt &ndash; NetNews Due Subscriptions Report (COBOL source)</title>

--- a/exercises/Exm-FileConversion/Exm-FileConversion.html
+++ b/exercises/Exm-FileConversion/Exm-FileConversion.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<title>File Conversion Program (Exam Paper)</title>
 	<meta content="width=device-width, initial-scale=1" name="viewport" />

--- a/exercises/Exm-FileConversion/Prg-FileConversion.html
+++ b/exercises/Exm-FileConversion/Prg-FileConversion.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>FileConversion &ndash; File Conversion Program (COBOL source)</title>

--- a/exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html
+++ b/exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<script

--- a/exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html
+++ b/exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>FlyByNight &ndash; Travel Agency Sorted Summary File (COBOL source)</title>

--- a/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html
+++ b/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta charset="utf-8" />

--- a/exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html
+++ b/exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>LibRoyaltyRpt &ndash; Library Royalty Payment Report (COBOL source)</title>

--- a/exercises/Exm-SFbyMail/Exm-SFbyMai.html
+++ b/exercises/Exm-SFbyMail/Exm-SFbyMai.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta charset="utf-8" />

--- a/exercises/Exm-SFbyMail/Prg-SFbyMail.html
+++ b/exercises/Exm-SFbyMail/Prg-SFbyMail.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<script

--- a/exercises/Exm-StudFeesRpt/Exm-StudPay.html
+++ b/exercises/Exm-StudFeesRpt/Exm-StudPay.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<title>Student Fee Payment - Update and Report (Exam Question)</title>
 	<meta content="width=device-width, initial-scale=1" name="viewport" />

--- a/exercises/Exm-StudFeesRpt/Prg-StudPay.html
+++ b/exercises/Exm-StudFeesRpt/Prg-StudPay.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>StudPay &ndash; Student Fee Payment Update and Report (COBOL source)</title>

--- a/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html
+++ b/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta charset="utf-8" />

--- a/exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html
+++ b/exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>TopSupplierRpt &ndash; Top Video Supplier Report (COBOL source)</title>

--- a/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html
+++ b/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<title>USSR Naval Vessel Inventory Report</title
 	><meta content="width=device-width, initial-scale=1" name="viewport" />

--- a/exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html
+++ b/exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>USSRshipRpt &ndash; USSR Naval Vessel Inventory Report (COBOL source)</title>

--- a/exercises/GettingStarted.html
+++ b/exercises/GettingStarted.html
@@ -1,315 +1,360 @@
+<!doctype html>
 <html>
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+		<title>Getting Started with the VISOC Environment</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<style type="text/css">
+			img {
+				max-width: 100%;
+				height: auto;
+			}
 
-<head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-  <title>Getting Started with the VISOC Environment</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <style type="text/css">
-    img {
-      max-width: 100%;
-      height: auto;
-    }
+			table {
+				max-width: 100%;
+			}
 
-    table {
-      max-width: 100%;
-    }
+			pre {
+				overflow-x: auto;
+				max-width: 100%;
+			}
 
-    pre {
-      overflow-x: auto;
-      max-width: 100%;
-    }
+			body {
+				-webkit-text-size-adjust: 100%;
+			}
 
-    body {
-      -webkit-text-size-adjust: 100%;
-    }
+			@media (max-width: 600px) {
+				body {
+					margin: 4px;
+					overflow-wrap: break-word;
+					word-wrap: break-word;
+				}
 
-    @media (max-width: 600px) {
-      body {
-        margin: 4px;
-        overflow-wrap: break-word;
-        word-wrap: break-word;
-      }
+				table[width] {
+					width: 100% !important;
+					height: auto !important;
+				}
 
-      table[width] {
-        width: 100% !important;
-        height: auto !important;
-      }
+				td[width],
+				th[width],
+				td[height],
+				th[height] {
+					width: auto !important;
+					height: auto !important;
+				}
 
-      td[width],
-      th[width],
-      td[height],
-      th[height] {
-        width: auto !important;
-        height: auto !important;
-      }
+				td[bgcolor="#993300"] > h2,
+				td[bgcolor="#993300"] > h3 {
+					margin: 0.3em 0;
+				}
 
-      td[bgcolor="#993300"]>h2,
-      td[bgcolor="#993300"]>h3 {
-        margin: 0.3em 0;
-      }
+				blockquote {
+					margin-left: 12px;
+					margin-right: 12px;
+				}
 
-      blockquote {
-        margin-left: 12px;
-        margin-right: 12px;
-      }
+				hr[width] {
+					width: 100% !important;
+				}
 
-      hr[width] {
-        width: 100% !important;
-      }
+				img,
+				iframe,
+				video,
+				embed,
+				object {
+					max-width: min(100%, calc(100vw - 16px)) !important;
+					height: auto;
+				}
 
-      img,
-      iframe,
-      video,
-      embed,
-      object {
-        max-width: min(100%, calc(100vw - 16px)) !important;
-        height: auto;
-      }
+				pre {
+					max-width: min(100%, calc(100vw - 16px)) !important;
+					white-space: pre-wrap;
+					word-wrap: break-word;
+					overflow-wrap: break-word;
+				}
 
-      pre {
-        max-width: min(100%, calc(100vw - 16px)) !important;
-        white-space: pre-wrap;
-        word-wrap: break-word;
-        overflow-wrap: break-word;
-      }
+				table[width="715"],
+				table[width="725"],
+				table[width="715"] > tbody,
+				table[width="725"] > tbody,
+				table[width="715"] > tbody > tr,
+				table[width="725"] > tbody > tr,
+				table[width="715"] > tbody > tr > td,
+				table[width="725"] > tbody > tr > td,
+				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])),
+				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])) > tbody,
+				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])) > tbody > tr,
+				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])) > tbody > tr > td {
+					display: block;
+					width: auto !important;
+				}
 
-      table[width="715"],
-      table[width="725"],
-      table[width="715"]>tbody,
-      table[width="725"]>tbody,
-      table[width="715"]>tbody>tr,
-      table[width="725"]>tbody>tr,
-      table[width="715"]>tbody>tr>td,
-      table[width="725"]>tbody>tr>td,
-      table[width="710"]:not(:has(> tbody > tr > td[width="93%"])),
-      table[width="710"]:not(:has(> tbody > tr > td[width="93%"]))>tbody,
-      table[width="710"]:not(:has(> tbody > tr > td[width="93%"]))>tbody>tr,
-      table[width="710"]:not(:has(> tbody > tr > td[width="93%"]))>tbody>tr>td {
-        display: block;
-        width: auto !important;
-      }
+				table[width="710"]:has(> tbody > tr > td[width="93%"]),
+				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody {
+					display: block;
+					width: 100% !important;
+				}
 
-      table[width="710"]:has(> tbody > tr > td[width="93%"]),
-      table[width="710"]:has(> tbody > tr > td[width="93%"])>tbody {
-        display: block;
-        width: 100% !important;
-      }
+				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr {
+					display: flex;
+					align-items: baseline;
+					gap: 0.4em;
+					margin: 0.4em 0;
+				}
 
-      table[width="710"]:has(> tbody > tr > td[width="93%"])>tbody>tr {
-        display: flex;
-        align-items: baseline;
-        gap: 0.4em;
-        margin: 0.4em 0;
-      }
+				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr > td[width="3%"] {
+					display: none;
+				}
 
-      table[width="710"]:has(> tbody > tr > td[width="93%"])>tbody>tr>td[width="3%"] {
-        display: none;
-      }
+				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr > td[width="4%"] {
+					display: block;
+					flex: 0 0 auto;
+					width: auto !important;
+					padding: 0;
+				}
 
-      table[width="710"]:has(> tbody > tr > td[width="93%"])>tbody>tr>td[width="4%"] {
-        display: block;
-        flex: 0 0 auto;
-        width: auto !important;
-        padding: 0;
-      }
+				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr > td[width="93%"] {
+					display: block;
+					flex: 1 1 auto;
+					width: auto !important;
+					padding: 0;
+				}
 
-      table[width="710"]:has(> tbody > tr > td[width="93%"])>tbody>tr>td[width="93%"] {
-        display: block;
-        flex: 1 1 auto;
-        width: auto !important;
-        padding: 0;
-      }
+				td[width="175"] > h4:not(:first-child):not(:has(img)),
+				td[width="160"] > h4:not(:first-child):not(:has(img)),
+				h4:has(> img[src*="PanelLine"]) {
+					display: none;
+				}
 
-      td[width="175"]>h4:not(:first-child):not(:has(img)),
-      td[width="160"]>h4:not(:first-child):not(:has(img)),
-      h4:has(> img[src*="PanelLine"]) {
-        display: none;
-      }
+				td[width="175"] > h3,
+				td[width="175"] > h4,
+				td[width="175"] > p,
+				td[width="160"] > h3,
+				td[width="160"] > h4,
+				td[width="160"] > p {
+					margin: 0.2em 0;
+				}
+			}
+		</style>
+	</head>
 
-      td[width="175"]>h3,
-      td[width="175"]>h4,
-      td[width="175"]>p,
-      td[width="160"]>h3,
-      td[width="160"]>h4,
-      td[width="160"]>p {
-        margin: 0.2em 0;
-      }
-    }
-  </style>
-</head>
+	<body text="#000000" bgcolor="#FFFFFF" link="#0000FF" vlink="#FF0000" alink="#009B00">
+		<center>
+			<h2>
+				<img src="T-CobolExercise.gif" height="56" width="183" />
+			</h2>
+		</center>
 
-<body text="#000000" bgcolor="#FFFFFF" link="#0000FF" vlink="#FF0000" alink="#009B00">
+		<center>
+			<h2><b>Getting Started with the NetExpress Environment</b></h2>
+		</center>
 
-  <center>
-    <h2>
-      <img src="T-CobolExercise.gif" height="56" width="183">
-    </h2>
-  </center>
+		<center>
+			<hr width="100%" />
+		</center>
 
-  <center>
-    <h2> <b>Getting Started with the NetExpress Environment</b></h2>
-  </center>
+		<center>
+			<font size="-1">ACCEPT, DISPLAY, MULTIPLY, COMPUTE</font>
+		</center>
 
-  <center>
-    <hr width="100%">
-  </center>
+		<hr width="100%" />
+		<h2>Starting NetExpress</h2>
+		<p>
+			We will start by loading an existing COBOL program into the development environment and then compiling and
+			running the program.
+		</p>
+		<p>
+			The development environment we are using for this course is Microfocus NetExpress. NetExpress is an
+			Integrated Development Environment (IDE) supporting an Object Oriented version of COBOL. The OO-COBOL
+			supported by NetExpress is a preview of the coming standard.
+		</p>
+		<p>
+			To load the program, click on the&nbsp;
+			<a href="../examples/Accept/gettingstarted.cbl">GettingStarted.Cbl</a>&nbsp; link.&nbsp;&nbsp; This will
+			allow you (depending on how your browser is set up) to either download the file to your local hard disk or
+			load it directly into the NetExpress environment.
+		</p>
+		<p>
+			If you download the program you should save it to the \WorkArea directory on the drive D:.&nbsp;&nbsp; When
+			the file has been downloaded, start NetExpress and load the program using the <b><i>File</i></b> option in
+			the main menu bar.
+		</p>
+		<p>
+			If you load it directly into the NetExpress environment you should use the <b><i>Save As</i></b> option in
+			the <b><i>File</i></b> menu to save it as GettingStarted.Cbl to the \WorkArea directory.
+		</p>
+		<p>The NetExpress programming environment should now be running with the GettingStarted.Cbl file loaded.</p>
+		<h2>Configuring the NetExpress environment</h2>
+		The default NetExpress Environment makes it difficult to write programs the way we would like so we need to make
+		some changes to it.
+		<p>
+			From the NetExpress <b><i>Options</i></b> menu select <b><i>Edit</i></b
+			>. This brings up a dialogue box with a number of tabs.&nbsp; Make sure the <b><i>Profile</i></b> tab has
+			the focus.
+		</p>
+		<p>
+			In the <b><i>Margins</i></b> option change the left margin to 0.
+		</p>
 
-  <center>
-    <font size="-1">ACCEPT, DISPLAY, MULTIPLY, COMPUTE</font>
-  </center>
+		<p>
+			Now select the <b><i>Blocks/Clipboard</i></b> tab.
+		</p>
+		<p>
+			In the "<b><i>Selecting line blocks and column blocks</i></b
+			>" option select "Select column blocks when dragging, except when in prefix area".
+		</p>
 
-  <hr width="100%">
-  <h2> Starting NetExpress</h2>
-  <p>We will start by loading an existing COBOL program into the development environment
-    and then compiling and running the program. </p>
-  <p>The development environment we are using for this course is Microfocus NetExpress.
-    NetExpress is an Integrated Development Environment (IDE) supporting an Object
-    Oriented version of COBOL. The OO-COBOL supported by NetExpress is a preview
-    of the coming standard.</p>
-  <p>To load the program, click on the&nbsp; <a
-      href="../examples/Accept/gettingstarted.cbl">GettingStarted.Cbl</a>&nbsp;
-    link.&nbsp;&nbsp; This will allow you (depending on how your browser is set
-    up) to either download the file to your local hard disk or load it directly
-    into the NetExpress environment.
-  <p>If you download the program you should save it to the \WorkArea directory on
-    the drive D:.&nbsp;&nbsp; When the file has been downloaded, start NetExpress
-    and load the program using the <b><i>File</i></b> option in the main menu bar.
-  <p>If you load it directly into the NetExpress environment you should use the
-    <b><i>Save As</i></b> option in the <b><i>File</i></b> menu to save it as GettingStarted.Cbl
-    to the \WorkArea directory.
-  <p>The NetExpress programming environment should now be running with the GettingStarted.Cbl
-    file loaded.</p>
-  <h2> Configuring the NetExpress environment</h2>
-  The default NetExpress Environment makes it difficult to write programs the way
-  we would like so we need to make some changes to it.
-  <p>From the NetExpress <b><i>Options</i></b> menu select <b><i>Edit</i></b>. This
-    brings up a dialogue box with a number of tabs.&nbsp; Make sure the <b><i>Profile</i></b>
-    tab has the focus.
-  <p>In the <b><i>Margins</i></b> option change the left margin to 0.
+		<p>
+			Select <b><i>OK</i></b> to close the dialogue box and observe the results.
+		</p>
+		<h2>Compiling the program</h2>
+		<p>
+			Click on the tick icon<img src="i-tick.gif" hspace="7" height="24" width="24" />in the NetExpress toolbar.
+			This compiles the program.
+		</p>
+		<h2>Starting to run the program</h2>
+		For the time being we will run our COBOL programs from within the NetExpress Animator.&nbsp; Later in the course
+		we will create stand alone programs (.EXE's).
+		<p>
+			Position the cursor over program statement&nbsp; "ACCEPT Num1.".&nbsp; Click the right mouse button.&nbsp;
+			From the menu which appears select <i><b>Set Breakpoint</b>.</i>
+		</p>
 
-  <p>Now select the <b><i>Blocks/Clipboard</i></b> tab.
-  <p>In the "<b><i>Selecting line blocks and column blocks</i></b>" option
-    select "Select column blocks when dragging, except when in prefix area".
+		<p>
+			Now select "<b><i>Start Animating</i></b
+			>" from within the <b><i>Animate</i></b> menu option and chose <b><i>OK</i></b> from the dialogue box which
+			appears.
+		</p>
 
-  <p>Select <b><i>OK</i></b> to close the dialogue box and observe the results.</p>
-  <h2>
-    Compiling the program</h2>
-  Click on the tick icon<img src="i-tick.gif" hspace="7" height="24" width="24">in the
-  NetExpress toolbar. This compiles the program.</p>
-  <h2>
-    Starting to run the program</h2>
-  For the time being we will run our COBOL programs from within the NetExpress Animator.&nbsp;
-  Later in the course we will create stand alone programs (.EXE's).
-  <p>Position the cursor over program statement&nbsp; "ACCEPT Num1.".&nbsp;
-    Click the right mouse button.&nbsp; From the menu which appears select
-    <i><b>Set Breakpoint</b>.</i>
+		<p>
+			The program starts to run, the first statement in the Procedure Division is highlighted but is not executed.
+		</p>
+		<h2>Using the Animator</h2>
+		Before we continue with running the program let's have a look at some of the facilities the Animator provides.
 
-  <p>Now select "<b><i>Start Animating</i></b>" from within the <b><i>Animate</i></b>
-    menu option and chose <b><i>OK</i></b> from the dialogue box which appears.
+		<p>
+			Right click on the variable Num1 in the program statement "MULTIPLY Num1 BY Num2 GIVING Result. " Take note
+			of all the options that appear in the right-click menu.
+		</p>
 
-  <p>The program starts to run, the first statement in the Procedure Division
-    is highlighted but is not executed.</p>
-  <h2>
-    Using the Animator</h2>
-  Before we continue with running the program let's have a look at some of
-  the facilities the Animator provides.
+		<p>Let's suppose that we want to find out the size and type of Num1.</p>
 
-  <p>Right click on the variable Num1 in the program statement "MULTIPLY
-    Num1 BY Num2 GIVING Result. " Take note of all the options that appear
-    in the right-click menu.
+		<p>
+			To do this select <b><i>Locate "Num1"</i></b> from the right-click menu.
+		</p>
 
-  <p>Let's suppose that we want to find out the size and type of Num1.
+		<p>
+			The cursor jumps up to the Num1 declaration. Now right-click on a blank part of the program text and select
+			"<b><i>Return</i></b
+			>" from the right-click menu.
+		</p>
 
-  <p>To do this select <b><i>Locate "Num1"</i></b> from the right-click menu.
+		<p>The cursor jumps back to where it came from.</p>
 
-  <p>The cursor jumps up to the Num1 declaration. Now right-click on a blank
-    part of the program text and select "<b><i>Return</i></b>" from the right-click
-    menu.
+		<p>Now let's examine two ways of monitoring the contents of variables.</p>
 
-  <p>The cursor jumps back to where it came from.
+		<p>In the program statement "MULTIPLY Num1 BY Num2 GIVING Result." right click on the variable Num1.</p>
 
-  <p>Now let's examine two ways of monitoring the contents of variables.
+		<p>
+			Select "<b><i>Examine Num1</i></b
+			>" from the right-click menu. From the "Examine List" dialogue that appears select the
+			<b><i>Monitor</i></b> option. This creates a little window which is used to monitor the contents of the
+			variable Num1.
+		</p>
 
-  <p>In the program statement "MULTIPLY Num1 BY Num2 GIVING Result." right
-    click on the variable Num1.
+		<p>
+			Right-click on Num2 and select "<b><i>Examine Num2</i></b
+			>" from the right-click menu. From the dialogue that appears select the "<b><i>Add to List</i></b
+			>" option. This creates a "Watch list" window and adds Num2 to the watch list.
+		</p>
 
-  <p>Select "<b><i>Examine Num1</i></b>" from the right-click menu. From
-    the "Examine List" dialogue that appears select the <b><i>Monitor</i></b>
-    option. This creates a little window which is used to monitor the contents
-    of the variable Num1.
+		<p>Do the same for the Result variable.</p>
 
-  <p>Right-click on Num2 and select "<b><i>Examine Num2</i></b>" from the
-    right-click menu. From the dialogue that appears select the "<b><i>Add
-        to List</i></b>" option. This creates a "Watch list" window and adds Num2
-    to the watch list.
+		<p>The watch list window should now have two entries - Num2 and Result.</p>
+		<h2>Continuing with the program run</h2>
+		Let's go back to running the program.
 
-  <p>Do the same for the Result variable.
+		<p>
+			From the NetExpress toolbar select the Step icon&nbsp;<img
+				src="i-step.gif"
+				hspace="7"
+				height="23"
+				width="23"
+			/>(if you position the cursor over each icon for a short time the computer will display a label for it). You
+			can also select step from the <b><i>Animate</i></b> menu or by pressing Ctrl-S.
+		</p>
+		<p>
+			The first Procedure Division statement should now be executed. A console window is created and has the focus
+			and the program waits for the user (that's you) to enter the first number. Enter the value 3 and press
+			return.
+		</p>
 
-  <p>The watch list window should now have two entries - Num2 and Result.</p>
-  <h2>
-    Continuing with the program run</h2>
-  Let's go back to running the program.
+		<p>The focus returns to the NetExpress environment.</p>
+		<p>Look at the monitoring window for the Num1 variable. Note the contents.</p>
 
-  <p>From the NetExpress toolbar select the Step icon&nbsp;<img src="i-step.gif" hspace="7" height="23" width="23">(if
-    you position the cursor over each icon for a short time the computer will display
-    a label for it). You can also select step from the <b><i>Animate</i></b> menu
-    or by pressing Ctrl-S.
-  <p>The first Procedure Division statement should now be executed. A console
-    window is created and has the focus and the program waits for the user
-    (that's you) to enter the first number. Enter the value 3 and press return.
+		<p>Click on the Step icon again to execute the Multiply instruction.</p>
 
-  <p>The focus returns to the NetExpress environment.
-  <p>Look at the monitoring window for the Num1 variable. Note the contents.
+		<p>Note that the contents of the Result variable in the watch list window do not change (3*0=0).</p>
 
-  <p>Click on the Step icon again to execute the Multiply instruction.
+		<p>Click on the step icon again and this time enter 5 in the console window and press return.</p>
 
-  <p>Note that the contents of the Result variable in the watch list window
-    do not change (3*0=0).
+		<p>Note the value that has been assigned to Num2 in the watch list window.</p>
 
-  <p>Click on the step icon again and this time enter 5 in the console window
-    and press return.
+		<p>Click on the step icon again to execute the Display instruction.</p>
 
-  <p>Note the value that has been assigned to Num2 in the watch list window.
+		<p>
+			Note that this time the console window does not take the focus. You have to click on the console window to
+			give it the focus.
+		</p>
 
-  <p>Click on the step icon again to execute the Display instruction.
+		<p>Note that the program produces the wrong answer.</p>
 
-  <p>Note that this time the console window does not take the focus. You
-    have to click on the console window to give it the focus.
+		<p>Click on the step icon again to execute the STOP-RUN.</p>
 
-  <p>Note that the program produces the wrong answer.
+		<p>
+			Select "<b><i>Stop Animating</i></b
+			>" from the <b><i>Animate</i></b> menu.
+		</p>
 
-  <p>Click on the step icon again to execute the STOP-RUN.
+		<p>
+			Select "<b><i>NO</i></b
+			>" in response to the question "Do you want to keep the project created for the animate session".
+		</p>
+		<h2>Fixing the Program</h2>
+		<p>
+			Change the program so that it prompts the user for input (hint&nbsp;
+			<font size="-1">DISPLAY WITH NO ADVANCING</font>) and produces the correct answer.
+		</p>
+		<h2>Conclusion</h2>
+		See if you can replace the MULTIPLY statement by the equivalent COMPUTE statement.
 
-  <p>Select "<b><i>Stop Animating</i></b>" from the <b><i>Animate</i></b>
-    menu.
+		<p>The format for the COMPUTE is&nbsp; -</p>
+		<ul>
+			<ul>
+				COMPUTE
+				<i>result</i>
+				=
+				<i>operand operator operand</i>
+			</ul>
+		</ul>
 
-  <p>Select "<b><i>NO</i></b>" in response to the question "Do you want to
-    keep the project created for the animate session".</p>
-  <h2>
-    Fixing the Program</h2>
-  Change the program so that it prompts the user for input (hint&nbsp; <font size="-1">DISPLAY
-    WITH NO ADVANCING</font>) and produces the correct answer.</p>
-  <h2>
-    Conclusion</h2>
-  See if you can replace the MULTIPLY statement by the equivalent COMPUTE
-  statement.
+		<br />
 
-  <p>The format for the COMPUTE is&nbsp; -
-  <ul>
-    <ul>COMPUTE <i>result</i> = <i>operand operator operand</i></ul>
-  </ul>
-
-  <br>
-
-  <hr>
-  <table cellspacing="0" cellpadding="0" cols="1" width="200">
-    <tr align="CENTER" valign="TOP">
-      <td><a href="index.html"><img src="../pics/B-BackArrow.gif" alt="Back to COBOL Exercises page" border="0"
-            height="52" width="52"></a>
-        <font size="-2">To COBOL Exercises</font>
-      </td>
-    </tr>
-  </table>
-</body>
-
+		<hr />
+		<table cellspacing="0" cellpadding="0" cols="1" width="200">
+			<tr align="CENTER" valign="TOP">
+				<td>
+					<a href="index.html"
+						><img
+							src="../pics/B-BackArrow.gif"
+							alt="Back to COBOL Exercises page"
+							border="0"
+							height="52"
+							width="52"
+					/></a>
+					<font size="-2">To COBOL Exercises</font>
+				</td>
+			</tr>
+		</table>
+	</body>
 </html>

--- a/exercises/MonthTable.html
+++ b/exercises/MonthTable.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 	<title>Using Tables</title>

--- a/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html
+++ b/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 	<link href="CSISEvalForm_files/editdata.mso" rel="Edit-Time-Data" />

--- a/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html
+++ b/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 	<link href="CSISEvalForm_files/editdata.mso" rel="Edit-Time-Data" />

--- a/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html
+++ b/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 	<link href="CSISEvalForm_files/editdata.mso" rel="Edit-Time-Data" />

--- a/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html
+++ b/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 	<link href="CSISEvalForm_files/editdata.mso" rel="Edit-Time-Data" />

--- a/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html
+++ b/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 	<link href="CSISEvalForm_files/editdata.mso" rel="Edit-Time-Data" />

--- a/exercises/Proj-CSISEvalform/CSISEvalForm.html
+++ b/exercises/Proj-CSISEvalform/CSISEvalForm.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 	<link href="CSISEvalForm_files/editdata.mso" rel="Edit-Time-Data" />
@@ -504,8 +505,7 @@
 					<pre><font color="#000000"><b>XXXXXXXXXXXXXXXXXXXX  XX,XXX  XXXXXXXXXXXXXXXXXXXXXXX           XXXXXXXXX</b></font></pre>
 					<pre><font color="#000000"><b>XXXXXXXXXXXXXXXXXXXX  XX,XXX  XXXXXXXXXXXXXXXXXXXXXXX           XXXXXXXXX</b></font></pre>
 					<pre><font color="#000000"><b>XXXXXXXXXXXXXXXXXXXX  XX,XXX  XXXXXXXXXXXXXXXXXXXXXXX           XXXXXXXXX</b></font></pre>
-					<pre><font color="#000000"><b><span style='font-size:10.0pt;font-family:"Courier New";
-"Times New Roman"'>-----------------------------------------------------------------</span></b></font></pre>
+					<pre><font color="#000000"><b><span style="font-size:10.0pt;font-family:&quot;Courier New&quot;,&quot;Times New Roman&quot;">-----------------------------------------------------------------</span></b></font></pre>
 					<pre><font color="#000000"><b>Total Visitors           -      XXX,XXX    </b></font></pre>
 					<pre><font color="#000000"><b>Overall Evaluation  - XXXXXXXXX</b></font></pre>
 					<hr />

--- a/exercises/SeqInsert.html
+++ b/exercises/SeqInsert.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/exercises/SeqRead.html
+++ b/exercises/SeqRead.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/exercises/SeqReadIf.html
+++ b/exercises/SeqReadIf.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/exercises/SeqUpdate.html
+++ b/exercises/SeqUpdate.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/exercises/SeqWrite.html
+++ b/exercises/SeqWrite.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/exercises/SortIP.html
+++ b/exercises/SortIP.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/exercises/index.html
+++ b/exercises/index.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<title>COBOL Programming Exercises</title>
 	<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />

--- a/faq/COBOLFAQ.html
+++ b/faq/COBOLFAQ.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html
 	xmlns="http://www.w3.org/TR/REC-html40"
 	xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
@@ -1573,8 +1574,7 @@
 						>ppendix C.7 - Changes to create Version
 						<span style="mso-bookmark: _Hlt451587931">3.03)</span></b
 					><span style="mso-bookmark: _Hlt451587931"></span></a
-				><?if !supportNestedAnchors?><a name="_Hlt451587931"></a
-				><?endif?><span style="mso-bookmark: _Hlt451587931"></span>
+				><a name="_Hlt451587931"></a><span style="mso-bookmark: _Hlt451587931"></span>
 			</p>
 			<span style="mso-bookmark: _Hlt451587931"></span>
 			<p align="left" class="MsoNormal" style="margin-top: 0in; text-align: left">
@@ -1618,8 +1618,7 @@
 			<p class="MsoNormal">
 				<a href="#Section4"
 					>4. Is there a free COBOL comp<span style="mso-bookmark: _Hlt461829002">i</span>ler? </a
-				><?if !supportNestedAnchors?><a name="_Hlt461829002"></a
-				><?endif?>
+				><a name="_Hlt461829002"></a>
 			</p>
 			<p class="MsoNormal" style="margin-left: 0.5in">
 				<a href="#Section41">4.1 for DOS, Windows or OS/2? </a>
@@ -1666,8 +1665,7 @@
 			</p>
 			<p class="MsoNormal" style="margin-left: 0.5in">
 				<a href="#com_fujitsu">5.4 Fujit<span style="mso-bookmark: _Hlt461968202">s</span>u Software</a
-				><?if !supportNestedAnchors?><a name="_Hlt461968202"></a
-				><?endif?>
+				><a name="_Hlt461968202"></a>
 			</p>
 			<p class="MsoNormal" style="margin-left: 0.5in; text-indent: 0.5in">
 				<span class="MsoHyperlink"><a href="#Fujitsu_Workstation">5.4.1 Fujitsu (WinTel)</a><o:p></o:p></span>
@@ -1686,8 +1684,7 @@
 			</p>
 			<p class="MsoNormal" style="margin-left: 0.5in">
 				<a href="#IBM_products">5.5 IBM Corporati<span style="mso-bookmark: _Hlt461830098">o</span>n</a
-				><?if !supportNestedAnchors?><a name="_Hlt461830098"></a
-				><?endif?><span class="MsoHyperlink"><o:p></o:p></span>
+				><a name="_Hlt461830098"></a><span class="MsoHyperlink"><o:p></o:p></span>
 			</p>
 			<p class="MsoNormal" style="margin-left: 0.5in">
 				<span class="MsoHyperlink"><a href="#Section57">5.6 LegacyJ Corporation</a><o:p></o:p></span>
@@ -1701,8 +1698,7 @@
 						style="mso-bookmark: _Hlt461824905"
 						>s</span
 					> </a
-				><?if !supportNestedAnchors?><a name="_Hlt461824905"></a><a name="_Hlt461827125"></a
-				><?endif?>
+				><a name="_Hlt461824905"></a><a name="_Hlt461827125"></a>
 			</p>
 			<p class="MsoNormal" style="margin-left: 0.5in">
 				<a href="#com_wang">5.10 Wang</a>
@@ -1726,8 +1722,7 @@
 			</p>
 			<p class="MsoNormal" style="margin-left: 0.5in">
 				<a href="#Section62">6.6 Lia<span style="mso-bookmark: _Hlt453659361">n</span>t? </a
-				><?if !supportNestedAnchors?><a name="_Hlt453659361"></a
-				><?endif?>
+				><a name="_Hlt453659361"></a>
 			</p>
 			<p class="MsoNormal" style="margin-left: 0.5in">
 				<a href="#where_merant">6.7 Micro Focus? </a>
@@ -1768,23 +1763,20 @@
 			</p>
 			<p class="MsoNormal" style="margin-left: 0.5in">
 				<a href="#section92">9.2 Micro<span style="mso-bookmark: _Hlt461968506"> </span>Focus</a
-				><?if !supportNestedAnchors?><a name="_Hlt461968506"></a
-				><?endif?>
+				><a name="_Hlt461968506"></a>
 			</p>
 			<p class="MsoNormal" style="margin-left: 0.5in">
 				<a href="#section93"
 					>9.3 IB<span style="mso-bookmark: _Hlt461968022">M</span
 					><span style="mso-bookmark: _Hlt461968022"></span></a
-				><?if !supportNestedAnchors?><a name="_Hlt461968022"></a
-				><?endif?>
+				><a name="_Hlt461968022"></a>
 			</p>
 			<p class="MsoNormal" style="margin-left: 0.5in">
 				<a href="#OO_Fuj"
 					>9.4 Fujit<span style="mso-bookmark: _Hlt461968140">s</span
 					><span style="mso-bookmark: _Hlt461968241">u</span
 					><span style="mso-bookmark: _Hlt461968241"></span></a
-				><?if !supportNestedAnchors?><a name="_Hlt461968241"></a><a name="_Hlt461968140"></a
-				><?endif?><span class="MsoHyperlink"><o:p></o:p></span>
+				><a name="_Hlt461968241"></a><a name="_Hlt461968140"></a><span class="MsoHyperlink"><o:p></o:p></span>
 			</p>
 			<p class="MsoNormal" style="margin-left: 0.5in">
 				<a href="#sec94">9.5 Others</a>
@@ -1798,8 +1790,7 @@
 						style="mso-bookmark: _Hlt451936403"
 						>m</span
 					>ies</a
-				><?if !supportNestedAnchors?><a name="_Hlt451936403"></a><a name="_Hlt451936836"></a
-				><?endif?>
+				><a name="_Hlt451936403"></a><a name="_Hlt451936836"></a>
 			</p>
 			<p class="MsoNormal" style="margin-left: 0.5in">
 				<span class="MsoHyperlink"
@@ -1808,9 +1799,7 @@
 							style="mso-bookmark: _Hlt451937387"
 							>i</span
 						>on</a
-					><?if !supportNestedAnchors?><a name="_Hlt451937387"></a
-					><?endif?><o:p
-					></o:p
+					><a name="_Hlt451937387"></a><o:p></o:p
 				></span>
 			</p>
 			<p class="MsoNormal" style="margin-left: 0.5in">
@@ -1822,8 +1811,7 @@
 			<p class="MsoNormal" style="margin-left: 0.5in">
 				<a href="#Books_21_days"
 					>10.22 Sams Teac<span style="mso-bookmark: _Hlt451885292">h</span> Yourself COBOL in 21 Days</a
-				><?if !supportNestedAnchors?><a name="_Hlt451885292"></a
-				><?endif?>
+				><a name="_Hlt451885292"></a>
 			</p>
 			<p class="MsoNormal" style="margin-left: 0.5in">
 				<span class="MsoHyperlink"
@@ -2024,8 +2012,8 @@
 				<a href="#Usages"
 					>19. What about USAGE? COMP? Storage for data i<span style="mso-bookmark: _Hlt461998389">n</span>
 					xyz format? etc?<span style="mso-bookmark: _Hlt461969001"></span></a
-				><?if !supportNestedAnchors?><a name="_Hlt461969001"></a><a name="_Hlt461998389"></a
-				><?endif?><a name="_Hlt462028006"></a><span class="MsoHyperlink"><o:p></o:p></span>
+				><a name="_Hlt461969001"></a><a name="_Hlt461998389"></a><a name="_Hlt462028006"></a
+				><span class="MsoHyperlink"><o:p></o:p></span>
 			</p>
 			<p class="MsoNormal">
 				<u
@@ -2064,8 +2052,7 @@
 				<a href="#App_Samples"
 					>Appendix A - Samples and Examples of COBOL Codin<span style="mso-bookmark: _Hlt462028595">g</span>
 					techniq<span style="mso-bookmark: _Hlt462027969"></span>ues</a
-				><?if !supportNestedAnchors?><a name="_Hlt462027969"></a><a name="_Hlt462028595"></a
-				><?endif?><span class="MsoHyperlink"><o:p></o:p></span>
+				><a name="_Hlt462027969"></a><a name="_Hlt462028595"></a><span class="MsoHyperlink"><o:p></o:p></span>
 			</p>
 			<p class="MsoNormal" style="margin-left: 0.5in">
 				<span style="mso-spacerun: yes"></span
@@ -2075,9 +2062,8 @@
 						>g</span
 					><span style="mso-bookmark: _Hlt461996460">i</span>t
 					<span style="mso-bookmark: _Hlt461972665">y</span>ear</a
-				><?if !supportNestedAnchors?><a name="_Hlt461972665"></a><a name="_Hlt461996460"></a
-				><a name="_Hlt461996376"></a><a name="_Hlt462027946"></a
-				><?endif?>
+				><a name="_Hlt461972665"></a><a name="_Hlt461996460"></a><a name="_Hlt461996376"></a
+				><a name="_Hlt462027946"></a>
 			</p>
 			<p class="MsoNormal" style="margin-left: 0.5in">
 				<a href="#Sample_date_compare"
@@ -2085,8 +2071,7 @@
 						style="mso-bookmark: _Hlt461973730"
 						>o</span
 					>ns</a
-				><?if !supportNestedAnchors?><a name="_Hlt461973730"></a><a name="_Hlt461972823"></a
-				><?endif?>
+				><a name="_Hlt461973730"></a><a name="_Hlt461972823"></a>
 			</p>
 			<p class="MsoNormal" style="margin-left: 0.5in">
 				<a href="#Sample_os390">Appendix A.3 - MVS (or OS/390) Control Blocks</a
@@ -2098,18 +2083,16 @@
 						style="mso-bookmark: _Hlt461991199"
 						>a</span
 					>numeric field<span style="mso-bookmark: _Hlt462221232"></span></a
-				><?if !supportNestedAnchors?><a name="_Hlt462221232"></a><a name="_Hlt461991199"></a
-				><a name="_Hlt462221383"></a
-				><?endif?><span class="MsoHyperlink"><o:p></o:p></span>
+				><a name="_Hlt462221232"></a><a name="_Hlt461991199"></a><a name="_Hlt462221383"></a
+				><span class="MsoHyperlink"><o:p></o:p></span>
 			</p>
 			<p class="MsoNormal" style="margin-left: 0.5in">
 				<a href="#Sampe_digit_to_words"
 					>Appendix A.5 - Ho<span style="mso-bookmark: _Hlt462396632">w</span>
 					<span style="mso-bookmark: _Hlt462396603">c</span>an you
 					<span style="mso-bookmark: _Hlt462221392">c</span>onvert a number to words</a
-				><?if !supportNestedAnchors?><a name="_Hlt462221392"></a><a name="_Hlt462396603"></a
-				><a name="_Hlt462396632"></a
-				><?endif?><span class="MsoHyperlink"><o:p></o:p></span>
+				><a name="_Hlt462221392"></a><a name="_Hlt462396603"></a><a name="_Hlt462396632"></a
+				><span class="MsoHyperlink"><o:p></o:p></span>
 			</p>
 			<p class="MsoNormal">
 				<a href="#App_MiscWeb">Appendix B Miscellaneous COBOL related web pages</a>
@@ -2122,9 +2105,8 @@
 					>
 					</span
 					>recent revisions<span style="mso-bookmark: _Hlt462396505"></span></a
-				><?if !supportNestedAnchors?><a name="_Hlt462396505"></a><a name="_Hlt462396608"></a
-				><a name="_Hlt462396636"></a
-				><?endif?><span class="MsoHyperlink"><o:p></o:p></span>
+				><a name="_Hlt462396505"></a><a name="_Hlt462396608"></a><a name="_Hlt462396636"></a
+				><span class="MsoHyperlink"><o:p></o:p></span>
 			</p>
 			<p class="MsoNormal" style="margin-left: 0.5in">
 				<a href="#AppA1"
@@ -2133,9 +2115,8 @@
 						>g</span
 					>es <span style="mso-bookmark: _Hlt462221312">t</span>o
 					<span style="mso-bookmark: _Hlt462396613">c</span>reate Version 2.0</a
-				><?if !supportNestedAnchors?><a name="_Hlt462396613"></a><a name="_Hlt462221312"></a
-				><a name="_Hlt461973768"></a><a name="_Hlt462396640"></a
-				><?endif?>
+				><a name="_Hlt462396613"></a><a name="_Hlt462221312"></a><a name="_Hlt461973768"></a
+				><a name="_Hlt462396640"></a>
 			</p>
 			<p class="MsoNormal" style="margin-left: 0.5in">
 				<a href="#AppA2">Appendix C.2 - Changes to create Version 2.05 </a>
@@ -2496,10 +2477,9 @@
 						style="mso-bookmark: _Hlt461828094"
 					></span
 					>L-GT</a
-				><?if !supportNestedAnchors?><a name="_Hlt461828094"></a><a name="_Hlt461828120"></a
-				><?endif?>. Available for the Windows 95 and Windows NT operating systems, AcuBench contains a set of
-				graphically based, GT-optimized development tools, including a Project Manager, WYSIWYG Screen Painter,
-				and language sensitive source Code Editor.
+				><a name="_Hlt461828094"></a><a name="_Hlt461828120"></a>. Available for the Windows 95 and Windows NT
+				operating systems, AcuBench contains a set of graphically based, GT-optimized development tools,
+				including a Project Manager, WYSIWYG Screen Painter, and language sensitive source Code Editor.
 			</p>
 			<p class="H4"><a name="com_compaq">5.2 Compaq COBOL </a></p>
 			<p class="H5">
@@ -2737,8 +2717,7 @@
 				<a href="http://www.adtools.com/products/windows/pgemplus.htm"
 					>http://www.adtools.com/products/windows/pgemplu<span style="mso-bookmark: Fujitsu_Siemens"></span
 					>s.htm</a
-				><?if !supportNestedAnchors?><a name="Fujitsu_Siemens"></a
-				><?endif?>)
+				><a name="Fujitsu_Siemens"></a>)
 			</p>
 			<p class="MsoNormal">
 				PowerGEM Plus is a graphical library system that allows you to maintain control of distributed
@@ -2832,8 +2811,8 @@
 							>bol</span
 						></span
 					><span style="mso-bookmark: LegacyJ_PERCobol"></span></a
-				><?if !supportNestedAnchors?><a name="_Hlt451887704"></a><a name="_Hlt451888005"></a
-				><?endif?><span style="mso-bookmark: LegacyJ_PERCobol"></span>
+				><a name="_Hlt451887704"></a><a name="_Hlt451888005"></a
+				><span style="mso-bookmark: LegacyJ_PERCobol"></span>
 			</p>
 			<span style="mso-bookmark: LegacyJ_PERCobol"></span>
 			<p class="MsoNormal">
@@ -3025,12 +3004,12 @@
 					tab-stops: list 58.5pt 1.25in;
 				"
 			>
-				<?if !supportLists?><span
+				<span
 					style="font-family: Wingdings; mso-fareast-font-family: Wingdings; mso-bidi-font-family: Wingdings"
 					><span style="mso-list: Ignore"
 						><span style="font: 7pt &quot;Times New Roman&quot;">          </span></span
 					></span
-				><?endif?>COBOL access to industry standard Object Request Broker (ORB) technology
+				>COBOL access to industry standard Object Request Broker (ORB) technology
 			</p>
 			<p
 				class="MsoNormal"
@@ -3045,12 +3024,12 @@
 					tab-stops: list 58.5pt 1.25in;
 				"
 			>
-				<?if !supportLists?><span
+				<span
 					style="font-family: Wingdings; mso-fareast-font-family: Wingdings; mso-bidi-font-family: Wingdings"
 					><span style="mso-list: Ignore"
 						><span style="font: 7pt &quot;Times New Roman&quot;">          </span></span
 					></span
-				><?endif?>A flexible, cross-platform COBOL compiler
+				>A flexible, cross-platform COBOL compiler
 			</p>
 			<p
 				class="MsoNormal"
@@ -3065,12 +3044,12 @@
 					tab-stops: list 58.5pt 1.25in;
 				"
 			>
-				<?if !supportLists?><span
+				<span
 					style="font-family: Wingdings; mso-fareast-font-family: Wingdings; mso-bidi-font-family: Wingdings"
 					><span style="mso-list: Ignore"
 						><span style="font: 7pt &quot;Times New Roman&quot;">          </span></span
 					></span
-				><?endif?>Powerful programmer productivity tools
+				>Powerful programmer productivity tools
 			</p>
 			<p
 				class="MsoNormal"
@@ -3085,12 +3064,12 @@
 					tab-stops: list 58.5pt 1.25in;
 				"
 			>
-				<?if !supportLists?><span
+				<span
 					style="font-family: Wingdings; mso-fareast-font-family: Wingdings; mso-bidi-font-family: Wingdings"
 					><span style="mso-list: Ignore"
 						><span style="font: 7pt &quot;Times New Roman&quot;">          </span></span
 					></span
-				><?endif?>Object COBOL class libraries
+				>Object COBOL class libraries
 			</p>
 			<p
 				class="MsoNormal"
@@ -3105,12 +3084,12 @@
 					tab-stops: list 58.5pt 1.25in;
 				"
 			>
-				<?if !supportLists?><span
+				<span
 					style="font-family: Wingdings; mso-fareast-font-family: Wingdings; mso-bidi-font-family: Wingdings"
 					><span style="mso-list: Ignore"
 						><span style="font: 7pt &quot;Times New Roman&quot;">          </span></span
 					></span
-				><?endif?>Transparent support for large files
+				>Transparent support for large files
 			</p>
 			<p
 				class="MsoNormal"
@@ -3125,12 +3104,12 @@
 					tab-stops: list 58.5pt 1.25in;
 				"
 			>
-				<?if !supportLists?><span
+				<span
 					style="font-family: Wingdings; mso-fareast-font-family: Wingdings; mso-bidi-font-family: Wingdings"
 					><span style="mso-list: Ignore"
 						><span style="font: 7pt &quot;Times New Roman&quot;">          </span></span
 					></span
-				><?endif?>DBCS application support
+				>DBCS application support
 			</p>
 			<p
 				class="MsoNormal"
@@ -3145,12 +3124,12 @@
 					tab-stops: list 58.5pt 1.25in;
 				"
 			>
-				<?if !supportLists?><span
+				<span
 					style="font-family: Wingdings; mso-fareast-font-family: Wingdings; mso-bidi-font-family: Wingdings"
 					><span style="mso-list: Ignore"
 						><span style="font: 7pt &quot;Times New Roman&quot;">          </span></span
 					></span
-				><?endif?>User interface development tools
+				>User interface development tools
 			</p>
 			<p
 				class="MsoNormal"
@@ -3165,12 +3144,12 @@
 					tab-stops: list 58.5pt 1.25in;
 				"
 			>
-				<?if !supportLists?><span
+				<span
 					style="font-family: Wingdings; mso-fareast-font-family: Wingdings; mso-bidi-font-family: Wingdings"
 					><span style="mso-list: Ignore"
 						><span style="font: 7pt &quot;Times New Roman&quot;">          </span></span
 					></span
-				><?endif?>Ability to execute Web server applications created using Micro Focus Micro Focus Net Express
+				>Ability to execute Web server applications created using Micro Focus Micro Focus Net Express
 			</p>
 			<p
 				class="MsoNormal"
@@ -3185,12 +3164,12 @@
 					tab-stops: list 58.5pt 1.25in;
 				"
 			>
-				<?if !supportLists?><span
+				<span
 					style="font-family: Wingdings; mso-fareast-font-family: Wingdings; mso-bidi-font-family: Wingdings"
 					><span style="mso-list: Ignore"
 						><span style="font: 7pt &quot;Times New Roman&quot;">          </span></span
 					></span
-				><?endif?>Run-time facilities that simplify application deployment
+				>Run-time facilities that simplify application deployment
 			</p>
 			<p class="H5">5.8.3 Micro Focus<sup></sup> Server Express</p>
 			<p class="MsoNormal">
@@ -3244,12 +3223,11 @@
 				"
 			>
 				<a name="Section55"
-					><?if !supportLists?><span
-						style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+					><span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 						><span style="mso-list: Ignore"
 							><span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 						></span
-					><?endif?></a
+					></a
 				><a href="http://www.microfocus.com/academic/ps003.asp?bhcp=1"
 					><span style="mso-bookmark: Section55"
 						><b style="mso-bidi-font-weight: normal">Net Express University Edition V3.0</b></span
@@ -3277,12 +3255,11 @@
 				"
 			>
 				<span style="mso-bookmark: Section55"
-					><?if !supportLists?><span
-						style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+					><span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 						><span style="mso-list: Ignore"
 							><span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 						></span
-					><?endif?></span
+					></span
 				><a href="http://www.microfocus.com/academic/ps001.asp?bhcp=1"
 					><span style="mso-bookmark: Section55"
 						><b style="mso-bidi-font-weight: normal">Personal COBOL for Windows 3.1 V1.1</b></span
@@ -3309,12 +3286,11 @@
 				"
 			>
 				<span style="mso-bookmark: Section55"
-					><?if !supportLists?><span
-						style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+					><span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 						><span style="mso-list: Ignore"
 							><span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 						></span
-					><?endif?></span
+					></span
 				><a href="http://www.microfocus.com/academic/ps002.asp?bhcp=1"
 					><span style="mso-bookmark: Section55"
 						><b style="mso-bidi-font-weight: normal">Personal COBOL for DOS V2.0</b></span
@@ -3455,7 +3431,7 @@
 						fillcolor="window"
 					>
 						<v:imagedata src="images/acucorp-logo.gif" /> </v:shape><!
-				[endif]--><?if !vml?><span
+				[endif]--><span
 					style="
 						mso-ignore: vglayout;
 						position: absolute;
@@ -3471,7 +3447,7 @@
 						src="https://web.archive.org/web/20070522181935im_/http://www.acucorp.com/images/logo.gif"
 						v:shapes="_x0000_s1040"
 						width="179" /></span
-				><?endif?><a name="Section61"></a>6.1 Acucorp?
+				><a name="Section61"></a>6.1 Acucorp?
 			</p>
 			<form>
 				<p align="left" class="Address" style="margin-bottom: 5pt; text-align: left">
@@ -4316,9 +4292,9 @@
 							tab-stops: list 0.5in;
 						"
 					>
-						<?if !supportLists?><span style="mso-list: Ignore"
+						<span style="mso-list: Ignore"
 							>1.<span style="font: 7pt &quot;Times New Roman&quot;">      </span></span
-						><?endif?>Major features/enhancements:
+						>Major features/enhancements:
 					</p>
 					<p
 						class="MsoNormal"
@@ -4330,9 +4306,9 @@
 							tab-stops: list 1in;
 						"
 					>
-						<?if !supportLists?><span style="mso-list: Ignore"
+						<span style="mso-list: Ignore"
 							>A.<span style="font: 7pt &quot;Times New Roman&quot;">     </span></span
-						><?endif?>OO gets all the press
+						>OO gets all the press
 					</p>
 					<p
 						class="MsoNormal"
@@ -4344,12 +4320,12 @@
 							tab-stops: list 1in;
 						"
 					>
-						<?if !supportLists?><span style="mso-list: Ignore"
+						<span style="mso-list: Ignore"
 							>B.<span style="font: 7pt &quot;Times New Roman&quot;">     </span></span
-						><?endif?>Common exception handling, C-ification (pointers, call prototypes, typedefs, and
-						everything else needed to use C-type APIs), user-defined functions, file-sharing/record-locking,
-						31-digit numbers, portable arithmetic, National character handling (MOCS or DBCS but more so),
-						are all some of the "biggies" that some people are looking for.
+						>Common exception handling, C-ification (pointers, call prototypes, typedefs, and everything
+						else needed to use C-type APIs), user-defined functions, file-sharing/record-locking, 31-digit
+						numbers, portable arithmetic, National character handling (MOCS or DBCS but more so), are all
+						some of the "biggies" that some people are looking for.
 					</p>
 					<p
 						class="MsoNormal"
@@ -4361,22 +4337,22 @@
 							tab-stops: list 1in;
 						"
 					>
-						<?if !supportLists?><span style="mso-list: Ignore"
+						<span style="mso-list: Ignore"
 							>C.<span style="font: 7pt &quot;Times New Roman&quot;">     </span></span
-						><?endif?>In the category of "old technology" getting a new face lift and being added to the
-						Standard (as required) see Report Writer enhancements, VALIDATE feature, and character screen
-						I/O support via ACCEPT/DISPLAY.
+						>In the category of "old technology" getting a new face lift and being added to the Standard (as
+						required) see Report Writer enhancements, VALIDATE feature, and character screen I/O support via
+						ACCEPT/DISPLAY.
 					</p>
 					<p
 						class="MsoNormal"
 						style="margin-left: 0.5in; text-indent: -0.25in; mso-outline-level: 2; mso-list: l2 level1 lfo5"
 					>
-						<?if !supportLists?><span style="mso-list: Ignore"
+						<span style="mso-list: Ignore"
 							>2.<span style="font: 7pt &quot;Times New Roman&quot;">      </span></span
-						><?endif?>Little things (and there are too many for me to remember off the top of my head)
-						include everything from dynamic file assignment (in the SELECT/ASSIGN statement), assigning
-						multiple values via the VALUE statement in tables, sorting tables, hex literals, GOBACK verb,
-						apostrophe as quote, bits and Boolean support,
+						>Little things (and there are too many for me to remember off the top of my head) include
+						everything from dynamic file assignment (in the SELECT/ASSIGN statement), assigning multiple
+						values via the VALUE statement in tables, sorting tables, hex literals, GOBACK verb, apostrophe
+						as quote, bits and Boolean support,
 					</p>
 					<p class="MsoNormal" style="margin-left: 1in">and LOTS more</p>
 					<h3><a name="Section8">8. COBOL 6.50</a></h3>
@@ -4404,9 +4380,9 @@
 							tab-stops: list 0.5in;
 						"
 					>
-						<?if !supportLists?><span style="mso-list: Ignore"
+						<span style="mso-list: Ignore"
 							>1)<span style="font: 7pt &quot;Times New Roman&quot;">     </span></span
-						><?endif?>Add C:\COBOL650 to the PATH
+						>Add C:\COBOL650 to the PATH
 					</p>
 					<p
 						class="MsoNormal"
@@ -4418,9 +4394,9 @@
 							tab-stops: list 0.5in;
 						"
 					>
-						<?if !supportLists?><span style="mso-list: Ignore"
+						<span style="mso-list: Ignore"
 							>2)<span style="font: 7pt &quot;Times New Roman&quot;">     </span></span
-						><?endif?>Run APPEND on C:\COBOL650 :
+						>Run APPEND on C:\COBOL650 :
 					</p>
 					<p class="MsoNormal" style="margin-left: 1in; mso-outline-level: 1; tab-stops: list 0.5in">
 						APPEND C:\COBOL650
@@ -4435,10 +4411,10 @@
 							tab-stops: list 0.5in;
 						"
 					>
-						<?if !supportLists?><span style="mso-list: Ignore"
+						<span style="mso-list: Ignore"
 							>3)<span style="font: 7pt &quot;Times New Roman&quot;">     </span></span
-						><?endif?>The install.doc contained in cobol650.zip refers to a program DPATH.COM to be run
-						instead of APPEND. The DOS program APPEND seems to work too.
+						>The install.doc contained in cobol650.zip refers to a program DPATH.COM to be run instead of
+						APPEND. The DOS program APPEND seems to work too.
 					</p>
 					<p
 						class="MsoNormal"
@@ -4450,9 +4426,9 @@
 							tab-stops: list 0.5in;
 						"
 					>
-						<?if !supportLists?><span style="mso-list: Ignore"
+						<span style="mso-list: Ignore"
 							>4)<span style="font: 7pt &quot;Times New Roman&quot;">     </span></span
-						><?endif?>Now you can compile your .cob files as explained in install.doc.
+						>Now you can compile your .cob files as explained in install.doc.
 					</p>
 					<p class="MsoNormal">
 						When trying to compile sources in a directory other than that where the compiler is installed,
@@ -5340,20 +5316,18 @@
 						></span>
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								><span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>max. 800 lines of code<span style="font-size: 14pt; mso-bidi-font-size: 10pt"> </span>
+						>max. 800 lines of code<span style="font-size: 14pt; mso-bidi-font-size: 10pt"> </span>
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								><span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?><span
+						><span
 							style="
 								font-family: &quot;Courier New&quot;;
 								mso-bidi-font-family: &quot;Times New Roman&quot;;
@@ -5362,12 +5336,11 @@
 						></span>
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								><span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?><span
+						><span
 							style="
 								font-family: &quot;Courier New&quot;;
 								mso-bidi-font-family: &quot;Times New Roman&quot;;
@@ -5391,12 +5364,11 @@
 						></span>
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								><span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?><span
+						><span
 							style="
 								font-family: &quot;Courier New&quot;;
 								mso-bidi-font-family: &quot;Times New Roman&quot;;
@@ -6077,8 +6049,7 @@
 									>BlueJ</span
 								></span
 							><span style="mso-bookmark: GUI_BlueJ"></span></a
-						><?if !supportNestedAnchors?><a name="GUI_BlueJ"></a
-						><?endif?>
+						><a name="GUI_BlueJ"></a>
 					</p>
 					<p class="MsoNormal">NOTE:</p>
 					<p class="MsoNormal">
@@ -7040,7 +7011,7 @@
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
 						<span style="mso-bookmark: Tools_Xinotech"
-							><?if !supportLists?><span
+							><span
 								style="
 									font-family: Symbol;
 									mso-fareast-font-family: Symbol;
@@ -7049,13 +7020,13 @@
 								><span style="mso-list: Ignore"
 									>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 								></span
-							><?endif?>High quality COBOL Parser that parses 12 most popular COBOL dialects and that has
+							>High quality COBOL Parser that parses 12 most popular COBOL dialects and that has
 							tremendous error recovery capability.</span
 						>
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
 						<span style="mso-bookmark: Tools_Xinotech"
-							><?if !supportLists?><span
+							><span
 								style="
 									font-family: Symbol;
 									mso-fareast-font-family: Symbol;
@@ -7064,14 +7035,14 @@
 								><span style="mso-list: Ignore"
 									>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 								></span
-							><?endif?>C++ library that client uses to browse and transform the tree-based Internal
-							Representation of COBOL programs. Definition-Use links attached to the Program Tree
-							effectively make it a general case Graph.</span
+							>C++ library that client uses to browse and transform the tree-based Internal Representation
+							of COBOL programs. Definition-Use links attached to the Program Tree effectively make it a
+							general case Graph.</span
 						>
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
 						<span style="mso-bookmark: Tools_Xinotech"
-							><?if !supportLists?><span
+							><span
 								style="
 									font-family: Symbol;
 									mso-fareast-font-family: Symbol;
@@ -7080,8 +7051,8 @@
 								><span style="mso-list: Ignore"
 									>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 								></span
-							><?endif?>PrettyPrinter that transforms our Internal Representation back into beautifully
-							indented human-readable COBOL program.</span
+							>PrettyPrinter that transforms our Internal Representation back into beautifully indented
+							human-readable COBOL program.</span
 						>
 					</p>
 					<p class="H6">
@@ -7104,9 +7075,9 @@
 						"
 					>
 						<span style="mso-bookmark: Tools_Xinotech"
-							><?if !supportLists?><span style="mso-list: Ignore"
+							><span style="mso-list: Ignore"
 								>a.<span style="font: 7pt &quot;Times New Roman&quot;">       </span></span
-							><?endif?>Beautifully indents your COBOL program.</span
+							>Beautifully indents your COBOL program.</span
 						>
 					</p>
 					<p
@@ -7120,9 +7091,9 @@
 						"
 					>
 						<span style="mso-bookmark: Tools_Xinotech"
-							><?if !supportLists?><span style="mso-list: Ignore"
+							><span style="mso-list: Ignore"
 								>b.<span style="font: 7pt &quot;Times New Roman&quot;">      </span></span
-							><?endif?>Renumbers paragraph-names, section-names, data-names</span
+							>Renumbers paragraph-names, section-names, data-names</span
 						>
 					</p>
 					<p
@@ -7136,9 +7107,9 @@
 						"
 					>
 						<span style="mso-bookmark: Tools_Xinotech"
-							><?if !supportLists?><span style="mso-list: Ignore"
+							><span style="mso-list: Ignore"
 								>c.<span style="font: 7pt &quot;Times New Roman&quot;">      </span></span
-							><?endif?>attach an increasing or decreasing prefix or suffix to all paragraph-names and/or
+							>attach an increasing or decreasing prefix or suffix to all paragraph-names and/or
 							section-names and/or data-names in your COBOL program. (Based on CobolTransformer.)</span
 						>
 					</p>
@@ -8223,21 +8194,19 @@
 					</p>
 					<span style="mso-bookmark: Section17"></span>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Yes, the year 2000 <b style="mso-bidi-font-weight: normal"><u>IS</u></b> a leap year
+						>Yes, the year 2000 <b style="mso-bidi-font-weight: normal"><u>IS</u></b> a leap year
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Yes, the millennium really starts on January 1, 2001 - but the software "bug" refers
-						to January 1, 2000 (and several other dates)
+						>Yes, the millennium really starts on January 1, 2001 - but the software "bug" refers to January
+						1, 2000 (and several other dates)
 					</p>
 					<p class="H4">
 						<a name="Section171">17.1 Where can I get information about the Y2K problem?</a>
@@ -8336,33 +8305,30 @@
 						both your viewing and postings at these sites.
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Comp.lang.cobol is the preferred site to use - especially for technical issues related
-						to COBOL.
+						>Comp.lang.cobol is the preferred site to use - especially for technical issues related to
+						COBOL.
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Although threads do stray from the topics, the more targeted your inquiry is - and the
-						more closely it relates to COBOL, the more likely you are to receive a useful and prompt
-						response. (If you know that you are leaving the current subject, consider changing the subject
-						line in your post.)
+						>Although threads do stray from the topics, the more targeted your inquiry is - and the more
+						closely it relates to COBOL, the more likely you are to receive a useful and prompt response.
+						(If you know that you are leaving the current subject, consider changing the subject line in
+						your post.)
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>When asking about a specific structure, error message, or situation, it is always best
-						to specify both the compiler that you are using and the operating system where you are working.
+						>When asking about a specific structure, error message, or situation, it is always best to
+						specify both the compiler that you are using and the operating system where you are working.
 						(What you may think is a general COBOL question may actually be very specific to your current
 						environment.)
 					</p>
@@ -8390,36 +8356,33 @@
 						include:
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Make it clear from the beginning that you are asking for homework help. (Most of the
-						newsgroup participants are very good at sniffing out those who try and pose homework questions
-						as "business need" questions - and they are not very polite in replying to such questions).
+						>Make it clear from the beginning that you are asking for homework help. (Most of the newsgroup
+						participants are very good at sniffing out those who try and pose homework questions as
+						"business need" questions - and they are not very polite in replying to such questions).
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Make certain that you specify what compiler and operating system your homework is
-						targeted at. Solutions may vary significantly based on this. (You might also want to include
-						what text book you are using.)
+						>Make certain that you specify what compiler and operating system your homework is targeted at.
+						Solutions may vary significantly based on this. (You might also want to include what text book
+						you are using.)
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>The more information that you can give that demonstrates that you really have tried to
-						solve the problem yourself (using your text book, class material/presentations, lab assistance,
-						etc), the more likely it is that you will get useful and friendly responses. If you let us know
-						what you have found on your own and why you are still uncertain or confused, you will usually
-						get helpful responses; if it looks like you are asking us questions without trying to solve it
+						>The more information that you can give that demonstrates that you really have tried to solve
+						the problem yourself (using your text book, class material/presentations, lab assistance, etc),
+						the more likely it is that you will get useful and friendly responses. If you let us know what
+						you have found on your own and why you are still uncertain or confused, you will usually get
+						helpful responses; if it looks like you are asking us questions without trying to solve it
 						yourself, you are likely to get very pointed replies.
 					</p>
 					<p class="MsoNormal">
@@ -8451,45 +8414,41 @@
 						newsgroup readers is:
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?><span style="mso-spacerun: yes"></span>that ALL such posts are "trolling" for resumes
-						or rates and not serious job searches.
+						><span style="mso-spacerun: yes"></span>that ALL such posts are "trolling" for resumes or rates
+						and not serious job searches.
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Try to give the best summary of job location and desired expertise in the subject line
-						of your posting. This will assist you in attracting readers that are actually potentially
-						interested in your openings.
+						>Try to give the best summary of job location and desired expertise in the subject line of your
+						posting. This will assist you in attracting readers that are actually potentially interested in
+						your openings.
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>The newsgroups are international in nature, but are dominated by Americans. If you are
-						posting a position outside the US, please make it clear whether foreigners are or are not
-						welcome to apply - and if so what visas and other paperwork is required If you are posting for a
-						job with specific citizenship requirements, please make that clear from the start.
+						>The newsgroups are international in nature, but are dominated by Americans. If you are posting
+						a position outside the US, please make it clear whether foreigners are or are not welcome to
+						apply - and if so what visas and other paperwork is required If you are posting for a job with
+						specific citizenship requirements, please make that clear from the start.
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>In general, the more information that you provide in your postings, the better the
-						match will be from those who reply. If, however, you are "attaching" a job description, please
-						make certain that you make it clear what type of document-reader is required to process it AND
-						make certain that you have virus scanned the document before you post it.
+						>In general, the more information that you provide in your postings, the better the match will
+						be from those who reply. If, however, you are "attaching" a job description, please make certain
+						that you make it clear what type of document-reader is required to process it AND make certain
+						that you have virus scanned the document before you post it.
 					</p>
 					<p class="MsoNormal">
 						<b style="mso-bidi-font-weight: normal">NOTE</b>: For those looking for jobs, you might want to
@@ -8529,12 +8488,11 @@
 							tab-stops: list 0.5in;
 						"
 					>
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Use the Standard-1 (or Standard-2) Collating Sequence
+						>Use the Standard-1 (or Standard-2) Collating Sequence
 					</p>
 					<p
 						align="left"
@@ -8547,12 +8505,11 @@
 							tab-stops: list 0.5in;
 						"
 					>
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Use the Standard-1 (or Standard-2) CODE-SET for input/output files
+						>Use the Standard-1 (or Standard-2) CODE-SET for input/output files
 					</p>
 					<p
 						align="left"
@@ -8565,12 +8522,11 @@
 							tab-stops: list 0.5in;
 						"
 					>
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Not rely on the order of keys of indexed files
+						>Not rely on the order of keys of indexed files
 					</p>
 					<p class="MsoNormal">
 						However, in most environments, you should be fairly safe in using the "native" coding system for
@@ -8588,13 +8544,11 @@
 							tab-stops: list 0.5in;
 						"
 					>
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Comparisons not working (are alphanumeric numbers "smaller" or "larger" than
-						"letters"?)
+						>Comparisons not working (are alphanumeric numbers "smaller" or "larger" than "letters"?)
 					</p>
 					<p
 						class="MsoNormal"
@@ -8605,12 +8559,11 @@
 							tab-stops: list 0.5in;
 						"
 					>
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>What order are indexed files stored in?
+						>What order are indexed files stored in?
 					</p>
 					<p
 						align="left"
@@ -8623,12 +8576,11 @@
 							tab-stops: list 0.5in;
 						"
 					>
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Remember that "true" ASCII (Standard-1) only includes 7-bit characters.<br />
+						>Remember that "true" ASCII (Standard-1) only includes 7-bit characters.<br />
 						(All the "extended" characters or the "top-half" of most common ASCII environments are NOT
 						standard and are not necessarily portable)
 					</p>
@@ -8684,12 +8636,11 @@
 							tab-stops: list 0.5in;
 						"
 					>
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>allow 1 byte binary fields (or may require half-word as the smallest storage)
+						>allow 1 byte binary fields (or may require half-word as the smallest storage)
 					</p>
 					<p
 						class="MsoNormal"
@@ -8700,12 +8651,11 @@
 							tab-stops: list 0.5in;
 						"
 					>
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>may use 1 or 2's complements for negative numbers
+						>may use 1 or 2's complements for negative numbers
 					</p>
 					<p
 						class="MsoNormal"
@@ -8716,12 +8666,11 @@
 							tab-stops: list 0.5in;
 						"
 					>
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>may be "big-endian" or "little-endian"
+						>may be "big-endian" or "little-endian"
 					</p>
 					<p class="MsoNormal">
 						All of these ARE hardware/operating system concepts, so you need to check your specific
@@ -8749,12 +8698,11 @@
 							tab-stops: list 0.5in;
 						"
 					>
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>USAGE BINARY (on IBM mainframes)
+						>USAGE BINARY (on IBM mainframes)
 					</p>
 					<p
 						class="MsoNormal"
@@ -8765,12 +8713,11 @@
 							tab-stops: list 0.5in;
 						"
 					>
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>USAGE PACKED-DECIMAL (on IBM COBOL/400)
+						>USAGE PACKED-DECIMAL (on IBM COBOL/400)
 					</p>
 					<p
 						class="MsoNormal"
@@ -8781,12 +8728,11 @@
 							tab-stops: list 0.5in;
 						"
 					>
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>USAGE DECIMAL (on ???)
+						>USAGE DECIMAL (on ???)
 					</p>
 					<p
 						class="MsoNormal"
@@ -8797,12 +8743,11 @@
 							tab-stops: list 0.5in;
 						"
 					>
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>USAGE COMP-5 (or COMP-X) (on some Unix or PC compilers)
+						>USAGE COMP-5 (or COMP-X) (on some Unix or PC compilers)
 					</p>
 					<p class="MsoNormal">
 						Without checking your compiler's documentation, you simply can<b
@@ -8828,12 +8773,11 @@
 							tab-stops: list 0.5in;
 						"
 					>
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>COMP-1 - Short Floating Point
+						>COMP-1 - Short Floating Point
 					</p>
 					<p
 						class="MsoNormal"
@@ -8844,12 +8788,11 @@
 							tab-stops: list 0.5in;
 						"
 					>
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>COMP-2 - Long Floating Point
+						>COMP-2 - Long Floating Point
 					</p>
 					<p
 						class="MsoNormal"
@@ -8860,12 +8803,11 @@
 							tab-stops: list 0.5in;
 						"
 					>
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>COMP-3 - Packed-Decimal
+						>COMP-3 - Packed-Decimal
 					</p>
 					<p
 						class="MsoNormal"
@@ -8876,12 +8818,11 @@
 							tab-stops: list 0.5in;
 						"
 					>
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>COMP-4 - Binary
+						>COMP-4 - Binary
 					</p>
 					<p class="MsoNormal">Other common USAGEs are:</p>
 					<p
@@ -8893,12 +8834,11 @@
 							tab-stops: list 0.5in;
 						"
 					>
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>COMP-5 - "native" binary
+						>COMP-5 - "native" binary
 					</p>
 					<p
 						class="MsoNormal"
@@ -8909,12 +8849,11 @@
 							tab-stops: list 0.5in;
 						"
 					>
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>COMP-X - "native" binary (allocated by bytes, not digits)
+						>COMP-X - "native" binary (allocated by bytes, not digits)
 					</p>
 					<p
 						class="MsoNormal"
@@ -8925,12 +8864,11 @@
 							tab-stops: list 0.5in;
 						"
 					>
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>COMP-6 - Packed-Decimal not requiring sign-nibbles.
+						>COMP-6 - Packed-Decimal not requiring sign-nibbles.
 					</p>
 					<p align="center" class="MsoNormal" style="text-align: center">
 						<br />
@@ -8962,12 +8900,11 @@
 							tab-stops: list 0.5in;
 						"
 					>
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>What compiler you are using What Operating System you are running on and
+						>What compiler you are using What Operating System you are running on and
 					</p>
 					<p
 						class="MsoNormal"
@@ -8978,12 +8915,11 @@
 							tab-stops: list 0.5in;
 						"
 					>
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Why you couldn't find the answer already in either google.COM or your documentation
+						>Why you couldn't find the answer already in either google.COM or your documentation
 					</p>
 					<p class="MsoNormal">
 						Given the answers to these 3 questions, you will probably get a quick and accurate answer -
@@ -10127,7 +10063,7 @@
 							tab-stops: list 0.75in;
 						"
 					>
-						<?if !supportLists?><span
+						<span
 							style="
 								font-family: Wingdings;
 								mso-fareast-font-family: Wingdings;
@@ -10136,7 +10072,7 @@
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?><a href="http://www.geocities.com/Eureka/2006/ring.htm"
+						><a href="http://www.geocities.com/Eureka/2006/ring.htm"
 							>http://www.geocities.com/Eureka/2006/ring.htm</a
 						>
 						(All Things COBOL Webring Page)
@@ -10150,7 +10086,7 @@
 							tab-stops: list 0.75in;
 						"
 					>
-						<?if !supportLists?><span
+						<span
 							style="
 								font-family: Wingdings;
 								mso-fareast-font-family: Wingdings;
@@ -10159,7 +10095,7 @@
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?><a href="http://www.jamesshuggins.com/h/tek1/cobol.htm"
+						><a href="http://www.jamesshuggins.com/h/tek1/cobol.htm"
 							>http://www.jamesshuggins.com/h/tek1/cobol.htm</a
 						>
 					</p>
@@ -10172,7 +10108,7 @@
 							tab-stops: list 0.75in;
 						"
 					>
-						<?if !supportLists?><span
+						<span
 							style="
 								font-family: Wingdings;
 								mso-fareast-font-family: Wingdings;
@@ -10181,7 +10117,7 @@
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?><a href="http://www.cobolportal.com/">http://www.cobolportal.com/</a> (<span
+						><a href="http://www.cobolportal.com/">http://www.cobolportal.com/</a> (<span
 							style="color: #480c56"
 							>The COBOL Portal)</span
 						>
@@ -10195,7 +10131,7 @@
 							tab-stops: list 0.75in;
 						"
 					>
-						<?if !supportLists?><span
+						<span
 							style="
 								font-family: Wingdings;
 								mso-fareast-font-family: Wingdings;
@@ -10204,9 +10140,7 @@
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?><a href="http://www.infogoal.com/cbd/cbdhome.htm"
-							>http://www.infogoal.com/cbd/cbdhome.htm</a
-						>
+						><a href="http://www.infogoal.com/cbd/cbdhome.htm">http://www.infogoal.com/cbd/cbdhome.htm</a>
 						(The
 						<st1:place w:st="on"
 							><st1:placename w:st="on">COBOL</st1:placename>
@@ -10222,7 +10156,7 @@
 							tab-stops: list 0.75in;
 						"
 					>
-						<?if !supportLists?><span
+						<span
 							style="
 								font-family: Wingdings;
 								mso-fareast-font-family: Wingdings;
@@ -10231,7 +10165,7 @@
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?><a href="http://home.swbell.net/mck9/cobol/cobol.html"
+						><a href="http://home.swbell.net/mck9/cobol/cobol.html"
 							>http://home.swbell.net/mck9/cobol/cobol.html</a
 						>
 						(The Kasten COBOL)
@@ -10245,7 +10179,7 @@
 							tab-stops: list 0.75in;
 						"
 					>
-						<?if !supportLists?><strong
+						<strong
 							><span
 								style="
 									font-family: Wingdings;
@@ -10257,9 +10191,7 @@
 									>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 								></span
 							></strong
-						><?endif?><a href="http://www.actscorp.com/acts/cobol.htm"
-							>http://www.actscorp.com/acts/cobol.htm</a
-						>
+						><a href="http://www.actscorp.com/acts/cobol.htm">http://www.actscorp.com/acts/cobol.htm</a>
 						(<strong
 							><span style="font-weight: normal; mso-bidi-font-weight: bold"
 								>COBOL and the Business Programming Paradigm)</span
@@ -10277,7 +10209,7 @@
 							tab-stops: list 0.75in;
 						"
 					>
-						<?if !supportLists?><span
+						<span
 							style="
 								font-family: Wingdings;
 								mso-fareast-font-family: Wingdings;
@@ -10286,7 +10218,7 @@
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?><a href="http://www.teo-computer.com/dev/cobol.html"
+						><a href="http://www.teo-computer.com/dev/cobol.html"
 							><span style="layout-grid-mode: line">http://www.teo-computer.com/dev/cobol.html</span></a
 						>
 						(COBOL Resource Information Page)
@@ -10300,7 +10232,7 @@
 							tab-stops: list 0.75in;
 						"
 					>
-						<?if !supportLists?><span
+						<span
 							style="
 								font-family: Wingdings;
 								mso-fareast-font-family: Wingdings;
@@ -10309,7 +10241,7 @@
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?><a href="http://www.aboutlegacycoding.com/">http://www.aboutlegacycoding.com/</a>
+						><a href="http://www.aboutlegacycoding.com/">http://www.aboutlegacycoding.com/</a>
 						(About Legacy Coding)
 					</p>
 					<p
@@ -10321,7 +10253,7 @@
 							tab-stops: list 0.75in;
 						"
 					>
-						<?if !supportLists?><span
+						<span
 							style="
 								font-family: Wingdings;
 								mso-fareast-font-family: Wingdings;
@@ -10330,7 +10262,7 @@
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?><a href="http://www.thefreecountry.com/developercity/cobol.html"
+						><a href="http://www.thefreecountry.com/developercity/cobol.html"
 							>http://www.thefreecountry.com/developercity/cobol.html</a
 						>
 						(<span style="mso-bidi-font-weight: bold">Free COBOL Compilers)</span>
@@ -10407,152 +10339,134 @@
 					</p>
 					<span style="mso-bookmark: AppA2"></span>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Significant reformatting
+						>Significant reformatting
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Updated OO COBOL Section
+						>Updated OO COBOL Section
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Add URL for IBM COBOL Web site
+						>Add URL for IBM COBOL Web site
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Added information on "COBOL for Dummies"
+						>Added information on "COBOL for Dummies"
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Added initial Y2K section
+						>Added initial Y2K section
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Added information on using the newsgroups
+						>Added information on using the newsgroups
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Added information on PCYACC
+						>Added information on PCYACC
 					</p>
 					<p class="H4">
 						<a name="AppA3">Appendix C.3 - Changes to create Version 2.08</a>
 					</p>
 					<span style="mso-bookmark: AppA3"></span>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Started adding Logos
+						>Started adding Logos
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Removed the detailed list of FAQ contributors
+						>Removed the detailed list of FAQ contributors
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Fixed erroneous Standards information
+						>Fixed erroneous Standards information
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Corrected information about Liant (who acquired RM)
+						>Corrected information about Liant (who acquired RM)
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Added information on Amiga freeware compiler
+						>Added information on Amiga freeware compiler
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Added information on Siber tools
+						>Added information on Siber tools
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Corrected CA company and product information
+						>Corrected CA company and product information
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Added information on where to turn for information not in the FAQ
+						>Added information on where to turn for information not in the FAQ
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Rephrased the information on what can/should be put in the newsgroups.
+						>Rephrased the information on what can/should be put in the newsgroups.
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Revised the information on the CobCy project/product
+						>Revised the information on the CobCy project/product
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Updated Micro Focus information<span
+						>Updated Micro Focus information<span
 							style="
 								font-family: &quot;Courier New&quot;;
 								mso-bidi-font-family: &quot;Times New Roman&quot;;
@@ -10562,12 +10476,11 @@
 						></span>
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?><span
+						><span
 							style="
 								font-family: &quot;Courier New&quot;;
 								mso-bidi-font-family: &quot;Times New Roman&quot;;
@@ -10576,12 +10489,11 @@
 						></span>
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?><span
+						><span
 							style="
 								font-family: &quot;Courier New&quot;;
 								mso-bidi-font-family: &quot;Times New Roman&quot;;
@@ -10591,12 +10503,11 @@
 					</p>
 					<p class="H4">Appendix C.4 - Changes to create Versio<a name="App_Upd209"></a>n 2.09</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?><span
+						><span
 							style="
 								font-family: &quot;Courier New&quot;;
 								mso-bidi-font-family: &quot;Times New Roman&quot;;
@@ -10605,12 +10516,11 @@
 						></span>
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?><span
+						><span
 							style="
 								font-family: &quot;Courier New&quot;;
 								mso-bidi-font-family: &quot;Times New Roman&quot;;
@@ -10631,7 +10541,7 @@
 							tab-stops: 0.5in list 0.75in;
 						"
 					>
-						<?if !supportLists?><span
+						<span
 							style="
 								font-family: Wingdings;
 								mso-fareast-font-family: Wingdings;
@@ -10640,7 +10550,7 @@
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Recorded new location of the FAQ
+						>Recorded new location of the FAQ
 					</p>
 					<p
 						class="MsoNormal"
@@ -10651,7 +10561,7 @@
 							tab-stops: 0.5in list 0.75in;
 						"
 					>
-						<?if !supportLists?><span
+						<span
 							style="
 								font-family: Wingdings;
 								mso-fareast-font-family: Wingdings;
@@ -10660,7 +10570,7 @@
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Updated some old (bad) web links
+						>Updated some old (bad) web links
 					</p>
 					<p
 						class="MsoNormal"
@@ -10672,7 +10582,7 @@
 						"
 					>
 						<a name="_Hlt451587826"
-							><?if !supportLists?><span
+							><span
 								style="
 									font-family: Wingdings;
 									mso-fareast-font-family: Wingdings;
@@ -10681,8 +10591,8 @@
 								><span style="mso-list: Ignore"
 									>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 								></span
-							><?endif?>Added some new COBOL books (particularly those written or contributed to - by
-							frequent comp.lang.cobol submitters).</a
+							>Added some new COBOL books (particularly those written or contributed to - by frequent
+							comp.lang.cobol submitters).</a
 						>
 					</p>
 					<p
@@ -10695,7 +10605,7 @@
 						"
 					>
 						<span style="mso-bookmark: _Hlt451587826"
-							><?if !supportLists?><span
+							><span
 								style="
 									font-family: Wingdings;
 									mso-fareast-font-family: Wingdings;
@@ -10704,7 +10614,7 @@
 								><span style="mso-list: Ignore"
 									>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 								></span
-							><?endif?>Added information about LegacyJ (PERCobol)</span
+							>Added information about LegacyJ (PERCobol)</span
 						>
 						and changed the company name from Synkronix to LegacyJ.
 					</p>
@@ -10717,7 +10627,7 @@
 							tab-stops: 0.5in list 0.75in;
 						"
 					>
-						<?if !supportLists?><span
+						<span
 							style="
 								font-family: Wingdings;
 								mso-fareast-font-family: Wingdings;
@@ -10726,8 +10636,7 @@
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Updated information for changes in product and company names and addresses where
-						available
+						>Updated information for changes in product and company names and addresses where available
 					</p>
 					<p
 						class="MsoNormal"
@@ -10738,7 +10647,7 @@
 							tab-stops: 0.5in list 0.75in;
 						"
 					>
-						<?if !supportLists?><span
+						<span
 							style="
 								font-family: Wingdings;
 								mso-fareast-font-family: Wingdings;
@@ -10747,7 +10656,7 @@
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Updated the URLs for downloading the draft of the next COBOL Standard and CobCy
+						>Updated the URLs for downloading the draft of the next COBOL Standard and CobCy
 					</p>
 					<p
 						class="MsoNormal"
@@ -10758,7 +10667,7 @@
 							tab-stops: 0.5in list 0.75in;
 						"
 					>
-						<?if !supportLists?><span
+						<span
 							style="
 								font-family: Wingdings;
 								mso-fareast-font-family: Wingdings;
@@ -10767,7 +10676,7 @@
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Started the Samples/Example Section
+						>Started the Samples/Example Section
 					</p>
 					<p
 						class="MsoNormal"
@@ -10778,7 +10687,7 @@
 							tab-stops: 0.5in list 0.75in;
 						"
 					>
-						<?if !supportLists?><span
+						<span
 							style="
 								font-family: Wingdings;
 								mso-fareast-font-family: Wingdings;
@@ -10787,8 +10696,8 @@
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Tried to get rid of most specific references to Windows/NT, Windows/95, Windows/98,
-						and Windows/2000.
+						>Tried to get rid of most specific references to Windows/NT, Windows/95, Windows/98, and
+						Windows/2000.
 					</p>
 					<p
 						class="MsoNormal"
@@ -10799,7 +10708,7 @@
 							tab-stops: 0.5in list 0.75in;
 						"
 					>
-						<?if !supportLists?><span
+						<span
 							style="
 								font-family: Wingdings;
 								mso-fareast-font-family: Wingdings;
@@ -10808,7 +10717,7 @@
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Added links to Xinotech
+						>Added links to Xinotech
 					</p>
 					<p
 						class="MsoNormal"
@@ -10819,7 +10728,7 @@
 							tab-stops: 0.5in list 0.75in;
 						"
 					>
-						<?if !supportLists?><span
+						<span
 							style="
 								font-family: Wingdings;
 								mso-fareast-font-family: Wingdings;
@@ -10828,7 +10737,7 @@
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Added information on Norcom and GUI ScreenIO
+						>Added information on Norcom and GUI ScreenIO
 					</p>
 					<p
 						class="MsoNormal"
@@ -10839,7 +10748,7 @@
 							tab-stops: 0.5in list 0.75in;
 						"
 					>
-						<?if !supportLists?><span
+						<span
 							style="
 								font-family: Wingdings;
 								mso-fareast-font-family: Wingdings;
@@ -10848,7 +10757,7 @@
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Added (back) information on Wang
+						>Added (back) information on Wang
 					</p>
 					<p
 						class="MsoNormal"
@@ -10859,7 +10768,7 @@
 							tab-stops: 0.5in list 0.75in;
 						"
 					>
-						<?if !supportLists?><span
+						<span
 							style="
 								font-family: Wingdings;
 								mso-fareast-font-family: Wingdings;
@@ -10868,18 +10777,17 @@
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Added (back) information on the Tiny-COBOL (74 Standard) project
+						>Added (back) information on the Tiny-COBOL (74 Standard) project
 					</p>
 					<p class="H4">
 						<a name="App_Upd302">Appendix C.6 - Changes to create Version 3.02</a>
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l16 level1 lfo25">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Significant updates to<span
+						>Significant updates to<span
 							style="
 								font-family: &quot;Courier New&quot;;
 								mso-bidi-font-family: &quot;Times New Roman&quot;;
@@ -10896,74 +10804,66 @@
 						></span>
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Changed several erroneous references to Cobol to the correct spelling COBOL
+						>Changed several erroneous references to Cobol to the correct spelling COBOL
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Added information on
+						>Added information on
 						<a href="#Tools_JCMigrations">J &amp; C Migrations</a>
 						conversion tools
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Updated information on the Tiny COBOL project to reflect their new goal of providing
-						an 85 Standard compiler
+						>Updated information on the Tiny COBOL project to reflect their new goal of providing an 85
+						Standard compiler
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Add information on the <a href="#Tools_Semantic">Semantic Designs</a> and
+						>Add information on the <a href="#Tools_Semantic">Semantic Designs</a> and
 						<a href="#Tools_Progeni">Progeni</a> tools
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Added information on
+						>Added information on
 						<a href="#com_compaq"><span style="mso-spacerun: yes"></span>Compaq COBOL</a>
 						(both for the formerly DEC COBOL and the formerly TANDEM COBOL)
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Added an appendix with miscellaneous COBOL-related web pages
+						>Added an appendix with miscellaneous COBOL-related web pages
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Updated the Acucorp phone numbers
+						>Updated the Acucorp phone numbers
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Updated the information on who distributes
+						>Updated the information on who distributes
 						<a href="#Tools_ETK">ETK</a>
 					</p>
 					<p class="H4">
@@ -10971,77 +10871,69 @@
 					</p>
 					<span style="mso-bookmark: App_Upd303"></span>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Verified and updated many links
+						>Verified and updated many links
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Did some restructuring of several major sections of the FAQ (e.g., removed some tool
-						vendors from where to contact)
+						>Did some restructuring of several major sections of the FAQ (e.g., removed some tool vendors
+						from where to contact)
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Started updates for MERANT (for COBOL issues) returning to an independent Micro Focus
+						>Started updates for MERANT (for COBOL issues) returning to an independent Micro Focus
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Updated much of the Computer Associate information
+						>Updated much of the Computer Associate information
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Started removing CompuServe references
+						>Started removing CompuServe references
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Add information on the various <a href="#RainCode">RainCode</a> products
+						>Add information on the various <a href="#RainCode">RainCode</a> products
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Added information on
+						>Added information on
 						<span style="mso-bidi-font-family: Arial; mso-bidi-font-style: italic"
 							><a href="#tools_Refactive">Refactive</a></span
 						>
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?><span style="mso-bidi-font-family: Arial; mso-bidi-font-style: italic"
+						><span style="mso-bidi-font-family: Arial; mso-bidi-font-style: italic"
 							>Updated <a href="#LegacyJ">LegacyJ</a> information</span
 						>
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
+						<span
 							style="
 								font-family: Symbol;
 								mso-fareast-font-family: Symbol;
@@ -11051,13 +10943,13 @@
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?><span style="mso-bidi-font-family: Arial; mso-bidi-font-style: italic"
+						><span style="mso-bidi-font-family: Arial; mso-bidi-font-style: italic"
 							>Added information about <a href="#Tools_COBOL_Explorer">COBOL Explorer</a
 							><b style="mso-bidi-font-weight: normal"><o:p></o:p></b
 						></span>
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
+						<span
 							style="
 								font-family: Symbol;
 								mso-fareast-font-family: Symbol;
@@ -11067,14 +10959,14 @@
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?><span style="mso-bidi-font-family: Arial; mso-bidi-font-style: italic"
+						><span style="mso-bidi-font-family: Arial; mso-bidi-font-style: italic"
 							>Added information about
 							<a href="#Fujitsu_Siemens">Fujitsu-Siemens</a>
 							commercial COBOL products<b style="mso-bidi-font-weight: normal"><o:p></o:p></b
 						></span>
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
+						<span
 							style="
 								font-family: Symbol;
 								mso-fareast-font-family: Symbol;
@@ -11084,7 +10976,7 @@
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?><span style="mso-bidi-font-family: Arial; mso-bidi-font-style: italic"
+						><span style="mso-bidi-font-family: Arial; mso-bidi-font-style: italic"
 							>Added a new section (and subsections) </span
 						><span class="MsoHyperlink"
 							><a href="#Education"
@@ -11097,7 +10989,7 @@
 						></b>
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
+						<span
 							style="
 								font-family: Symbol;
 								mso-fareast-font-family: Symbol;
@@ -11107,7 +10999,7 @@
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?><span style="mso-bidi-font-family: Arial; mso-bidi-font-style: italic"
+						><span style="mso-bidi-font-family: Arial; mso-bidi-font-style: italic"
 							>Started a new section (and subsection) </span
 						><span class="MsoHyperlink"
 							><a href="#Tools_IBM_Debug">IBM Mainframe Debugging and Development Tools</a></span
@@ -11117,7 +11009,7 @@
 						></u>
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
+						<span
 							style="
 								font-family: Symbol;
 								mso-fareast-font-family: Symbol;
@@ -11130,7 +11022,7 @@
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?><span style="mso-bidi-font-family: Arial; mso-bidi-font-style: italic"
+						><span style="mso-bidi-font-family: Arial; mso-bidi-font-style: italic"
 							>Added information on </span
 						><span class="MsoHyperlink"><a href="#Tools_SANFACE">SANFACE Software</a></span
 						><span class="MsoHyperlink"
@@ -11145,12 +11037,11 @@
 						></span>
 					</p>
 					<p class="MsoNormal" style="margin-left: 0.5in; text-indent: -0.25in; mso-list: l0 level1 lfo7">
-						<?if !supportLists?><span
-							style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
+						<span style="font-family: Symbol; mso-fareast-font-family: Symbol; mso-bidi-font-family: Symbol"
 							><span style="mso-list: Ignore"
 								>•<span style="font: 7pt &quot;Times New Roman&quot;">        </span></span
 							></span
-						><?endif?>Added information on<span class="MsoHyperlink"> </span
+						>Added information on<span class="MsoHyperlink"> </span
 						><span style="mso-bidi-font-weight: bold"
 							><a href="#Fujitsu_NetCOBOL">Fujitsu NetCOBOL for .NET</a></span
 						>

--- a/index.html
+++ b/index.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/lectures/Basics2.html
+++ b/lectures/Basics2.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>basics2 - COBOL Lecture</title>

--- a/lectures/COPY.html
+++ b/lectures/COPY.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>COPY - COBOL Lecture</title>

--- a/lectures/GenIntro.html
+++ b/lectures/GenIntro.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>GenIntro - COBOL Lecture</title>

--- a/lectures/ReportWriterSSWeb.html
+++ b/lectures/ReportWriterSSWeb.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 	<title>COBOL Report Writer - Syntax and Semantics</title>

--- a/lectures/ReportWriterWeb.html
+++ b/lectures/ReportWriterWeb.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 	<title>COBOL Report Writer</title>

--- a/lectures/SeqFile3.html
+++ b/lectures/SeqFile3.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>SeqFile3 - COBOL Lecture</title>

--- a/lectures/Unstring.html
+++ b/lectures/Unstring.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Unstring - COBOL Lecture</title>

--- a/lectures/Usage.html
+++ b/lectures/Usage.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Usage - COBOL Lecture</title>

--- a/lectures/arithmetic.html
+++ b/lectures/arithmetic.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Arithmetic - COBOL Lecture</title>

--- a/lectures/basics1.html
+++ b/lectures/basics1.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Basics1 - COBOL Lecture</title>

--- a/lectures/call.html
+++ b/lectures/call.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>call - COBOL Lecture</title>

--- a/lectures/cobintro.html
+++ b/lectures/cobintro.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>cobintro - COBOL Lecture</title>

--- a/lectures/conditions.html
+++ b/lectures/conditions.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Conditions - COBOL Lecture</title>

--- a/lectures/design.html
+++ b/lectures/design.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>design - COBOL Lecture</title>

--- a/lectures/direct1.html
+++ b/lectures/direct1.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>direct1 - COBOL Lecture</title>

--- a/lectures/dsr1.html
+++ b/lectures/dsr1.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>dsr1 - COBOL Lecture</title>

--- a/lectures/index.html
+++ b/lectures/index.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />

--- a/lectures/indexed.html
+++ b/lectures/indexed.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Indexed - COBOL Lecture</title>

--- a/lectures/inspect.html
+++ b/lectures/inspect.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Inspect - COBOL Lecture</title>

--- a/lectures/perform.html
+++ b/lectures/perform.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>perform - COBOL Lecture</title>

--- a/lectures/relative.html
+++ b/lectures/relative.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Relative - COBOL Lecture</title>

--- a/lectures/search.html
+++ b/lectures/search.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Search - COBOL Lecture</title>

--- a/lectures/seqfile1.html
+++ b/lectures/seqfile1.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>SeqFile1 - COBOL Lecture</title>

--- a/lectures/seqfile2.html
+++ b/lectures/seqfile2.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>SeqFile2 - COBOL Lecture</title>

--- a/lectures/sort.html
+++ b/lectures/sort.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>SORT - COBOL Lecture</title>

--- a/lectures/string.html
+++ b/lectures/string.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>String - COBOL Lecture</title>

--- a/lectures/tables1.html
+++ b/lectures/tables1.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Tables1 - COBOL Lecture</title>

--- a/lectures/tables2.html
+++ b/lectures/tables2.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Tables2 - COBOL Lecture</title>


### PR DESCRIPTION
## Summary

- Add `<!DOCTYPE html>` to all 169 files that were missing the declaration (`doctype-first` rule)
- Remove MS Word `<?if...?>`/`<?endif?>` processing instructions from `faq/COBOLFAQ.html` that contained unescaped `<` and `>` characters (`spec-char-escape` rule)
- Move `<title>` inside `<head>` in `Exm-DueSubsRpt.html` and `Exm-AcmeStockReorder.html` (`title-require` rule)
- Fix single-quoted `style` attribute in `CSISEvalForm.html` (`attr-value-double-quotes` rule)
- Close unclosed `<p>` tags and fix orphaned `</p>` tags in `GettingStarted.html` (`tag-pair` rule)
- Run Prettier to reformat the structurally-changed files

## Result

`npx htmlhint "**/*.html"` now reports: `Scanned 171 files, no errors found`

## Notes for reviewer

The MS Word processing instructions in `COBOLFAQ.html` (e.g. `<?if !supportLists?>`, `<?if !supportNestedAnchors?>`) were legacy artifacts from the original Word-to-HTML export. Removing the instruction tokens preserves all the HTML content between them — the anchor elements and bullet spans remain intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)