### PR TITLE
Replace layout tables on index.html with CSS Grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,10 +96,9 @@
 		</div>
 		<hr />
 		<div id="page-description">
-			COBOL programming site with a comprehensive set of COBOL tutorials making a full COBOL
-			course as well as COBOL lecture notes, COBOL programming exercises with sample solutions,
-			COBOL programming exam specifications with model answers, COBOL project specifications, and
-			over 50 example COBOL programs.
+			COBOL programming site with a comprehensive set of COBOL tutorials making a full COBOL course as well as
+			COBOL lecture notes, COBOL programming exercises with sample solutions, COBOL programming exam
+			specifications with model answers, COBOL project specifications, and over 50 example COBOL programs.
 		</div>
 		<hr />
 		<ul class="toc">

--- a/index.html
+++ b/index.html
@@ -26,8 +26,23 @@
 				height: auto;
 			}
 
-			table {
-				max-width: 100%;
+			#page-header {
+				display: grid;
+				grid-template-columns: 40px 1fr;
+				align-items: start;
+				width: 97%;
+			}
+
+			#page-header .header-icon {
+				display: flex;
+				justify-content: center;
+				padding-top: 4px;
+			}
+
+			#page-description {
+				width: 80%;
+				margin: 0 auto;
+				font-size: smaller;
 			}
 
 			ul.toc {
@@ -46,6 +61,15 @@
 					margin: 4px;
 				}
 
+				#page-header {
+					grid-template-columns: 40px 1fr;
+					width: 100%;
+				}
+
+				#page-description {
+					width: 100%;
+				}
+
 				ul.toc {
 					margin-left: 12px;
 					margin-right: 12px;
@@ -59,44 +83,24 @@
 		</style>
 	</head>
 	<body text="#000000" bgcolor="#FFFFFF" link="#0000FF" vlink="#FF0000" alink="#009B00">
-		<div align="left">
-			<table width="97%">
-				<tr>
-					<td valign="top" align="center" width="3%">
-						<img
-							src="pics/i-program.gif"
-							hspace="0"
-							vspace="0"
-							border="0"
-							height="42"
-							width="40"
-							align="top"
-						/>
-					</td>
-					<td width="97%">
-						<h1>
-							<img src="pics/T-Dept.gif" width="297" height="36" /><br />
-							<font size="5">COBOL programming - tutorials, lectures, exercises, examples</font>
-						</h1>
-					</td>
-				</tr>
-			</table>
+		<div id="page-header">
+			<div class="header-icon">
+				<img src="pics/i-program.gif" height="42" width="40" />
+			</div>
+			<div>
+				<h1>
+					<img src="pics/T-Dept.gif" width="297" height="36" /><br />
+					<font size="5">COBOL programming - tutorials, lectures, exercises, examples</font>
+				</h1>
+			</div>
 		</div>
 		<hr />
-		<table width="80%" border="0" align="center">
-			<tr>
-				<td>
-					<div align="left">
-						<font size="-1"
-							>COBOL programming site with a comprehensive set of COBOL tutorials making a full COBOL
-							course as well as COBOL lecture notes, COBOL programming exercises with sample solutions,
-							COBOL programming exam specifications with model answers, COBOL project specifications, and
-							over 50 example COBOL programs.</font
-						>
-					</div>
-				</td>
-			</tr>
-		</table>
+		<div id="page-description">
+			COBOL programming site with a comprehensive set of COBOL tutorials making a full COBOL
+			course as well as COBOL lecture notes, COBOL programming exercises with sample solutions,
+			COBOL programming exam specifications with model answers, COBOL project specifications, and
+			over 50 example COBOL programs.
+		</div>
 		<hr />
 		<ul class="toc">
 			<li>


### PR DESCRIPTION
## Summary

- Replaces the two-column header `<table>` (icon + h1) with a CSS Grid `<div id="page-header">` using `grid-template-columns: 40px 1fr`
- Replaces the centered description `<table width="80%">` with `<div id="page-description">` using `width: 80%; margin: 0 auto`
- Removes all legacy presentational attributes (`hspace`, `vspace`, `border`, `align`, `valign`) from the replaced elements
- Drops the now-unused `table { max-width: 100% }` CSS rule
- Adds responsive overrides for the new IDs in the existing `@media (max-width: 600px)` block

## Test plan

- [ ] Verify header icon and h1 remain side-by-side at desktop widths
- [ ] Verify description text is centered at 80% width on desktop
- [ ] Verify both sections stack/expand correctly at mobile widths (≤600px)
- [ ] Confirm no visual regression on the TOC list below the fold

🤖 Generated with [Claude Code](https://claude.com/claude-code)