### PR TITLE
Fix duplicate id-unique htmlhint errors in CS4312Topics.html

### DIFF
--- a/lectures/CS4312Topics.html
+++ b/lectures/CS4312Topics.html
@@ -141,7 +141,6 @@
 			<img align="abscenter" height="36" src="../pics/T-Dept.gif" width="297" /><br />
 			&nbsp;Software Engineering 2 - Module Outline
 		</h2>
-		<h3 id="General"></h3>
 		<hr width="100%" />
 		<h3 id="General">General Introduction</h3>
 		<ul>
@@ -175,7 +174,6 @@
 				</td>
 			</tr>
 		</table>
-		<h3 id="Introduction"></h3>
 		<hr width="100%" />
 		<h3 id="Introduction">Introduction to COBOL</h3>
 		<ul>
@@ -212,7 +210,6 @@
 				</td>
 			</tr>
 		</table>
-		<h3 id="Basics1"></h3>
 		<hr width="100%" />
 		<h3 id="Basics1">COBOL Basics 1</h3>
 		<ul>
@@ -251,7 +248,6 @@
 				</td>
 			</tr>
 		</table>
-		<h3 id="Basics2"></h3>
 		<hr width="100%" />
 		<h3 id="Basics2">COBOL Basics 2</h3>
 		<ul>
@@ -286,7 +282,6 @@
 				</td>
 			</tr>
 		</table>
-		<h3 id="IntroSeqFiles"></h3>
 		<hr width="100%" />
 		<h3 id="IntroSeqFiles">Introduction to Sequential Files</h3>
 		<ul>
@@ -320,7 +315,6 @@
 				</td>
 			</tr>
 		</table>
-		<h3 id="ProcessingSeqFiles"></h3>
 		<hr width="100%" />
 		<h3 id="ProcessingSeqFiles">Processing Sequential Files</h3>
 		<ul>
@@ -354,7 +348,6 @@
 				</td>
 			</tr>
 		</table>
-		<h3 id="PERFORM"></h3>
 		<hr width="100%" />
 		<h3 id="PERFORM">Simple iteration with the PERFORM verb</h3>
 		<ul>
@@ -390,7 +383,6 @@
 				</td>
 			</tr>
 		</table>
-		<h3 id="Arithmetic"></h3>
 		<hr width="100%" />
 		<h3 id="Arithmetic">Arithmetic and Edited Pictures</h3>
 		<ul>
@@ -433,7 +425,6 @@
 				</td>
 			</tr>
 		</table>
-		<h3 id="Conditions"></h3>
 		<hr width="100%" />
 		<h3 id="Conditions">Conditions</h3>
 		<ul>
@@ -472,7 +463,6 @@
 				</td>
 			</tr>
 		</table>
-		<h3 id="Designing"></h3>
 		<hr width="100%" />
 		<h3 id="Designing">Designing Programs</h3>
 		<ul>
@@ -509,7 +499,6 @@
 				</td>
 			</tr>
 		</table>
-		<h3 id="DSR1"></h3>
 		<hr width="100%" />
 		<h3 id="DSR1">Introduction to Diagrammatic Stepwise Refinement</h3>
 		<ul>
@@ -546,7 +535,6 @@
 				</td>
 			</tr>
 		</table>
-		<h3 id="SORT"></h3>
 		<hr width="100%" />
 		<h3 id="SORT">SORT and MERGE</h3>
 		<ul>
@@ -581,7 +569,6 @@
 				</td>
 			</tr>
 		</table>
-		<h3 id="Tables"></h3>
 		<hr width="100%" />
 		<h3 id="Tables">Tables and the PERFORM ... VARYING</h3>
 		<ul>
@@ -614,7 +601,6 @@
 				</td>
 			</tr>
 		</table>
-		<h3 id="AdvancedTables"></h3>
 		<hr width="100%" />
 		<h3 id="AdvancedTables">Advanced Tables</h3>
 		<ul>
@@ -650,7 +636,6 @@
 				</td>
 			</tr>
 		</table>
-		<h3 id="SearchingTAbles"></h3>
 		<hr width="100%" />
 		<h3 id="SearchingTAbles">Searching Tables</h3>
 		<ul>
@@ -682,7 +667,6 @@
 				</td>
 			</tr>
 		</table>
-		<h3 id="AdvancedSeqFiles"></h3>
 		<hr width="100%" />
 		<h3 id="AdvancedSeqFiles">Advanced Sequential Files</h3>
 		<ul>
@@ -714,7 +698,6 @@
 				</td>
 			</tr>
 		</table>
-		<h3 id="IntroDirectAccessFiles"></h3>
 		<hr width="100%" />
 		<h3 id="IntroDirectAccessFiles">Introduction to Direct Access Files</h3>
 		<ul>
@@ -747,7 +730,6 @@
 				</td>
 			</tr>
 		</table>
-		<h3 id="RelativeFiles"></h3>
 		<hr width="100%" />
 		<h3 id="RelativeFiles">Relative Files</h3>
 		<ul>
@@ -781,7 +763,6 @@
 				</td>
 			</tr>
 		</table>
-		<h3 id="IndexedFiles"></h3>
 		<hr width="100%" />
 		<h3 id="IndexedFiles">Indexed Files</h3>
 		<ul>
@@ -815,7 +796,6 @@
 				</td>
 			</tr>
 		</table>
-		<h3 id="Calling"></h3>
 		<hr width="100%" />
 		<h3 id="Calling">Calling Subprograms</h3>
 		<ul>
@@ -854,7 +834,6 @@
 				</td>
 			</tr>
 		</table>
-		<h3 id="Inspect"></h3>
 		<hr width="100%" />
 		<h3 id="Inspect">The INSPECT</h3>
 		<table border="0" width="25%">
@@ -882,7 +861,6 @@
 				</td>
 			</tr>
 		</table>
-		<h3 id="String"></h3>
 		<hr width="100%" />
 		<h3 id="String">The STRING</h3>
 		<table border="0" width="25%">
@@ -910,7 +888,6 @@
 				</td>
 			</tr>
 		</table>
-		<h3 id="Unstring"></h3>
 		<hr width="100%" />
 		<h3 id="Unstring">The UNSTRING</h3>
 		<table border="0" width="25%">
@@ -938,7 +915,6 @@
 				</td>
 			</tr>
 		</table>
-		<h3 id="Usage"></h3>
 		<hr width="100%" />
 		<h3 id="Usage">The USAGE clause</h3>
 		<table border="0" width="25%">
@@ -966,7 +942,6 @@
 				</td>
 			</tr>
 		</table>
-		<h3 id="ReportWriter1"></h3>
 		<hr width="100%" />
 		<h3 id="ReportWriter1">The COBOL Report Writer - A worked example</h3>
 		<blockquote>
@@ -1001,7 +976,6 @@
 				<td width="32%"></td>
 			</tr>
 		</table>
-		<h3 id="ReportWriter2"></h3>
 		<hr width="100%" />
 		<h3 id="ReportWriter2">The COBOL Report Writer - Syntax and Semantics</h3>
 		<blockquote>


### PR DESCRIPTION
## Summary

- Removed 26 empty `<h3 id="..."></h3>` anchor tags from `lectures/CS4312Topics.html`
- Each section heading had an empty `<h3>` with the same `id` immediately before the real heading, causing `id-unique` violations in htmlhint
- The real headings already carry the ids, so the empty tags were fully redundant

## Test plan

- [ ] Run `npx htmlhint "**/*.html"` — should report 0 errors across all 171 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)