### PR TITLE
Remove font tags, add scoped CSS for heading and TOC typography

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -31,11 +31,6 @@
 				line-height: 1.2;
 			}
 
-			td[width="175"] h4 font {
-				color: inherit;
-				font-family: inherit;
-			}
-
 			td[width="175"] h4 b {
 				font-weight: inherit;
 			}
@@ -130,10 +125,17 @@
 			ul.toc > li {
 				padding-left: 0.4em;
 				margin-bottom: 0.6em;
+				font-size: smaller;
 			}
 
 			ul.toc a {
 				font-weight: bold;
+				font-size: larger;
+			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
 			}
 		</style>
 	</head>
@@ -150,37 +152,28 @@
 					<ul class="toc">
 						<li>
 							<a href="#intro">Introduction</a><br />
-							<font size="-1">Unit aims, objectives, prerequisites.</font>
+							Unit aims, objectives, prerequisites.
 						</li>
 						<li>
 							<a href="#part1">What is COBOL?</a><br />
-							<font size="-1"
-								>A brief introduction to the COBOL programming language. A historical overview. COBOL's
-								dominance in the business computing domain. Characteristics of COBOL applications. Some
-								reasons for COBOL's success.</font
-							>
+							A brief introduction to the COBOL programming language. A historical overview. COBOL's
+							dominance in the business computing domain. Characteristics of COBOL applications. Some
+							reasons for COBOL's success.
 						</li>
 						<li>
 							<a href="#part2">Introduction to Programming</a><br />
-							<font size="-1"
-								>This section provides a gentle introduction to programing in general and to programming
-								in COBOL in particular by means of writing some simple COBOL programs.</font
-							>
+							This section provides a gentle introduction to programing in general and to programming in
+							COBOL in particular by means of writing some simple COBOL programs.
 						</li>
 						<li>
 							<a href="#part3">COBOL basics</a><br />
-							<font size="-1"
-								>This section presents the fundamentals of constructing COBOL programs. It explains the
-								notation used in COBOL syntax diagrams, enumerates the COBOL coding rules, and examines
-								the hierarchical structure of COBOL programs.</font
-							>
+							This section presents the fundamentals of constructing COBOL programs. It explains the
+							notation used in COBOL syntax diagrams, enumerates the COBOL coding rules, and examines the
+							hierarchical structure of COBOL programs.
 						</li>
 						<li>
 							<a href="#part4">The Four Divisions</a><br />
-							<font size="-1"
-								>Provides an introduction to the structure and purpose of the four COBOL
-								divisions.</font
-							>
+							Provides an introduction to the structure and purpose of the four COBOL divisions.
 						</li>
 					</ul>
 					<hr />
@@ -188,18 +181,12 @@
 			</tr>
 			<tr>
 				<td valign="top" align="left" bgcolor="#993300" colspan="2">
-					<h2 align="center" id="intro">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Introduction</font>
-						</font>
-					</h2>
+					<h2 align="center" id="intro">Introduction</h2>
 				</td>
 			</tr>
 			<tr>
 				<td valign="top" width="175" bgcolor="#FFFFCC">
-					<h4>
-						<font color="#993300" face="Arial, Helvetica, sans-serif">Aims</font>
-					</h4>
+					<h4>Aims</h4>
 				</td>
 				<td width="525" valign="top">
 					<div align="center">
@@ -215,9 +202,7 @@
 			</tr>
 			<tr>
 				<td valign="top" align="left" width="175" bgcolor="#FFFFCC">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Objectives</font>
-					</h4>
+					<h4>Objectives</h4>
 				</td>
 				<td width="525" valign="top">
 					<p>By the end of this unit you should -</p>
@@ -240,9 +225,7 @@
 			</tr>
 			<tr>
 				<td valign="top" align="left" width="175" bgcolor="#FFFFCC">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font>
-					</h4>
+					<h4>Prerequisites</h4>
 				</td>
 				<td width="525" valign="top">
 					<p>None. This is the first unit in the course.</p>
@@ -262,18 +245,12 @@
 			</tr>
 			<tr>
 				<td valign="top" align="left" bgcolor="#993300" colspan="2">
-					<h2 align="center" id="part1">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">What is COBOL?</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part1">What is COBOL?</h2>
 				</td>
 			</tr>
 			<tr>
 				<td valign="top" align="left" width="175" bgcolor="#FFFFCC">
-					<h4>
-						<font face="Arial, Helvetica, sans-serif" color="#800000">Introduction</font>
-					</h4>
+					<h4>Introduction</h4>
 				</td>
 				<td width="525" valign="top">
 					<p>
@@ -298,9 +275,7 @@
 			</tr>
 			<tr>
 				<td valign="top" align="left" width="175" bgcolor="#FFFFCC">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">How widely used is COBOL?</font>
-					</h4>
+					<h4>How widely used is COBOL?</h4>
 				</td>
 				<td width="525" valign="top">
 					<p>
@@ -317,8 +292,7 @@
 							the world. Of that they estimated that about 80% (240 billion lines) were in COBOL and 20%
 							(60 billion lines) were written in all the other computer languages combined [<a
 								href="#brown"
-							>
-								<font size="-1">Brown</font> </a
+								>Brown</a
 							>].
 						</p>
 						<p>
@@ -338,9 +312,7 @@
 			</tr>
 			<tr>
 				<td valign="top" align="left" width="175" bgcolor="#FFFFCC">
-					<h4>
-						<font face="Arial, Helvetica, sans-serif" color="#800000">Surprised by COBOL's success?</font>
-					</h4>
+					<h4>Surprised by COBOL's success?</h4>
 				</td>
 				<td width="525" valign="top">
 					<p>
@@ -361,9 +333,7 @@
 						example of this kind of application is the DoD MRP II system. This system is "used to manage
 						almost 550,000 spare and repair parts and equipment items with an inventory value of $28
 						billion. The system runs on Amdahl mainframes at multiple locations throughout the U.S. and
-						contains over 4,000,000 lines of COBOL code." [<a href="#uppermohawk">
-							<font size="-1">Upper Mohawk</font> </a
-						>]
+						contains over 4,000,000 lines of COBOL code." [<a href="#uppermohawk">Upper Mohawk</a>]
 					</p>
 					<p>
 						In the horizontal software market, applications may still cost millions of dollars to produce
@@ -395,11 +365,7 @@
 			</tr>
 			<tr>
 				<td valign="top" align="left" width="175" bgcolor="#FFFFCC">
-					<h4>
-						<font face="Arial, Helvetica, sans-serif" color="#800000"
-							>Some characteristics of COBOL applications
-						</font>
-					</h4>
+					<h4>Some characteristics of COBOL applications</h4>
 				</td>
 				<td width="525" valign="top">
 					<p>
@@ -413,16 +379,14 @@
 						simply be discarded when some new programming language or technology appears. As a consequence
 						business applications between 10 and 30 years-old are common. This accounts for the predominance
 						of COBOL programs in the year 2000 problem (12,000,000 COBOL applications vs 375,000 C and C++
-						applications in the US alone - [<a href="#capers"> <font size="-1">Capers Jones</font> </a>]).
-						Twenty years ago when programmers were writing these applications they just didn't anticipate
-						that they would last into this millennium.
+						applications in the US alone - [<a href="#capers">Capers Jones</a>]). Twenty years ago when
+						programmers were writing these applications they just didn't anticipate that they would last
+						into this millennium.
 					</p>
 					<p>
 						COBOL applications often run in critical areas of business. For instance, over 95% of
-						finance–insurance data is processed with COBOL [<font size="-1"
-							><a href="#arranga">In Cobol’s Defense</a>].</font
-						>
-						The serious financial and legal consequences that can result from an application failure is one
+						finance–insurance data is processed with COBOL [<a href="#arranga">In Cobol’s Defense</a>]. The
+						serious financial and legal consequences that can result from an application failure is one
 						reason for the near panic over the year 2000 problem.
 					</p>
 					<p>
@@ -434,11 +398,7 @@
 			</tr>
 			<tr>
 				<td valign="top" align="left" width="175" bgcolor="#FFFFCC">
-					<h4>
-						<font face="Arial, Helvetica, sans-serif" color="#800000"
-							>Some characteristics that contribute to COBOL's success</font
-						>
-					</h4>
+					<h4>Some characteristics that contribute to COBOL's success</h4>
 				</td>
 				<td width="525" valign="top">
 					<p>
@@ -513,8 +473,9 @@
 						<b>COBOL is Maintainable<br /></b> COBOL has a 30 year proven track record for application
 						maintenance, enhancement and production support at the enterprise level. Early indications from
 						the year 2000 problem are that COBOL applications were actually cheaper to fix than applications
-						written in more recent languages. [ <font size="-1"><a href="#capers">Capers Jones</a></font> ]
-						[<a href="#kapple"> <font size="-1">Kappleman</font> </a>]
+						written in more recent languages. [<a href="#capers">Capers Jones</a>] [<a href="#kapple"
+							>Kappleman</a
+						>]
 					</p>
 					<p>
 						One reason for the maintainability of COBOL programs has been given above - the readability of
@@ -538,9 +499,7 @@
 			</tr>
 			<tr>
 				<td valign="top" align="left" width="175" bgcolor="#FFFFCC">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">References and further reading</font>
-					</h4>
+					<h4>References and further reading</h4>
 				</td>
 				<td width="525" valign="top">
 					<p>
@@ -638,18 +597,12 @@
 			</tr>
 			<tr>
 				<td valign="top" align="left" bgcolor="#993300" colspan="2">
-					<h2 align="center" id="part2">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Introduction to Programming</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part2">Introduction to Programming</h2>
 				</td>
 			</tr>
 			<tr>
 				<td valign="top" align="left" width="175" bgcolor="#FFFFCC">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4>Introduction</h4>
 				</td>
 				<td width="525" valign="top">
 					<p align="left">
@@ -666,9 +619,7 @@
 			</tr>
 			<tr>
 				<td valign="top" align="left" width="175" bgcolor="#FFFFCC">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Let's write a program</font>
-					</h4>
+					<h4>Let's write a program</h4>
 				</td>
 				<td width="525" valign="top">
 					<p align="left">
@@ -696,9 +647,7 @@
 			</tr>
 			<tr>
 				<td valign="top" align="left" width="175" bgcolor="#FFFFCC">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Sequence Program Specification</font>
-					</h4>
+					<h4>Sequence Program Specification</h4>
 				</td>
 				<td width="525" valign="top">
 					<p align="left">
@@ -719,11 +668,7 @@
 			</tr>
 			<tr>
 				<td valign="top" align="left" width="175" bgcolor="#FFFFCC">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Program Statements and Data items</font
-						>
-					</h4>
+					<h4>Program Statements and Data items</h4>
 				</td>
 				<td width="525" valign="top">
 					<p align="left">
@@ -765,9 +710,7 @@
 			</tr>
 			<tr>
 				<td valign="top" align="left" width="175" bgcolor="#FFFFCC">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Getting the Algorithm right</font>
-					</h4>
+					<h4>Getting the Algorithm right</h4>
 				</td>
 				<td width="525" valign="top">
 					<p>
@@ -833,11 +776,7 @@
 			</tr>
 			<tr>
 				<td valign="top" align="left" width="175" bgcolor="#FFFFCC">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>An annotated look at the COBOL program
-						</font>
-					</h4>
+					<h4>An annotated look at the COBOL program</h4>
 				</td>
 				<td width="525" valign="top">
 					<p>
@@ -855,17 +794,13 @@
 			</tr>
 			<tr>
 				<td valign="top" align="left" width="175" bgcolor="#FFFFCC">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Selection Program Specification</font>
-					</h4>
+					<h4>Selection Program Specification</h4>
 					<aside>
 						<p align="center">
 							<img src="Resources/pics/i-Detail.gif" width="30" height="37" /><br />
-							<font size="-1"
-								>Note that these example programs are not meant to be realistic. For instance, at the
-								very least, a program operating in the real world would have to ensure that the input
-								data was validated before it was used.</font
-							>
+							Note that these example programs are not meant to be realistic. For instance, at the very
+							least, a program operating in the real world would have to ensure that the input data was
+							validated before it was used.
 						</p>
 					</aside>
 				</td>
@@ -887,9 +822,7 @@
 			</tr>
 			<tr>
 				<td valign="top" align="left" width="175" bgcolor="#FFFFCC">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Iteration Program Specification</font>
-					</h4>
+					<h4>Iteration Program Specification</h4>
 				</td>
 				<td width="525" valign="top">
 					<p>
@@ -923,18 +856,12 @@
 			</tr>
 			<tr>
 				<td valign="top" align="left" bgcolor="#993300" colspan="2">
-					<h2 align="center" id="part3">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">COBOL basics</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part3">COBOL basics</h2>
 				</td>
 			</tr>
 			<tr>
 				<td valign="top" align="left" width="175" bgcolor="#FFFFCC">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4>Introduction</h4>
 				</td>
 				<td width="525" valign="top">
 					<p>
@@ -947,9 +874,7 @@
 			</tr>
 			<tr>
 				<td valign="top" align="left" width="175" bgcolor="#FFFFCC">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">COBOL idiosyncrasies</font>
-					</h4>
+					<h4 align="left">COBOL idiosyncrasies</h4>
 				</td>
 				<td width="525" valign="top">
 					<p>
@@ -979,9 +904,7 @@
 			</tr>
 			<tr>
 				<td valign="top" align="left" width="175" bgcolor="#FFFFCC">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">COBOL syntax</font>
-					</h4>
+					<h4>COBOL syntax</h4>
 				</td>
 				<td width="525" valign="top">
 					<p>COBOL syntax is defined using particular notation sometimes called the COBOL MetaLanguage.</p>
@@ -1012,9 +935,7 @@
 			</tr>
 			<tr>
 				<td valign="top" align="left" width="175" bgcolor="#FFFFCC">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Some notes on syntax diagrams</font>
-					</h4>
+					<h4>Some notes on syntax diagrams</h4>
 				</td>
 				<td width="525" valign="top">
 					<p>
@@ -1027,72 +948,33 @@
 						<table width="100%" border="1" cellspacing="1" cellpadding="5">
 							<tr>
 								<td>
-									<b>
-										<font face="Arial, Helvetica, sans-serif">$i</font>
-									</b>
+									<b>$i</b>
 								</td>
-								<td>
-									<font face="Arial, Helvetica, sans-serif">uses an alphanumeric data-item</font>
-									<b>
-										<font face="Arial, Helvetica, sans-serif"></font>
-									</b>
-								</td>
+								<td>uses an alphanumeric data-item</td>
 							</tr>
 							<tr>
 								<td>
-									<b>
-										<font face="Arial, Helvetica, sans-serif">$il</font>
-									</b>
+									<b>$il</b>
 								</td>
-								<td>
-									<font face="Arial, Helvetica, sans-serif"
-										>uses an alphanumeric data-item or a string literal</font
-									>
-									<b>
-										<font face="Arial, Helvetica, sans-serif"></font>
-									</b>
-								</td>
+								<td>uses an alphanumeric data-item or a string literal</td>
 							</tr>
 							<tr>
 								<td>
-									<b>
-										<font face="Arial, Helvetica, sans-serif">#i</font>
-									</b>
+									<b>#i</b>
 								</td>
-								<td>
-									<font face="Arial, Helvetica, sans-serif">uses a numeric data-item</font>
-									<b>
-										<font face="Arial, Helvetica, sans-serif"></font>
-									</b>
-								</td>
+								<td>uses a numeric data-item</td>
 							</tr>
 							<tr>
 								<td>
-									<b>
-										<font face="Arial, Helvetica, sans-serif">#il</font>
-									</b>
-									<font face="Arial, Helvetica, sans-serif"></font>
+									<b>#il</b>
 								</td>
-								<td>
-									<font face="Arial, Helvetica, sans-serif"
-										>uses a numeric data-item or numeric literal
-									</font>
-									<b>
-										<font face="Arial, Helvetica, sans-serif"></font>
-									</b>
-								</td>
+								<td>uses a numeric data-item or numeric literal</td>
 							</tr>
 							<tr>
 								<td>
-									<b>
-										<font face="Arial, Helvetica, sans-serif">$#i</font>
-									</b>
+									<b>$#i</b>
 								</td>
-								<td>
-									<font face="Arial, Helvetica, sans-serif"
-										>uses a numeric or an alphanumeric data-item
-									</font>
-								</td>
+								<td>uses a numeric or an alphanumeric data-item</td>
 							</tr>
 						</table>
 					</blockquote>
@@ -1100,17 +982,13 @@
 			</tr>
 			<tr>
 				<td valign="top" align="left" width="175" bgcolor="#FFFFCC">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">An example syntax diagram</font>
-					</h4>
+					<h4>An example syntax diagram</h4>
 					<aside>
 						<p align="center">
 							<img src="Resources/pics/i-Detail.gif" width="30" height="37" /><br />
-							<font size="-1"
-								>Note that for clarity data items may be separated from one another by means of an
-								optional comma.<br />
-								This has been done in the COMPUTE statement opposite</font
-							>
+							Note that for clarity data items may be separated from one another by means of an optional
+							comma.<br />
+							This has been done in the COMPUTE statement opposite
 						</p>
 					</aside>
 				</td>
@@ -1158,9 +1036,7 @@
 			</tr>
 			<tr>
 				<td valign="top" align="left" width="175" bgcolor="#FFFFCC">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">COBOL coding rules</font>
-					</h4>
+					<h4>COBOL coding rules</h4>
 				</td>
 				<td width="525" valign="top">
 					<p>
@@ -1200,9 +1076,7 @@
 			</tr>
 			<tr>
 				<td valign="top" align="left" width="175" bgcolor="#FFFFCC">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Name construction</font>
-					</h4>
+					<h4>Name construction</h4>
 				</td>
 				<td width="525" valign="top">
 					<p>
@@ -1227,9 +1101,7 @@
 			</tr>
 			<tr>
 				<td valign="top" align="left" width="175" bgcolor="#FFFFCC">
-					<h4>
-						<font face="Arial, Helvetica, sans-serif" color="#800000">The structure of COBOL programs</font>
-					</h4>
+					<h4>The structure of COBOL programs</h4>
 				</td>
 				<td width="525" valign="top">
 					<p>
@@ -1244,14 +1116,14 @@
 					<p>We can represent the COBOL hierarchy using the COBOL metalanguage as follows;</p>
 					<p align="center"><img src="Resources/pics/CobolStructure.gif" width="467" height="203" /><br /></p>
 					<p align="left">
-						<b> <font face="Arial, Helvetica, sans-serif">Divisions</font> </b><br />
+						<b>Divisions</b><br />
 						A division is a block of code, usually containing one or more sections, that starts where the
 						division name is encountered and ends with the beginning of the next division or with the end of
 						the program text.
 					</p>
 					<p align="left">
 						<br />
-						<b> <font face="Arial, Helvetica, sans-serif">Sections</font> </b><br />
+						<b>Sections</b><br />
 						A section is a block of code usually containing one or more paragraphs. A section begins with
 						the section name and ends where the next section name is encountered or where the program text
 						ends.
@@ -1264,8 +1136,7 @@
 					<pre class="language-cobol"><code class="language-cobol">SelectUnpaidBills SECTION.
 FILE SECTION.</code></pre>
 					<p>
-						<font face="Arial, Helvetica, sans-serif"><b>Paragraphs</b></font
-						><br />
+						<b>Paragraphs</b><br />
 						A paragraph is a block of code made up of one or more sentences. A paragraph begins with the
 						paragraph name and ends with the next paragraph or section name or the end of the program text.
 					</p>
@@ -1277,8 +1148,7 @@ FILE SECTION.</code></pre>
 					<pre class="language-cobol"><code class="language-cobol">PrintFinalTotals.
 PROGRAM-ID.</code></pre>
 					<p>
-						<font face="Arial, Helvetica, sans-serif"><b>Sentences and statements</b></font
-						><br />
+						<b>Sentences and statements</b><br />
 						A sentence consists of one or more statements and is terminated by a period.<br />
 						For example:
 					</p>
@@ -1309,18 +1179,12 @@ PROGRAM-ID.</code></pre>
 			</tr>
 			<tr>
 				<td valign="top" align="left" bgcolor="#993300" colspan="2">
-					<h2 align="center" id="part4">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">The Four Divisions</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part4">The Four Divisions</h2>
 				</td>
 			</tr>
 			<tr>
 				<td valign="top" align="left" width="175" bgcolor="#FFFFCC">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4>Introduction</h4>
 				</td>
 				<td width="525" valign="top">
 					<p>
@@ -1331,27 +1195,19 @@ PROGRAM-ID.</code></pre>
 					<blockquote>
 						<p align="center">
 							<br />
-							<b> <font face="Arial, Helvetica, sans-serif" size="+1">IDENTIFICATION DIVISION.</font> </b
-							><br />
+							<b>IDENTIFICATION DIVISION.</b><br />
 							Contains program information
 						</p>
 						<p align="center">
-							<font face="Arial, Helvetica, sans-serif"
-								><b> <code class="language-cobol">ENVIRONMENT DIVISION</code>. </b></font
-							><br />
+							<b> <code class="language-cobol">ENVIRONMENT DIVISION</code>. </b><br />
 							Contains environment information
 						</p>
 						<p align="center">
-							<font face="Arial, Helvetica, sans-serif"
-								><b>
-									<font size="+1">DATA DIVISION.</font>
-								</b></font
-							><br />
+							<b>DATA DIVISION.</b><br />
 							Contains data descriptions
 						</p>
 						<p align="center">
-							<b> <font face="Arial, Helvetica, sans-serif" size="+1">PROCEDURE DIVISION.</font> </b
-							><br />
+							<b>PROCEDURE DIVISION.</b><br />
 							Contains the program algorithms<br />
 						</p>
 					</blockquote>
@@ -1360,9 +1216,7 @@ PROGRAM-ID.</code></pre>
 			</tr>
 			<tr>
 				<td valign="top" align="left" width="175" bgcolor="#FFFFCC">
-					<h4 align="left">
-						<font face="Arial, Helvetica, sans-serif" color="#800000">The IDENTIFICATION DIVISION</font>
-					</h4>
+					<h4 align="left">The IDENTIFICATION DIVISION</h4>
 				</td>
 				<td width="525" valign="top">
 					<p>
@@ -1412,11 +1266,7 @@ AUTHOR. Michael Coughlan.</code></pre>
 			</tr>
 			<tr>
 				<td valign="top" align="left" width="175" bgcolor="#FFFFCC">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>The <code class="language-cobol">ENVIRONMENT DIVISION</code></font
-						>
-					</h4>
+					<h4 align="left">The <code class="language-cobol">ENVIRONMENT DIVISION</code></h4>
 				</td>
 				<td width="525" valign="top">
 					<p>
@@ -1442,9 +1292,7 @@ AUTHOR. Michael Coughlan.</code></pre>
 			</tr>
 			<tr>
 				<td valign="top" align="left" width="175" bgcolor="#FFFFCC">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">The DATA DIVISION</font>
-					</h4>
+					<h4 align="left">The DATA DIVISION</h4>
 				</td>
 				<td width="525" valign="top">
 					<p>
@@ -1496,9 +1344,7 @@ WORKING-STORAGE SECTION.
 			</tr>
 			<tr>
 				<td valign="top" align="left" width="175" bgcolor="#FFFFCC">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">The PROCEDURE DIVISION</font>
-					</h4>
+					<h4 align="left">The PROCEDURE DIVISION</h4>
 				</td>
 				<td width="525" valign="top">
 					<p>
@@ -1583,17 +1429,12 @@ DisplayGreeting.
 							These COBOL course materials are the copyright property of Michael Coughlan.
 						</p>
 						<p align="left">
-							<font size="2"
-								>All rights reserved. No part of these course materials may be reproduced in any form or
-								by any means - graphic, electronic, mechanical, photocopying, printing, recording,
-								taping or stored in an information storage and retrieval system - without the written
-								permission of</font
-							>
-							<font size="2">the author.</font>
+							All rights reserved. No part of these course materials may be reproduced in any form or by
+							any means - graphic, electronic, mechanical, photocopying, printing, recording, taping or
+							stored in an information storage and retrieval system - without the written permission of
+							the author.
 						</p>
-						<p align="center">
-							<font size="2">(c) Michael Coughlan</font>
-						</p>
+						<p align="center">(c) Michael Coughlan</p>
 					</div>
 				</td>
 			</tr>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -128,10 +128,22 @@
 			ul.toc > li {
 				padding-left: 0.4em;
 				margin-bottom: 0.6em;
+				font-size: smaller;
 			}
 
 			ul.toc a {
 				font-weight: bold;
+				font-size: larger;
+			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			td[bgcolor="#FFFFCC"] h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
 			}
 		</style>
 	</head>
@@ -148,24 +160,20 @@
 					<ul class="toc">
 						<li>
 							<a href="#intro">Introduction</a><br />
-							<font size="-1">Unit aims, objectives, prerequisites.</font>
+							Unit aims, objectives, prerequisites.
 						</li>
 						<li>
 							<a href="#part1">Basic User Input and Output</a><br />
-							<font size="-1"
-								>This section introduces the ACCEPT and DISPLAY verbs and shows how the ACCEPT may be
-								used to get the system date and time.</font
-							>
+							This section introduces the ACCEPT and DISPLAY verbs and shows how the ACCEPT may be used to
+							get the system date and time.
 						</li>
 						<li>
 							<a href="#part2">Assignment using the MOVE verb</a><br />
-							<font size="-1">This section demonstrates how assignment is achieved in COBOL.</font>
+							This section demonstrates how assignment is achieved in COBOL.
 						</li>
 						<li>
 							<a href="#part3">Arithmetic in COBOL</a><br />
-							<font size="-1"
-								>This section introduces the ADD, SUBTRACT, MULTIPLY, DIVIDE and COMPUTE verbs.
-							</font>
+							This section introduces the ADD, SUBTRACT, MULTIPLY, DIVIDE and COMPUTE verbs.
 						</li>
 					</ul>
 					<hr />
@@ -173,18 +181,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="intro">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Introduction</font>
-						</font>
-					</h2>
+					<h2 align="center" id="intro">Introduction</h2>
 				</td>
 			</tr>
 			<tr>
 				<td bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#993300" face="Arial, Helvetica, sans-serif">Aims</font>
-					</h4>
+					<h4>Aims</h4>
 				</td>
 				<td width="540">
 					<p>
@@ -202,9 +204,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Objectives</font>
-					</h4>
+					<h4>Objectives</h4>
 				</td>
 				<td width="540">
 					<p>By the end of this unit you should -</p>
@@ -220,9 +220,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="77" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font>
-					</h4>
+					<h4>Prerequisites</h4>
 				</td>
 				<td height="77" valign="top" width="525">
 					<ul>
@@ -245,18 +243,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part1">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Basic User Input and Output</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part1">Basic User Input and Output</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4>Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -285,35 +277,24 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">The DISPLAY verb</font>
-					</h4>
+					<h4>The DISPLAY verb</h4>
 					<aside>
 						<p align="center">
 							<img height="44" src="Resources/pics/i-LightBulbTip.gif" width="42" />
 						</p>
 						<p align="left">
-							<font size="-1"
-								>In the COBOL syntax diagrams ( the COBOL metalanguage) upper case words are keywords.
-								If underlined, they are mandatory.<br
-							/></font>
-							<font size="-1">{ } brackets mean that one of the options must be selected<br /></font>
-							<font size="-1">[ ] brackets mean that the item is optional<br /></font>
-							<font size="-1"
-								>ellipses (...) mean that the item may be repeated at the programmer's discretion.</font
-							>
+							In the COBOL syntax diagrams ( the COBOL metalanguage) upper case words are keywords. If
+							underlined, they are mandatory.<br />
+							{ } brackets mean that one of the options must be selected<br />
+							[ ] brackets mean that the item is optional<br />
+							ellipses (...) mean that the item may be repeated at the programmer's discretion.
 						</p>
 						<p align="left">
-							<font size="-1"
-								>The symbols used in the syntax diagram identifiers have the following
-								significance:-</font
-							><br />
-							<font size="-1"
-								><b>$</b> signifies a string item,<br />
-								<b>#</b> is numeric item,<br />
-								<b>i</b> indicates that the item can be a variable identifier<br />
-								<b>l</b> indicates that the item can be a literal.
-							</font>
+							The symbols used in the syntax diagram identifiers have the following significance:-<br />
+							<b>$</b> signifies a string item,<br />
+							<b>#</b> is numeric item,<br />
+							<b>i</b> indicates that the item can be a variable identifier<br />
+							<b>l</b> indicates that the item can be a literal.
 						</p>
 					</aside>
 				</td>
@@ -365,9 +346,7 @@ DISPLAY PrinterSetupCodes UPON PrinterPort1.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">The ACCEPT verb</font>
-					</h4>
+					<h4>The ACCEPT verb</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -390,11 +369,7 @@ DISPLAY PrinterSetupCodes UPON PrinterPort1.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Using the ACCEPT to get the system date and time</font
-						>
-					</h4>
+					<h4>Using the ACCEPT to get the system date and time</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -440,9 +415,7 @@ DISPLAY PrinterSetupCodes UPON PrinterPort1.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">New formats for the ACCEPT</font>
-					</h4>
+					<h4>New formats for the ACCEPT</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -470,11 +443,7 @@ DISPLAY PrinterSetupCodes UPON PrinterPort1.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>ACCEPT and DISPLAY example program</font
-						>
-					</h4>
+					<h4 align="left">ACCEPT and DISPLAY example program</h4>
 					<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
 				</td>
 				<td valign="top" width="525">
@@ -553,7 +522,7 @@ Begin.
 						"
 					>
 						<p align="center">
-							<b>Results of running <font size="-1">ACCEPT.CBL</font></b>
+							<b>Results of running ACCEPT.CBL</b>
 						</p>
 						<pre>
 Enter student details using template below
@@ -583,18 +552,12 @@ The time is 14:41
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part2">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Assignment using the MOVE verb</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part2">Assignment using the MOVE verb</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4 align="left">Introduction</h4>
 				</td>
 				<td valign="top" width="540">
 					<p>
@@ -617,9 +580,7 @@ The time is 14:41
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">The MOVE verb</font>
-					</h4>
+					<h4 align="left">The MOVE verb</h4>
 				</td>
 				<td valign="top" width="525">
 					<p align="left"><u>MOVE</u> Source$#il <u>TO</u> Destination$#i ...</p>
@@ -674,15 +635,12 @@ The time is 14:41
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">MOVE examples</font>
-					</h4>
+					<h4 align="left">MOVE examples</h4>
 				</td>
 				<td valign="top" width="525">
 					<p id="com1">
-						Examine the examples in the animation below in combination with the
-						<font color="#000000" size="-1">MOVE</font> rules above. Make sure you understand the why the
-						moves produce the results shown.
+						Examine the examples in the animation below in combination with the MOVE rules above. Make sure
+						you understand the why the moves produce the results shown.
 					</p>
 					<p align="center">
 						<a href="Resources/ppz/TC-Commands1.html"
@@ -710,18 +668,12 @@ The time is 14:41
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part3">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Arithmetic in COBOL</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part3">Arithmetic in COBOL</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4>Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -736,9 +688,7 @@ The time is 14:41
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Data Movement</font>
-					</h4>
+					<h4 align="left">Data Movement</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -755,9 +705,7 @@ The time is 14:41
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">General Rules</font>
-					</h4>
+					<h4>General Rules</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -791,9 +739,7 @@ The time is 14:41
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">The ROUNDED option</font>
-					</h4>
+					<h4>The ROUNDED option</h4>
 				</td>
 				<td valign="top" width="525">
 					<p align="left">
@@ -823,7 +769,7 @@ The time is 14:41
 								<p><b>PIC 9(3)V9</b></p>
 							</td>
 							<td>
-								<b>123.2<font color="#FF0000">5</font></b>
+								<b>123.2<span style="color: #ff0000">5</span></b>
 							</td>
 							<td><b>123.2</b></td>
 							<td><b>123.3</b></td>
@@ -831,7 +777,7 @@ The time is 14:41
 						<tr>
 							<td><b>PIC 9(3)V9</b></td>
 							<td>
-								<b>123.2<font color="#FF0000">47</font></b>
+								<b>123.2<span style="color: #ff0000">47</span></b>
 							</td>
 							<td><b>123.2</b></td>
 							<td><b>123.2</b></td>
@@ -839,7 +785,7 @@ The time is 14:41
 						<tr>
 							<td><b>PIC 9(3)</b></td>
 							<td>
-								<b>123.<font color="#FF0000">25</font></b>
+								<b>123.<span style="color: #ff0000">25</span></b>
 							</td>
 							<td><b>123</b></td>
 							<td><b>123</b></td>
@@ -850,9 +796,7 @@ The time is 14:41
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">ON SIZE ERROR</font>
-					</h4>
+					<h4>ON SIZE ERROR</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -883,28 +827,28 @@ The time is 14:41
 								<th bgcolor="#FFFFCC" width="45%">
 									<div align="center">
 										<b>
-											<font color="#FF0000">Receiving Field</font>
+											<span style="color: #ff0000">Receiving Field</span>
 										</b>
 									</div>
 								</th>
 								<th bgcolor="#FFFFCC" width="19%">
 									<div align="center">
 										<b>
-											<font color="#FF0000">Actual Result</font>
+											<span style="color: #ff0000">Actual Result</span>
 										</b>
 									</div>
 								</th>
 								<th bgcolor="#FFFFCC" width="22%">
 									<div align="center">
 										<b>
-											<font color="#FF0000">Truncated Result</font>
+											<span style="color: #ff0000">Truncated Result</span>
 										</b>
 									</div>
 								</th>
 								<th bgcolor="#FFFFCC" width="14%">
 									<div align="center">
 										<b>
-											<font color="#FF0000">Size Error?</font>
+											<span style="color: #ff0000">Size Error?</span>
 										</b>
 									</div>
 								</th>
@@ -912,18 +856,14 @@ The time is 14:41
 							<tr>
 								<td width="45%"><b>PIC 9(3)V9</b></td>
 								<td width="19%">
-									<b>&nbsp;&nbsp;245.9<font color="#FF0000">6</font></b>
+									<b>&nbsp;&nbsp;245.9<span style="color: #ff0000">6</span></b>
 								</td>
 								<td width="22%">
 									<div align="left"><b>&nbsp;&nbsp;&nbsp;245.9</b></div>
 								</td>
 								<td width="14%">
 									<div align="center">
-										<b>
-											<font size="-1">
-												<font color="#000000">YES</font>
-											</font>
-										</b>
+										<b>YES</b>
 									</div>
 								</td>
 							</tr>
@@ -931,7 +871,7 @@ The time is 14:41
 								<td width="45%"><b>PIC 9(3)V9</b></td>
 								<td width="19%">
 									<div align="left">
-										<b>&nbsp;&nbsp;<font color="#FF0000">3</font>245.9</b>
+										<b>&nbsp;&nbsp;<span style="color: #ff0000">3</span>245.9</b>
 									</div>
 								</td>
 								<td width="22%">
@@ -965,7 +905,7 @@ The time is 14:41
 								<td width="45%"><b>PIC 9(3)</b></td>
 								<td width="19%">
 									<div align="left">
-										<b>&nbsp;<font color="#FF0000">&nbsp;5</font>324</b>
+										<b>&nbsp;<span style="color: #ff0000">&nbsp;5</span>324</b>
 									</div>
 								</td>
 								<td width="22%">
@@ -983,7 +923,7 @@ The time is 14:41
 								<td valign="top" width="45%"><b>PIC 9(3)V9 not Rounded</b></td>
 								<td width="19%">
 									<div align="left">
-										<b>&nbsp;&nbsp;523.3<font color="#FF0000">5</font></b>
+										<b>&nbsp;&nbsp;523.3<span style="color: #ff0000">5</span></b>
 									</div>
 								</td>
 								<td width="22%">
@@ -1000,7 +940,7 @@ The time is 14:41
 							<tr>
 								<td width="45%"><b>PIC 9(3)V9 Rounded</b></td>
 								<td width="19%">
-									<b>&nbsp;&nbsp;523.3<font color="#FF0000">5</font></b>
+									<b>&nbsp;&nbsp;523.3<span style="color: #ff0000">5</span></b>
 								</td>
 								<td width="22%"><b>&nbsp;&nbsp;&nbsp;523.4</b></td>
 								<td width="14%">
@@ -1016,8 +956,9 @@ The time is 14:41
 								<td width="19%">
 									<div align="left">
 										<b>
-											<font color="#FF0000">&nbsp;&nbsp;3</font>523.3<font color="#FF0000"
-												>5</font
+											<span style="color: #ff0000">&nbsp;&nbsp;3</span>523.3<span
+												style="color: #ff0000"
+												>5</span
 											>
 										</b>
 									</div>
@@ -1040,9 +981,7 @@ The time is 14:41
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">ADD verb</font>
-					</h4>
+					<h4 align="left">ADD verb</h4>
 				</td>
 				<td valign="top" width="525">
 					<p><img height="74" src="Resources/pics/Add.gif" width="499" /></p>
@@ -1061,9 +1000,7 @@ The time is 14:41
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">SUBTRACT verb</font>
-					</h4>
+					<h4 align="left">SUBTRACT verb</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -1087,9 +1024,7 @@ The time is 14:41
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">MULTIPLY verb</font>
-					</h4>
+					<h4>MULTIPLY verb</h4>
 				</td>
 				<td valign="top" width="525">
 					<p><img height="72" src="Resources/pics/Mult.gif" width="498" /></p>
@@ -1110,9 +1045,7 @@ The time is 14:41
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">DIVIDE verb</font>
-					</h4>
+					<h4>DIVIDE verb</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>The Divide has two main formats. One produces a remainder and the other does not.</p>
@@ -1144,9 +1077,7 @@ The time is 14:41
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">COMPUTE verb</font>
-					</h4>
+					<h4>COMPUTE verb</h4>
 				</td>
 				<td valign="top" width="525">
 					<p><img height="77" src="Resources/pics/Compute.gif" width="509" /></p>
@@ -1227,9 +1158,7 @@ The time is 14:41
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Arithmetic examples</font>
-					</h4>
+					<h4>Arithmetic examples</h4>
 				</td>
 				<td valign="top" width="525">
 					<p id="com2">
@@ -1269,17 +1198,12 @@ The time is 14:41
 							These COBOL course materials are the copyright property of Michael Coughlan.
 						</p>
 						<p align="left">
-							<font size="2"
-								>All rights reserved. No part of these course materials may be reproduced in any form or
-								by any means - graphic, electronic, mechanical, photocopying, printing, recording,
-								taping or stored in an information storage and retrieval system - without the written
-								permission of</font
-							>
-							<font size="2">the author.</font>
+							All rights reserved. No part of these course materials may be reproduced in any form or by
+							any means - graphic, electronic, mechanical, photocopying, printing, recording, taping or
+							stored in an information storage and retrieval system - without the written permission of
+							the author.
 						</p>
-						<p align="center">
-							<font size="2">(c) Michael Coughlan</font>
-						</p>
+						<p align="center">(c) Michael Coughlan</p>
 					</div>
 				</td>
 			</tr>

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -167,10 +167,22 @@
 			ul.toc > li {
 				padding-left: 0.4em;
 				margin-bottom: 0.6em;
+				font-size: smaller;
 			}
 
 			ul.toc a {
 				font-weight: bold;
+				font-size: larger;
+			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			td[bgcolor="#FFFFCC"] h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
 			}
 		</style>
 	</head>
@@ -190,33 +202,27 @@
 								<ul class="toc">
 									<li>
 										<a href="#intro">Introduction</a><br />
-										<font size="-1">Unit aims, objectives, prerequisites.</font>
+										Unit aims, objectives, prerequisites.
 									</li>
 									<li>
 										<a href="#part1">Using COPY statements</a><br />
-										<font size="-1"
-											>Introduction to the <code class="language-cobol">COPY</code> verb. Using
-											the <code class="language-cobol">COPY</code> verb when creating large
-											software systems</font
-										>
+										Introduction to the <code class="language-cobol">COPY</code> verb. Using the
+										<code class="language-cobol">COPY</code> verb when creating large software
+										systems
 									</li>
 									<li>
 										<a href="#part2">The COPY verb - Syntax and Semantics</a><br />
-										<font size="-1"
-											>The <code class="language-cobol">COPY</code> syntax. How the
-											<code class="language-cobol">COPY</code> works. How the
-											<code class="language-cobol">REPLACING</code> phrase works.
-											<code class="language-cobol">COPY</code> rules.</font
-										>
+										The <code class="language-cobol">COPY</code> syntax. How the
+										<code class="language-cobol">COPY</code> works. How the
+										<code class="language-cobol">REPLACING</code> phrase works.
+										<code class="language-cobol">COPY</code> rules.
 									</li>
 									<li>
 										<a href="#part3">COPY examples</a><br />
-										<font size="-1"
-											>Four example programs showing the program source text before processing the
-											<code class="language-cobol">COPY</code> statements, the copy library text,
-											and the program source text after processing the
-											<code class="language-cobol">COPY</code> statements in the program.</font
-										>
+										Four example programs showing the program source text before processing the
+										<code class="language-cobol">COPY</code> statements, the copy library text, and
+										the program source text after processing the
+										<code class="language-cobol">COPY</code> statements in the program.
 									</li>
 								</ul>
 								<hr />
@@ -224,18 +230,12 @@
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#993300" colspan="2" valign="top">
-								<h2 align="center" id="intro">
-									<font color="#FFFF00">
-										<font face="Arial, Helvetica, sans-serif">Introduction</font>
-									</font>
-								</h2>
+								<h2 align="center" id="intro">Introduction</h2>
 							</td>
 						</tr>
 						<tr>
 							<td bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#993300" face="Arial, Helvetica, sans-serif">Aims</font>
-								</h4>
+								<h4>Aims</h4>
 								<h4><img height="1" src="Resources/pics/PanelLine.gif" width="175" /></h4>
 							</td>
 							<td valign="top" width="525">
@@ -270,9 +270,7 @@
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#800000" face="Arial, Helvetica, sans-serif">Objectives</font>
-								</h4>
+								<h4>Objectives</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>By the end of this unit you should -</p>
@@ -296,9 +294,7 @@
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font>
-								</h4>
+								<h4>Prerequisites</h4>
 							</td>
 							<td valign="top" width="525">
 								<ul>
@@ -337,18 +333,12 @@
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#993300" colspan="2" valign="top">
-								<h2 align="center" id="part1">
-									<font color="#FFFF00">
-										<font face="Arial, Helvetica, sans-serif">Using the COPY verb</font>
-									</font>
-								</h2>
+								<h2 align="center" id="part1">Using the COPY verb</h2>
 							</td>
 						</tr>
 						<tr>
 							<td bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#993300" face="Arial, Helvetica, sans-serif">Introduction</font>
-								</h4>
+								<h4>Introduction</h4>
 								<h4><img height="1" src="Resources/pics/PanelLine.gif" width="175" /></h4>
 							</td>
 							<td valign="top" width="525">
@@ -390,13 +380,7 @@
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
 								<h4>
-									<font color="#800000"
-										><b>
-											<font face="Arial, Helvetica, sans-serif"
-												>Using the COPY verb in large software systems</font
-											>
-										</b></font
-									>
+									<b>Using the COPY verb in large software systems</b>
 								</h4>
 							</td>
 							<td valign="top" width="525">
@@ -454,30 +438,22 @@
 						<tr>
 							<td align="left" bgcolor="#993300" colspan="2" valign="top">
 								<h2 align="center" id="part2">
-									<font color="#FFFF00">
-										<font color="#FFFF00" face="Arial, Helvetica, sans-serif"
-											><b
-												>The COPY verb<br />
-												Syntax and Semantics</b
-											></font
-										>
-									</font>
+									<b
+										>The COPY verb<br />
+										Syntax and Semantics</b
+									>
 								</h2>
 							</td>
 						</tr>
 						<tr>
 							<td bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#993300" face="Arial, Helvetica, sans-serif">COPY Syntax</font>
-								</h4>
+								<h4>COPY Syntax</h4>
 								<aside>
 									<p align="center">
 										<img height="37" src="Resources/pics/aa%20i-Detail.gif" width="30" /><br />
-										<font size="-1"
-											>The syntax diagram shown opposite has been simplified for the sake of
-											completeness and clarity. It is the author's opinion that the standard
-											syntax diagram does not clearly identify all the replaceable objects.</font
-										>
+										The syntax diagram shown opposite has been simplified for the sake of
+										completeness and clarity. It is the author's opinion that the standard syntax
+										diagram does not clearly identify all the replaceable objects.
 									</p>
 								</aside>
 								<h4><img height="1" src="Resources/pics/PanelLine.gif" width="175" /></h4>
@@ -495,10 +471,10 @@
 									<div align="left">
 										<ul>
 											<li>
-												Any COBOL text enclosed in double equal signs (e.g.
-												<font face="Arial, Helvetica, sans-serif">==ADD 1==</font>). This text
-												is known as PseudoText and it allows us to replace a series of words or
-												characters as opposed to an individual identifier, literal or word.<br />
+												Any COBOL text enclosed in double equal signs (e.g. ==ADD 1==). This
+												text is known as PseudoText and it allows us to replace a series of
+												words or characters as opposed to an individual identifier, literal or
+												word.<br />
 												<br />
 											</li>
 											<li>
@@ -533,38 +509,40 @@
 											1 Text Word<br />
 											<br />
 											<b>MOVE Total TO Print-Total</b><br />
-											4 Text Words - <font color="#0000FF"><b>MOVE</b></font>
+											4 Text Words - <span style="color: #0000ff"><b>MOVE</b></span>
 											<b>
-												<font color="#0000FF">
-													<font color="#FF0000">Total</font> TO
-													<font color="#FF0000">Print-Total</font>
-												</font>
+												<span style="color: #0000ff">
+													<span style="color: #ff0000">Total</span> TO
+													<span style="color: #ff0000">Print-Total</span>
+												</span>
 											</b>
 										</p>
 										<p align="left">
 											<b>MOVE Total TO Print-Total.</b><br />
-											5 Text Words - <font color="#0000FF"><b>MOVE</b></font>
+											5 Text Words - <span style="color: #0000ff"><b>MOVE</b></span>
 											<b>
-												<font color="#FF0000">Total</font>
-												<font color="#0000FF">TO</font>
-												<font color="#FF0000">Print-Total</font>
-												<font color="#0000FF">.</font>
+												<span style="color: #ff0000">Total</span>
+												<span style="color: #0000ff">TO</span>
+												<span style="color: #ff0000">Print-Total</span>
+												<span style="color: #0000ff">.</span>
 											</b>
 										</p>
 										<p align="left">
 											<b>PIC S9(4)V9(6)</b><br />
 											9 Text words -
 											<b>
-												<font color="#0000FF">PIC</font>
-												<font color="#0000FF">
-													<font color="#FF0000">S9</font> ( <font color="#FF0000">4</font> )
-													<font color="#FF0000">V9</font> ( <font color="#FF0000">6</font> )
-												</font>
+												<span style="color: #0000ff">PIC</span>
+												<span style="color: #0000ff">
+													<span style="color: #ff0000">S9</span> (
+													<span style="color: #ff0000">4</span> )
+													<span style="color: #ff0000">V9</span> (
+													<span style="color: #ff0000">6</span> )
+												</span>
 											</b>
 										</p>
 										<p align="left">
 											<b>“PIC S9(4)V9(6)”</b><br />
-											1 Text word - <font color="#0000FF"><b>“PIC S9(4)V9(6)”</b></font
+											1 Text word - <span style="”color:" #0000FF”><b>”PIC S9(4)V9(6)”</b></span
 											><br />
 										</p>
 									</blockquote>
@@ -575,11 +553,7 @@
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
 								<h4>
-									<b>
-										<font color="#800000" face="Arial, Helvetica, sans-serif"
-											>How the COPY works</font
-										>
-									</b>
+									<b>How the COPY works</b>
 								</h4>
 							</td>
 							<td valign="top" width="525">
@@ -606,11 +580,7 @@ COPY CopyFile4 IN EGLIB.</code></pre>
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>How the REPLACING phrase works
-									</font>
-								</h4>
+								<h4>How the REPLACING phrase works</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -636,9 +606,7 @@ COPY CopyFile4 IN EGLIB.</code></pre>
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#800000" face="Arial, Helvetica, sans-serif">COPY Rules</font>
-								</h4>
+								<h4>COPY Rules</h4>
 							</td>
 							<td valign="top" width="525">
 								<ol>
@@ -649,8 +617,7 @@ COPY CopyFile4 IN EGLIB.</code></pre>
 									</li>
 									<li>
 										When TextWord2 is PseudoText it can be null. Null PseudoText is indicated by
-										four equal signs (e.g.
-										<font face="Arial, Helvetica, sans-serif">====</font>)<br />
+										four equal signs (e.g. ====)<br />
 										<br />
 									</li>
 									<li>
@@ -701,48 +668,38 @@ COPY CopyFile4 IN EGLIB.</code></pre>
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#993300" colspan="2" valign="top">
-								<h2 align="center" id="part3">
-									<font color="#FFFF00">
-										<font face="Arial, Helvetica, sans-serif">COPY examples</font>
-									</font>
-								</h2>
+								<h2 align="center" id="part3">COPY examples</h2>
 							</td>
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
 								<p>
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										><b>COPY Example1</b></font
-									>
+									<b>COPY Example1</b>
 								</p>
 								<p align="center">
 									<b>
-										<font color="#800000" face="Arial, Helvetica, sans-serif"
-											><img height="62" src="Resources/pics/aai-Legend.gif" width="65"
-										/></font>
+										<img height="62" src="Resources/pics/aai-Legend.gif" width="65" />
 									</b>
 								</p>
 								<p>
-									<font size="-1">Text in</font>
-									<font color="#006600"><b>green</b></font>
-									<font size="-1">is the copy statement in the source text before processing.</font>
+									Text in
+									<span style="color: #006600"><b>green</b></span>
+									is the copy statement in the source text before processing.
 								</p>
 								<p>
-									<font size="-1">Text in</font>
+									Text in
 									<b>
-										<font color="#FF0000">red</font>
+										<span style="color: #ff0000">red</span>
 									</b>
-									<font size="-1"
-										>is the copied library text which may have been altered by the REPLACING phrase
-										if one was present and found matching text in the library file.</font
-									>
+									is the copied library text which may have been altered by the REPLACING phrase if
+									one was present and found matching text in the library file.
 								</p>
 								<p>
-									<font size="-1">Text in</font>
+									Text in
 									<b>
-										<font color="#CCCCCC">grey</font>
+										<span style="color: #cccccc">grey</span>
 									</b>
-									<font size="-1">is the COPY statement which has been applied.</font>
+									is the COPY statement which has been applied.
 								</p>
 							</td>
 							<td valign="top" width="525">
@@ -756,13 +713,7 @@ COPY CopyFile4 IN EGLIB.</code></pre>
 									<tr>
 										<td valign="top">
 											<div align="center">
-												<font color="#009933"
-													><b>
-														<font color="#000099" face="Arial, Helvetica, sans-serif"
-															>Source Text</font
-														>
-														<font color="#000099"></font> </b
-												></font>
+												<b>Source Text</b>
 											</div>
 											<pre
 												class="language-cobol"
@@ -801,11 +752,7 @@ BeginProg.
 									<tr>
 										<td bgcolor="#FFFFFF" valign="top">
 											<div align="center">
-												<b>
-													<font color="#000099" face="Arial, Helvetica, sans-serif"
-														>Text in COPYFILE1</font
-													> </b
-												><br />
+												<b>Text in COPYFILE1</b><br />
 												<br />
 											</div>
 											<pre class="language-cobol"><code class="language-cobol">
@@ -822,20 +769,16 @@ BeginProg.
 									<tr>
 										<td valign="top">
 											<div align="center">
-												<b>
-													<font color="#000099" face="Arial, Helvetica, sans-serif"
-														>Source Text after processing</font
-													><br />
-												</b>
+												<b>Source Text after processing<br /> </b>
 											</div>
 											<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
-IDENTIFICATION DIVISION.                                 
-PROGRAM-ID. COPYEG1.                                     
-AUTHOR.  Michael Coughlan.                               
-                                                         
-ENVIRONMENT DIVISION.                                    
-FILE-CONTROL.                                            
+IDENTIFICATION DIVISION.
+PROGRAM-ID. COPYEG1.
+AUTHOR.  Michael Coughlan.
+
+ENVIRONMENT DIVISION.
+FILE-CONTROL.
     SELECT StudentFile ASSIGN TO "STUDENTS.DAT"          
     ORGANIZATION IS LINE SEQUENTIAL.                     
                                                          
@@ -874,67 +817,48 @@ BeginProg.
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
 								<p>
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										><b>COPY Example2</b></font
-									>
+									<b>COPY Example2</b>
 								</p>
 								<aside>
 									<p align="center">
 										<img height="37" src="Resources/pics/aa%20i-Detail.gif" width="30" />
 									</p>
 									<p align="left">
-										<font size="-1"
-											><b>Note1</b><br />
-											The TextWord XYZ in the library text is replaced by 120.</font
-										>
+										<b>Note1</b><br />
+										The TextWord XYZ in the library text is replaced by 120.
 									</p>
 									<p align="left">
-										<font size="-1"
-											><b>Note2</b><br />
-											The PseudoText symbols tell us that we are looking for the text word R in
-											the library text. Other R's in the text which might be part of a word are
-											not matched because they are not text words. The replaced R is a text word
-											because it is bounded by two other text words i.e. the parentheses ( and
-											).</font
-										>
+										<b>Note2</b><br />
+										The PseudoText symbols tell us that we are looking for the text word R in the
+										library text. Other R's in the text which might be part of a word are not
+										matched because they are not text words. The replaced R is a text word because
+										it is bounded by two other text words i.e. the parentheses ( and ).
 									</p>
 									<p align="left">
-										<font size="-1"
-											><b>Note3</b><br />
-											The PseudoText ==V99== is replaced by nothing; effectively deleting
-											it.</font
-										>
+										<b>Note3</b><br />
+										The PseudoText ==V99== is replaced by nothing; effectively deleting it.
 									</p>
 									<p align="left">
-										<font size="-1"
-											><b>Note4</b><br />
-											The literal "KEY" in the library text is replaced by "ABC"</font
-										>
+										<b>Note4</b><br />
+										The literal "KEY" in the library text is replaced by "ABC"
 									</p>
 									<p align="left">
-										<font size="-1"
-											><b>Note5</b><br />
-											In this case the library text is copied without change because the literal
-											"KEY" in the library text is not the same as the word <i>KEY</i> in
-											TextWord2.</font
-										>
+										<b>Note5</b><br />
+										In this case the library text is copied without change because the literal "KEY"
+										in the library text is not the same as the word <i>KEY</i> in TextWord2.
 									</p>
 									<p align="left">
-										<font size="-1"
-											><b>Note6</b><br />
-											Similar to the previous example demonstrates the difference between CustKey
-											and the literal "CustKey". A literal text word includes the opening and
-											closing quotes.</font
-										>
+										<b>Note6</b><br />
+										Similar to the previous example demonstrates the difference between CustKey and
+										the literal "CustKey". A literal text word includes the opening and closing
+										quotes.
 									</p>
 									<p align="left">
-										<font size="-1"
-											><b>Note7</b><br />
-											Replaces "KEY" by two lines of text. Note that we are only replacing the
-											literal "KEY" in the library text. So the full stop after "KEY" is not
-											replaced and that is why there is no full stop after the PIC 9(8) in the
-											TextWord2 replacement text.</font
-										>
+										<b>Note7</b><br />
+										Replaces "KEY" by two lines of text. Note that we are only replacing the literal
+										"KEY" in the library text. So the full stop after "KEY" is not replaced and that
+										is why there is no full stop after the PIC 9(8) in the TextWord2 replacement
+										text.
 									</p>
 								</aside>
 								<p align="left"><img height="1" src="Resources/pics/PanelLine.gif" width="175" /></p>
@@ -950,13 +874,7 @@ BeginProg.
 									<tr>
 										<td valign="top">
 											<div align="center">
-												<font color="#009933"
-													><b>
-														<font color="#000099" face="Arial, Helvetica, sans-serif"
-															>Source Text</font
-														>
-														<font color="#000099"></font> </b
-												></font>
+												<b>Source Text</b>
 											</div>
 											<pre
 												class="language-cobol"
@@ -1003,7 +921,7 @@ STOP RUN.
 									<tr>
 										<td bgcolor="#FFFFFF" valign="top">
 											<div align="center">
-												<b> <font color="#000099">Text in CopyFile2</font> </b><br />
+												<b>Text in CopyFile2</b><br />
 												<br />
 											</div>
 											<pre class="language-cobol"><code class="language-cobol">
@@ -1014,7 +932,7 @@ STOP RUN.
 									<tr>
 										<td bgcolor="#FFFFFF" valign="top">
 											<div align="center">
-												<b> <font color="#000099">Text in CopyFile3</font> </b><br />
+												<b>Text in CopyFile3</b><br />
 												<br />
 											</div>
 											<pre class="language-cobol"><code class="language-cobol">
@@ -1025,7 +943,7 @@ STOP RUN.
 									<tr>
 										<td bgcolor="#FFFFFF" valign="top">
 											<div align="center">
-												<b> <font color="#000099">Text in CopyFile4</font> </b><br />
+												<b>Text in CopyFile4</b><br />
 												<br />
 											</div>
 											<pre class="language-cobol"><code class="language-cobol">
@@ -1036,7 +954,7 @@ STOP RUN.
 									<tr>
 										<td bgcolor="#FFFFFF" valign="top">
 											<div align="center">
-												<b> <font color="#000099">Text in CopyFile5</font> </b><br />
+												<b>Text in CopyFile5</b><br />
 												<br />
 											</div>
 											<pre class="language-cobol"><code class="language-cobol">
@@ -1047,17 +965,13 @@ STOP RUN.
 									<tr>
 										<td valign="top">
 											<div align="center">
-												<b>
-													<font color="#000099" face="Arial, Helvetica, sans-serif"
-														>Source Text after processing</font
-													><br />
-												</b>
+												<b>Source Text after processing<br /> </b>
 											</div>
 											<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
-IDENTIFICATION DIVISION.                         
-PROGRAM-ID. COPYEG2.                             
-AUTHOR.  Michael Coughlan.                       
+IDENTIFICATION DIVISION.
+PROGRAM-ID. COPYEG2.
+AUTHOR.  Michael Coughlan.
                                                  
 DATA DIVISION.                                   
 WORKING-STORAGE SECTION.                         
@@ -1110,81 +1024,57 @@ STOP RUN.
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
 								<p>
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										><b>COPY Example3</b></font
-									>
+									<b>COPY Example3</b>
 								</p>
 								<aside>
 									<p align="center">
 										<img height="37" src="Resources/pics/aa%20i-Detail.gif" width="30" />
 									</p>
 									<p align="left">
-										<font size="-1"
-											>Note that these COPY statements, which are themselves syntactically
-											correct, result in statements which cause syntax errors. This is a clear
-											indication that COPY statements are processed before the resulting program
-											is compiled.</font
-										>
+										Note that these COPY statements, which are themselves syntactically correct,
+										result in statements which cause syntax errors. This is a clear indication that
+										COPY statements are processed before the resulting program is compiled.
 									</p>
 									<p align="left">
-										<font size="-1"
-											><b>Note1</b><br />
-											The text word ( in the library text is replaced by @. Demonstrates that ( is
-											a text word.</font
-										>
+										<b>Note1</b><br />
+										The text word ( in the library text is replaced by @. Demonstrates that ( is a
+										text word.
 									</p>
 									<p align="left">
-										<font size="-1"
-											><b>Note2</b><br />
-											Demonstrates that the 3 between ( and ) is a text word.</font
-										>
+										<b>Note2</b><br />
+										Demonstrates that the 3 between ( and ) is a text word.
 									</p>
 									<p align="left">
-										<font size="-1"
-											>Note3<br />
-											Demonstrates that ) is a textword.</font
-										>
+										Note3<br />
+										Demonstrates that ) is a textword.
 									</p>
 									<p align="left">
-										<font size="-1"
-											><b>Note4</b><br />
-											Demonstrates that the X before (3) is a textword and is replaced by the
-											PseudoText "Replace the X"</font
-										>
+										<b>Note4</b><br />
+										Demonstrates that the X before (3) is a textword and is replaced by the
+										PseudoText "Replace the X"
 									</p>
 									<p>
-										<font size="-1"
-											><b>Note5</b><br />
-											The PseudoText X(3) is replaced by X(19)</font
-										>
+										<b>Note5</b><br />
+										The PseudoText X(3) is replaced by X(19)
 									</p>
 									<p>
-										<font size="-1"
-											><b>Note6</b><br />
-											This looks the same as number 5 but what is actually happening is that the
-											series of textwords<br
-										/></font>
-										<font size="-1"
-											><b>X</b> and <b>(</b> and <b>3</b> and <b>)</b> is replaced by the series
-											<b>X ( 19 )</b>
-										</font>
+										<b>Note6</b><br />
+										This looks the same as number 5 but what is actually happening is that the
+										series of textwords<br />
+										<b>X</b> and <b>(</b> and <b>3</b> and <b>)</b> is replaced by the series
+										<b>X ( 19 )</b>
 									</p>
 									<p>
-										<font size="-1"
-											><b>Note7</b><br />
-											The textword PIC (bounded by separator spaces) is replaced by the PseudoText
-											<i>Pic is Replaced</i>
-										</font>
+										<b>Note7</b><br />
+										The textword PIC (bounded by separator spaces) is replaced by the PseudoText
+										<i>Pic is Replaced</i>
 									</p>
 									<p>
-										<font size="-1"
-											><b>Note8</b><br />
-											But the letter P in PIC is not a textword by itself and so is not
-											replaced.</font
-										>
+										<b>Note8</b><br />
+										But the letter P in PIC is not a textword by itself and so is not replaced.
 									</p>
 									<p align="left">
-										<font size="-1"><br /></font>
+										<br />
 									</p>
 								</aside>
 							</td>
@@ -1199,13 +1089,7 @@ STOP RUN.
 									<tr>
 										<td valign="top">
 											<div align="center">
-												<font color="#009933"
-													><b>
-														<font color="#000099" face="Arial, Helvetica, sans-serif"
-															>Source Text</font
-														>
-														<font color="#000099"></font> </b
-												></font>
+												<b>Source Text</b>
 											</div>
 											<pre
 												class="language-cobol"
@@ -1253,7 +1137,7 @@ BeginProg.
 									<tr>
 										<td bgcolor="#FFFFFF" valign="top">
 											<div align="center">
-												<b> <font color="#000099">Library Text in CopyFile5</font> </b><br />
+												<b>Library Text in CopyFile5</b><br />
 												<br />
 											</div>
 											<pre class="language-cobol"><code class="language-cobol">
@@ -1264,17 +1148,13 @@ BeginProg.
 									<tr>
 										<td valign="top">
 											<div align="center">
-												<b>
-													<font color="#000099" face="Arial, Helvetica, sans-serif"
-														>Source Text after processing</font
-													><br />
-												</b>
+												<b>Source Text after processing<br /> </b>
 											</div>
 											<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
-IDENTIFICATION DIVISION. 
-PROGRAM-ID. COPYEG3. 
-AUTHOR.  Michael Coughlan. 
+IDENTIFICATION DIVISION.
+PROGRAM-ID. COPYEG3.
+AUTHOR.  Michael Coughlan.
 
 DATA DIVISION. 
 WORKING-STORAGE SECTION. 
@@ -1326,26 +1206,20 @@ BeginProg.
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
 								<p>
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										><b>COPY Example4</b></font
-									>
+									<b>COPY Example4</b>
 								</p>
 								<aside>
 									<p align="center">
 										<img height="37" src="Resources/pics/aa%20i-Detail.gif" width="30" />
 									</p>
 									<p align="left">
-										<font size="-1"
-											><b>Note1</b><br />
-											This example demonstrates that a single COPY statement can be used to
-											replace more than one set of items.</font
-										>
+										<b>Note1</b><br />
+										This example demonstrates that a single COPY statement can be used to replace
+										more than one set of items.
 									</p>
 									<p align="left">
-										<font size="-1"
-											><b>Note2</b><br />
-											As above.</font
-										>
+										<b>Note2</b><br />
+										As above.
 									</p>
 								</aside>
 							</td>
@@ -1360,13 +1234,7 @@ BeginProg.
 									<tr>
 										<td valign="top">
 											<div align="center">
-												<font color="#009933"
-													><b>
-														<font color="#000099" face="Arial, Helvetica, sans-serif"
-															>Source Text</font
-														>
-														<font color="#000099"></font> </b
-												></font>
+												<b>Source Text</b>
 											</div>
 											<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
@@ -1399,7 +1267,7 @@ COPY CopyFile7 REPLACING N1 BY Num1
 									<tr>
 										<td bgcolor="#FFFFFF" valign="top">
 											<div align="center">
-												<b> <font color="#000099">Library Text in CopyFile6</font> </b><br />
+												<b>Library Text in CopyFile6</b><br />
 												<br />
 											</div>
 											<pre class="language-cobol"><code class="language-cobol">
@@ -1411,7 +1279,7 @@ COPY CopyFile7 REPLACING N1 BY Num1
 									<tr>
 										<td bgcolor="#FFFFFF" valign="top">
 											<div align="center">
-												<b> <font color="#000099">Library Text in CopyFile7</font> </b><br />
+												<b>Library Text in CopyFile7</b><br />
 												<br />
 											</div>
 											<pre class="language-cobol"><code class="language-cobol">
@@ -1422,18 +1290,14 @@ COPY CopyFile7 REPLACING N1 BY Num1
 									<tr>
 										<td valign="top">
 											<div align="center">
-												<b>
-													<font color="#000099" face="Arial, Helvetica, sans-serif"
-														>Source Text after processing</font
-													><br />
-												</b>
+												<b>Source Text after processing<br /> </b>
 											</div>
 											<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
-IDENTIFICATION DIVISION.                               
-PROGRAM-ID. COPYEG4.                                   
-AUTHOR.  Michael Coughlan.                             
-                                                       
+IDENTIFICATION DIVISION.
+PROGRAM-ID. COPYEG4.
+AUTHOR.  Michael Coughlan.
+
 DATA DIVISION.                                         
 WORKING-STORAGE SECTION.                               
 01 Num1     PIC 9 VALUE 3.                             
@@ -1476,17 +1340,12 @@ COPY CopyFile7 REPLACING N1 BY Num1
 										These COBOL course materials are the copyright property of Michael Coughlan.
 									</p>
 									<p align="left">
-										<font size="2"
-											>All rights reserved. No part of these course materials may be reproduced in
-											any form or by any means - graphic, electronic, mechanical, photocopying,
-											printing, recording, taping or stored in an information storage and
-											retrieval system - without the written permission of</font
-										>
-										<font size="2">the author.</font>
+										All rights reserved. No part of these course materials may be reproduced in any
+										form or by any means - graphic, electronic, mechanical, photocopying, printing,
+										recording, taping or stored in an information storage and retrieval system -
+										without the written permission of the author.
 									</p>
-									<p align="center">
-										<font size="2">(c) Michael Coughlan</font>
-									</p>
+									<p align="center">(c) Michael Coughlan</p>
 								</div>
 							</td>
 						</tr>

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -128,10 +128,22 @@
 			ul.toc > li {
 				padding-left: 0.4em;
 				margin-bottom: 0.6em;
+				font-size: smaller;
 			}
 
 			ul.toc a {
 				font-weight: bold;
+				font-size: larger;
+			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			td[bgcolor="#FFFFCC"] h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
 			}
 		</style>
 	</head>
@@ -147,42 +159,34 @@
 					<ul class="toc">
 						<li>
 							<a href="#intro">Introduction</a><br />
-							<font size="-1">Unit aims, objectives, prerequisites and further reading.</font>
+							Unit aims, objectives, prerequisites and further reading.
 						</li>
 						<li>
 							<a href="#part1">Categories of COBOL data</a><br />
-							<font size="-1"
-								>This section introduces the three categories of COBOL data - Literals, Variables and
-								Figurative Constants.</font
-							>
+							This section introduces the three categories of COBOL data - Literals, Variables and
+							Figurative Constants.
 						</li>
 						<li>
 							<a href="#part2">Declaring Data-Items in COBOL</a><br />
-							<font size="-1"
-								>In this section we show how variables are declared in COBOL using the
-								<code class="language-cobol">PICTURE</code> clause.</font
-							>
+							In this section we show how variables are declared in COBOL using the
+							<code class="language-cobol">PICTURE</code> clause.
 						</li>
 						<li>
 							<a href="#part3">Group and Elementary Data-Items</a><br />
-							<font size="-1"
-								>This section demonstrates how record structures can be specified using an appropriate
-								arrangement of level numbers.</font
-							>
+							This section demonstrates how record structures can be specified using an appropriate
+							arrangement of level numbers.
 						</li>
 					</ul>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="intro">
-						<font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Introduction</font></font>
-					</h2>
+					<h2 align="center" id="intro">Introduction</h2>
 				</td>
 			</tr>
 			<tr>
 				<td bgcolor="#FFFFCC" valign="top" width="160">
-					<h4><font color="#993300" face="Arial, Helvetica, sans-serif">Aims</font></h4>
+					<h4>Aims</h4>
 				</td>
 				<td width="540">
 					<p>
@@ -194,7 +198,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Objectives</font></h4>
+					<h4>Objectives</h4>
 				</td>
 				<td width="540">
 					<p>By the end of this unit you should -</p>
@@ -213,7 +217,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font></h4>
+					<h4>Prerequisites</h4>
 				</td>
 				<td width="525">
 					<p>Introduction to COBOL.</p>
@@ -227,9 +231,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Further reading</font>
-					</h4>
+					<h4>Further reading</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>More information on declaring data items in COBOL can be found in the units covering -</p>
@@ -254,18 +256,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part1">
-						<font color="#FFFF00"
-							><font face="Arial, Helvetica, sans-serif">Categories of COBOL data</font></font
-						>
-					</h2>
+					<h2 align="center" id="part1">Categories of COBOL data</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4 align="left">Introduction</h4>
 				</td>
 				<td valign="top" width="540">
 					<p>There are three categories of data item used in COBOL programs:</p>
@@ -279,9 +275,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Variables</font>
-					</h4>
+					<h4 align="left">Variables</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -301,16 +295,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Variable Data types</font>
-					</h4>
+					<h4 align="left">Variable Data types</h4>
 					<aside>
 						<p align="center">
 							<img height="62" src="Resources/pics/i-BugAlert.gif" width="56" /><br />
-							<font size="-1"
-								>Attempting to perform computations on numeric data items that contain non-numeric data
-								is a frequent cause of program crashes for beginning COBOL programmers.</font
-							>
+							Attempting to perform computations on numeric data items that contain non-numeric data is a
+							frequent cause of program crashes for beginning COBOL programmers.
 						</p>
 					</aside>
 				</td>
@@ -348,9 +338,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Literals</font>
-					</h4>
+					<h4 align="left">Literals</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -366,9 +354,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">String Literals</font>
-					</h4>
+					<h4 align="left">String Literals</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>String/Alphanumeric literals are enclosed in quotes and consist of alphanumeric characters.</p>
@@ -377,9 +363,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Numeric Literals</font>
-					</h4>
+					<h4 align="left">Numeric Literals</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -392,34 +376,24 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Figurative Constants</font>
-					</h4>
+					<h4 align="left">Figurative Constants</h4>
 					<aside>
 						<p align="center">
 							<img height="37" src="Resources/pics/i-Detail.gif" width="30" />
 						</p>
 						<p align="center">
-							<font size="-1"
-								>Actually <font size="-2">COBOL</font> does allow you to set up single character
-								user-defined Figurative Constants. These can be useful if you need to use the
-								non-printable <font size="-2">ASCII</font> characters such as
-								<font size="-2">ESC</font> or FormFeed.</font
-							>
+							Actually COBOL does allow you to set up single character user-defined Figurative Constants.
+							These can be useful if you need to use the non-printable ASCII characters such as ESC or
+							FormFeed.
 						</p>
 						<p align="center">
-							<font size="-1"
-								>User-defined Figurative Constants are declared in the
-								<code class="language-cobol">SYMBOLIC CHARACTERS</code> clause of the
-								<code class="language-cobol">ENVIRONMENT DIVISION</code>.</font
-							>
+							User-defined Figurative Constants are declared in the
+							<code class="language-cobol">SYMBOLIC CHARACTERS</code> clause of the
+							<code class="language-cobol">ENVIRONMENT DIVISION</code>.
 						</p>
 						<p align="center">
-							<font size="-1"
-								>In an extension that previews the new <font size="-2">COBOL</font> specification,
-								NetExpress does allow user-defined constants. It uses the level 78 for this
-								purpose.</font
-							>
+							In an extension that previews the new COBOL specification, NetExpress does allow
+							user-defined constants. It uses the level 78 for this purpose.
 						</p>
 					</aside>
 				</td>
@@ -498,14 +472,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Using COBOL data — examples</font>
-					</h4>
+					<h4 align="left">Using COBOL data — examples</h4>
 				</td>
 				<td valign="top" width="525">
 					<p id="data1">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"></font>The animated program fragments
-						below demonstrate how variables, literals and Figurative Constants may be created and used.
+						The animated program fragments below demonstrate how variables, literals and Figurative
+						Constants may be created and used.
 					</p>
 					<p align="center">
 						<a href="Resources/ppz/TC-Data1.html"
@@ -533,14 +505,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top">
-					<h2 align="center" id="part2">
-						<font color="#FFFF00" face="Arial, Helvetica, sans-serif">Declaring Data-Items in COBOL</font>
-					</h2>
+					<h2 align="center" id="part2">Declaring Data-Items in COBOL</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font></h4>
+					<h4>Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -566,16 +536,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">COBOL picture clauses</font>
-					</h4>
+					<h4 align="left">COBOL picture clauses</h4>
 					<aside>
 						<p align="center">
 							<img height="37" src="Resources/pics/i-Detail.gif" width="30" /><br />
-							<font size="-1"
-								>There are actually many more picture symbols than these. Most of these will be
-								introduced when we cover Edited Pictures.</font
-							>
+							There are actually many more picture symbols than these. Most of these will be introduced
+							when we cover Edited Pictures.
 						</p>
 					</aside>
 				</td>
@@ -588,77 +554,67 @@
 						<tr>
 							<td valign="top" width="14%">
 								<p align="center">
-									<b><font face="TIMES" size="2">9</font></b>
+									<b>9</b>
 								</p>
 							</td>
 							<td valign="top" width="86%">
 								<p>
-									<font face="TIMES" size="2"
-										>The digit nine is used to indicate the occurrence of a digit at the
-										corresponding position in the picture.</font
-									>
+									The digit nine is used to indicate the occurrence of a digit at the corresponding
+									position in the picture.
 								</p>
 							</td>
 						</tr>
 						<tr>
 							<td valign="top" width="14%">
 								<p align="center">
-									<b><font face="TIMES" size="2">X</font></b>
+									<b>X</b>
 								</p>
 							</td>
 							<td valign="top" width="86%">
 								<p>
-									<font face="TIMES" size="2"
-										>The character X is used to indicate the occurrence of any character from the
-										character set at the corresponding position in the picture.</font
-									>
+									The character X is used to indicate the occurrence of any character from the
+									character set at the corresponding position in the picture.
 								</p>
 							</td>
 						</tr>
 						<tr>
 							<td valign="top" width="14%">
 								<p align="center">
-									<b><font face="TIMES" size="2">A</font></b>
+									<b>A</b>
 								</p>
 							</td>
 							<td valign="top" width="86%">
 								<p>
-									<font face="TIMES" size="2"
-										>The character A is used to indicate the occurrence of any alphabetic character
-										(A to Z plus blank) at the corresponding position in the picture.</font
-									>
+									The character A is used to indicate the occurrence of any alphabetic character (A to
+									Z plus blank) at the corresponding position in the picture.
 								</p>
 							</td>
 						</tr>
 						<tr>
 							<td valign="top" width="14%">
 								<p align="center">
-									<b><font face="TIMES" size="2">V</font></b>
+									<b>V</b>
 								</p>
 							</td>
 							<td valign="top" width="86%">
 								<p>
-									<font face="TIMES" size="2"
-										>The character V is used to indicate the position of the decimal point in a
-										numeric value. It is often referred to as the "assumed decimal point". It is
-										called that because, although the actual decimal point is not stored, values are
-										treated as if they had a decimal point in that position.</font
-									>
+									The character V is used to indicate the position of the decimal point in a numeric
+									value. It is often referred to as the "assumed decimal point". It is called that
+									because, although the actual decimal point is not stored, values are treated as if
+									they had a decimal point in that position.
 								</p>
 							</td>
 						</tr>
 						<tr>
 							<td valign="top" width="14%">
 								<p align="center">
-									<b><font face="TIMES" size="2">S</font></b>
+									<b>S</b>
 								</p>
 							</td>
 							<td valign="top" width="86%">
 								<p>
-									<font face="TIMES" size="2"
-										>The character S indicates the presence of a sign and can only appear at the
-										beginning of a picture.</font
-									>
+									The character S indicates the presence of a sign and can only appear at the
+									beginning of a picture.
 								</p>
 							</td>
 						</tr>
@@ -668,9 +624,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Picture clause notes</font>
-					</h4>
+					<h4 align="left">Picture clause notes</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -703,16 +657,12 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part3">
-						<font color="#FFFF00"
-							><font face="Arial, Helvetica, sans-serif">Group and Elementary data-items</font></font
-						>
-					</h2>
+					<h2 align="center" id="part3">Group and Elementary data-items</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font></h4>
+					<h4>Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -730,17 +680,13 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Elementary items</font>
-					</h4>
+					<h4 align="left">Elementary items</h4>
 					<aside>
 						<p align="center">
 							<img height="37" src="Resources/pics/i-Detail.gif" width="30" /><br />
-							<font size="-1"
-								>A variable declaration may also have a number of other clauses such as
-								<code class="language-cobol">USAGE</code> or
-								<code class="language-cobol">BLANK WHEN ZERO</code></font
-							>
+							A variable declaration may also have a number of other clauses such as
+							<code class="language-cobol">USAGE</code> or
+							<code class="language-cobol">BLANK WHEN ZERO</code>
 						</p>
 					</aside>
 				</td>
@@ -777,7 +723,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Group items</font></h4>
+					<h4>Group items</h4>
 				</td>
 				<td valign="top" width="525">
 					<p align="left">
@@ -823,19 +769,14 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Level Numbers</font></h4>
+					<h4>Level Numbers</h4>
 					<aside>
 						<p align="center">
 							<img height="44" src="Resources/pics/i-LightBulbTip.gif" width="42" /><br />
-							<font size="-1"
-								>Although level numbers specify the actual data hierarchy you should use indentation to
-								provide a graphic representation of it.</font
-							>
-							<font size="-1"
-								>This will make your programs easier to read. For instance, indentation makes it obvious
-								that DayOfBirth, MonthOfBirth and YearOfBirth are subordinate items of DateOfBirth,
-								while CourseCode is not.</font
-							>
+							Although level numbers specify the actual data hierarchy you should use indentation to
+							provide a graphic representation of it. This will make your programs easier to read. For
+							instance, indentation makes it obvious that DayOfBirth, MonthOfBirth and YearOfBirth are
+							subordinate items of DateOfBirth, while CourseCode is not.
 						</p>
 					</aside>
 				</td>
@@ -901,9 +842,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Some observations on Record-A</font>
-					</h4>
+					<h4 align="left">Some observations on Record-A</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>It is useful to examine Record-A above and to answer the following questions:</p>
@@ -956,9 +895,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Level number notes</font>
-					</h4>
+					<h4 align="left">Level number notes</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -987,9 +924,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Building a record structure</font>
-					</h4>
+					<h4>Building a record structure</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1025,15 +960,12 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 							These COBOL course materials are the copyright property of Michael Coughlan.
 						</p>
 						<p align="left">
-							<font size="2"
-								>All rights reserved. No part of these course materials may be reproduced in any form or
-								by any means - graphic, electronic, mechanical, photocopying, printing, recording,
-								taping or stored in an information storage and retrieval system - without the written
-								permission of</font
-							>
-							<font size="2">the author.</font>
+							All rights reserved. No part of these course materials may be reproduced in any form or by
+							any means - graphic, electronic, mechanical, photocopying, printing, recording, taping or
+							stored in an information storage and retrieval system - without the written permission of
+							the author.
 						</p>
-						<p align="center"><font size="2">(c) Michael Coughlan</font></p>
+						<p align="center">(c) Michael Coughlan</p>
 					</div>
 				</td>
 			</tr>

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -128,10 +128,23 @@
 			ul.toc > li {
 				padding-left: 0.4em;
 				margin-bottom: 0.6em;
+				font-size: smaller;
 			}
 
 			ul.toc a {
 				font-weight: bold;
+				font-size: larger;
+			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			td[bgcolor="#FFFFCC"] h3,
+			td[bgcolor="#FFFFCC"] h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
 			}
 		</style>
 	</head>
@@ -148,29 +161,22 @@
 					<ul class="toc">
 						<li>
 							<a href="#intro">Introduction</a><br />
-							<font size="-1">Unit aims, objectives, prerequisites.</font>
+							Unit aims, objectives, prerequisites.
 						</li>
 						<li>
 							<a href="#part1">What is an Edited Picture?</a><br />
-							<font size="-1"
-								>This section introduces Edited Pictures, the types of edited pictures, and the edit
-								symbols used.</font
-							>
+							This section introduces Edited Pictures, the types of edited pictures, and the edit symbols
+							used.
 						</li>
 						<li>
 							<a href="#part2">Insertion Editing</a><br />
-							<font size="-1"
-								>This section introduces the four types of Insertion Editing - Simple Insertion, Special
-								Insertion, Fixed Insertion, and Floating Insertion</font
-							>
+							This section introduces the four types of Insertion Editing - Simple Insertion, Special
+							Insertion, Fixed Insertion, and Floating Insertion
 						</li>
 						<li>
 							<a href="#part3">Suppression and Replacement Editing</a><br />
-							<font size="-1"
-								>This section introduces the two types Suppresion and Replacement Editng - suppression
-								of leading zeros and replacement with spaces, and suppresion and replacement with
-								asterisks.</font
-							>
+							This section introduces the two types Suppresion and Replacement Editng - suppression of
+							leading zeros and replacement with spaces, and suppresion and replacement with asterisks.
 						</li>
 					</ul>
 					<hr />
@@ -178,18 +184,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="intro">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Introduction</font>
-						</font>
-					</h2>
+					<h2 align="center" id="intro">Introduction</h2>
 				</td>
 			</tr>
 			<tr>
 				<td bgcolor="#FFFFCC" height="172" valign="top" width="175">
-					<h4>
-						<font color="#993300" face="Arial, Helvetica, sans-serif">Aims</font>
-					</h4>
+					<h4>Aims</h4>
 				</td>
 				<td height="172" valign="top" width="540">
 					<div align="center">
@@ -215,9 +215,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="135" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Objectives</font>
-					</h4>
+					<h4>Objectives</h4>
 				</td>
 				<td height="135" valign="top" width="540">
 					<p>By the end of this unit you should -</p>
@@ -230,9 +228,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="77" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font>
-					</h4>
+					<h4>Prerequisites</h4>
 				</td>
 				<td height="77" valign="top" width="525">
 					<ul>
@@ -260,18 +256,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part1">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">What is an Edited Picture?</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part1">What is an Edited Picture?</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="321" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4>Introduction</h4>
 				</td>
 				<td height="321" valign="top" width="525">
 					<p align="left">
@@ -324,9 +314,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Edit Symbols</font>
-					</h4>
+					<h4>Edit Symbols</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -357,9 +345,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="97" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Types of editing picture</font>
-					</h4>
+					<h4 align="left">Types of editing picture</h4>
 				</td>
 				<td height="97" valign="top" width="525">
 					<p>COBOL permits two basic types of editing picture:</p>
@@ -390,9 +376,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="97" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Editing symbols</font>
-					</h4>
+					<h4 align="left">Editing symbols</h4>
 				</td>
 				<td height="97" valign="top" width="525">
 					<p>COBOL permits two basic types of editing picture:&gt;</p>
@@ -407,62 +391,42 @@
 						</tr>
 						<tr>
 							<td valign="top" width="32%">
-								<p align="center">
-									<font face="TIMES"><b>, B 0 /</b></font>
-								</p>
+								<p align="center"><b>, B 0 /</b></p>
 							</td>
 							<td valign="top" width="68%">
-								<p>
-									<font face="TIMES">Simple Insertion</font>
-								</p>
+								<p>Simple Insertion</p>
 							</td>
 						</tr>
 						<tr>
 							<td valign="top" width="32%">
-								<p align="center">
-									<font face="TIMES"><b>.</b></font>
-								</p>
+								<p align="center"><b>.</b></p>
 							</td>
 							<td valign="top" width="68%">
-								<p>
-									<font face="TIMES">Special Insertion</font>
-								</p>
+								<p>Special Insertion</p>
 							</td>
 						</tr>
 						<tr>
 							<td valign="top" width="32%">
-								<p align="center">
-									<font face="TIMES"><b>+ - CR DB $</b></font>
-								</p>
+								<p align="center"><b>+ - CR DB $</b></p>
 							</td>
 							<td valign="top" width="68%">
-								<p>
-									<font face="TIMES">Fixed Insertion</font>
-								</p>
+								<p>Fixed Insertion</p>
 							</td>
 						</tr>
 						<tr>
 							<td valign="top" width="32%">
-								<p align="center">
-									<font face="TIMES"><b>+ - $</b></font>
-								</p>
+								<p align="center"><b>+ - $</b></p>
 							</td>
 							<td valign="top" width="68%">
-								<p>
-									<font face="TIMES">Floating Insertion</font>
-								</p>
+								<p>Floating Insertion</p>
 							</td>
 						</tr>
 						<tr>
 							<td valign="top" width="32%">
-								<p align="center">
-									<font face="TIMES"><b>Z *</b></font>
-								</p>
+								<p align="center"><b>Z *</b></p>
 							</td>
 							<td valign="top" width="68%">
-								<p>
-									<font face="TIMES">Suppression and Replacement</font>
-								</p>
+								<p>Suppression and Replacement</p>
 							</td>
 						</tr>
 					</table>
@@ -483,18 +447,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part2">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Insertion Editing</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part2">Insertion Editing</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="97" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4 align="left">Introduction</h4>
 				</td>
 				<td height="97" valign="top" width="525">
 					<p>There are four types of Insertion Editing:-</p>
@@ -513,9 +471,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="420" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Simple Insertion editing</font>
-					</h4>
+					<h4 align="left">Simple Insertion editing</h4>
 				</td>
 				<td height="420" valign="top" width="525">
 					<p>
@@ -553,9 +509,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="413" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Simple Insertion examples</font>
-					</h4>
+					<h4 align="left">Simple Insertion examples</h4>
 					<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" /></p>
 				</td>
 				<td height="413" valign="top" width="525">
@@ -747,9 +701,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="135" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Special Insertion</font>
-					</h4>
+					<h4 align="left">Special Insertion</h4>
 				</td>
 				<td height="135" valign="top" width="525">
 					<p>
@@ -771,9 +723,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="177" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Special Insertion examples</font>
-					</h4>
+					<h4>Special Insertion examples</h4>
 					<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" /></p>
 				</td>
 				<td height="177" valign="top" width="525">
@@ -903,21 +853,17 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="135" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Fixed Insertion</font>
-					</h4>
+					<h4 align="left">Fixed Insertion</h4>
 					<aside>
 						<p align="center">
 							<img height="37" src="Resources/pics/i-Detail.gif" width="30" />
 						</p>
 						<p align="left">
-							<font size="-1"
-								>The default currency symbol is the dollar sign ($) but it may be changed to a different
-								symbol by the <code class="language-cobol">CURRENCY SIGN IS</code> clause, in the
-								<code class="language-cobol">SPECIAL-NAMES</code> paragraph, of the
-								<code class="language-cobol">CONFIGURATION SECTION</code>, in the
-								<code class="language-cobol">ENVIRONMENT DIVISION</code>.
-							</font>
+							The default currency symbol is the dollar sign ($) but it may be changed to a different
+							symbol by the <code class="language-cobol">CURRENCY SIGN IS</code> clause, in the
+							<code class="language-cobol">SPECIAL-NAMES</code> paragraph, of the
+							<code class="language-cobol">CONFIGURATION SECTION</code>, in the
+							<code class="language-cobol">ENVIRONMENT DIVISION</code>.
 						</p>
 					</aside>
 				</td>
@@ -962,9 +908,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="135" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Fixed Insertion examples</font>
-					</h4>
+					<h4 align="left">Fixed Insertion examples</h4>
 					<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" /></p>
 				</td>
 				<td height="135" valign="top" width="525">
@@ -1198,9 +1142,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="135" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Floating Insertion</font>
-					</h4>
+					<h4 align="left">Floating Insertion</h4>
 				</td>
 				<td height="135" valign="top" width="525">
 					<p>
@@ -1232,9 +1174,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="135" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Floating Insertion examples</font>
-					</h4>
+					<h4 align="left">Floating Insertion examples</h4>
 				</td>
 				<td height="135" valign="top" width="525">
 					<p>
@@ -1424,18 +1364,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part3">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Suppression and Replacement Editing</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part3">Suppression and Replacement Editing</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4 align="left">Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1466,11 +1400,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="389" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Suppression and Replacement editing examples</font
-						>
-					</h4>
+					<h4 align="left">Suppression and Replacement editing examples</h4>
 					<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" /></p>
 				</td>
 				<td height="389" valign="top" width="525">
@@ -1634,9 +1564,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="293" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Picture string restrictions</font>
-					</h4>
+					<h4 align="left">Picture string restrictions</h4>
 				</td>
 				<td height="293" valign="top" width="525">
 					<p>
@@ -1698,17 +1626,12 @@ B 0 / , + - CR DB 9</code></pre>
 							These COBOL course materials are the copyright property of Michael Coughlan.
 						</p>
 						<p align="left">
-							<font size="2"
-								>All rights reserved. No part of these course materials may be reproduced in any form or
-								by any means - graphic, electronic, mechanical, photocopying, printing, recording,
-								taping or stored in an information storage and retrieval system - without the written
-								permission of</font
-							>
-							<font size="2">the author.</font>
+							All rights reserved. No part of these course materials may be reproduced in any form or by
+							any means - graphic, electronic, mechanical, photocopying, printing, recording, taping or
+							stored in an information storage and retrieval system - without the written permission of
+							the author.
 						</p>
-						<p align="center">
-							<font size="2">(c) Michael Coughlan</font>
-						</p>
+						<p align="center">(c) Michael Coughlan</p>
 					</div>
 				</td>
 			</tr>

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -16,10 +16,23 @@
 			ul.toc > li {
 				padding-left: 0.4em;
 				margin-bottom: 0.6em;
+				font-size: smaller;
 			}
 
 			ul.toc a {
 				font-weight: bold;
+				font-size: larger;
+			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			td[bgcolor="#FFFFCC"] h3,
+			td[bgcolor="#FFFFCC"] h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
 			}
 		</style>
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
@@ -208,59 +221,48 @@
 						<ul class="toc">
 							<li>
 								<a href="#intro">Introduction</a><br />
-								<font size="-1">Unit aims, objectives and prerequisites.</font>
+								Unit aims, objectives and prerequisites.
 							</li>
 							<li>
 								<a href="#progs">A look at some programs that use Indexed files</a><br />
-								<font size="-1"
-									>We begin with three example programs. The first creates an Indexed file from a
-									Sequential file, the second reads the Indexed file sequentially or either the
-									primary or the alternate key, and the third reads the file directly on either
-									key.</font
-								>
+								We begin with three example programs. The first creates an Indexed file from a
+								Sequential file, the second reads the Indexed file sequentially or either the primary or
+								the alternate key, and the third reads the file directly on either key.
 							</li>
 							<li>
 								<a href="#org">Indexed file organization</a><br />
-								<font size="-1"
-									>Explains by means of an animated diagram how the index of the primary key is
-									organized and shows how it is used to read a record directly. Explains how the
-									alternate key index is organized and shows how it is used to read a record
-									directly.</font
-								>
+								Explains by means of an animated diagram how the index of the primary key is organized
+								and shows how it is used to read a record directly. Explains how the alternate key index
+								is organized and shows how it is used to read a record directly.
 							</li>
 							<li>
 								<a href="#declar">Indexed file - declarations</a><br />
-								<font size="-1"
-									>Examines the <code class="language-cobol">SELECT</code> and
-									<code class="language-cobol">ASSIGN</code> clause declarations required for an
-									Indexed file.</font
-								>
+								Examines the <code class="language-cobol">SELECT</code> and
+								<code class="language-cobol">ASSIGN</code> clause declarations required for an Indexed
+								file.
 							</li>
 							<li>
 								<a href="#verbs">Indexed file - file processing verbs</a><br />
-								<font size="-1"
-									>Examines the Procedure Division verbs used to process Indexed files -
-									<code class="language-cobol">OPEN</code>, <code class="language-cobol">CLOSE</code>,
-									<code class="language-cobol">READ</code>, <code class="language-cobol">WRITE</code>,
-									<code class="language-cobol">REWRITE</code>,
-									<code class="language-cobol">DELETE</code>,
-									<code class="language-cobol">START</code></font
-								>
+								Examines the Procedure Division verbs used to process Indexed files -
+								<code class="language-cobol">OPEN</code>, <code class="language-cobol">CLOSE</code>,
+								<code class="language-cobol">READ</code>, <code class="language-cobol">WRITE</code>,
+								<code class="language-cobol">REWRITE</code>, <code class="language-cobol">DELETE</code>,
+								<code class="language-cobol">START</code>
 							</li>
 							<li>
 								<a href="#example">A comprehensive example</a><br />
-								<font size="-1">We end with a comprehensive problem specification and solution.</font>
+								We end with a comprehensive problem specification and solution.
 							</li>
 						</ul>
 						<table border="0" cellpadding="4" cellspacing="0" width="710">
 							<tr>
 								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="175">
-									<h2 align="center" id="intro"><font color="#FFFF00">Introduction</font></h2>
+									<h2 align="center" id="intro">Introduction</h2>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#993300">Aims</font></h3>
+									<h3>Aims</h3>
 								</td>
 								<td width="525">
 									<p>
@@ -273,7 +275,7 @@
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Objectives</font></h3>
+									<h3>Objectives</h3>
 								</td>
 								<td width="525">
 									<p>By the end of this unit you should:</p>
@@ -306,7 +308,7 @@
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Prerequisites</font></h3>
+									<h3>Prerequisites</h3>
 								</td>
 								<td width="525">
 									<p>You should be familiar with the material covered in the unit;</p>
@@ -331,16 +333,12 @@
 						<table border="0" cellpadding="4" cellspacing="0" width="710">
 							<tr>
 								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="progs">
-										<font color="#FFFF00">A look at some programs that use Indexed files</font>
-									</h2>
+									<h2 align="center" id="progs">A look at some programs that use Indexed files</h2>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="left">
-										<font color="#800000">Example program - Creating an Indexed file</font>
-									</h3>
+									<h3 align="left">Example program - Creating an Indexed file</h3>
 								</td>
 								<td width="525">
 									<table border="0" width="100%">
@@ -396,11 +394,7 @@
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>
-										<font color="#800000"
-											>Example program - Reading an Indexed file sequentially</font
-										>
-									</h3>
+									<h3>Example program - Reading an Indexed file sequentially</h3>
 								</td>
 								<td width="525">
 									<table border="0" width="100%">
@@ -513,9 +507,7 @@ Enter key : 1=VideoCode, 2=VideoTitle -&gt;2
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>
-										<font color="#800000">Example program - Reading an Indexed file directly</font>
-									</h3>
+									<h3>Example program - Reading an Indexed file directly</h3>
 								</td>
 								<td width="525">
 									<table border="0" width="100%">
@@ -607,14 +599,12 @@ VIDEO STATUS :- 23</code></pre>
 						<table border="0" cellpadding="4" cellspacing="0" width="710">
 							<tr>
 								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="175">
-									<h2 align="center" id="org">
-										<font color="#FFFF00">Indexed file organization</font>
-									</h2>
+									<h2 align="center" id="org">Indexed file organization</h2>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#993300">Introduction</font></h3>
+									<h3>Introduction</h3>
 								</td>
 								<td width="525">
 									<p>
@@ -652,7 +642,7 @@ VIDEO STATUS :- 23</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Primary Key Index</font></h3>
+									<h3>Primary Key Index</h3>
 								</td>
 								<td width="525">
 									<p>
@@ -672,7 +662,7 @@ VIDEO STATUS :- 23</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Alternate Key Index</font></h3>
+									<h3>Alternate Key Index</h3>
 								</td>
 								<td width="525">
 									<p>
@@ -699,9 +689,7 @@ VIDEO STATUS :- 23</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="left">
-										<font color="#800000">Animation of the primary and alternate key indexes</font>
-									</h3>
+									<h3 align="left">Animation of the primary and alternate key indexes</h3>
 								</td>
 								<td width="525">
 									<table border="0" width="100%">
@@ -761,14 +749,12 @@ END-IF</code></pre>
 						<table border="0" cellpadding="4" cellspacing="0" width="710">
 							<tr>
 								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="175">
-									<h2 align="center" id="declar">
-										<font color="#FFFF00">Indexed file - Declarations</font>
-									</h2>
+									<h2 align="center" id="declar">Indexed file - Declarations</h2>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Introduction</font></h3>
+									<h3>Introduction</h3>
 								</td>
 								<td width="525">
 									<p>
@@ -781,7 +767,7 @@ END-IF</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Select and Assign clause syntax</font></h3>
+									<h3>Select and Assign clause syntax</h3>
 								</td>
 								<td width="525">
 									<p><img height="245" src="Resources/pics/I-DFidx1.gif" width="474" /></p>
@@ -789,13 +775,10 @@ END-IF</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">The Record Key phrase</font></h3>
+									<h3>The Record Key phrase</h3>
 								</td>
 								<td width="525">
-									<p>
-										The <font size="2">RECORD KEY</font> phrase defines the Indexed file's primary
-										key.
-									</p>
+									<p>The RECORD KEY phrase defines the Indexed file's primary key.</p>
 									<p>
 										Every Indexed file must have a primary key. The key <b>must</b> be a field in
 										the record description that contains a unique value for each record.
@@ -809,7 +792,7 @@ END-IF</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">The Alternate Record Key phrase</font></h3>
+									<h3>The Alternate Record Key phrase</h3>
 								</td>
 								<td width="525">
 									<div align="center">
@@ -824,7 +807,7 @@ END-IF</code></pre>
 											</p>
 											<p>
 												Each alternate key may be unique or may have duplicate values (for this
-												the <font size="2">WITH DUPLICATES</font> clause is required).
+												the WITH DUPLICATES clause is required).
 											</p>
 										</div>
 									</div>
@@ -847,14 +830,12 @@ END-IF</code></pre>
 						<table border="0" cellpadding="4" cellspacing="0" width="710">
 							<tr>
 								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="verbs">
-										<font color="#FFFF00">Indexed file - file processing verbs</font>
-									</h2>
+									<h2 align="center" id="verbs">Indexed file - file processing verbs</h2>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Introduction</font></h3>
+									<h3>Introduction</h3>
 								</td>
 								<td width="525">
 									<p>
@@ -862,12 +843,9 @@ END-IF</code></pre>
 										Relative files.
 									</p>
 									<p>
-										Indexed files use the same file processing verbs as Relative files (<font
-											size="2"
-											>OPEN, CLOSE, READ, WRITE, REWRITE, DELETE</font
-										>
-										and <font size="2">START</font>) but there are some syntactic and semantic
-										differences.
+										Indexed files use the same file processing verbs as Relative files (OPEN, CLOSE,
+										READ, WRITE, REWRITE, DELETE and START) but there are some syntactic and
+										semantic differences.
 									</p>
 									<p>
 										In this section we will only examine those verbs which differ in syntax or
@@ -878,77 +856,69 @@ END-IF</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">The READ verb</font></h3>
+									<h3>The READ verb</h3>
 								</td>
 								<td width="525">
 									<p>
-										When an Indexed file has an <font size="2">ACCESS MODE</font> of
-										<font size="2">SEQUENTIAL</font> , the format of the
-										<font size="2">READ</font> is the same as for Sequential files, but when the
-										<font size="2">ACCESS MODE</font> is <font size="2">DYNAMIC</font> Sequential
-										processing of the file is complicated by the presence of a number of indexes.
-										The order in which the data records will be read, will depend on which index is
-										being processed sequentially.
+										When an Indexed file has an ACCESS MODE of SEQUENTIAL , the format of the READ
+										is the same as for Sequential files, but when the ACCESS MODE is DYNAMIC
+										Sequential processing of the file is complicated by the presence of a number of
+										indexes. The order in which the data records will be read, will depend on which
+										index is being processed sequentially.
 									</p>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Key Of Reference</font></h3>
+									<h3>Key Of Reference</h3>
 								</td>
 								<td width="525">
 									<p>
-										When an Indexed file has an <font size="2">ACCESS MODE</font> of
-										<font size="2">SEQUENTIAL</font> , the file is always processed in ascending
-										primary key order.
+										When an Indexed file has an ACCESS MODE of SEQUENTIAL , the file is always
+										processed in ascending primary key order.
 									</p>
 									<p>
-										But, if an Indexed file has an <font size="2">ACCESS MODE</font> of
-										<font size="2">DYNAMIC</font> and is processed sequentially, the file system
-										must be able to tell which of the keys to use as the basis for processing the
-										file.
+										But, if an Indexed file has an ACCESS MODE of DYNAMIC and is processed
+										sequentially, the file system must be able to tell which of the keys to use as
+										the basis for processing the file.
 									</p>
 									<p>
-										Since the format of the sequential <font size="2">READ</font> does not have a
-										key phrase, the file system refers to a special item called the Key Of Reference
-										to discover which key to use for processing the file.
+										Since the format of the sequential READ does not have a key phrase, the file
+										system refers to a special item called the Key Of Reference to discover which
+										key to use for processing the file.
 									</p>
 									<p>
-										Before reading a file that has an <font size="2">ACCESS MODE</font> of
-										<font size="2">DYNAMIC</font> sequentially, the programmer must establish one of
-										the file's keys as the Key Of Reference.
+										Before reading a file that has an ACCESS MODE of DYNAMIC sequentially, the
+										programmer must establish one of the file's keys as the Key Of Reference.
 									</p>
 									<p>
-										A Key Of Reference is established by using the key in a
-										<font size="2">START</font> or a direct <font size="2">READ</font>.
+										A Key Of Reference is established by using the key in a START or a direct READ.
 									</p>
 									<p>When the file is opened the primary key is, by default, the Key Of Reference.</p>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Reading Sequentially</font></h3>
+									<h3>Reading Sequentially</h3>
 								</td>
 								<td width="525">
 									<p><img src="Resources/pics/I-DFrel4.gif" /></p>
 									<p>
-										<b>Notes</b><b><br /></b> This format is used when the
-										<font size="2">ACCESS MODE</font> is <font size="2">DYNAMIC</font> and we wish
-										to read the file sequentially.
+										<b>Notes</b><b><br /></b> This format is used when the ACCESS MODE is DYNAMIC
+										and we wish to read the file sequentially.
 									</p>
 									<p>
 										This format will read the file in ascending sequence on the key that has been
 										established as the key of reference.
 									</p>
 									<p>
-										The <font size="2">READ NEXT</font> will read the logical record pointed to by
-										the next record pointer (This will be the current record if positioned by the
-										<font size="2">START</font> and the next record if positioned by a direct
-										<font size="2">READ</font>).
+										The READ NEXT will read the logical record pointed to by the next record pointer
+										(This will be the current record if positioned by the START and the next record
+										if positioned by a direct READ).
 									</p>
 									<p>
 										<b>Operation<br /></b> To read a record sequentially from an Indexed file that
-										has an <font size="2">ACCESS MODE</font> of <font size="2">DYNAMIC</font>
+										has an ACCESS MODE of DYNAMIC
 									</p>
 									<ol>
 										<li>
@@ -956,13 +926,13 @@ END-IF</code></pre>
 											established as the Key Of Reference by doing a START or a direct READ using
 											that key.
 										</li>
-										<li>Then the <font size="2">READ</font> must be executed.</li>
+										<li>Then the READ must be executed.</li>
 									</ol>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Reading using a key</font></h3>
+									<h3>Reading using a key</h3>
 								</td>
 								<td width="525">
 									<p><img src="Resources/pics/I-DFrel3.gif" /></p>
@@ -977,40 +947,35 @@ END-IF</code></pre>
 										<li>
 											The key value must be placed in the <i>KeyName</i> data item (the
 											<i>KeyName</i> data item is the area of storage identified as the primary
-											key or one of the alternate keys in the the <font size="2">SELECT</font> and
-											<font size="2">ASSIGN</font> clause).
+											key or one of the alternate keys in the the SELECT and ASSIGN clause).
 										</li>
-										<li>Then the <font size="2">READ</font> must be executed.</li>
+										<li>Then the READ must be executed.</li>
 									</ol>
 									<p>
-										When the <font size="2">READ</font> is executed the record with the key value
-										equal to the present value of <i>KeyName</i> will be read.
+										When the READ is executed the record with the key value equal to the present
+										value of <i>KeyName</i> will be read.
 									</p>
 									<p>
-										<b>Notes<br /></b> If the record does not exist the
-										<font size="2">INVALID KEY</font> clause will activate and the statement block
-										following the clause will be executed.
+										<b>Notes<br /></b> If the record does not exist the INVALID KEY clause will
+										activate and the statement block following the clause will be executed.
 									</p>
+									<p>If the KEY IS clause is omitted, the key used will be the primary key.</p>
 									<p>
-										If the <font size="2">KEY IS</font> clause is omitted, the key used will be the
-										primary key.
-									</p>
-									<p>
-										When the <font size="2">READ</font> is executed, the key mentioned in the
-										<font size="2">KEY IS</font> phrase will be established as the Key Of Reference.
-									</p>
-									<p>
-										If there is no <font size="2">KEY IS</font> phrase, the primary key will be
+										When the READ is executed, the key mentioned in the KEY IS phrase will be
 										established as the Key Of Reference.
+									</p>
+									<p>
+										If there is no KEY IS phrase, the primary key will be established as the Key Of
+										Reference.
 									</p>
 									<p>
 										If duplicates are allowed, only the first record in a group with duplicates can
 										be read directly. The rest of the duplicates must be read sequentially using the
-										<font size="2">READ NEXT</font> format.
+										READ NEXT format.
 									</p>
 									<p>
-										The <font size="2">KEY IS</font> phrase can only be used with Indexed files and
-										it is used because Indexed files may have more than one key.
+										The KEY IS phrase can only be used with Indexed files and it is used because
+										Indexed files may have more than one key.
 									</p>
 									<p>
 										After the record has been read, the next record pointer points to the next
@@ -1019,25 +984,19 @@ END-IF</code></pre>
 										alternate keys then the pointer will point to the next alternate index base
 										record.
 									</p>
-									<p>
-										The file must have an <font size="2">ACCESS MODE</font> of
-										<font size="2">DYNAMIC</font> or <font size="2">RANDOM</font>.
-									</p>
-									<p>The file must be opened for I-O or <font size="2">INPUT</font>.&nbsp;</p>
+									<p>The file must have an ACCESS MODE of DYNAMIC or RANDOM.</p>
+									<p>The file must be opened for I-O or INPUT.&nbsp;</p>
 									<hr />
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="left">
-										<font color="#800000">The WRITE, REWRITE and DELETE verbs.</font>
-									</h3>
+									<h3 align="left">The WRITE, REWRITE and DELETE verbs.</h3>
 								</td>
 								<td width="525">
 									<p>
-										The syntax and semantics of the <font size="2">WRITE</font> ,
-										<font size="2">REWRITE</font> and <font size="2">DELETE</font> verbs is the same
-										as that for Relative files with the following exceptions;
+										The syntax and semantics of the WRITE , REWRITE and DELETE verbs is the same as
+										that for Relative files with the following exceptions;
 									</p>
 									<ul>
 										<li>
@@ -1045,8 +1004,8 @@ END-IF</code></pre>
 											key only.
 										</li>
 										<li>
-											The <font size="2">REWRITE</font> may not change the value of the primary
-											key but it may change the values of any of the alternate keys.
+											The REWRITE may not change the value of the primary key but it may change
+											the values of any of the alternate keys.
 										</li>
 									</ul>
 									<hr />
@@ -1054,18 +1013,16 @@ END-IF</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">The START verb</font></h3>
+									<h3>The START verb</h3>
 								</td>
 								<td width="525">
 									<p>
-										In Indexed files, the the <font size="2">START</font> verb is used to control
-										the position of the next record pointer and to establish a key as the Key Of
-										Reference.
+										In Indexed files, the the START verb is used to control the position of the next
+										record pointer and to establish a key as the Key Of Reference.
 									</p>
 									<p>
-										Where the <font size="2">START</font> verb appears in a program it is usually
-										followed by a sequential <font size="2">READ</font> or
-										<font size="2">WRITE</font> .
+										Where the START verb appears in a program it is usually followed by a sequential
+										READ or WRITE .
 									</p>
 									<p><img src="Resources/pics/I-DFrel8.gif" /></p>
 									<p>
@@ -1078,7 +1035,7 @@ END-IF</code></pre>
 											back to the example programs, we might move "Hope and glory" to the
 											VideoTitle if we wanted to establish VideoTitle as the Key Of Reference.
 										</li>
-										<li>Execute the <font size="2">START..KEY IS EQUAL TO</font></li>
+										<li>Execute the START..KEY IS EQUAL TO</li>
 									</ol>
 									<p>
 										To establish a key as the Key of Reference and position the Next Record Pointer
@@ -1090,34 +1047,24 @@ END-IF</code></pre>
 											spaces to VideoTitle to position the pointer at the first logical record in
 											VideoTitle sequence.
 										</li>
-										<li>Execute the <font size="2">START..KEY IS GREATER THAN</font></li>
+										<li>Execute the START..KEY IS GREATER THAN</li>
 									</ol>
 									<p>
 										<b>Notes<br /></b> <i>KeyName</i> is the primary key or one of the alternate
 										keys. It is the key of comparison.
 									</p>
+									<p>Before the START is executed some value must be moved to the <i>KeyName</i>.</p>
+									<p>Using the START with some key establishes that key as the Key Of Reference.</p>
+									<p>The file must be opened for INPUT or I-O when the START is executed.</p>
 									<p>
-										Before the <font size="2">START</font> is executed some value must be moved to
-										the <i>KeyName</i>.
+										Execution of the START statement does not change the contents of the record area
+										(i.e. the START does not actually read the record it merely positions the Next
+										Record Pointer).
 									</p>
 									<p>
-										Using the <font size="2">START</font> with some key establishes that key as the
-										Key Of Reference.
-									</p>
-									<p>
-										The file must be opened for <font size="2">INPUT</font> or I-O when the
-										<font size="2">START</font> is executed.
-									</p>
-									<p>
-										Execution of the <font size="2">START</font> statement does not change the
-										contents of the record area (i.e. the <font size="2">START</font> does not
-										actually read the record it merely positions the Next Record Pointer).
-									</p>
-									<p>
-										When the <font size="2">START</font> is executed the Next Record Pointer is set
-										to the first logical record in the file whose key satisfies the condition. If no
-										record satisfies the condition then the <font size="2">INVALID</font> key clause
-										is activated.
+										When the START is executed the Next Record Pointer is set to the first logical
+										record in the file whose key satisfies the condition. If no record satisfies the
+										condition then the INVALID key clause is activated.
 									</p>
 								</td>
 							</tr>
@@ -1137,14 +1084,12 @@ END-IF</code></pre>
 						<table border="0" cellpadding="4" cellspacing="0" width="710">
 							<tr>
 								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="example">
-										<font color="#FFFF00">An Comprehensive Example Program</font>
-									</h2>
+									<h2 align="center" id="example">An Comprehensive Example Program</h2>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="left"><font color="#800000">Program Specification</font></h3>
+									<h3 align="left">Program Specification</h3>
 								</td>
 								<td width="525">
 									<p align="center">ROYALTY PAYMENT REPORT PROGRAM.</p>
@@ -1171,10 +1116,8 @@ END-IF</code></pre>
 										specification for the report is on the next page.
 									</p>
 									<p>
-										All the data required to produce the
-										<font size="2">ROYALTY PAYMENT REPORT</font> is contained in two indexed files.
-										The indexed file <font size="2">BOOKS.DAT</font> has the following record
-										description;-
+										All the data required to produce the ROYALTY PAYMENT REPORT is contained in two
+										indexed files. The indexed file BOOKS.DAT has the following record description;-
 									</p>
 									<table border="1" width="100%">
 										<tr>
@@ -1230,10 +1173,7 @@ END-IF</code></pre>
 											<td align="center" width="18%">0-999</td>
 										</tr>
 									</table>
-									<p>
-										The indexed file <font size="2">AUTHOR.DAT</font> has the following record
-										description;-
-									</p>
+									<p>The indexed file AUTHOR.DAT has the following record description;-</p>
 									<table border="1" width="100%">
 										<tr>
 											<td width="26%">
@@ -1554,15 +1494,12 @@ ProcessOneBook.
 										These COBOL course materials are the copyright property of Michael Coughlan.
 									</p>
 									<p>
-										<font size="2"
-											>All rights reserved. No part of these course materials may be reproduced in
-											any form or by any means - graphic, electronic, mechanical, photocopying,
-											printing, recording, taping or stored in an information storage and
-											retrieval system - without the written permission of</font
-										>
-										<font size="2">the author.</font>
+										All rights reserved. No part of these course materials may be reproduced in any
+										form or by any means - graphic, electronic, mechanical, photocopying, printing,
+										recording, taping or stored in an information storage and retrieval system -
+										without the written permission of the author.
 									</p>
-									<p align="center"><font size="2">(c) Michael Coughlan</font></p>
+									<p align="center">(c) Michael Coughlan</p>
 								</td>
 							</tr>
 						</table>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -15,12 +15,25 @@
 			ul.toc > li {
 				padding-left: 0.4em;
 				margin-bottom: 0.6em;
+				font-size: smaller;
 			}
 			ul.toc a {
 				font-weight: bold;
+				font-size: larger;
 			}
 			ol.spaced > li + li {
 				margin-top: 0.6em;
+			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			td[bgcolor="#FFFFCC"] h3,
+			td[bgcolor="#FFFFCC"] h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
 			}
 		</style>
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
@@ -208,65 +221,51 @@
 						<ul class="toc">
 							<li>
 								<a href="#intro">Introduction</a><br />
-								<font size="-1"
-									>Unit aims, objectives, prerequisites and a legend for this unit's syntax
-									diagrams.</font
-								>
+								Unit aims, objectives, prerequisites and a legend for this unit's syntax diagrams.
 							</li>
 							<li>
 								<a href="#inspect">Using the INSPECT</a><br />
-								<font size="-1"
-									>The <code class="language-cobol">INSPECT</code> is introduced by looking at an
-									example program. The way the <code class="language-cobol">INSPECT</code> works is
-									explained and its modifying phrases are explored.</font
-								>
+								The <code class="language-cobol">INSPECT</code> is introduced by looking at an example
+								program. The way the <code class="language-cobol">INSPECT</code> works is explained and
+								its modifying phrases are explored.
 							</li>
 							<li>
 								<a href="#count">The counting format</a><br />
-								<font size="-1"
-									>Presents the syntax and rules of the counting format of the
-									<code class="language-cobol">INSPECT</code>.</font
-								>
+								Presents the syntax and rules of the counting format of the
+								<code class="language-cobol">INSPECT</code>.
 							</li>
 							<li>
 								<a href="#replace">The replacing format</a><br />
-								<font size="-1"
-									>Presents the syntax and rules of the replacing format of the
-									<code class="language-cobol">INSPECT</code></font
-								>
+								Presents the syntax and rules of the replacing format of the
+								<code class="language-cobol">INSPECT</code>
 							</li>
 							<li>
 								<a href="#combine">The combined format</a><br />
-								<font size="-1"
-									>This version combines the syntax and rules of the other two formats. The syntax of
-									this combined format is presented.</font
-								>
+								This version combines the syntax and rules of the other two formats. The syntax of this
+								combined format is presented.
 							</li>
 							<li>
 								<a href="#convert">The converting format</a><br />
-								<font size="-1"
-									>Presents the syntax and rules of the converting format of the
-									<code class="language-cobol">INSPECT</code>.</font
-								>
+								Presents the syntax and rules of the converting format of the
+								<code class="language-cobol">INSPECT</code>.
 							</li>
 						</ul>
 						<table border="0" cellpadding="4" cellspacing="0" width="710">
 							<tr>
 								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="intro"><font color="#FFFF00">Introduction</font></h2>
+									<h2 align="center" id="intro">Introduction</h2>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#993300">Aims</font></h3>
+									<h3>Aims</h3>
 								</td>
 								<td width="525">
 									<p>
 										Many programming languages rely on library functions for string handling. COBOL
 										too, uses Intrinsic Functions for some tasks but most string manipulation is
-										done using Reference Modification and the three string handling verbs :
-										<font size="2">INSPECT</font>, <font size="2">STRING</font> and
-										<font size="2">UNSTRING</font>.
+										done using Reference Modification and the three string handling verbs : INSPECT,
+										STRING and UNSTRING.
 									</p>
 									<p>
 										This unit examines the first of three string handling verbs and aims to provide
@@ -277,19 +276,19 @@
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Objectives</font></h3>
+									<h3>Objectives</h3>
 								</td>
 								<td width="525">
 									<p>By the end of this unit you should:</p>
 									<ol>
-										<li>Understand how the <font size="2">INSPECT</font> verb works.</li>
+										<li>Understand how the INSPECT verb works.</li>
 										<li>
 											Have a good knowledge of the different formats and modifying phrases of the
-											<font size="2">INSPECT</font> verb.
+											INSPECT verb.
 										</li>
 										<li>
-											Be able to use the <font size="2">INSPECT</font> to count, replace and
-											convert characters in a string.
+											Be able to use the INSPECT to count, replace and convert characters in a
+											string.
 										</li>
 									</ol>
 									<hr />
@@ -297,7 +296,7 @@
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Prerequisites</font></h3>
+									<h3>Prerequisites</h3>
 								</td>
 								<td width="525">
 									<p>You should be familiar with the following material;</p>
@@ -313,7 +312,7 @@
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Syntax legend</font></h3>
+									<h3>Syntax legend</h3>
 								</td>
 								<td width="525">
 									<p>
@@ -363,15 +362,15 @@
 						<table border="0" cellpadding="4" cellspacing="0" width="710">
 							<tr>
 								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="inspect"><font color="#FFFF00">Using the INSPECT</font></h2>
+									<h2 align="center" id="inspect">Using the INSPECT</h2>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="left"><font color="#800000">Introduction</font></h3>
+									<h3 align="left">Introduction</h3>
 								</td>
 								<td width="525">
-									<p>The <font size="2">INSPECT</font> has four formats;</p>
+									<p>The INSPECT has four formats;</p>
 									<ol class="spaced">
 										<li>The first format is used for counting characters in a string.</li>
 										<li>
@@ -389,40 +388,35 @@
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="left">
-										<font color="#800000"
-											>Example program Counting letter occurences using the INSPECT</font
-										>
-									</h3>
+									<h3 align="left">Example program Counting letter occurences using the INSPECT</h3>
 								</td>
 								<td width="525">
 									<table border="0" width="100%">
 										<tr>
 											<td height="43" width="525">
 												<p>
-													We'll start by looking at the
-													<font size="2">PROCEDURE DIVISION</font> of an example program that
-													uses the <font size="2">INSPECT</font> verb. This program reads
-													through a file, counts how many times each letter of the alphabet
-													occurs and displays the results
+													We'll start by looking at the PROCEDURE DIVISION of an example
+													program that uses the INSPECT verb. This program reads through a
+													file, counts how many times each letter of the alphabet occurs and
+													displays the results
 												</p>
 												<p>To do this the program;</p>
 												<ul>
 													<li>Reads in a line of text</li>
 													<li>
 														Converts all the characters to upper case using the
-														<font size="2">INSPECT..CONVERTING</font>
+														INSPECT..CONVERTING
 													</li>
 													<li>
 														Counts the number of times each letter appears in the line using
-														the <font size="2">INSPECT..TALLYING</font> and increments the
-														count in LetterCount. It gets the letters from inspection from a
-														pre-defined table of letters (see the unit on tables for the
-														definition of this letter table)
+														the INSPECT..TALLYING and increments the count in LetterCount.
+														It gets the letters from inspection from a pre-defined table of
+														letters (see the unit on tables for the definition of this
+														letter table)
 													</li>
 													<li>
-														Uses a <font size="2">PERFORM..VARYING</font> to display the
-														counts after they have been accumulated.
+														Uses a PERFORM..VARYING to display the counts after they have
+														been accumulated.
 													</li>
 												</ul>
 											</td>
@@ -464,54 +458,47 @@ Begin.
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">How the INSPECT works.</font></h3>
+									<h3>How the INSPECT works.</h3>
 								</td>
 								<td width="525">
 									<p>
-										The <font size="2">INSPECT</font> scans the source string from left to right
-										counting, replacing or converting characters under the control of the
-										<font size="2">TALLYING</font>, <font size="2">REPLACING</font> or
-										<font size="2">CONVERTING</font> phrases.
+										The INSPECT scans the source string from left to right counting, replacing or
+										converting characters under the control of the TALLYING, REPLACING or CONVERTING
+										phrases.
 									</p>
 									<p>
-										The behavior of the <font size="2">INSPECT</font> is modified by using the
-										<font size="2">LEADING, FIRST, BEFORE</font> and
-										<font size="2">AFTER</font> phrases.
+										The behavior of the INSPECT is modified by using the LEADING, FIRST, BEFORE and
+										AFTER phrases.
 									</p>
 									<p>
-										An <font size="2">ALL, LEADING, CHARACTERS, FIRST</font> or
-										<font size="2">CONVERTING</font> phrase may only be followed by one
-										<font size="2">BEFORE</font> and one <font size="2">AFTER</font> phrase.
+										An ALL, LEADING, CHARACTERS, FIRST or CONVERTING phrase may only be followed by
+										one BEFORE and one AFTER phrase.
 									</p>
 									<hr />
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">The modifying phrases</font></h3>
+									<h3>The modifying phrases</h3>
 								</td>
 								<td width="525">
 									<p>
-										The <b><font size="2">LEADING</font></b> phrase causes counting/replacement of
-										all Compare$il characters from the first valid one encountered to the first
-										invalid one.
+										The <b>LEADING</b> phrase causes counting/replacement of all Compare$il
+										characters from the first valid one encountered to the first invalid one.
+									</p>
+									<p>The <b>FIRST</b> phrase causes only the first valid character to be replaced.</p>
+									<p>
+										The <b>BEFORE</b> phrase designates as valid those characters to the left of the
+										delimiter associated with it.
 									</p>
 									<p>
-										The <font size="2"><b>FIRST</b></font> phrase causes only the first valid
-										character to be replaced.
+										The <b>AFTER</b> phrase designates as valid those characters to the right of the
+										delimiter associated with it.
 									</p>
 									<p>
-										The <font size="2"><b>BEFORE</b></font> phrase designates as valid those
-										characters to the left of the delimiter associated with it.
-									</p>
-									<p>
-										The <font size="2"><b>AFTER</b></font> phrase designates as valid those
-										characters to the right of the delimiter associated with it.
-									</p>
-									<p>
-										If the delimiter is not present in the SourceStr$i then using the
-										<font size="2">BEFORE</font> phrase implies the whole string and using the
-										<font size="2">AFTER</font> phrase implies no characters at all.
+										If the delimiter is not present in the SourceStr$i then using the BEFORE phrase
+										implies the whole string and using the AFTER phrase implies no characters at
+										all.
 									</p>
 								</td>
 							</tr>
@@ -531,12 +518,12 @@ Begin.
 						<table border="0" cellpadding="4" cellspacing="0" width="710">
 							<tr>
 								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="count"><font color="#FFFF00">The counting INSPECT</font></h2>
+									<h2 align="center" id="count">The counting INSPECT</h2>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" colspan="2" valign="top" width="175">
-									<h3><font color="#993300">Syntax</font></h3>
+									<h3>Syntax</h3>
 									<p><img src="Resources/pics/CntInspect.gif" /></p>
 									<p align="left">
 										This format of the Inspect is used to count characters in a string.
@@ -546,21 +533,19 @@ Begin.
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Notes</font></h3>
+									<h3>Notes</h3>
 								</td>
 								<td width="525">
 									<p>If Compare$il or Delim$il is a figurative constant it is 1 character in size.</p>
 									<p>
-										An <font size="2">ALL</font>, <font size="2">LEADING</font> or
-										<font size="2">CHARACTERS</font> phrase can have not more than one
-										<font size="2">BEFORE</font> and one <font size="2">AFTER</font> phrase
-										following it.
+										An ALL, LEADING or CHARACTERS phrase can have not more than one BEFORE and one
+										AFTER phrase following it.
 									</p>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Examples</font></h3>
+									<h3>Examples</h3>
 								</td>
 								<td width="525">
 									<pre
@@ -588,33 +573,29 @@ INSPECT SourceLine TALLYING ECount
 						<table border="0" cellpadding="4" cellspacing="0" width="710">
 							<tr>
 								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="replace">
-										<font color="#FFFF00">The replacing INSPECT</font>
-									</h2>
+									<h2 align="center" id="replace">The replacing INSPECT</h2>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" colspan="2" valign="top" width="175">
-									<h3><font color="#993300">Syntax</font></h3>
+									<h3>Syntax</h3>
 									<p><img height="255" src="Resources/pics/RepInspect.gif" width="619" /></p>
 									<p align="left">
-										This format of the <font size="2">INSPECT</font> is used to count characters in
-										a string.
+										This format of the INSPECT is used to count characters in a string.
 									</p>
 									<hr />
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Rules</font></h3>
+									<h3>Rules</h3>
 								</td>
 								<td width="525">
 									<p>The sizes of Compare$il and Replace$il must be equal.</p>
 									<p>When Replace$il is a figurative constant its size equals that of Compare$il.</p>
 									<p>
-										When there is a <font size="2">CHARACTERS</font> phrase, the size of
-										ReplaceChar$il and the delimiter which may follow it (Delim$il) must be one
-										character.
+										When there is a CHARACTERS phrase, the size of ReplaceChar$il and the delimiter
+										which may follow it (Delim$il) must be one character.
 									</p>
 									<p>
 										If Compare$il, Delim$il or Replace$il is a figurative constant it is 1 character
@@ -626,10 +607,8 @@ INSPECT SourceLine TALLYING ECount
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
 									<h3>
-										<font color="#800000"
-											>Example 1<br />
-											with animation</font
-										>
+										Example 1<br />
+										with animation
 									</h3>
 								</td>
 								<td width="525">
@@ -638,9 +617,9 @@ INSPECT SourceLine TALLYING ECount
 										shown in the storage schematic below.
 									</p>
 									<p>
-										Click on the storage schematic to see the result of each of these
-										<font size="2">INSPECT</font> statements (use left click or PageDown for next
-										item and right click or PageUp for previsou item) .&nbsp;
+										Click on the storage schematic to see the result of each of these INSPECT
+										statements (use left click or PageDown for next item and right click or PageUp
+										for previsou item) .&nbsp;
 									</p>
 									<pre class="language-cobol"><code class="language-cobol">
 1. INSPECT StringData REPLACING ALL "R" BY "G"
@@ -674,7 +653,7 @@ INSPECT SourceLine TALLYING ECount
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Example 2</font></h3>
+									<h3>Example 2</h3>
 								</td>
 								<td width="525">
 									<p>
@@ -692,10 +671,8 @@ END-PERFORM</code></pre>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
 									<h3>
-										<font color="#800000"
-											>Example 3<br />
-											with animation</font
-										>
+										Example 3<br />
+										with animation
 									</h3>
 								</td>
 								<td width="525">
@@ -705,17 +682,15 @@ END-PERFORM</code></pre>
 									</p>
 									<p>
 										To achieve we use a picture clause edited with a floating dollar sign and then
-										we use the <font size="2">INSPECT</font> to replace the dollar sign with the
-										Rouble symbol "R".
+										we use the INSPECT to replace the dollar sign with the Rouble symbol "R".
 									</p>
 									<p>
 										This works because when a value is moved into an edited item the editing is
 										immediately applied to the value.
 									</p>
 									<p>
-										Click on the diagram below to see how this use of the
-										<font size="2">INSPECT</font> works (use left click or PageDown for next item
-										and right click or PageUp for previsou item) .
+										Click on the diagram below to see how this use of the INSPECT works (use left
+										click or PageDown for next item and right click or PageUp for previsou item) .
 									</p>
 									<center>
 										<iframe
@@ -743,19 +718,16 @@ END-PERFORM</code></pre>
 						<table border="0" cellpadding="4" cellspacing="0" width="710">
 							<tr>
 								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="combine">
-										<font color="#FFFF00">The combined INSPECT</font>
-									</h2>
+									<h2 align="center" id="combine">The combined INSPECT</h2>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" colspan="2" valign="top" width="175">
-									<h3><font color="#800000">Syntax</font></h3>
+									<h3>Syntax</h3>
 									<p><img height="338" src="Resources/pics/CombInspect.gif" width="649" /></p>
 									<p>
-										This format of the <font size="2">INSPECT</font> combines the syntactic elements
-										of the previous two formats allowing both counting and replacing to be done in
-										one statement.&nbsp;
+										This format of the INSPECT combines the syntactic elements of the previous two
+										formats allowing both counting and replacing to be done in one statement.&nbsp;
 									</p>
 								</td>
 							</tr>
@@ -776,30 +748,25 @@ END-PERFORM</code></pre>
 						<table border="0" cellpadding="4" cellspacing="0" width="710">
 							<tr>
 								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="convert">
-										<font color="#FFFF00">The converting INSPECT</font>
-									</h2>
+									<h2 align="center" id="convert">The converting INSPECT</h2>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" colspan="2" valign="top" width="175">
-									<h3><font color="#800000">Syntax</font></h3>
+									<h3>Syntax</h3>
 									<p><img src="Resources/pics/ConvInspect.gif" /></p>
 									<hr />
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>
-										<font color="#800000">How th</font>
-										<font color="#800000">is format of the INSPECT works</font>
-									</h3>
+									<h3>How this format of the INSPECT works</h3>
 								</td>
 								<td width="525">
 									<p>
-										The <font size="2">INSPECT..CONVERTING</font> works on individual characters.
-										Compare$il is a list of characters that will be replaced with the characters in
-										Convert$il on a one for one basis.
+										The INSPECT..CONVERTING works on individual characters. Compare$il is a list of
+										characters that will be replaced with the characters in Convert$il on a one for
+										one basis.
 									</p>
 									<p>For instance the statement -</p>
 									<pre
@@ -811,7 +778,7 @@ END-PERFORM</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Rules</font></h3>
+									<h3>Rules</h3>
 								</td>
 								<td width="525">
 									<ol class="spaced">
@@ -830,10 +797,8 @@ END-PERFORM</code></pre>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
 									<h3>
-										<font color="#800000"
-											>Example 1<br />
-											with animation</font
-										>
+										Example 1<br />
+										with animation
 									</h3>
 								</td>
 								<td width="525">
@@ -843,9 +808,9 @@ END-PERFORM</code></pre>
 											shown in the storage schematic below.
 										</p>
 										<p align="left">
-											Click on the storage schematic to see the result of each of these
-											<font size="2">INSPECT</font> statements (use left click or PageDown for
-											next item and right click or PageUp for previsou item).&nbsp;
+											Click on the storage schematic to see the result of each of these INSPECT
+											statements (use left click or PageDown for next item and right click or
+											PageUp for previsou item).&nbsp;
 										</p>
 										<pre class="language-cobol"><code class="language-cobol">
 1. INSPECT StringData CONVERTING "fxtd" TO "ZYAB".
@@ -871,12 +836,12 @@ END-PERFORM</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Example 2</font></h3>
+									<h3>Example 2</h3>
 								</td>
 								<td width="525">
 									<p>
-										This example shows how the <font size="2">INSPECT..CONVERTING</font> can be used
-										to implement a simple encoding mechanism.
+										This example shows how the INSPECT..CONVERTING can be used to implement a simple
+										encoding mechanism.
 									</p>
 									<p>
 										It converts the character 0 to character 5, 1 to 2, 2 to 9, 3 to 8 etc.
@@ -891,21 +856,20 @@ END-PERFORM</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Example 3</font></h3>
+									<h3>Example 3</h3>
 								</td>
 								<td width="525">
 									<p>
-										In this example, the <font size="2">INSPECT..CONVERTING</font> is used to
-										convert upper case letters to lower case and visa versa.
+										In this example, the INSPECT..CONVERTING is used to convert upper case letters
+										to lower case and visa versa.
 									</p>
 									<p>
-										The first <font size="2">INSPECT</font> shows how we can convert the characters
-										using string literals and the next two show how storing the strings in data
-										items makes the conversion operation more versatile.
+										The first INSPECT shows how we can convert the characters using string literals
+										and the next two show how storing the strings in data items makes the conversion
+										operation more versatile.
 									</p>
 									<p>
-										Actually, these days we can do this with the
-										<font size="2">UPPER-CASE</font> and <font size="2">LOWER-CASE</font> Intrinsic
+										Actually, these days we can do this with the UPPER-CASE and LOWER-CASE Intrinsic
 										Functions.
 									</p>
 									<pre class="language-cobol"><code class="language-cobol">*&gt; Data Division entries
@@ -946,15 +910,12 @@ END-PERFORM</code></pre>
 										These COBOL course materials are the copyright property of Michael Coughlan.
 									</p>
 									<p>
-										<font size="2"
-											>All rights reserved. No part of these course materials may be reproduced in
-											any form or by any means - graphic, electronic, mechanical, photocopying,
-											printing, recording, taping or stored in an information storage and
-											retrieval system - without the written permission of</font
-										>
-										<font size="2">the author.</font>
+										All rights reserved. No part of these course materials may be reproduced in any
+										form or by any means - graphic, electronic, mechanical, photocopying, printing,
+										recording, taping or stored in an information storage and retrieval system -
+										without the written permission of the author.
 									</p>
-									<p align="center"><font size="2">(c) Michael Coughlan</font></p>
+									<p align="center">(c) Michael Coughlan</p>
 								</td>
 							</tr>
 						</table>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -16,10 +16,12 @@
 			ul.toc > li {
 				padding-left: 0.4em;
 				margin-bottom: 0.6em;
+				font-size: smaller;
 			}
 
 			ul.toc a {
 				font-weight: bold;
+				font-size: larger;
 			}
 		</style>
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
@@ -173,6 +175,17 @@
 					margin: 0.2em 0;
 				}
 			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			td[bgcolor="#FFFFCC"] h3,
+			td[bgcolor="#FFFFCC"] h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
+			}
 		</style>
 	</head>
 	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
@@ -208,48 +221,39 @@
 							<ul class="toc">
 								<li>
 									<a href="#intro">Introduction</a><br />
-									<font size="-1">Unit aims, objectives and prerequisites.</font>
+									Unit aims, objectives and prerequisites.
 								</li>
 								<li>
 									<a href="#seq">Organization of Sequential files</a><br />
-									<font size="-1"
-										>Provides a recap of Sequential file organization and the difficulties of
-										adding, removing and updating records in an ordered Sequential file.</font
-									>
+									Provides a recap of Sequential file organization and the difficulties of adding,
+									removing and updating records in an ordered Sequential file.
 								</li>
 								<li>
 									<a href="#rel">Organization of Relative files</a><br />
-									<font size="-1"
-										>Describes how Relative files are organized and shows how records may be added,
-										deleted or updated.</font
-									>
+									Describes how Relative files are organized and shows how records may be added,
+									deleted or updated.
 								</li>
 								<li>
 									<a href="#idx">Organization of Indexed files</a><br />
-									<font size="-1"
-										>Describes the organization of Indexed files. Shows how records may be added,
-										deleted or updated and describes how records in an Indexed file may be processed
-										directly or sequentially on any key.</font
-									>
+									Describes the organization of Indexed files. Shows how records may be added, deleted
+									or updated and describes how records in an Indexed file may be processed directly or
+									sequentially on any key.
 								</li>
 								<li>
 									<a href="#comp">Comparison of COBOL file organizations</a><br />
-									<font size="-1"
-										>Summarizes the advantages and disadvantages of each of the file organizations
-										above.</font
-									>
+									Summarizes the advantages and disadvantages of each of the file organizations above.
 								</li>
 							</ul>
 						</div>
 						<table border="0" cellpadding="4" cellspacing="0" width="710">
 							<tr>
 								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="175">
-									<h2 align="center" id="intro"><font color="#FFFF00">Introduction</font></h2>
+									<h2 align="center" id="intro">Introduction</h2>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#993300">Aims</font></h3>
+									<h3>Aims</h3>
 								</td>
 								<td width="525">
 									<p>
@@ -262,7 +266,7 @@
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Objectives</font></h3>
+									<h3>Objectives</h3>
 								</td>
 								<td width="525">
 									<p>By the end of this unit you should:</p>
@@ -290,7 +294,7 @@
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Prerequisites</font></h3>
+									<h3>Prerequisites</h3>
 								</td>
 								<td width="525">
 									<p>You should be familiar with the material covered in the unit;</p>
@@ -315,12 +319,12 @@
 						<table border="0" cellpadding="4" cellspacing="0" width="710">
 							<tr>
 								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="175">
-									<h2 align="center" id="seq"><font color="#FFFF00">Sequential files</font></h2>
+									<h2 align="center" id="seq">Sequential files</h2>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Introduction</font></h3>
+									<h3>Introduction</h3>
 								</td>
 								<td width="525">
 									<p>
@@ -343,16 +347,15 @@
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Problems accessing ordered Sequential files.</font></h3>
+									<h3>Problems accessing ordered Sequential files.</h3>
 								</td>
 								<td width="525">
 									<p>
-										Records in <font color="#000000">an order</font>ed Sequential file are arranged,
-										in order, on some key field or fields. When we want to insert,delete or amend a
-										record we must preserve the ordering. The only way to do this is to create a new
-										file. In the case of an insertion or update, the new file will contain the
-										inserted or updated record. In the case of a deletion, the deleted record will
-										be missing from the new file.
+										Records in an ordered Sequential file are arranged, in order, on some key field
+										or fields. When we want to insert,delete or amend a record we must preserve the
+										ordering. The only way to do this is to create a new file. In the case of an
+										insertion or update, the new file will contain the inserted or updated record.
+										In the case of a deletion, the deleted record will be missing from the new file.
 									</p>
 									<p>
 										The main drawback to inserting, deleting or amending records in an ordered
@@ -371,7 +374,7 @@
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Contrast with direct access files</font></h3>
+									<h3>Contrast with direct access files</h3>
 								</td>
 								<td width="525">
 									<p>
@@ -388,9 +391,7 @@
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>
-										<font color="#800000">Inserting records in an ordered Sequential file</font>
-									</h3>
+									<h3>Inserting records in an ordered Sequential file</h3>
 								</td>
 								<td width="525">
 									<p>To insert a record in an ordered Sequential file:</p>
@@ -411,13 +412,7 @@
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>
-										<font color="#808080"
-											><font color="#800000"
-												>Deleting records from an ordered Sequential file</font
-											></font
-										>
-									</h3>
+									<h3>Deleting records from an ordered Sequential file</h3>
 								</td>
 								<td width="525">
 									<p>To delete a record in an ordered Sequential file:</p>
@@ -439,7 +434,7 @@
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Amending records in an ordered Sequential file</font></h3>
+									<h3>Amending records in an ordered Sequential file</h3>
 								</td>
 								<td width="525">
 									<p>To amend a record in an ordered Sequential file:</p>
@@ -461,7 +456,7 @@
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Sequential files - animation</font></h3>
+									<h3>Sequential files - animation</h3>
 								</td>
 								<td width="525">
 									<p>
@@ -481,7 +476,7 @@
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Summary</font></h3>
+									<h3>Summary</h3>
 								</td>
 								<td width="525">
 									<p>
@@ -511,12 +506,12 @@
 						<table border="0" cellpadding="4" cellspacing="0" width="710">
 							<tr>
 								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="175">
-									<h2 align="center" id="rel"><font color="#FFFF00">Relative Files</font></h2>
+									<h2 align="center" id="rel">Relative Files</h2>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Introduction</font></h3>
+									<h3>Introduction</h3>
 								</td>
 								<td width="525">
 									<p>
@@ -538,7 +533,7 @@
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Organization of Relative files</font></h3>
+									<h3>Organization of Relative files</h3>
 								</td>
 								<td width="525">
 									<p>
@@ -590,7 +585,7 @@
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Accessing records in a Relative file</font></h3>
+									<h3>Accessing records in a Relative file</h3>
 								</td>
 								<td width="525">
 									<div align="center">
@@ -621,10 +616,7 @@
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>
-										<font color="#800000">Animation - Organization and use of</font>
-										<font color="#800000">Relative files</font>
-									</h3>
+									<h3>Animation - Organization and use of Relative files</h3>
 								</td>
 								<td width="525">
 									<table border="0" width="525">
@@ -658,7 +650,7 @@
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Summary</font></h3>
+									<h3>Summary</h3>
 								</td>
 								<td width="525">
 									<p>
@@ -684,12 +676,12 @@
 						<table border="0" cellpadding="4" cellspacing="0" width="710">
 							<tr>
 								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="175">
-									<h2 align="center" id="idx"><font color="#FFFF00">Indexed Files</font></h2>
+									<h2 align="center" id="idx">Indexed Files</h2>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Introduction</font></h3>
+									<h3>Introduction</h3>
 								</td>
 								<td width="525">
 									<p>
@@ -709,7 +701,7 @@
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Organization of Indexed files</font></h3>
+									<h3>Organization of Indexed files</h3>
 								</td>
 								<td width="525">
 									<p>
@@ -747,10 +739,7 @@
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>
-										<font color="#800000">Animation - O</font>
-										<font color="#800000">rganization and use of Indexed files</font>
-									</h3>
+									<h3>Animation - Organization and use of Indexed files</h3>
 								</td>
 								<td width="525">
 									<div align="center">
@@ -804,7 +793,7 @@ END-IF</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Summary</font></h3>
+									<h3>Summary</h3>
 								</td>
 								<td width="525">
 									<p>An Indexed file may have multiple, alphanumeric, keys.</p>
@@ -828,14 +817,12 @@ END-IF</code></pre>
 						<table border="0" cellpadding="4" cellspacing="0" width="710">
 							<tr>
 								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="175">
-									<h2 align="center" id="comp">
-										<font color="#FFFF00">Comparison of COBOL file organizations</font>
-									</h2>
+									<h2 align="center" id="comp">Comparison of COBOL file organizations</h2>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Introduction</font></h3>
+									<h3>Introduction</h3>
 								</td>
 								<td width="525">
 									<p>
@@ -847,7 +834,7 @@ END-IF</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Sequential files</font></h3>
+									<h3>Sequential files</h3>
 								</td>
 								<td width="525">
 									<h3 align="center">Disadvantages</h3>
@@ -945,7 +932,7 @@ END-IF</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Relative files</font></h3>
+									<h3>Relative files</h3>
 								</td>
 								<td width="525">
 									<h3 align="center">Disadvantages</h3>
@@ -1133,7 +1120,7 @@ END-IF</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Indexed files</font></h3>
+									<h3>Indexed files</h3>
 								</td>
 								<td width="525">
 									<h3 align="center">Disadvantages</h3>
@@ -1227,7 +1214,7 @@ END-IF</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Summary</font></h3>
+									<h3>Summary</h3>
 								</td>
 								<td width="525">
 									<p>
@@ -1271,16 +1258,12 @@ END-IF</code></pre>
 											These COBOL course materials are the copyright property of Michael Coughlan.
 										</p>
 										<p>
-											<font size="2"
-												>All rights reserved. No part of these course materials may be
-												reproduced in any form or by any means - graphic, electronic,
-												mechanical, photocopying, printing, recording, taping or stored in an
-												information storage and retrieval system - without the written
-												permission of</font
-											>
-											<font size="2">the author.</font>
+											All rights reserved. No part of these course materials may be reproduced in
+											any form or by any means - graphic, electronic, mechanical, photocopying,
+											printing, recording, taping or stored in an information storage and
+											retrieval system - without the written permission of the author.
 										</p>
-										<p align="center"><font size="2">(c) Michael Coughlan</font></p>
+										<p align="center">(c) Michael Coughlan</p>
 									</td>
 								</tr>
 							</table>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -150,10 +150,23 @@
 			ul.toc > li {
 				padding-left: 0.4em;
 				margin-bottom: 0.6em;
+				font-size: smaller;
 			}
 
 			ul.toc a {
 				font-weight: bold;
+				font-size: larger;
+			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			td[bgcolor="#FFFFCC"] h3,
+			td[bgcolor="#FFFFCC"] h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
 			}
 		</style>
 	</head>
@@ -170,44 +183,34 @@
 					<ul class="toc">
 						<li>
 							<a href="#intro">Introduction</a><br />
-							<font size="-1">Unit aims, objectives, prerequisites.</font>
+							Unit aims, objectives, prerequisites.
 						</li>
 						<li>
 							<a href="#part1">PERFORM..Proc</a><br />
-							<font size="-1"
-								>This section introduces the format of the
-								<code class="language-cobol">PERFORM</code> that is used to transfer control to a
-								paragraph or section.</font
-							>
+							This section introduces the format of the
+							<code class="language-cobol">PERFORM</code> that is used to transfer control to a paragraph
+							or section.
 						</li>
 						<li>
 							<a href="#part2">Using the PERFORM..THRU</a><br />
-							<font size="-1"
-								>This section demonstrates how the <code class="language-cobol">PERFORM..THRU</code> can
-								be used to implement an emergency exit from a paragraph.</font
-							>
+							This section demonstrates how the <code class="language-cobol">PERFORM..THRU</code> can be
+							used to implement an emergency exit from a paragraph.
 						</li>
 						<li>
 							<a href="#part3">PERFORM..TIMES</a><br />
-							<font size="-1"
-								>This section introduces the <code class="language-cobol">PERFORM..TIMES</code> which
-								allow us to create an iteration that executes x number of times. Also discusses the use
-								of in-line versus out-of-line <code class="language-cobol">PERFORM</code>s</font
-							>
+							This section introduces the <code class="language-cobol">PERFORM..TIMES</code> which allow
+							us to create an iteration that executes x number of times. Also discusses the use of in-line
+							versus out-of-line <code class="language-cobol">PERFORM</code>s
 						</li>
 						<li>
 							<a href="#part4">PERFORM..UNTIL</a><br />
-							<font size="-1"
-								>In this section <code class="language-cobol">PERFORM..UNTIL</code>, COBOL's version of
-								the while and do/repeat loops, is introduced.</font
-							>
+							In this section <code class="language-cobol">PERFORM..UNTIL</code>, COBOL's version of the
+							while and do/repeat loops, is introduced.
 						</li>
 						<li>
 							<a href="#part5">PERFORM..VARYING</a><br />
-							<font size="-1"
-								>This section demonstrates <code class="language-cobol">PERFORM..VARYING</code>, COBOL's
-								version of the for loop.</font
-							>
+							This section demonstrates <code class="language-cobol">PERFORM..VARYING</code>, COBOL's
+							version of the for loop.
 						</li>
 					</ul>
 					<hr />
@@ -215,18 +218,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="intro">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Introduction</font>
-						</font>
-					</h2>
+					<h2 align="center" id="intro">Introduction</h2>
 				</td>
 			</tr>
 			<tr>
 				<td bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#993300" face="Arial, Helvetica, sans-serif">Aims</font>
-					</h4>
+					<h4>Aims</h4>
 				</td>
 				<td width="540">
 					<div align="center">
@@ -245,9 +242,7 @@
 					</div>
 					<div align="center">
 						<p align="center">
-							<b>
-								<font face="TIMES">Iteration constructs and their COBOL equivalents</font>
-							</b>
+							<b>Iteration constructs and their COBOL equivalents</b>
 						</p>
 						<center>
 							<table bgcolor="#E1FFE1" border cellpadding="7" cellspacing="1" width="411">
@@ -303,9 +298,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Objectives</font>
-					</h4>
+					<h4>Objectives</h4>
 				</td>
 				<td valign="top" width="540">
 					<p>By the end of this unit you should -</p>
@@ -335,9 +328,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="77" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font>
-					</h4>
+					<h4>Prerequisites</h4>
 				</td>
 				<td height="77" valign="top" width="525">
 					<ul>
@@ -362,18 +353,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part1">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">PERFORM..Proc</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part1">PERFORM..Proc</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4>Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -426,25 +411,18 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">PERFORM format 1 syntax</font>
-					</h4>
+					<h4>PERFORM format 1 syntax</h4>
 					<aside>
 						<p align="center">
 							<img height="44" src="Resources/pics/i-LightBulbTip.gif" width="42" />
 						</p>
 						<p align="left">
-							<font size="-1"
-								>A paragraph is a block of code that starts at the paragraph name and extends to the
-								next paragraph name, the next section name or the end of the program text.</font
-							>
+							A paragraph is a block of code that starts at the paragraph name and extends to the next
+							paragraph name, the next section name or the end of the program text.
 						</p>
 						<p align="left">
-							<font size="-1"
-								>A section is a block of code that starts at the section name and extends to the next
-								section name or the end of the program text. A section must contain at least one
-								paragraph.</font
-							>
+							A section is a block of code that starts at the section name and extends to the next section
+							name or the end of the program text. A section must contain at least one paragraph.
 						</p>
 					</aside>
 				</td>
@@ -479,9 +457,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">How this format works</font>
-					</h4>
+					<h4>How this format works</h4>
 					<aside>
 						<p align="center">
 							<img height="62" src="Resources/pics/i-BugAlert.gif" width="56" />
@@ -492,14 +468,12 @@
 							succeeding paragraph.
 						</p>
 						<p align="left">
-							<font size="-1"
-								>The problem with using the <code class="language-cobol">PERFORM..THRU</code> to execute
-								an number of paragraphs as one unit is that, in the maintenance phase of your program's
-								life, another programmer may insert a paragraph in the middle of your
-								<code class="language-cobol">PERFORM..THRU</code>
-								block. Suddenly your block won't work correctly because now its executing an additional,
-								unintentional paragraph.
-							</font>
+							The problem with using the <code class="language-cobol">PERFORM..THRU</code> to execute an
+							number of paragraphs as one unit is that, in the maintenance phase of your program's life,
+							another programmer may insert a paragraph in the middle of your
+							<code class="language-cobol">PERFORM..THRU</code>
+							block. Suddenly your block won't work correctly because now its executing an additional,
+							unintentional paragraph.
 						</p>
 					</aside>
 					<aside>
@@ -507,14 +481,8 @@
 							<img height="37" src="Resources/pics/i-Detail.gif" width="30" />
 						</p>
 						<p align="left">
-							<font size="-1">
-								<font size="-2">
-									<font size="-1"
-										>Although Netexpress does allow recursive Performs, this is a nonstandard
-										extension. Please do not take advantage of it..</font
-									>
-								</font>
-							</font>
+							Although Netexpress does allow recursive Performs, this is a nonstandard extension. Please
+							do not take advantage of it..
 						</p>
 					</aside>
 				</td>
@@ -551,7 +519,7 @@
 					<blockquote>
 						<div align="left">
 							<p>
-								<b> <font size="-1">PERFORMs</font> may be nested. </b><br />
+								<b> PERFORMs may be nested. </b><br />
 								That is, a PERFORM may execute a paragraph that contains a
 								<code class="language-cobol">PERFORM</code> which in turn may execute a paragraph that
 								contains another <code class="language-cobol">PERFORM</code>. As control reaches the end
@@ -566,12 +534,11 @@
 							</p>
 							<p>
 								<b>Recursion not allowed.</b><br />
-								Although <font size="-1">Performs</font> can be nested, neither direct nor indirect
-								recursion is allowed. This means that a paragraph must not contain a
+								Although Performs can be nested, neither direct nor indirect recursion is allowed. This
+								means that a paragraph must not contain a
 								<code class="language-cobol">PERFORM</code> that invokes itself or any ancestor
 								paragraph (parent, grandparent etc). Unfortunately this restriction is not enforced by
-								the compiler but your program will not work correctly if you use recursive
-								<font size="-1">Performs</font>
+								the compiler but your program will not work correctly if you use recursive Performs
 							</p>
 						</div>
 					</blockquote>
@@ -582,9 +549,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Why use this format?</font>
-					</h4>
+					<h4 align="left">Why use this format?</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -606,9 +571,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">PERFORM..PROC example</font>
-					</h4>
+					<h4>PERFORM..PROC example</h4>
 					<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
 				</td>
 				<td valign="top" width="525">
@@ -650,9 +613,7 @@ ThreeLevelsDown.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Self Assessment Questions</font>
-					</h4>
+					<h4 align="left">Self Assessment Questions</h4>
 					<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" /></p>
 				</td>
 				<td valign="top" width="525">
@@ -785,18 +746,12 @@ ThreeLevelsDown.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part2">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Using the PERFORM..THRU</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part2">Using the PERFORM..THRU</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4 align="left">Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -811,9 +766,7 @@ ThreeLevelsDown.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="355" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Coping with errors</font>
-					</h4>
+					<h4 align="left">Coping with errors</h4>
 					<p align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48" /></p>
 				</td>
 				<td height="355" valign="top" width="525">
@@ -856,18 +809,14 @@ SumSales.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="355" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Using the PERFORM..THRU</font>
-					</h4>
+					<h4 align="left">Using the PERFORM..THRU</h4>
 					<aside>
 						<p align="center">
 							<img height="37" src="Resources/pics/i-Detail.gif" width="30" /><br />
-							<font size="-1"
-								>Actually this approach will soon be unnecessary on the way out, because the coming
-								COBOL standard solves the problem by having an
-								<code class="language-cobol">EXIT PARAGRAPH</code> statement, that can be used to exit a
-								paragraph prematurely.
-							</font>
+							Actually this approach will soon be unnecessary on the way out, because the coming COBOL
+							standard solves the problem by having an
+							<code class="language-cobol">EXIT PARAGRAPH</code> statement, that can be used to exit a
+							paragraph prematurely.
 						</p>
 					</aside>
 					<p align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48" /></p>
@@ -928,9 +877,7 @@ SumSalesExit.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">PERFORM..THRU restrictions</font>
-					</h4>
+					<h4 align="left">PERFORM..THRU restrictions</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -958,18 +905,12 @@ SumSalesExit.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part3">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">PERFORM..TIMES</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part3">PERFORM..TIMES</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4 align="left">Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -982,9 +923,7 @@ SumSalesExit.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">PERFORM..TIMES Syntax</font>
-					</h4>
+					<h4 align="left">PERFORM..TIMES Syntax</h4>
 				</td>
 				<td valign="top" width="525">
 					<p align="left"><img height="105" src="Resources/pics/Perform2.gif" width="406" /></p>
@@ -1002,9 +941,7 @@ SumSalesExit.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">In-line vs Out-of-line</font>
-					</h4>
+					<h4 align="left">In-line vs Out-of-line</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1048,9 +985,7 @@ SumSalesExit.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="355" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Example</font>
-					</h4>
+					<h4 align="left">Example</h4>
 				</td>
 				<td height="355" valign="top" width="525">
 					<table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="49%">
@@ -1091,9 +1026,7 @@ OutOfLineEG.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Self Assessment Questions</font>
-					</h4>
+					<h4 align="left">Self Assessment Questions</h4>
 					<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" /></p>
 				</td>
 				<td valign="top" width="525">
@@ -1133,18 +1066,12 @@ OutOfLineEG.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part4">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">PERFORM..UNTIL</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part4">PERFORM..UNTIL</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="188" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4 align="left">Introduction</h4>
 				</td>
 				<td height="188" valign="top" width="525">
 					<p>
@@ -1157,9 +1084,7 @@ OutOfLineEG.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">PERFORM..UNTIL syntax</font>
-					</h4>
+					<h4 align="left">PERFORM..UNTIL syntax</h4>
 				</td>
 				<td valign="top" width="525">
 					<p><img height="126" src="Resources/pics/Perform3.gif" width="502" /></p>
@@ -1182,9 +1107,7 @@ OutOfLineEG.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="355" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">How the PERFORM..UNTIL works</font>
-					</h4>
+					<h4 align="left">How the PERFORM..UNTIL works</h4>
 				</td>
 				<td height="355" valign="top" width="525">
 					<p>
@@ -1218,9 +1141,7 @@ OutOfLineEG.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">TEST BEFORE Vs TEST AFTER</font>
-					</h4>
+					<h4 align="left">TEST BEFORE Vs TEST AFTER</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1230,8 +1151,7 @@ OutOfLineEG.
 					</p>
 					<p>
 						There really isn't a cookbook answer to this. It's a matter of experience. But we can identify
-						some circumstances, when it is better to use the
-						<font size="-1">WITH TEST BEFORE,</font> than the
+						some circumstances, when it is better to use the WITH TEST BEFORE, than the
 						<code class="language-cobol">WITH TEST AFTER</code>.
 					</p>
 					<p>
@@ -1247,9 +1167,7 @@ OutOfLineEG.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="188" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">The "read ahead" technique</font>
-					</h4>
+					<h4 align="left">The "read ahead" technique</h4>
 				</td>
 				<td height="188" valign="top" width="525">
 					<p>
@@ -1307,9 +1225,7 @@ END-PERFORM</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="122" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">PERFORM..UNTIL comment</font>
-					</h4>
+					<h4 align="left">PERFORM..UNTIL comment</h4>
 				</td>
 				<td height="122" valign="top" width="525">
 					<p>
@@ -1336,37 +1252,29 @@ END-PERFORM</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part5">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">PERFORM..VARYING</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part5">PERFORM..VARYING</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4 align="left">Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
-						The <font size="-1">PERFORM..VARYING</font> is used to implement counting iteration. It is
-						similar to the For construct in languages like Modula-2, Pascal and C. However, these languages
-						permit only one counting variable per loop instruction, while COBOL allows up to three.
+						The PERFORM..VARYING is used to implement counting iteration. It is similar to the For construct
+						in languages like Modula-2, Pascal and C. However, these languages permit only one counting
+						variable per loop instruction, while COBOL allows up to three.
 					</p>
 					<p>
 						Why three? Earlier versions of COBOL only allowed tables with a maximum of three dimensions, and
-						the <font size="-1">PERFORM..VARYING</font> was a mechanism for processing them.
+						the PERFORM..VARYING was a mechanism for processing them.
 					</p>
 					<hr width="50%" />
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="355" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">PERFORM..VARYING syntax</font>
-					</h4>
+					<h4 align="left">PERFORM..VARYING syntax</h4>
 				</td>
 				<td height="355" valign="top" width="525">
 					<p><img height="234" src="Resources/pics/Perform4.gif" width="502" /></p>
@@ -1385,13 +1293,10 @@ END-PERFORM</code></pre>
 						The least significant counter must go though all its values and reach its terminating condition
 						before the next most significant counter can be incremented.
 					</p>
-					<p>The item after the <font size="-1">FROM,</font> is the starting value of the counter.</p>
+					<p>The item after the FROM, is the starting value of the counter.</p>
 					<p>
-						The item after the <font size="-1">BY,</font> is the step value of the counter. This can be
-						negative or positive. If a negative step value is used, the counter should be signed (<font
-							size="-1"
-							>PIC S99</font
-						>, etc.).
+						The item after the BY, is the step value of the counter. This can be negative or positive. If a
+						negative step value is used, the counter should be signed (PIC S99, etc.).
 					</p>
 					<p>When the iteration ends, the counters retain their terminating values.</p>
 					<p>
@@ -1409,18 +1314,13 @@ END-PERFORM</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>PERFORM..VARYING using one counter</font
-						>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Example</font>
-					</h4>
+					<h4 align="left">PERFORM..VARYING using one counter Example</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
-						The example animation below demonstrates how a simple
-						<font size="-1">PERFORM..VARYING</font>, using only one counter, work. Pay particular attention
-						to when the counter is incremented. In the example note that the condition
+						The example animation below demonstrates how a simple PERFORM..VARYING, using only one counter,
+						work. Pay particular attention to when the counter is incremented. In the example note that the
+						condition
 						<i>Idx1 = 3</i> results in only two passes through the loop body.
 					</p>
 					<p align="center">
@@ -1433,17 +1333,10 @@ END-PERFORM</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="372" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>PERFORM..VARYING using two counter Example
-						</font>
-					</h4>
+					<h4 align="left">PERFORM..VARYING using two counter Example</h4>
 				</td>
 				<td height="372" valign="top" width="525">
-					<p>
-						This example animation demonstrates how a <font size="-1">PERFORM..VARYING</font>, with two
-						counters, works.
-					</p>
+					<p>This example animation demonstrates how a PERFORM..VARYING, with two counters, works.</p>
 					<p>
 						Note how the counter Idx2 must go through all its values and reach its terminating value before
 						the Idx1 counter is incremented. An easy way to think about this is to think of it as a mileage
@@ -1465,10 +1358,7 @@ END-PERFORM</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">PERFORM..VARYING</font>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Example Program</font>
-					</h4>
+					<h4 align="left">PERFORM..VARYING Example Program</h4>
 					<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
 					<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" /></p>
 				</td>
@@ -1582,7 +1472,7 @@ CountMileage.
 								<td bgcolor="#FFFFCC" width="8%">Q3</td>
 								<td width="62%">
 									In the in-line <code class="language-cobol">PERFORM</code> why are there three
-									separate <font size="-1">Performs</font>?
+									separate Performs?
 								</td>
 								<td valign="top" width="30%">
 									<select name="select2" size="1">
@@ -1616,17 +1506,12 @@ CountMileage.
 							These COBOL course materials are the copyright property of Michael Coughlan.
 						</p>
 						<p align="left">
-							<font size="2"
-								>All rights reserved. No part of these course materials may be reproduced in any form or
-								by any means - graphic, electronic, mechanical, photocopying, printing, recording,
-								taping or stored in an information storage and retrieval system - without the written
-								permission of</font
-							>
-							<font size="2">the author.</font>
+							All rights reserved. No part of these course materials may be reproduced in any form or by
+							any means - graphic, electronic, mechanical, photocopying, printing, recording, taping or
+							stored in an information storage and retrieval system - without the written permission of
+							the author.
 						</p>
-						<p align="center">
-							<font size="2">(c) Michael Coughlan</font>
-						</p>
+						<p align="center">(c) Michael Coughlan</p>
 					</div>
 				</td>
 			</tr>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -128,10 +128,23 @@
 			ul.toc > li {
 				padding-left: 0.4em;
 				margin-bottom: 0.6em;
+				font-size: smaller;
 			}
 
 			ul.toc a {
 				font-weight: bold;
+				font-size: larger;
+			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			td[bgcolor="#FFFFCC"] h3,
+			td[bgcolor="#FFFFCC"] h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
 			}
 		</style>
 	</head>
@@ -147,58 +160,46 @@
 					<ul class="toc">
 						<li>
 							<a href="#intro">Introduction</a><br />
-							<font size="-1">Unit aims, objectives and prerequisites.</font>
+							Unit aims, objectives and prerequisites.
 						</li>
 						<li>
 							<a href="#part1">Reference Modification</a><br />
-							<font size="-1"
-								>This section examines the syntax and semantics of Reference Modification. The section
-								ends with some animated examples.</font
-							>
+							This section examines the syntax and semantics of Reference Modification. The section ends
+							with some animated examples.
 						</li>
 						<li>
 							<a href="#part2">Intrinsic Functions - Introduction</a><br />
-							<font size="-1"
-								>This section introduces COBOL's predefined functions - called Intrinsic Functions. It
-								explains how they may be used and introduces the notation used in the Intrinsic Function
-								definitions in the later sections.</font
-							>
+							This section introduces COBOL's predefined functions - called Intrinsic Functions. It
+							explains how they may be used and introduces the notation used in the Intrinsic Function
+							definitions in the later sections.
 						</li>
 						<li>
 							<a href="#part3">String Functions</a><br />
-							<font size="-1"
-								>This section presents the definitions of the Intrinsic Functions used for string
-								handling . The section ends with some examples.</font
-							>
+							This section presents the definitions of the Intrinsic Functions used for string handling .
+							The section ends with some examples.
 						</li>
 						<li>
 							<a href="#part4">Date Functions</a><br />
-							<font size="-1"
-								>This section presents the definitions of the Intrinsic Functions used for date
-								manipulations . The section ends with a set of comprehensive examples.</font
-							>
+							This section presents the definitions of the Intrinsic Functions used for date manipulations
+							. The section ends with a set of comprehensive examples.
 						</li>
 						<li>
 							<a href="#part5">Miscellaneous Functions</a><br />
-							<font size="-1"
-								>This section presents the definitions of the other (mainly maths) Intrinsic Functions
-								including used for string handling . The section ends with an example using the RANDOM
-								Intrinsic Function..</font
-							>
+							This section presents the definitions of the other (mainly maths) Intrinsic Functions
+							including used for string handling . The section ends with an example using the RANDOM
+							Intrinsic Function..
 						</li>
 					</ul>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="intro">
-						<font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Introduction</font></font>
-					</h2>
+					<h2 align="center" id="intro">Introduction</h2>
 				</td>
 			</tr>
 			<tr>
 				<td bgcolor="#FFFFCC" valign="top" width="160">
-					<h4><font color="#993300" face="Arial, Helvetica, sans-serif">Aims</font></h4>
+					<h4>Aims</h4>
 				</td>
 				<td width="540">
 					<p>
@@ -211,7 +212,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Objectives</font></h4>
+					<h4>Objectives</h4>
 				</td>
 				<td width="540">
 					<p>By the end of this unit you should:</p>
@@ -226,7 +227,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font></h4>
+					<h4>Prerequisites</h4>
 				</td>
 				<td width="525">
 					<p>You should be familiar with the material covered in the unit;</p>
@@ -236,8 +237,8 @@
 						<li>Selection</li>
 						<li>Tables</li>
 						<li>Edited Pictures</li>
-						<li>The <font size="2">INSPECT</font> verb</li>
-						<li>The <font size="2">STRING</font> verb</li>
+						<li>The <code class="language-cobol">INSPECT</code> verb</li>
+						<li>The <code class="language-cobol">STRING</code> verb</li>
 						<li>The <code class="language-cobol">UNSTRING</code> verb</li>
 					</ul>
 				</td>
@@ -256,18 +257,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part1">
-						<font color="#FFFF00"
-							><font face="Arial, Helvetica, sans-serif">Reference Modification</font></font
-						>
-					</h2>
+					<h2 align="center" id="part1">Reference Modification</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Definition & Syntax</font>
-					</h4>
+					<h4>Definition &amp; Syntax</h4>
 				</td>
 				<td valign="top" width="540">
 					<p>
@@ -284,11 +279,7 @@
 					</blockquote>
 					<p>To apply Reference Modification the following syntax must be used.</p>
 					<blockquote>
-						<p>
-							<font face="Arial, Helvetica, sans-serif"
-								><b>DataName(</b><i>StartPos</i> [<b>:</b><i>SubStrLength</i>]<b>)</b></font
-							>
-						</p>
+						<p><b>DataName(</b><i>StartPos</i> [<b>:</b><i>SubStrLength</i>]<b>)</b></p>
 					</blockquote>
 					<p align="left">
 						<i>StartPos</i> is the character position of the first character in the sub-string and
@@ -304,13 +295,13 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Examples</font></h4>
+					<h4>Examples</h4>
 				</td>
 				<td valign="top" width="525">
 					<pre class="language-cobol"><code class="language-cobol">WORKING-STORAGE SECTION.
-01 xString    PIC X(38) VALUE "This is the alphanumeric string". 
-01 nString    PIC 9(5)V99 VALUE 34526.56. 
-01 SubStrSize PIC 99 VALUE 12. 
+01 xString    PIC X(38) VALUE "This is the alphanumeric string".
+01 nString    PIC 9(5)V99 VALUE 34526.56.
+01 SubStrSize PIC 99 VALUE 12.
 01 StartPos   PIC 99 VALUE 18.
              </code></pre>
 					<p align="center">
@@ -326,16 +317,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part2">
-						<font color="#FFFF00"
-							><font face="Arial, Helvetica, sans-serif">Intrinsic Functions</font></font
-						>
-					</h2>
+					<h2 align="center" id="part2">Intrinsic Functions</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font></h4>
+					<h4>Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -351,9 +338,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Using Intrinsic Functions</font>
-					</h4>
+					<h4>Using Intrinsic Functions</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -373,9 +358,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Intrinsic Function Notes</font>
-					</h4>
+					<h4>Intrinsic Function Notes</h4>
 				</td>
 				<td valign="top" width="525">
 					<ul>
@@ -385,7 +368,7 @@
 							<br />
 						</li>
 						<li>
-							Functions that return a number value (numeric & integer) are always considered to be
+							Functions that return a number value (numeric &amp; integer) are always considered to be
 							signed.<br />
 							<br />
 						</li>
@@ -404,9 +387,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Intrinsic Function Template</font>
-					</h4>
+					<h4>Intrinsic Function Template</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>An Intrinsic Function consists of three parts;</p>
@@ -438,9 +419,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Intrinsic Function Notation</font>
-					</h4>
+					<h4>Intrinsic Function Notation</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -480,14 +459,12 @@ MOVE FUNCTION ORD-MAX(IntElement(ALL)) TO OrdPos             </code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part3">
-						<font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">String Functions</font></font>
-					</h2>
+					<h2 align="center" id="part3">String Functions</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Definitions</font></h4>
+					<h4>Definitions</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -499,149 +476,103 @@ MOVE FUNCTION ORD-MAX(IntElement(ALL)) TO OrdPos             </code></pre>
 							</tr>
 							<tr>
 								<td valign="top" width="34%">
-									<font face="TIMES" size="2"></font>
-									<p><font face="TIMES" size="2">CHAR(PosInt)</font></p>
+									<p>CHAR(PosInt)</p>
 								</td>
 								<td valign="top" width="20%">
-									<div align="center"><font size="2">Alphanumeric</font></div>
+									<div align="center">Alphanumeric</div>
 								</td>
 								<td valign="top" width="46%">
-									<font face="TIMES" size="2"></font>
 									<p>
-										<font face="TIMES" size="2"
-											>Returns the character at ordinal position <b>PosInt</b> of the collating
-											sequence.</font
-										>
+										Returns the character at ordinal position <b>PosInt</b> of the collating
+										sequence.
 									</p>
-									<font face="TIMES" size="2"></font>
 								</td>
 							</tr>
 							<tr>
 								<td valign="top" width="34%">
-									<font face="TIMES" size="2"></font>
-									<p><font face="TIMES" size="2">ORD(Alph)</font></p>
+									<p>ORD(Alph)</p>
 								</td>
 								<td valign="top" width="20%">
-									<div align="center"><font size="2">Integer</font></div>
+									<div align="center">Integer</div>
 								</td>
 								<td valign="top" width="46%">
-									<font face="TIMES" size="2"></font>
-									<p>
-										<font face="TIMES" size="2"
-											>Returns the ordinal position of character <b>Alph</b>.</font
-										>
-									</p>
-									<font face="TIMES" size="2"></font>
+									<p>Returns the ordinal position of character <b>Alph</b>.</p>
 								</td>
 							</tr>
 							<tr>
 								<td valign="top" width="34%">
-									<p>
-										<font face="TIMES" size="2">ORD-MAX({Any}...)<br /></font>
-										<font face="TIMES" size="2"></font>
-									</p>
+									<p>ORD-MAX({Any}...)<br /></p>
 								</td>
 								<td valign="top" width="20%">
-									<div align="center"><font size="2">Integer</font></div>
+									<div align="center">Integer</div>
 								</td>
 								<td valign="top" width="46%">
-									<font size="2">Returns the</font>
-									<font face="TIMES" size="2">ordinal position of</font>
-									<font size="2"
-										>whichever of the parameters has the highest value. All parameters must be of
-										the same type. The parameter list may be replaced by an array.</font
-									>
+									Returns the ordinal position of whichever of the parameters has the highest value.
+									All parameters must be of the same type. The parameter list may be replaced by an
+									array.
+								</td>
+							</tr>
+							<tr>
+								<td valign="top" width="34%">ORD-MIN({Any}...)</td>
+								<td valign="top" width="20%">
+									<div align="center">Integer</div>
+								</td>
+								<td valign="top" width="46%">
+									Returns the ordinal position of whichever of the parameters has the lowest value.
+									All parameters must be of the same type.
 								</td>
 							</tr>
 							<tr>
 								<td valign="top" width="34%">
-									<font face="TIMES" size="2">ORD-MIN({Any}...)</font>
+									<p>LENGTH(Any)</p>
 								</td>
 								<td valign="top" width="20%">
-									<div align="center"><font size="2">Integer</font></div>
+									<div align="center">Integer</div>
 								</td>
 								<td valign="top" width="46%">
-									<font size="2">Returns the</font>
-									<font face="TIMES" size="2">ordinal position of</font>
-									<font size="2"
-										>whichever of the parameters has the lowest value. All parameters must be of the
-										same type.</font
-									>
+									<p>Returns the number of characters in <b>Any</b>.</p>
 								</td>
 							</tr>
 							<tr>
 								<td valign="top" width="34%">
-									<font face="TIMES" size="2"></font>
-									<p><font face="TIMES" size="2">LENGTH(Any)</font></p>
+									<p>REVERSE(Alph)</p>
 								</td>
 								<td valign="top" width="20%">
-									<div align="center"><font size="2">Integer</font></div>
+									<div align="center">Alphanumeric</div>
 								</td>
 								<td valign="top" width="46%">
-									<font face="TIMES" size="2"></font>
 									<p>
-										<font face="TIMES" size="2"
-											>Returns the number of characters in <b>Any</b>.</font
-										>
+										Returns a character string with the characters in
+										<b>Alph</b> reversed.
 									</p>
-									<font face="TIMES" size="2"></font>
 								</td>
 							</tr>
 							<tr>
 								<td valign="top" width="34%">
-									<font face="TIMES" size="2"></font>
-									<p><font face="TIMES" size="2">REVERSE(Alph)</font></p>
+									<p>LOWER-CASE(Alph)</p>
 								</td>
 								<td valign="top" width="20%">
-									<div align="center"><font size="2">Alphanumeric</font></div>
+									<div align="center">Alphanumeric</div>
 								</td>
 								<td valign="top" width="46%">
-									<font face="TIMES" size="2"></font>
 									<p>
-										<font face="TIMES" size="2"
-											>Returns a character string with the characters in
-											<b>Alph</b> reversed.</font
-										>
+										Returns a character string with the characters in <b>Alph</b> changed to their
+										lower case equivalents.
 									</p>
-									<font face="TIMES" size="2"></font>
 								</td>
 							</tr>
 							<tr>
 								<td valign="top" width="34%">
-									<font face="TIMES" size="2"></font>
-									<p><font face="TIMES" size="2">LOWER-CASE(Alph)</font></p>
+									<p>UPPER-CASE(Alph)</p>
 								</td>
 								<td valign="top" width="20%">
-									<div align="center"><font size="2">Alphanumeric</font></div>
+									<div align="center">Alphanumeric</div>
 								</td>
 								<td valign="top" width="46%">
-									<font face="TIMES" size="2"></font>
 									<p>
-										<font face="TIMES" size="2"
-											>Returns a character string with the characters in <b>Alph</b> changed to
-											their lower case equivalents.</font
-										>
+										Returns a character string with the characters in <b>Alph</b> changed to their
+										upper case equivalents
 									</p>
-									<font face="TIMES" size="2"></font>
-								</td>
-							</tr>
-							<tr>
-								<td valign="top" width="34%">
-									<font face="TIMES" size="2"></font>
-									<p><font face="TIMES" size="2">UPPER-CASE(Alph)</font></p>
-								</td>
-								<td valign="top" width="20%">
-									<div align="center"><font size="2">Alphanumeric</font></div>
-								</td>
-								<td valign="top" width="46%">
-									<font face="TIMES" size="2"></font>
-									<p>
-										<font face="TIMES" size="2"
-											>Returns a character string with the characters in <b>Alph</b> changed to
-											their upper case equivalents</font
-										>
-									</p>
-									<font face="TIMES" size="2"></font>
 								</td>
 							</tr>
 						</table>
@@ -651,7 +582,7 @@ MOVE FUNCTION ORD-MAX(IntElement(ALL)) TO OrdPos             </code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Examples</font></h4>
+					<h4>Examples</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>The statements in the following examples produce the results shown below.</p>
@@ -660,31 +591,31 @@ MOVE FUNCTION ORD-MAX(IntElement(ALL)) TO OrdPos             </code></pre>
 						<tr>
 							<td>
 								<pre class="language-cobol"><code class="language-cobol">
-WORKING-STORAGE SECTION. 
-01 xString PIC X(38) VALUE "This is the alphanumeric string". 
-01 OrdPos PIC 99. 
-01 IntArray VALUE "1223037865".      
+WORKING-STORAGE SECTION.
+01 xString PIC X(38) VALUE "This is the alphanumeric string".
+01 OrdPos PIC 99.
+01 IntArray VALUE "1223037865".
    02 Ielement OCCURS 5 TIMES PIC 99.
 
-PROCEDURE DIVISION. 
-Begin. 
-PROCEDURE DIVISION.                                               
-Begin.                                                            
-  DISPLAY "Character at pos 39 is = " FUNCTION CHAR(39) 
-                                                                  
+PROCEDURE DIVISION.
+Begin.
+PROCEDURE DIVISION.
+Begin.
+  DISPLAY "Character at pos 39 is = " FUNCTION CHAR(39)
+
   MOVE FUNCTION ORD("A") TO OrdPos
-  DISPLAY "Ord pos of A is = " OrdPos 
-                                                                  
+  DISPLAY "Ord pos of A is = " OrdPos
+
   MOVE FUNCTION ORD-MAX("t" "b" "x" "s") TO OrdPos
   DISPLAY "Highest character in sequence is at pos " OrdPos
-                                                                  
+
   MOVE FUNCTION ORD-MIN("t" "b" "x" "s") TO OrdPos
   DISPLAY "Lowest character in sequence is at pos " OrdPos
-                                                                  
+
   MOVE FUNCTION ORD-MAX(Ielement(ALL)) TO OrdPos
   DISPLAY "Number " Ielement(OrdPos) " is the highest in array".
-                                                                  
-  DISPLAY "Length of xString is " FUNCTION LENGTH(xString) 
+
+  DISPLAY "Length of xString is " FUNCTION LENGTH(xString)
   DISPLAY FUNCTION REVERSE(xString(1:31))
   DISPLAY FUNCTION UPPER-CASE(xString)
   DISPLAY FUNCTION LOWER-CASE(xString)
@@ -700,40 +631,33 @@ Begin.
 							<tr>
 								<td colspan="2" height="33" valign="top" width="21%">
 									<div align="center">
-										<font face="Arial, Helvetica, sans-serif"><b>Results</b></font>
-										<font face="TIMES" size="2"></font>
+										<b>Results</b>
 									</div>
 								</td>
 							</tr>
 							<tr>
 								<td height="137" valign="top" width="21%">
-									<font size="2"
-										>Display 1 =<br />
-										Display 2 =<br />
-										Display 3 =<br />
-										Display 4 =<br />
-										Display 5 =<br />
-										Display 6 =<br />
-										Display 7 =<br />
-										Display 8 =<br />
-										Display 9 =</font
-									>
+									Display 1 =<br />
+									Display 2 =<br />
+									Display 3 =<br />
+									Display 4 =<br />
+									Display 5 =<br />
+									Display 6 =<br />
+									Display 7 =<br />
+									Display 8 =<br />
+									Display 9 =
 								</td>
 								<td height="137" valign="top" width="79%">
-									<font size="2"
-										>Character at pos 39 is = <b>&</b><br />
-										Ord pos of A is = <b>66</b><br />
-										Highest character in sequence is at pos <b>03</b></font
-									>
-									<font size="2"
-										><br />
-										Lowest character in sequence is at pos <b>02</b><br />
-										Number <b>78</b> is the highest in array<br />
-										Length of xString is <b>38</b><br />
-										<b>gnirts ciremunahpla eht si sihT</b><br />
-										<b>THIS IS THE ALPHANUMERIC STRING</b><br />
-										<b>this is the alphanumeric string</b></font
-									>
+									Character at pos 39 is = <b>&amp;</b><br />
+									Ord pos of A is = <b>66</b><br />
+									Highest character in sequence is at pos <b>03</b>
+									<br />
+									Lowest character in sequence is at pos <b>02</b><br />
+									Number <b>78</b> is the highest in array<br />
+									Length of xString is <b>38</b><br />
+									<b>gnirts ciremunahpla eht si sihT</b><br />
+									<b>THIS IS THE ALPHANUMERIC STRING</b><br />
+									<b>this is the alphanumeric string</b>
 								</td>
 							</tr>
 						</table>
@@ -743,14 +667,12 @@ Begin.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part4">
-						<font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Date Functions</font></font>
-					</h2>
+					<h2 align="center" id="part4">Date Functions</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Definitions</font></h4>
+					<h4>Definitions</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -762,119 +684,90 @@ Begin.
 							</tr>
 							<tr>
 								<td valign="top" width="36%">
-									<p><font face="TIMES" size="2">CURRENT-DATE</font></p>
+									<p>CURRENT-DATE</p>
 								</td>
 								<td valign="top" width="20%">
-									<div align="center"><font size="2">Alphanumeric</font></div>
+									<div align="center">Alphanumeric</div>
 								</td>
 								<td valign="top" width="44%">
-									<font face="TIMES" size="2"></font>
 									<p>
-										<font face="TIMES" size="2"
-											>Returns a 21 character string representing the current date and time, and
-											the difference between the local time and Greenwich Mean Time. The format of
-											the string is yyyymmddhhmmsshhxhhmm, where xhhmm is the number of hours and
-											minutes the local time is ahead or behind GMT ( x = + or - or 0). If x = 0,
-											the hardware cannot provide this information.</font
-										>
+										Returns a 21 character string representing the current date and time, and the
+										difference between the local time and Greenwich Mean Time. The format of the
+										string is yyyymmddhhmmsshhxhhmm, where xhhmm is the number of hours and minutes
+										the local time is ahead or behind GMT ( x = + or - or 0). If x = 0, the hardware
+										cannot provide this information.
 									</p>
-									<font face="TIMES" size="2"></font>
 								</td>
 							</tr>
 							<tr>
 								<td valign="top" width="36%">
-									<font face="TIMES" size="2"></font>
-									<p><font face="TIMES" size="2">DATE-OF-INTEGER(PosInt)</font></p>
+									<p>DATE-OF-INTEGER(PosInt)</p>
 								</td>
 								<td valign="top" width="20%">
-									<div align="center"><font size="2">Integer</font></div>
+									<div align="center">Integer</div>
 								</td>
 								<td valign="top" width="44%">
-									<font face="TIMES" size="2"></font>
 									<p>
-										<font face="TIMES" size="2"
-											>Returns the yyyymmdd (standard date) equivalent of the integer date -
-											<b>PosInt</b>. The integer date is the number of days that have passed since
-											Dec 31st 1600 in the Gregorian Calendar.</font
-										>
+										Returns the yyyymmdd (standard date) equivalent of the integer date -
+										<b>PosInt</b>. The integer date is the number of days that have passed since Dec
+										31st 1600 in the Gregorian Calendar.
 									</p>
-									<font face="TIMES" size="2"></font>
 								</td>
 							</tr>
 							<tr>
 								<td valign="top" width="36%">
-									<font face="TIMES" size="2"></font>
-									<p><font face="TIMES" size="2">DAY-OF-INTEGER(PosInt)</font></p>
+									<p>DAY-OF-INTEGER(PosInt)</p>
 								</td>
 								<td valign="top" width="20%">
-									<div align="center"><font size="2">Integer</font></div>
+									<div align="center">Integer</div>
 								</td>
 								<td valign="top" width="44%">
-									<font face="TIMES" size="2"></font>
 									<p>
-										<font face="TIMES" size="2"
-											>Returns the yyyddd ( Julien Date) equivalent of the integer date -
-											<b>PosInt</b>.</font
-										>
+										Returns the yyyddd ( Julien Date) equivalent of the integer date -
+										<b>PosInt</b>.
 									</p>
-									<font face="TIMES" size="2"></font>
 								</td>
 							</tr>
 							<tr>
 								<td valign="top" width="36%">
-									<font face="TIMES" size="2"></font>
-									<p><font face="TIMES" size="2">INTEGER-OF-DATE(PosInt)</font></p>
+									<p>INTEGER-OF-DATE(PosInt)</p>
 								</td>
 								<td valign="top" width="20%">
-									<div align="center"><font size="2">Integer</font></div>
+									<div align="center">Integer</div>
 								</td>
 								<td valign="top" width="44%">
-									<font face="TIMES" size="2"></font>
 									<p>
-										<font face="TIMES" size="2"
-											>Returns the integer date equivalent of standard date <b>PosInt</b>. Posint
-											is an integer of the form yyyymmdd.</font
-										>
+										Returns the integer date equivalent of standard date <b>PosInt</b>. Posint is an
+										integer of the form yyyymmdd.
 									</p>
-									<font face="TIMES" size="2"></font>
 								</td>
 							</tr>
 							<tr>
 								<td valign="top" width="36%">
-									<font face="TIMES" size="2"></font>
-									<p><font face="TIMES" size="2">INTEGER-OF-DAY(PosInt)</font></p>
+									<p>INTEGER-OF-DAY(PosInt)</p>
 								</td>
 								<td valign="top" width="20%">
-									<div align="center"><font size="2">Integer</font></div>
+									<div align="center">Integer</div>
 								</td>
 								<td valign="top" width="44%">
-									<font face="TIMES" size="2"></font>
 									<p>
-										<font face="TIMES" size="2"
-											>Returns the integer date equivalent of Julian date (yyyyddd) represented by
-											<b>PosInt</b>.</font
-										>
+										Returns the integer date equivalent of Julian date (yyyyddd) represented by
+										<b>PosInt</b>.
 									</p>
-									<font face="TIMES" size="2"></font>
 								</td>
 							</tr>
 							<tr>
 								<td valign="top" width="36%">
-									<font face="TIMES" size="2"></font>
-									<p><font face="TIMES" size="2">WHEN-COMPILED</font></p>
+									<p>WHEN-COMPILED</p>
 								</td>
 								<td valign="top" width="20%">
-									<div align="center"><font size="2">Integer</font></div>
+									<div align="center">Integer</div>
 								</td>
 								<td valign="top" width="44%">
-									<font face="TIMES" size="2"></font>
 									<p>
-										<font face="TIMES" size="2"
-											>Returns the date and time the program was compiled. Uses the same format as
-											CURRENT-DATE.</font
-										>
+										Returns the date and time the program was compiled. Uses the same format as
+										CURRENT-DATE.
 									</p>
-									<font face="TIMES" size="2"></font>
 								</td>
 							</tr>
 						</table>
@@ -884,7 +777,7 @@ Begin.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Examples</font></h4>
+					<h4>Examples</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -925,7 +818,7 @@ WORKING-STORAGE SECTION.
    02 YearD       PIC 9999.
    02 MonthD      PIC 99.
    02 DayD        PIC 99.
- 
+
 PROCEDURE DIVISION.
 Begin.
 *&gt; This example gets the current date and displays
@@ -976,22 +869,19 @@ Begin.
 							<tr>
 								<td height="33" valign="top" width="21%">
 									<div align="center">
-										<font face="Arial, Helvetica, sans-serif"><b>Results</b></font>
-										<font face="TIMES" size="2"></font>
+										<b>Results</b>
 									</div>
 								</td>
 							</tr>
 							<tr>
 								<td height="137" valign="top" width="79%">
-									<font size="2"
-										>Current Date is 01/26/1998<br />
-										Current Time is 12:20:17<br />
-										The local time is - GMT +00:00<br />
-										Enter the date of the bill (yyyymmdd) 19971227<br />
-										This bill is due today<br />
-										Enter the number of days - 365<br />
-										The date in 365 days time will be 01/27/1999</font
-									>
+									Current Date is 01/26/1998<br />
+									Current Time is 12:20:17<br />
+									The local time is - GMT +00:00<br />
+									Enter the date of the bill (yyyymmdd) 19971227<br />
+									This bill is due today<br />
+									Enter the number of days - 365<br />
+									The date in 365 days time will be 01/27/1999
 								</td>
 							</tr>
 						</table>
@@ -1001,18 +891,12 @@ Begin.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part5">
-						<font color="#FFFF00"
-							><font face="Arial, Helvetica, sans-serif">Miscellaneous Functions</font></font
-						>
-					</h2>
+					<h2 align="center" id="part5">Miscellaneous Functions</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Other Functions</font>
-					</h4>
+					<h4>Other Functions</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -1024,421 +908,316 @@ Begin.
 							</tr>
 							<tr>
 								<td valign="top" width="36%">
-									<p>
-										<font face="Times New Roman, Times, serif" size="2">ACOS(Num)</font>
-									</p>
+									<p>ACOS(Num)</p>
 								</td>
 								<td valign="top" width="21%">
-									<div align="center"><font size="2">Numeric</font></div>
+									<div align="center">Numeric</div>
 								</td>
 								<td valign="top" width="43%">
 									<p>
-										<font face="TIMES" size="2"
-											>Returns a numeric value in radians that approximates the arccosine of
-											<font face="Times New Roman, Times, serif" size="2"><b>Num</b></font>
-											<font face="TIMES" size="2">.</font></font
-										>
-										<font face="TIMES" size="2"></font>
+										Returns a numeric value in radians that approximates the arccosine of
+										<b>Num</b>.
 									</p>
 									<p>
-										<font face="TIMES" size="2"
-											>The value of
-											<font face="Times New Roman, Times, serif" size="2">Num</font>
-											<font face="TIMES" size="2"></font> must be greater than or equal to ï¿½1
-											and less than or equal to +1.</font
-										>
-									</p>
-									<font face="TIMES" size="2"></font>
-								</td>
-							</tr>
-							<tr>
-								<td valign="top" width="36%">
-									<p>
-										<font face="Times New Roman, Times, serif" size="2">ANNUITY(Num PosInt)</font>
-									</p>
-								</td>
-								<td valign="top" width="21%">
-									<div align="center"><font size="2">Numeric</font></div>
-								</td>
-								<td valign="top" width="43%">
-									<font size="2"
-										>Returns a numeric value approximating the ratio of an annuity paid at the end
-										of each period for the number of periods specified by <b>PosInt</b> to an
-										initial investment of one. Interest is earned at the rate specified by
-										<b>Num</b> and is applied at the end of the period, before the payment.</font
-									>
-								</td>
-							</tr>
-							<tr>
-								<td valign="top" width="36%">
-									<font face="TIMES" size="2"></font>
-									<p><font face="TIMES" size="2">ASIN(Num)</font></p>
-								</td>
-								<td valign="top" width="21%">
-									<div align="center"><font size="2">Numeric</font></div>
-								</td>
-								<td valign="top" width="43%">
-									<font face="TIMES" size="2"></font>
-									<p>
-										<font face="TIMES" size="2"
-											>Returns a numeric value in radians that approximates the arcsine of
-											<b>Num</b>.</font
-										>
-									</p>
-									<font face="TIMES" size="2"></font>
-								</td>
-							</tr>
-							<tr>
-								<td valign="top" width="36%">
-									<font face="TIMES" size="2"></font>
-									<p><font face="TIMES" size="2">ATAN(Num)</font></p>
-								</td>
-								<td valign="top" width="21%">
-									<div align="center"><font size="2">Numeric</font></div>
-								</td>
-								<td valign="top" width="43%">
-									<font face="TIMES" size="2"></font>
-									<p>
-										<font face="TIMES" size="2"
-											>Returns a numeric value in radians that approximates the arctangent of
-											<b>Num</b>.<br
-										/></font>
-									</p>
-									<font face="TIMES" size="2"></font>
-								</td>
-							</tr>
-							<tr>
-								<td valign="top" width="36%">
-									<font face="TIMES" size="2"></font>
-									<p><font face="TIMES" size="2">FACTORIAL(PosInt)</font></p>
-								</td>
-								<td valign="top" width="21%">
-									<div align="center"><font size="2">Integer</font></div>
-								</td>
-								<td valign="top" width="43%">
-									<font face="TIMES" size="2"></font>
-									<p>
-										<font face="TIMES" size="2"
-											>Returns an integer that is the factorial of <b>PosInt</b>.</font
-										>
-									</p>
-									<font face="TIMES" size="2"></font>
-								</td>
-							</tr>
-							<tr>
-								<td valign="top" width="36%">
-									<font face="TIMES" size="2"></font>
-									<p><font face="TIMES" size="2">INTEGER(Num)</font></p>
-								</td>
-								<td valign="top" width="21%">
-									<div align="center"><font size="2">Integer</font></div>
-								</td>
-								<td valign="top" width="43%">
-									<font face="TIMES" size="2"></font>
-									<p>
-										<font face="TIMES" size="2"
-											>Returns the greatest integer value that is less than or equal to
-											<b>Num</b>. For instance -2 is returned if the Num has a value of -1.5 and 1
-											is returned if it has a value of 1.5.</font
-										>
-									</p>
-									<font face="TIMES" size="2"></font>
-								</td>
-							</tr>
-							<tr>
-								<td valign="top" width="36%">
-									<font face="TIMES" size="2">INTEGER-PART(Num)</font>
-								</td>
-								<td valign="top" width="21%">
-									<div align="center"><font size="2">Integer</font></div>
-								</td>
-								<td valign="top" width="43%">
-									<font size="2"
-										>Returns the integer part of <b>Num</b> so a value of -1.5 is returned as -1 and
-										a value of 1.5 is returned as 1.</font
-									>
-								</td>
-							</tr>
-							<tr>
-								<td valign="top" width="36%">
-									<font face="TIMES" size="2"></font>
-									<p><font face="TIMES" size="2">LOG(PosNum)</font></p>
-								</td>
-								<td valign="top" width="21%">
-									<div align="center"><font size="2">Numeric</font></div>
-								</td>
-								<td valign="top" width="43%">
-									<font face="TIMES" size="2"></font>
-									<p>
-										<font face="TIMES" size="2"
-											>Returns a numeric value that approximates the logarithm to the base e
-											(natural log) of <b>PosNum</b>.<br />
-											<font face="TIMES" size="2">PosNum must be greater than 0.</font></font
-										>
-									</p>
-									<font face="TIMES" size="2"></font>
-								</td>
-							</tr>
-							<tr>
-								<td valign="top" width="36%">
-									<font face="Times New Roman, Times, serif" size="2">LOG10(</font>
-									<font face="TIMES" size="2">PosNum</font>)
-								</td>
-								<td valign="top" width="21%">
-									<div align="center"><font size="2">Numeric</font></div>
-								</td>
-								<td valign="top" width="43%">
-									<font size="2"
-										>Returns a numeric value that approximates the logarithm to the base 10 of
-										<b>PosNum</b>.</font
-									>
-									<font face="TIMES" size="2"
-										><br />
-										<font face="TIMES" size="2">PosNum must be greater than 0.</font></font
-									>
-									<font size="2"></font>
-								</td>
-							</tr>
-							<tr>
-								<td valign="top" width="36%">
-									<p><font size="2">MAX({Any}...)</font></p>
-								</td>
-								<td valign="top" width="21%">
-									<font size="2">Depends on type of <b>Any</b> see note.</font>
-								</td>
-								<td valign="top" width="43%">
-									<p>
-										<font size="2"
-											>Takes a parameter list and returns the content of whichever parameter
-											contains the maximum value.<br />
-											Note. The returned type depends upon the parameter types as follows;<br
-										/></font>
-										<font size="2"
-											><b>Alphanumeric</b> if parameters are Alphabetic or Alphnumeric.<br />
-											<b>Integer</b> if all are integer.<br />
-											<b>Numeric</b> if all are Numeric or mixed with Integer.<br />
-											An array may be used instead of the parameter list.</font
-										>
+										The value of Num must be greater than or equal to ï¿½1 and less than or equal to
+										+1.
 									</p>
 								</td>
 							</tr>
 							<tr>
-								<td valign="top" width="36%"><font size="2">MEAN({Num}...)</font></td>
+								<td valign="top" width="36%">
+									<p>ANNUITY(Num PosInt)</p>
+								</td>
 								<td valign="top" width="21%">
-									<div align="center"><font size="2">Numeric</font></div>
+									<div align="center">Numeric</div>
 								</td>
 								<td valign="top" width="43%">
-									<font size="2"
-										>Returns a numeric value that is the arithmetic mean (average) of its
-										parameters. An array may be used.</font
-									>
-								</td>
-							</tr>
-							<tr>
-								<td valign="top" width="36%"><font size="2">MEDIAN({Num}...)</font></td>
-								<td valign="top" width="21%">
-									<div align="center"><font size="2">Numeric</font></div>
-								</td>
-								<td valign="top" width="43%">
-									<font size="2"
-										>Returns the middle value of a list of values after the values have been
-										arranged in sorted order. An array may be used.</font
-									>
-								</td>
-							</tr>
-							<tr>
-								<td valign="top" width="36%"><font size="2">MIDRANGE({Num}...)</font></td>
-								<td valign="top" width="21%">
-									<div align="center"><font size="2">Numeric</font></div>
-								</td>
-								<td valign="top" width="43%">
-									<font size="2"
-										>Returns a numeric value that is the arithmetic mean (average) of the minimum
-										value and the maximum value. An array may be used.</font
-									>
+									Returns a numeric value approximating the ratio of an annuity paid at the end of
+									each period for the number of periods specified by <b>PosInt</b> to an initial
+									investment of one. Interest is earned at the rate specified by <b>Num</b> and is
+									applied at the end of the period, before the payment.
 								</td>
 							</tr>
 							<tr>
 								<td valign="top" width="36%">
-									<p><font size="2">MIN({Any}...)</font></p>
+									<p>ASIN(Num)</p>
 								</td>
 								<td valign="top" width="21%">
-									<font size="2">Depends on type of <b>Any</b> see note in MAX above.</font>
-								</td>
-								<td valign="top" width="43%">
-									<font size="2"
-										>Takes a parameter list and returns the content of whichever parameter contains
-										the minimum value. An array may be used.</font
-									>
-									<font size="2"></font> <font size="2"></font>
-								</td>
-							</tr>
-							<tr>
-								<td valign="top" width="36%"><font size="2">MOD(Int1 Int2)</font></td>
-								<td valign="top" width="21%">
-									<div align="center"><font size="2">Integer</font></div>
+									<div align="center">Numeric</div>
 								</td>
 								<td valign="top" width="43%">
 									<p>
-										<font size="2">Returns an integer value defined as</font>
-										<font size="2"
-											><b>Int1</b> ï¿½ (<b>Int2</b> * FUNCTION INTEGER (Int1 / Int2)).</font
-										>
+										Returns a numeric value in radians that approximates the arcsine of
+										<b>Num</b>.
 									</p>
 								</td>
 							</tr>
 							<tr>
-								<td valign="top" width="36%"><font size="2">NUMVAL(Alph)</font></td>
+								<td valign="top" width="36%">
+									<p>ATAN(Num)</p>
+								</td>
 								<td valign="top" width="21%">
-									<div align="center"><font size="2">Numeric</font></div>
+									<div align="center">Numeric</div>
 								</td>
 								<td valign="top" width="43%">
-									<font size="2"
-										>Converts the edited numeric string contained in <b>Alph</b> to a numeric item.
-										Leading and trailing spaces are ignored and + - CR DB and the decimal point are
-										stripped off.</font
-									>
+									<p>
+										Returns a numeric value in radians that approximates the arctangent of
+										<b>Num</b>.<br />
+									</p>
 								</td>
 							</tr>
 							<tr>
 								<td valign="top" width="36%">
-									<font size="2"
-										>PRESENT-VALUE(Num1<br />
-										{Num2}...)</font
-									>
+									<p>FACTORIAL(PosInt)</p>
 								</td>
 								<td valign="top" width="21%">
-									<div align="center"><font size="2">Numeric</font></div>
+									<div align="center">Integer</div>
+								</td>
+								<td valign="top" width="43%">
+									<p>Returns an integer that is the factorial of <b>PosInt</b>.</p>
+								</td>
+							</tr>
+							<tr>
+								<td valign="top" width="36%">
+									<p>INTEGER(Num)</p>
+								</td>
+								<td valign="top" width="21%">
+									<div align="center">Integer</div>
 								</td>
 								<td valign="top" width="43%">
 									<p>
-										<font size="2"
-											>Returns the amount to be invested today to produce a future value at a
-											particular rate of interest.<br />
-											<b>Num1</b> is the percent interest rate expressed as a decimal valu</font
-										>
-										<font size="2"
-											>e (.7 = 7%).<br />
-											<b>Num2</b> is the future desired value at the end of the period.</font
-										>
+										Returns the greatest integer value that is less than or equal to
+										<b>Num</b>. For instance -2 is returned if the Num has a value of -1.5 and 1 is
+										returned if it has a value of 1.5.
+									</p>
+								</td>
+							</tr>
+							<tr>
+								<td valign="top" width="36%">INTEGER-PART(Num)</td>
+								<td valign="top" width="21%">
+									<div align="center">Integer</div>
+								</td>
+								<td valign="top" width="43%">
+									Returns the integer part of <b>Num</b> so a value of -1.5 is returned as -1 and a
+									value of 1.5 is returned as 1.
+								</td>
+							</tr>
+							<tr>
+								<td valign="top" width="36%">
+									<p>LOG(PosNum)</p>
+								</td>
+								<td valign="top" width="21%">
+									<div align="center">Numeric</div>
+								</td>
+								<td valign="top" width="43%">
+									<p>
+										Returns a numeric value that approximates the logarithm to the base e (natural
+										log) of <b>PosNum</b>.<br />
+										PosNum must be greater than 0.
+									</p>
+								</td>
+							</tr>
+							<tr>
+								<td valign="top" width="36%">LOG10(PosNum)</td>
+								<td valign="top" width="21%">
+									<div align="center">Numeric</div>
+								</td>
+								<td valign="top" width="43%">
+									Returns a numeric value that approximates the logarithm to the base 10 of
+									<b>PosNum</b>.
+									<br />
+									PosNum must be greater than 0.
+								</td>
+							</tr>
+							<tr>
+								<td valign="top" width="36%">
+									<p>MAX({Any}...)</p>
+								</td>
+								<td valign="top" width="21%">Depends on type of <b>Any</b> see note.</td>
+								<td valign="top" width="43%">
+									<p>
+										Takes a parameter list and returns the content of whichever parameter contains
+										the maximum value.<br />
+										Note. The returned type depends upon the parameter types as follows;<br />
+										<b>Alphanumeric</b> if parameters are Alphabetic or Alphnumeric.<br />
+										<b>Integer</b> if all are integer.<br />
+										<b>Numeric</b> if all are Numeric or mixed with Integer.<br />
+										An array may be used instead of the parameter list.
+									</p>
+								</td>
+							</tr>
+							<tr>
+								<td valign="top" width="36%">MEAN({Num}...)</td>
+								<td valign="top" width="21%">
+									<div align="center">Numeric</div>
+								</td>
+								<td valign="top" width="43%">
+									Returns a numeric value that is the arithmetic mean (average) of its parameters. An
+									array may be used.
+								</td>
+							</tr>
+							<tr>
+								<td valign="top" width="36%">MEDIAN({Num}...)</td>
+								<td valign="top" width="21%">
+									<div align="center">Numeric</div>
+								</td>
+								<td valign="top" width="43%">
+									Returns the middle value of a list of values after the values have been arranged in
+									sorted order. An array may be used.
+								</td>
+							</tr>
+							<tr>
+								<td valign="top" width="36%">MIDRANGE({Num}...)</td>
+								<td valign="top" width="21%">
+									<div align="center">Numeric</div>
+								</td>
+								<td valign="top" width="43%">
+									Returns a numeric value that is the arithmetic mean (average) of the minimum value
+									and the maximum value. An array may be used.
+								</td>
+							</tr>
+							<tr>
+								<td valign="top" width="36%">
+									<p>MIN({Any}...)</p>
+								</td>
+								<td valign="top" width="21%">Depends on type of <b>Any</b> see note in MAX above.</td>
+								<td valign="top" width="43%">
+									Takes a parameter list and returns the content of whichever parameter contains the
+									minimum value. An array may be used.
+								</td>
+							</tr>
+							<tr>
+								<td valign="top" width="36%">MOD(Int1 Int2)</td>
+								<td valign="top" width="21%">
+									<div align="center">Integer</div>
+								</td>
+								<td valign="top" width="43%">
+									<p>
+										Returns an integer value defined as
+										<b>Int1</b> ï¿½ (<b>Int2</b> * FUNCTION INTEGER (Int1 / Int2)).
+									</p>
+								</td>
+							</tr>
+							<tr>
+								<td valign="top" width="36%">NUMVAL(Alph)</td>
+								<td valign="top" width="21%">
+									<div align="center">Numeric</div>
+								</td>
+								<td valign="top" width="43%">
+									Converts the edited numeric string contained in <b>Alph</b> to a numeric item.
+									Leading and trailing spaces are ignored and + - CR DB and the decimal point are
+									stripped off.
+								</td>
+							</tr>
+							<tr>
+								<td valign="top" width="36%">
+									PRESENT-VALUE(Num1<br />
+									{Num2}...)
+								</td>
+								<td valign="top" width="21%">
+									<div align="center">Numeric</div>
+								</td>
+								<td valign="top" width="43%">
+									<p>
+										Returns the amount to be invested today to produce a future value at a
+										particular rate of interest.<br />
+										<b>Num1</b> is the percent interest rate expressed as a decimal value (.7 =
+										7%).<br />
+										<b>Num2</b> is the future desired value at the end of the period.
 									</p>
 								</td>
 							</tr>
 							<tr>
 								<td valign="top" width="36%">
 									<p>
-										<font size="2"
-											>RANDOM(PosInt)<br />
-											or<br />
-											RANDOM</font
-										>
+										RANDOM(PosInt)<br />
+										or<br />
+										RANDOM
 									</p>
 								</td>
 								<td valign="top" width="21%">
-									<div align="center"><font size="2">Numeric</font></div>
+									<div align="center">Numeric</div>
 								</td>
 								<td valign="top" width="43%">
 									<p>
-										<font size="2"
-											>Returns a numeric value that is a pseudo-random number.<br />
-											If a parameter is used then <b>PosInt</b> is the seed. Subsequent references
-											without the parameter return the next number in the sequence.<br />
-											A value &gt;0 and &lt;1 will be returned.</font
-										>
+										Returns a numeric value that is a pseudo-random number.<br />
+										If a parameter is used then <b>PosInt</b> is the seed. Subsequent references
+										without the parameter return the next number in the sequence.<br />
+										A value &gt;0 and &lt;1 will be returned.
 									</p>
 								</td>
 							</tr>
 							<tr>
-								<td valign="top" width="36%"><font size="2">RANGE({Num1}...)</font></td>
+								<td valign="top" width="36%">RANGE({Num1}...)</td>
 								<td valign="top" width="21%">
-									<div align="center">
-										<font size="2">Integer if all parameter are Integer else Numeric</font>
-									</div>
+									<div align="center">Integer if all parameter are Integer else Numeric</div>
 								</td>
 								<td valign="top" width="43%">
-									<font size="2"
-										>Examines a list of parameters and returns a value that is equal to the value of
-										the maximum argument minus the value of the minimum argument.</font
-									>
+									Examines a list of parameters and returns a value that is equal to the value of the
+									maximum argument minus the value of the minimum argument.
 								</td>
 							</tr>
 							<tr>
-								<td valign="top" width="36%"><font size="2">REM(Num1 Num2)</font></td>
+								<td valign="top" width="36%">REM(Num1 Num2)</td>
 								<td valign="top" width="21%">
-									<div align="center"><font size="2">Numeric</font></div>
+									<div align="center">Numeric</div>
 								</td>
 								<td valign="top" width="43%">
-									<font size="2"
-										>Returns a numeric value that is the remainder of <b>Num1</b> divided by
-										<b>Num2</b>.</font
-									>
+									Returns a numeric value that is the remainder of <b>Num1</b> divided by <b>Num2</b>.
 								</td>
 							</tr>
 							<tr>
-								<td valign="top" width="36%"><font size="2">SIN(Num)</font></td>
+								<td valign="top" width="36%">SIN(Num)</td>
 								<td valign="top" width="21%">
-									<div align="center"><font size="2">Numeric</font></div>
+									<div align="center">Numeric</div>
 								</td>
 								<td valign="top" width="43%">
-									<font size="2"
-										>Returns an approximation of the sine of an angle or arc, expressed in radians,
-										that is specified by <b>Num</b>.</font
-									>
+									Returns an approximation of the sine of an angle or arc, expressed in radians, that
+									is specified by <b>Num</b>.
 								</td>
 							</tr>
 							<tr>
-								<td valign="top" width="36%"><font size="2">SQRT(Num)</font></td>
+								<td valign="top" width="36%">SQRT(Num)</td>
 								<td valign="top" width="21%">
-									<div align="center"><font size="2">Numeric</font></div>
+									<div align="center">Numeric</div>
 								</td>
 								<td valign="top" width="43%">
-									<font size="2">Returns an approximation of the square root of <b>Num</b>.</font>
+									Returns an approximation of the square root of <b>Num</b>.
 								</td>
 							</tr>
 							<tr>
-								<td valign="top" width="36%">
-									<font size="2">STANDARD-DEVIATION({Num}...)</font>
-								</td>
+								<td valign="top" width="36%">STANDARD-DEVIATION({Num}...)</td>
 								<td valign="top" width="21%">
-									<div align="center"><font size="2">Numeric</font></div>
+									<div align="center">Numeric</div>
 								</td>
 								<td valign="top" width="43%">
-									<font size="2"
-										>Returns an approximation of the standard deviation of its parameters.</font
-									>
+									Returns an approximation of the standard deviation of its parameters.
 								</td>
 							</tr>
 							<tr>
-								<td valign="top" width="36%"><font size="2">SUM({Num}...)</font></td>
+								<td valign="top" width="36%">SUM({Num}...)</td>
 								<td valign="top" width="21%">
-									<div align="center">
-										<font size="2">Integer if all parameter are Integer else Numeric</font>
-									</div>
+									<div align="center">Integer if all parameter are Integer else Numeric</div>
+								</td>
+								<td valign="top" width="43%">Returns the sum of the parameters.</td>
+							</tr>
+							<tr>
+								<td valign="top" width="36%">TAN(Num)</td>
+								<td valign="top" width="21%">
+									<div align="center">Numeric</div>
 								</td>
 								<td valign="top" width="43%">
-									<font size="2">Returns the sum of the parameters.</font>
+									Returns an approximation of the tangent of an angle or arc, expressed in radians,
+									that is specified by <b>Num</b>.
 								</td>
 							</tr>
 							<tr>
-								<td valign="top" width="36%"><font size="2">TAN(Num)</font></td>
+								<td valign="top" width="36%">VARIANCE({Num}...)</td>
 								<td valign="top" width="21%">
-									<div align="center"><font size="2">Numeric</font></div>
+									<div align="center">Numeric</div>
 								</td>
 								<td valign="top" width="43%">
-									<font size="2"
-										>Returns an approximation of the tangent of an angle or arc, expressed in
-										radians, that is specified by <b>Num</b>.</font
-									>
-								</td>
-							</tr>
-							<tr>
-								<td valign="top" width="36%"><font size="2">VARIANCE({Num}...)</font></td>
-								<td valign="top" width="21%">
-									<div align="center"><font size="2">Numeric</font></div>
-								</td>
-								<td valign="top" width="43%">
-									<font size="2">Returns an approximation of the</font>
-									<font size="2">variance of its arguments</font>
+									Returns an approximation of the variance of its arguments
 								</td>
 							</tr>
 						</table>
@@ -1448,9 +1227,7 @@ Begin.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">General Examples</font>
-					</h4>
+					<h4>General Examples</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1470,36 +1247,36 @@ DATA DIVISION.
 WORKING-STORAGE SECTION.
 01  IntParameters.
     02 IP1          PIC 99   VALUE 25.
-    02 IP2          PIC 99   VALUE 50. 
+    02 IP2          PIC 99   VALUE 50.
     02 IP3          PIC 9(5) VALUE 12.
     02 IResult      PIC 9(5).
-                                                     
+
 01  NumResult       PIC 9.9(5).
-                                                     
+
 01 IntArray VALUE "1223037865".
    02 Ielement OCCURS 5 TIMES PIC 99.
-                                                     
+
 PROCEDURE DIVISION.
 Begin.
-  MOVE FUNCTION MAX(IP1 545 IP3 IP2) TO IResult 
+  MOVE FUNCTION MAX(IP1 545 IP3 IP2) TO IResult
   DISPLAY "Max value is = " IResult
-                                                     
+
   MOVE FUNCTION MAX(Ielement(ALL)) TO IResult
   DISPLAY "Max value is = " IResult
-                                                     
+
   MOVE FUNCTION MEDIAN(Ielement(ALL)) TO IResult
   DISPLAY "Median value is = " IResult
-                                                     
+
   MOVE FUNCTION MIDRANGE(Ielement(ALL)) TO IResult
   DISPLAY "Midrange value is = " IResult
-                                                     
+
   MOVE FUNCTION MIN(Ielement(ALL)) TO IResult
   DISPLAY "Min value is = " IResult
-                                                     
-  MOVE FUNCTION RANGE(Ielement(ALL)) TO IResult 
-  DISPLAY "Range is " IResult 
-                                                     
-  MOVE FUNCTION SUM(Ielement(ALL)) TO IResult 
+
+  MOVE FUNCTION RANGE(Ielement(ALL)) TO IResult
+  DISPLAY "Range is " IResult
+
+  MOVE FUNCTION SUM(Ielement(ALL)) TO IResult
   DISPLAY "The sum of the values is " IResult
 
   MOVE FUNCTION VARIANCE(Ielement(ALL)) TO IResult
@@ -1514,23 +1291,20 @@ Begin.
 							<tr>
 								<td height="33" valign="top" width="21%">
 									<div align="center">
-										<font face="Arial, Helvetica, sans-serif"><b>Results</b></font>
-										<font face="TIMES" size="2"></font>
+										<b>Results</b>
 									</div>
 								</td>
 							</tr>
 							<tr>
 								<td height="137" valign="top" width="79%">
 									<p>
-										<font size="2"
-											>Max value is = 00545<br />
-											Max value is = 00078<br />
-											Median value is = 00023<br />
-											Midrange value is = 00040<br />
-											Min value is = 00003<br />
-											The sum of the values is 00181<br />
-											The variance of the values is 00887</font
-										>
+										Max value is = 00545<br />
+										Max value is = 00078<br />
+										Median value is = 00023<br />
+										Midrange value is = 00040<br />
+										Min value is = 00003<br />
+										The sum of the values is 00181<br />
+										The variance of the values is 00887
 									</p>
 								</td>
 							</tr>
@@ -1541,7 +1315,7 @@ Begin.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Lotto Example</font></h4>
+					<h4>Lotto Example</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1587,7 +1361,7 @@ Begin.
    MOVE FUNCTION CURRENT-DATE TO SysDate
    COMPUTE RandNum = FUNCTION RANDOM(Seed)
 
-   SET i to ZERO 
+   SET i to ZERO
    PERFORM 6 TIMES
       PERFORM WITH TEST AFTER UNTIL i + 1 = j
         COMPUTE LottoNum(i + 1), RandNum =
@@ -1601,7 +1375,7 @@ Begin.
       DISPLAY LottoNum(i) SPACE WITH NO ADVANCING
    END-PERFORM
    STOP RUN.
-                                      
+
 </code></pre>
 							</td>
 						</tr>
@@ -1621,15 +1395,12 @@ Begin.
 						<h3 align="center">Copyright Notice</h3>
 						<p align="left">These COBOL course materials are the copyright property of Michael Coughlan.</p>
 						<p align="left">
-							<font size="2"
-								>All rights reserved. No part of these course materials may be reproduced in any form or
-								by any means - graphic, electronic, mechanical, photocopying, printing, recording,
-								taping or stored in an information storage and retrieval system - without the written
-								permission of</font
-							>
-							<font size="2">the author.</font>
+							All rights reserved. No part of these course materials may be reproduced in any form or by
+							any means - graphic, electronic, mechanical, photocopying, printing, recording, taping or
+							stored in an information storage and retrieval system - without the written permission of
+							the author.
 						</p>
-						<p align="center"><font size="2">(c) Michael Coughlan</font></p>
+						<p align="center">(c) Michael Coughlan</p>
 					</div>
 				</td>
 			</tr>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -16,10 +16,23 @@
 			ul.toc > li {
 				padding-left: 0.4em;
 				margin-bottom: 0.6em;
+				font-size: smaller;
 			}
 
 			ul.toc a {
 				font-weight: bold;
+				font-size: larger;
+			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			td[bgcolor="#FFFFCC"] h3,
+			td[bgcolor="#FFFFCC"] h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
 			}
 		</style>
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
@@ -208,45 +221,38 @@
 							<ul class="toc">
 								<li>
 									<a href="#intro">Introduction</a><br />
-									<font size="-1">Unit aims, objectives and prerequisites.</font>
+									Unit aims, objectives and prerequisites.
 								</li>
 								<li>
 									<a href="#progs">A look at some programs that use Relative files</a><br />
-									<font size="-1"
-										>We begin with two example programs. The first creates a Relative File from a
-										Sequential file and the second reads and displays records from the Relative
-										file.</font
-									>
+									We begin with two example programs. The first creates a Relative File from a
+									Sequential file and the second reads and displays records from the Relative file.
 								</li>
 								<li>
 									<a href="#declar">Relative file - declarations</a><br />
-									<font size="-1"
-										>Examines the declarations required for a Relative file including the SELECT and
-										ASSIGN clause and the key.</font
-									>
+									Examines the declarations required for a Relative file including the SELECT and
+									ASSIGN clause and the key.
 								</li>
 								<li>
 									<a href="#verbs">Relative file - file processing verbs</a><br />
-									<font size="-1"
-										>Examines the Procedure Division verbs used to process Relative files - OPEN,
-										CLOSE, READ, WRITE, REWRITE, DELETE, START</font
-									>
+									Examines the Procedure Division verbs used to process Relative files - OPEN, CLOSE,
+									READ, WRITE, REWRITE, DELETE, START
 								</li>
 								<li>
 									<a href="#declaratives">Introduction to Declaratives</a><br />
-									<font size="-1">Introduces Declaratives, showing when and how to use them.</font>
+									Introduces Declaratives, showing when and how to use them.
 								</li>
 							</ul>
 						</div>
 						<table border="0" cellpadding="4" cellspacing="0" width="710">
 							<tr>
 								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="intro"><font color="#FFFF00">Introduction</font></h2>
+									<h2 align="center" id="intro">Introduction</h2>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#993300">Aims</font></h3>
+									<h3>Aims</h3>
 								</td>
 								<td width="550">
 									<p>
@@ -263,7 +269,7 @@
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Objectives</font></h3>
+									<h3>Objectives</h3>
 								</td>
 								<td width="550">
 									<p>By the end of this unit you should:</p>
@@ -277,11 +283,8 @@
 											Understand the difference between a file's access mode and its organization.
 										</li>
 										<li>
-											Be able to used the use the
-											<font size="-1"
-												><font size="-1">START, OPEN, CLOSE, READ, WRITE, REWRITE</font> and
-												<code class="language-cobol">DELETE</code></font
-											>
+											Be able to used the use the START, OPEN, CLOSE, READ, WRITE, REWRITE and
+											<code class="language-cobol">DELETE</code>
 											Procedure Division verbs required to process Relative files.
 										</li>
 										<li>Be able to process a Relative file directly or sequentially.</li>
@@ -291,7 +294,7 @@
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Prerequisites</font></h3>
+									<h3>Prerequisites</h3>
 								</td>
 								<td width="550">
 									<p>You should be familiar with the material covered in the unit;</p>
@@ -316,16 +319,12 @@
 						<table border="0" cellpadding="4" cellspacing="0" width="710">
 							<tr>
 								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="progs">
-										<font color="#FFFF00">A look at some programs that use Relative files</font>
-									</h2>
+									<h2 align="center" id="progs">A look at some programs that use Relative files</h2>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="left">
-										<font color="#800000">Example program - Creating a Relative file</font>
-									</h3>
+									<h3 align="left">Example program - Creating a Relative file</h3>
 								</td>
 								<td width="525">
 									<table border="0" width="100%">
@@ -381,7 +380,7 @@
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Example program - Reading a Relative file</font></h3>
+									<h3>Example program - Reading a Relative file</h3>
 								</td>
 								<td width="525">
 									<table border="0" width="100%">
@@ -462,14 +461,12 @@ Enter supplier key (2 digits)-&gt; 05
 						<table border="0" cellpadding="4" cellspacing="0" width="710">
 							<tr>
 								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="declar">
-										<font color="#FFFF00">Relative file - Declarations</font>
-									</h2>
+									<h2 align="center" id="declar">Relative file - Declarations</h2>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Introduction</font></h3>
+									<h3>Introduction</h3>
 								</td>
 								<td width="525">
 									<p>
@@ -482,7 +479,7 @@ Enter supplier key (2 digits)-&gt; 05
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Select and Assign clause syntax</font></h3>
+									<h3>Select and Assign clause syntax</h3>
 								</td>
 								<td width="525">
 									<p><img height="189" src="Resources/pics/I-DFrel1.gif" width="507" /></p>
@@ -490,16 +487,14 @@ Enter supplier key (2 digits)-&gt; 05
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">The Optional phrase</font></h3>
+									<h3>The Optional phrase</h3>
 								</td>
 								<td width="525">
 									<div align="center">
 										<div align="left">
 											<p>
-												The <font size="2">OPTIONAL</font> phrase must be specified for files
-												opened for <font size="2">INPUT</font>, <font size="2">I-O</font>, or
-												<font size="2">EXTEND</font> that need not be present when the program
-												runs.
+												The OPTIONAL phrase must be specified for files opened for INPUT, I-O,
+												or EXTEND that need not be present when the program runs.
 											</p>
 										</div>
 									</div>
@@ -507,34 +502,32 @@ Enter supplier key (2 digits)-&gt; 05
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">The Access Mode</font></h3>
+									<h3>The Access Mode</h3>
 								</td>
 								<td width="525">
 									<p>
-										The <font size="2">ACCESS MODE</font> of a file refers to the way in which the
-										file is to be used. If an <font size="2">ACCESS MODE</font> of
-										<font size="2">SEQUENTIAL</font> is specified then it will only be possible to
-										process the records in the file sequentially. If <font size="2">RANDOM</font> is
-										specified it will only be possible to access the file directly. If
-										<font size="2">DYNAMIC</font> is specified, the file may be accessed both
-										directly and sequentially.
+										The ACCESS MODE of a file refers to the way in which the file is to be used. If
+										an ACCESS MODE of SEQUENTIAL is specified then it will only be possible to
+										process the records in the file sequentially. If RANDOM is specified it will
+										only be possible to access the file directly. If DYNAMIC is specified, the file
+										may be accessed both directly and sequentially.
 									</p>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">The Record Key phrase</font></h3>
+									<h3>The Record Key phrase</h3>
 								</td>
 								<td width="525">
 									<div align="center">
 										<div align="left">
 											<p>
-												The <font size="2">RECORD KEY</font> phrase is used to define the
-												relative key. There can be only one key in a Relative File. The
+												The RECORD KEY phrase is used to define the relative key. There can be
+												only one key in a Relative File. The
 												<i>UniqueRecKey</i> must be a numeric data item and must not be part of
 												the file's record description although it may be part of another file's
-												record description. It is normally described in the
-												<font size="2">WORKING-STORAGE SECTION</font>.
+												record description. It is normally described in the WORKING-STORAGE
+												SECTION.
 											</p>
 										</div>
 									</div>
@@ -542,18 +535,16 @@ Enter supplier key (2 digits)-&gt; 05
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">The File Status</font></h3>
+									<h3>The File Status</h3>
 								</td>
 								<td width="525">
 									<div align="center">
 										<div align="left">
 											<p>
-												The <font size="2">FILE STATUS</font> clause identifies a two character
-												area of storage that holds the result of every I-O operation for the
-												file. The <font size="2">FILE STATUS</font> data item is declared as
-												<font size="2">PIC X(2)</font> in the
-												<font size="2">WORKING-STORAGE SECTION</font>. Whenever an I-O operation
-												is performed, some value will be returned to
+												The FILE STATUS clause identifies a two character area of storage that
+												holds the result of every I-O operation for the file. The FILE STATUS
+												data item is declared as PIC X(2) in the WORKING-STORAGE SECTION.
+												Whenever an I-O operation is performed, some value will be returned to
 												<i>FileStatus</i> indicating whether or not the operation was
 												successful.
 											</p>
@@ -561,8 +552,8 @@ Enter supplier key (2 digits)-&gt; 05
 									</div>
 									<div align="center">
 										<div align="left">
-											There are a large number of <font size="2">FILE STATUS</font> values but
-											three of major interest are;
+											There are a large number of FILE STATUS values but three of major interest
+											are;
 										</div>
 									</div>
 									<blockquote>
@@ -574,7 +565,7 @@ Enter supplier key (2 digits)-&gt; 05
 										<div align="left">
 											<p>
 												22 may occur after an attempt to write a record and 23 after trying to
-												<font size="2">READ</font> or <font size="2">DELETE</font> a record.
+												READ or DELETE a record.
 											</p>
 											<p>
 												Note that although a code of 00 generally means the operation was
@@ -600,24 +591,19 @@ Enter supplier key (2 digits)-&gt; 05
 						<table border="0" cellpadding="4" cellspacing="0" width="710">
 							<tr>
 								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="verbs">
-										<font color="#FFFF00">Relative file - file processing verbs</font>
-									</h2>
+									<h2 align="center" id="verbs">Relative file - file processing verbs</h2>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Introduction</font></h3>
+									<h3>Introduction</h3>
 								</td>
 								<td width="525">
 									<p>
 										Direct access files can support a far greater range of operations than
 										Sequential files. Just like Sequential files, direct access files support the
-										<font size="2">OPEN</font>, <font size="2">CLOSE</font>,
-										<font size="2">READ</font> and <font size="2">WRITE</font> operations. But in
-										addition to these, direct access files also support the
-										<font size="2">DELETE</font>, <font size="2">REWRITE</font> and
-										<font size="2">START</font> operations.
+										OPEN, CLOSE, READ and WRITE operations. But in addition to these, direct access
+										files also support the DELETE, REWRITE and START operations.
 									</p>
 									<p>
 										In this section we examine these new operations and any changes to the
@@ -628,26 +614,24 @@ Enter supplier key (2 digits)-&gt; 05
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">The Invalid Key clause</font></h3>
+									<h3>The Invalid Key clause</h3>
 								</td>
 								<td width="525">
 									<p>
-										When any of the file processing verbs are used for direct access, the
-										<font size="2">INVALID KEY</font> clause must be used unless declaratives have
-										been specified.
+										When any of the file processing verbs are used for direct access, the INVALID
+										KEY clause must be used unless declaratives have been specified.
 									</p>
 									<p>
-										When the <font size="2">INVALID KEY</font> clause is specified, any I-O error,
-										such as attempting to read a record that does not exist or write a record that
-										already exists, will activate the clause and cause the statement block following
-										it to be executed.
+										When the INVALID KEY clause is specified, any I-O error, such as attempting to
+										read a record that does not exist or write a record that already exists, will
+										activate the clause and cause the statement block following it to be executed.
 									</p>
 									<hr />
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">OPEN/CLOSE verbs</font></h3>
+									<h3>OPEN/CLOSE verbs</h3>
 								</td>
 								<td width="525">
 									<div align="center">
@@ -661,27 +645,23 @@ Enter supplier key (2 digits)-&gt; 05
 										</p>
 										<p align="left"><img src="Resources/pics/I-DFrel2.gif" /></p>
 										<p align="left">
-											<b>Notes<br /></b> If the file is opened for input then only
-											<font size="2">READ</font> and <font size="2">START</font> will be allowed.
+											<b>Notes<br /></b> If the file is opened for input then only READ and START
+											will be allowed.
 										</p>
 										<p align="left">
-											If the file is opened for output then only <font size="2">WRITE</font> will
-											be allowed.
+											If the file is opened for output then only WRITE will be allowed.
 										</p>
 										<p align="left">
-											If the file is opened for I-O then
-											<font size="2">READ, WRITE, START, REWRITE</font> and
-											<font size="2">DELETE</font> will be allowed.&nbsp;
+											If the file is opened for I-O then READ, WRITE, START, REWRITE and DELETE
+											will be allowed.&nbsp;
 										</p>
 										<p align="left">
-											If <font size="2">OPEN INPUT</font> is used, and the file does not possess
-											the <font size="2">OPTIONAL</font> tag, then the file must exist or the
-											<font size="2">OPEN</font> will fail. &nbsp;
+											If OPEN INPUT is used, and the file does not possess the OPTIONAL tag, then
+											the file must exist or the OPEN will fail. &nbsp;
 										</p>
 										<p align="left">
-											If <font size="2">OPEN OUTPUT</font> or I-O is used then the file will be
-											created if it does not already exist as long as the file possesses the
-											<font size="2">OPTIONAL</font> tag<font size="2">.</font>
+											If OPEN OUTPUT or I-O is used then the file will be created if it does not
+											already exist as long as the file possesses the OPTIONAL tag.
 										</p>
 									</div>
 									<div align="center">
@@ -691,22 +671,19 @@ Enter supplier key (2 digits)-&gt; 05
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">The READ verb</font></h3>
+									<h3>The READ verb</h3>
 								</td>
 								<td width="525">
 									<p>
-										When a Relative file has an <font size="2">ACCESS MODE</font> of
-										<font size="2">SEQUENTIAL</font> , the format of the
-										<font size="2">READ</font> is the same as for Sequential files, but when the
-										<font size="2">ACCESS MODE</font> is <font size="2">DYNAMIC</font> or
-										<font size="2">RANDOM</font>, the <font size="2">READ</font> has a different
-										format.
+										When a Relative file has an ACCESS MODE of SEQUENTIAL , the format of the READ
+										is the same as for Sequential files, but when the ACCESS MODE is DYNAMIC or
+										RANDOM, the READ has a different format.
 									</p>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Reading using a key</font></h3>
+									<h3>Reading using a key</h3>
 								</td>
 								<td width="525">
 									<p><img src="Resources/pics/I-DFrel3.gif" /></p>
@@ -717,80 +694,69 @@ Enter supplier key (2 digits)-&gt; 05
 										<li>
 											The key value must be placed in the <i>KeyName</i> data item (the
 											<i>KeyName</i> data item is the area of storage identified as the relative
-											key in the <font size="2">RECORD KEY IS</font> phrase of the
-											<font size="2">SELECT</font> and <font size="2">ASSIGN</font> clause).
+											key in the RECORD KEY IS phrase of the SELECT and ASSIGN clause).
 										</li>
-										<li>Then the <font size="2">READ</font> must be executed.</li>
+										<li>Then the READ must be executed.</li>
 									</ol>
 									<p>
-										When the <font size="2">READ</font> is executed, the record with the Relative
-										Record Number equal to the present value of the relative key
-										(i.e.<i>KeyName</i>) will be read into the file's record buffer (defined in the
-										FD entry).
+										When the READ is executed, the record with the Relative Record Number equal to
+										the present value of the relative key (i.e.<i>KeyName</i>) will be read into the
+										file's record buffer (defined in the FD entry).
 									</p>
 									<p>
-										If the record does not exist the <font size="2">INVALID KEY</font> clause will
-										activate and the statement block following the clause will be executed.
+										If the record does not exist the INVALID KEY clause will activate and the
+										statement block following the clause will be executed.
 									</p>
 									<p>
 										After the record has been read the next record pointer will be pointing to the
 										next record in the file.
 									</p>
 									<p>
-										<b>Notes<br /></b> The file must have an
-										<font size="2">ACCESS MODE</font> declaration for the file specifying an
-										<font size="2">ACCESS MODE</font> <font size="2">DYNAMIC</font> or
-										<font size="2">RANDOM</font>.
+										<b>Notes<br /></b> The file must have an ACCESS MODE declaration for the file
+										specifying an ACCESS MODE DYNAMIC or RANDOM.
 									</p>
-									<p>The file must be opened for I-O or <font size="2">INPUT</font>.&nbsp;</p>
+									<p>The file must be opened for I-O or INPUT.&nbsp;</p>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Reading Sequentially</font></h3>
+									<h3>Reading Sequentially</h3>
 								</td>
 								<td width="525">
 									<p>
-										When the <font size="2">ACCESS MODE</font> is <font size="2">DYNAMIC</font> and
-										we wish to read the file sequentially then we must use the format below for the
-										<font size="2">READ</font>. There is very little difference between this format
-										and the format of the ordinary sequential <font size="2">READ</font> except that
-										in this format the <font size="2">NEXT RECORD</font> phrase is used.
+										When the ACCESS MODE is DYNAMIC and we wish to read the file sequentially then
+										we must use the format below for the READ. There is very little difference
+										between this format and the format of the ordinary sequential READ except that
+										in this format the NEXT RECORD phrase is used.
 									</p>
 									<p><img src="Resources/pics/I-DFrel4.gif" /></p>
 									<p>
 										<b>Notes<br /></b> This format is used to access a Relative file sequentially
-										when the <font size="2">ACCESS MODE</font> has been declared as
-										<font size="2">DYNAMIC</font> and the file has been opened for
-										<font size="2">INPUT</font> or I-O.
+										when the ACCESS MODE has been declared as DYNAMIC and the file has been opened
+										for INPUT or I-O.
 									</p>
 									<p>
-										For Relative files the next record pointer may be positioned by the
-										<font size="2">START</font> verb or by doing a direct
-										<font size="2">READ</font> .
+										For Relative files the next record pointer may be positioned by the START verb
+										or by doing a direct READ .
 									</p>
 									<p>
-										The <font size="2">READ NEXT</font> will read the record pointed to by the next
-										record pointer (This will be the current record if positioned by the
-										<font size="2">START</font> and the next record if positioned by a direct
-										<font size="2">READ</font>).
+										The READ NEXT will read the record pointed to by the next record pointer (This
+										will be the current record if positioned by the START and the next record if
+										positioned by a direct READ).
 									</p>
-									<p>
-										The <font size="2">AT END</font> statement is activated when the end of the file
-										has been reached
-									</p>
+									<p>The AT END statement is activated when the end of the file has been reached</p>
 									<hr />
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="left"><font color="#800000">The WRITE verb</font></h3>
+									<h3 align="left">The WRITE verb</h3>
 								</td>
 								<td width="525">
 									<p>
 										The format for writing sequentially to a Relative file is the same as that used
 										for writing to a Sequential file, but to write directly to a Relative file a key
-										must be used and this requires a different <font size="2">WRITE</font> format.
+										must be used and this requires a different WRITE format.
 									</p>
 									<p><img src="Resources/pics/I-DFrel5.gif" /></p>
 									<p>
@@ -799,58 +765,51 @@ Enter supplier key (2 digits)-&gt; 05
 									<ol>
 										<li>The record value must be placed in the files record buffer.</li>
 										<li>The key value must be placed in the file's relative key.</li>
-										<li>The <font size="2">WRITE</font> must be executed.</li>
+										<li>The WRITE must be executed.</li>
 									</ol>
 									<p>
-										When the <font size="2">WRITE</font> is executed the data in the record buffer
-										is written to the record position with a Relative Record Number equal to the
-										present value of the key.
+										When the WRITE is executed the data in the record buffer is written to the
+										record position with a Relative Record Number equal to the present value of the
+										key.
 									</p>
 									<p>
-										<b>Notes<br /></b> The <font size="2">INVALID KEY</font> clause must be used for
-										direct access to Relative files. If the record being written already 'exists'
-										the <font size="2">INVALID KEY</font> clause will be activate and the statement
-										following the clause will be done. Any other I-O error will also activate the
-										<font size="2">INVALID KEY</font> clause.
+										<b>Notes<br /></b> The INVALID KEY clause must be used for direct access to
+										Relative files. If the record being written already 'exists' the INVALID KEY
+										clause will be activate and the statement following the clause will be done. Any
+										other I-O error will also activate the INVALID KEY clause.
 									</p>
 									<hr />
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="left"><font color="#800000">The REWRITE verb</font></h3>
+									<h3 align="left">The REWRITE verb</h3>
 								</td>
 								<td width="525">
 									<p>
-										The <font size="2">REWRITE</font> is used to update a record in situ by
-										overwriting it. The format of the <font size="2">REWRITE</font> verb is shown
-										below.
+										The REWRITE is used to update a record in situ by overwriting it. The format of
+										the REWRITE verb is shown below.
 									</p>
 									<p><img src="Resources/pics/I-DFrel6.gif" /></p>
 									<p>
-										<b>Operation<br /></b> The <font size="2">REWRITE</font> is normally used in the
-										following way;
+										<b>Operation<br /></b> The REWRITE is normally used in the following way;
 									</p>
 									<ol>
 										<li>
 											The record we wish to update is read directly into the record buffer (place
-											the key value in the key are and execute the <font size="2">READ</font>).
+											the key value in the key are and execute the READ).
 										</li>
 										<li>The required changes are made to the record in the buffer.</li>
 										<li>The record in the buffer is rewritten to the file.</li>
 									</ol>
 									<p>
-										<b>Notes<br /></b> If the file has an <font size="2">ACCESS MODE</font> of
-										<font size="2">SEQUENTIAL</font> then the
-										<font size="2">INVALID KEY</font> clause cannot be used but if the
-										<font size="2">ACCESS MODE</font> is <font size="2">RANDOM</font> or
-										<font size="2">DYNAMIC</font> the <font size="2">INVALID KEY</font> clause must
-										be present (unless declaratives are being used).
+										<b>Notes<br /></b> If the file has an ACCESS MODE of SEQUENTIAL then the INVALID
+										KEY clause cannot be used but if the ACCESS MODE is RANDOM or DYNAMIC the
+										INVALID KEY clause must be present (unless declaratives are being used).
 									</p>
 									<p>
-										When the file has <font size="2">ACCESS MODE IS SEQUENTIAL</font> the record
-										that is replaced must have been the subject of a <font size="2">READ</font> or
-										<font size="2">START</font> before the <font size="2">REWRITE</font> is used.
+										When the file has ACCESS MODE IS SEQUENTIAL the record that is replaced must
+										have been the subject of a READ or START before the REWRITE is used.
 									</p>
 									<p>For all access modes the file must be opened for I-O.</p>
 									<hr />
@@ -858,7 +817,7 @@ Enter supplier key (2 digits)-&gt; 05
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="left"><font color="#800000">The DELETE verb</font></h3>
+									<h3 align="left">The DELETE verb</h3>
 								</td>
 								<td width="525">
 									<p><img src="Resources/pics/I-DFrel7.gif" /></p>
@@ -870,29 +829,24 @@ Enter supplier key (2 digits)-&gt; 05
 											The Relative Record Number of the record to be deleted must be placed in the
 											file's relative key.
 										</li>
-										<li>Then the <font size="2">DELETE</font> must be executed.</li>
+										<li>Then the DELETE must be executed.</li>
 									</ol>
 									<p>
 										The record with the Relative Record number equal to the current value of the key
 										are will be deleted.
 									</p>
 									<p>
-										<b>Notes<br /></b> To use the <font size="2">DELETE</font>, the file must have
-										been opened for I-O.
+										<b>Notes<br /></b> To use the DELETE, the file must have been opened for I-O.
 									</p>
 									<p>
-										When the <font size="2">ACCESS MODE IS SEQUENTIAL</font> a
-										<font size="2">READ</font> statement must access the record to be deleted.
+										When the ACCESS MODE IS SEQUENTIAL a READ statement must access the record to be
+										deleted.
 									</p>
 									<p>
-										When the <font size="2">ACCESS MODE IS RANDOM</font> or
-										<font size="2">DYNAMIC</font> the record to be deleted is identified by the
-										file's Relative key.
+										When the ACCESS MODE IS RANDOM or DYNAMIC the record to be deleted is identified
+										by the file's Relative key.
 									</p>
-									<p>
-										If the record does not exist the <font size="2">INVALID KEY</font> statement
-										will be activated.
-									</p>
+									<p>If the record does not exist the INVALID KEY statement will be activated.</p>
 									<p>
 										Note that when a record is deleted its space does not become available to other
 										records.
@@ -902,14 +856,13 @@ Enter supplier key (2 digits)-&gt; 05
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">The START verb</font></h3>
+									<h3>The START verb</h3>
 								</td>
 								<td width="525">
 									<p>
-										In Relative files, the only thing the the <font size="2">START</font> verb is
-										used for, is to control the position of the next record pointer. Where the
-										<font size="2">START</font> verb appears in a program it is usually followed by
-										a sequential <font size="2">READ</font> or <font size="2">WRITE</font> .
+										In Relative files, the only thing the the START verb is used for, is to control
+										the position of the next record pointer. Where the START verb appears in a
+										program it is usually followed by a sequential READ or WRITE .
 									</p>
 									<p><img src="Resources/pics/I-DFrel8.gif" /></p>
 									<p>
@@ -920,36 +873,32 @@ Enter supplier key (2 digits)-&gt; 05
 										<li>
 											Move the Relative Record Number of the record to the file's relative key.
 										</li>
-										<li>Execute the <font size="2">START..KEY IS EQUAL TO</font></li>
+										<li>Execute the START..KEY IS EQUAL TO</li>
 									</ol>
 									<p>To position the Next Record Pointer at the first record in the file</p>
 									<ol>
 										<li>Move zeros to the file's relative key.</li>
-										<li>Execute the <font size="2">START..KEY IS GREATER THAN</font></li>
+										<li>Execute the START..KEY IS GREATER THAN</li>
 									</ol>
 									<p>To position the pointer at the last record in the file</p>
 									<ol>
 										<li>Move all 9's to the file's relative key.</li>
-										<li>Execute the <font size="2">START..KEY IS LESS THAN</font></li>
+										<li>Execute the START..KEY IS LESS THAN</li>
 									</ol>
 									<p>
 										<b>Notes<br /></b> <i>KeyDataName</i> is the file's relative key. It is the key
 										of comparison.
 									</p>
+									<p>The file must be opened for INPUT or I-O when the START is executed.</p>
 									<p>
-										The file must be opened for <font size="2">INPUT</font> or I-O when the
-										<font size="2">START</font> is executed.
+										Execution of the START statement does not change the contents of the record area
+										(i.e. the START does not actually read the record it merely positions the next
+										record pointer).
 									</p>
 									<p>
-										Execution of the <font size="2">START</font> statement does not change the
-										contents of the record area (i.e. the <font size="2">START</font> does not
-										actually read the record it merely positions the next record pointer).
-									</p>
-									<p>
-										When the <font size="1">START</font> is executed the Next Record Pointer is set
-										to the first record in the file whose key satisfies the condition. If no record
-										satisfies the condition then the <font size="2">INVALID KEY</font> clause is
-										activated.
+										When the START is executed the Next Record Pointer is set to the first record in
+										the file whose key satisfies the condition. If no record satisfies the condition
+										then the INVALID KEY clause is activated.
 									</p>
 								</td>
 							</tr>
@@ -969,27 +918,24 @@ Enter supplier key (2 digits)-&gt; 05
 						<table border="0" cellpadding="4" cellspacing="0" width="710">
 							<tr>
 								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="declaratives">
-										<font color="#FFFF00">Introduction to Declaratives</font>
-									</h2>
+									<h2 align="center" id="declaratives">Introduction to Declaratives</h2>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="left"><font color="#800000">Introduction</font></h3>
+									<h3 align="left">Introduction</h3>
 								</td>
 								<td width="525">
 									<p>
 										Declaratives allow us to define exception handling procedures for files. When
-										there are declaratives for a file the <font size="2">INVALID KEY</font> clause
-										is not required.
+										there are declaratives for a file the INVALID KEY clause is not required.
 									</p>
 									<hr />
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="left"><font color="#800000">The Declaratives template</font></h3>
+									<h3 align="left">The Declaratives template</h3>
 								</td>
 								<td width="525">
 									<table border="0" width="100%">
@@ -997,25 +943,23 @@ Enter supplier key (2 digits)-&gt; 05
 											<td width="50%">
 												<p>The template opposite shows how declaratives are set up.</p>
 												<p>
-													Declaratives must be defined at the start of the
-													<font size="2">PROCEDURE DIVISION.</font>
+													Declaratives must be defined at the start of the PROCEDURE DIVISION.
 												</p>
 												<p>
-													They must start with the <font size="2">DECLARATIVES</font> keyword
-													and end with the keyword <font size="2">END-DECLARATIVES</font> .
+													They must start with the DECLARATIVES keyword and end with the
+													keyword END-DECLARATIVES .
 												</p>
 												<p>
 													Declaratives are divided into sections and each section is
-													associated with a particular <font size="2">USE</font> phrase.
+													associated with a particular USE phrase.
 												</p>
 												<p>
-													The sections and <font size="2">USE</font> phrases allow us to
-													specify a separate exception procedure for each file.
+													The sections and USE phrases allow us to specify a separate
+													exception procedure for each file.
 												</p>
 												<p>
-													We can also specify general exception procedures for all
-													<font size="2">INPUT, OUTPUT, I-O</font> and
-													<font size="2">EXTEND</font> errors.
+													We can also specify general exception procedures for all INPUT,
+													OUTPUT, I-O and EXTEND errors.
 												</p>
 											</td>
 											<td align="center" width="50%">
@@ -1062,7 +1006,7 @@ Begin.</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="left"><font color="#800000">The Use phrase</font></h3>
+									<h3 align="left">The Use phrase</h3>
 								</td>
 								<td width="525">
 									<div align="center">
@@ -1070,15 +1014,11 @@ Begin.</code></pre>
 											<p><img src="Resources/pics/I-DFrel9.gif" /></p>
 											<p><b>Notes</b></p>
 											<p>
-												A <font size="2">USE</font> statement can be used only in a sentence
-												immediately after a section header in the
-												<font size="2">PROCEDURE DIVISION</font> declaratives area. It must be
+												A USE statement can be used only in a sentence immediately after a
+												section header in the PROCEDURE DIVISION declaratives area. It must be
 												the only statement in the sentence.
 											</p>
-											<p>
-												<font size="2">ERROR</font> and <font size="2">EXCEPTION</font> are
-												synonyms.
-											</p>
+											<p>ERROR and EXCEPTION are synonyms.</p>
 											<p>
 												A Declarative cannot refer to a non-Declarative procedure. However, the
 												PERFORM can transfer control from a Declarative procedure to another
@@ -1087,15 +1027,12 @@ Begin.</code></pre>
 											</p>
 											<p>
 												A Declarative executes automatically whenever an I-O condition occurs
-												that would result in a non-zero value in the
-												<font size="2">FILE STATUS</font> data item.
+												that would result in a non-zero value in the FILE STATUS data item.
 											</p>
 											<p>
-												When <font size="2">USE</font> phrases refer to both a
-												<i>FileName</i> and the more general <font size="2">INPUT</font>,
-												<font size="2">OUTPUT</font>, <font size="2">I-O</font> and
-												<font size="2">EXTEND</font> then the <i>FileName</i> procedure takes
-												precedence.
+												When USE phrases refer to both a
+												<i>FileName</i> and the more general INPUT, OUTPUT, I-O and EXTEND then
+												the <i>FileName</i> procedure takes precedence.
 											</p>
 											<hr />
 										</div>
@@ -1104,7 +1041,7 @@ Begin.</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="center"><font color="#800000">Example program - fragment</font></h3>
+									<h3 align="center">Example program - fragment</h3>
 								</td>
 								<td background="Resources/pics/code.gif" width="525">
 									<pre class="language-cobol"><code class="language-cobol"> PROCEDURE DIVISION. 
@@ -1144,15 +1081,12 @@ Begin.</code></pre>
 										These COBOL course materials are the copyright property of Michael Coughlan.
 									</p>
 									<p>
-										<font size="2"
-											>All rights reserved. No part of these course materials may be reproduced in
-											any form or by any means - graphic, electronic, mechanical, photocopying,
-											printing, recording, taping or stored in an information storage and
-											retrieval system - without the written permission of</font
-										>
-										<font size="2">the author.</font>
+										All rights reserved. No part of these course materials may be reproduced in any
+										form or by any means - graphic, electronic, mechanical, photocopying, printing,
+										recording, taping or stored in an information storage and retrieval system -
+										without the written permission of the author.
 									</p>
-									<p align="center"><font size="2">(c) Michael Coughlan</font></p>
+									<p align="center">(c) Michael Coughlan</p>
 								</td>
 							</tr>
 						</table>

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -128,10 +128,23 @@
 			ul.toc > li {
 				padding-left: 0.4em;
 				margin-bottom: 0.6em;
+				font-size: smaller;
 			}
 
 			ul.toc a {
 				font-weight: bold;
+				font-size: larger;
+			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			td[bgcolor="#FFFFCC"] h3,
+			td[bgcolor="#FFFFCC"] h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
 			}
 		</style>
 	</head>
@@ -147,57 +160,44 @@
 					<ul class="toc">
 						<li>
 							<a href="#intro">Introduction</a><br />
-							<font size="-1">Unit aims, objectives and prerequisites.</font>
+							Unit aims, objectives and prerequisites.
 						</li>
 						<li>
 							<a href="#part1">The Report Writer in action</a><br />
-							<font size="-1"
-								>This section examines a report produced by a Report Writer program and then examines
-								the Procedure Division of the program that produced the report.</font
-							>
+							This section examines a report produced by a Report Writer program and then examines the
+							Procedure Division of the program that produced the report.
 						</li>
 						<li>
 							<a href="#part1b">How the Report Writer works</a><br />
-							<font size="-1"
-								>This section explains how the Report Writer works. It examines the seven report groups
-								a report produced by a Report Writer program and then examines the Procedure Division of
-								the program that produced the report.</font
-							>
+							This section explains how the Report Writer works. It examines the seven report groups a
+							report produced by a Report Writer program and then examines the Procedure Division of the
+							program that produced the report.
 						</li>
 						<li>
 							<a href="#part2">Let's write a Report Writer p</a><a href="#part2">rogram</a><br />
-							<font size="-1"
-								>This section uses learning by doing as its mode of instruction. We learn how to write a
-								simple version of the report program shown in the previous section.</font
-							>
+							This section uses learning by doing as its mode of instruction. We learn how to write a
+							simple version of the report program shown in the previous section.
 						</li>
 						<li>
 							<a href="#part3">Let's add some features to our Report Program</a><br />
-							<font size="-1"
-								>In this section we amend the report program to include more functionality</font
-							>
-							<font size="-1">.</font>
+							In this section we amend the report program to include more functionality.
 						</li>
 						<li>
 							<a href="#part4">Report Writer Declaratives</a><br />
-							<font size="-1"
-								>When the requirements of the report do not coincide with the way the Report Writer
-								works Declaratives can be used to extend the functionality of the Report Writer.</font
-							>
+							When the requirements of the report do not coincide with the way the Report Writer works
+							Declaratives can be used to extend the functionality of the Report Writer.
 						</li>
 					</ul>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="intro">
-						<font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Introduction</font></font>
-					</h2>
+					<h2 align="center" id="intro">Introduction</h2>
 				</td>
 			</tr>
 			<tr>
 				<td bgcolor="#FFFFCC" valign="top" width="160">
-					<h4><font color="#993300" face="Arial, Helvetica, sans-serif">Aims</font></h4>
+					<h4>Aims</h4>
 				</td>
 				<td width="540">
 					<p>
@@ -224,7 +224,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Objectives</font></h4>
+					<h4>Objectives</h4>
 				</td>
 				<td width="540">
 					<p>By the end of this unit you should -</p>
@@ -247,7 +247,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font></h4>
+					<h4>Prerequisites</h4>
 				</td>
 				<td width="525">
 					<p>You should be familiar with the material covered in the unit;</p>
@@ -257,8 +257,8 @@
 						<li>Selection</li>
 						<li>Tables</li>
 						<li>Edited Pictures</li>
-						<li>The <font size="2">INSPECT</font> verb</li>
-						<li>The <font size="2">STRING</font> verb</li>
+						<li>The <code class="language-cobol">INSPECT</code> verb</li>
+						<li>The <code class="language-cobol">STRING</code> verb</li>
 						<li>The <code class="language-cobol">UNSTRING</code> verb</li>
 						<li>Sequential files</li>
 					</ul>
@@ -278,16 +278,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part1">
-						<font color="#FFFF00"
-							><font face="Arial, Helvetica, sans-serif">The Report Writer in Action</font></font
-						>
-					</h2>
+					<h2 align="center" id="part1">The Report Writer in Action</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font></h4>
+					<h4>Introduction</h4>
 				</td>
 				<td valign="top" width="540">
 					<p>
@@ -298,19 +294,16 @@
 					</p>
 					<p>
 						The COBOL Report Writer is very large. It includes many new
-						<font size="2">DATA DIVISION</font> entries, including a <font size="2">REPORT SECTION</font>,
-						and a number of new <font size="2">PROCEDURE DIVISION</font> verbs.
+						<code class="language-cobol">DATA DIVISION</code> entries, including a
+						<code class="language-cobol">REPORT SECTION</code>, and a number of new
+						<code class="language-cobol">PROCEDURE DIVISION</code> verbs.
 					</p>
 					<hr />
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="center">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>An example report - with animated commentary.</font
-						>
-					</h4>
+					<h4 align="center">An example report - with animated commentary.</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -340,11 +333,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="center">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>The Procedure Division that produces the sales report</font
-						>
-					</h4>
+					<h4 align="center">The Procedure Division that produces the sales report</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -386,11 +375,7 @@ PrintSalaryReport.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="center">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>So much work, so little Procedure Division code</font
-						>
-					</h4>
+					<h4 align="center">So much work, so little Procedure Division code</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -419,14 +404,12 @@ PrintSalaryReport.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top">
-					<h2 align="center" id="part1b">
-						<font color="#FFFF00" face="Arial, Helvetica, sans-serif">How the Report Writer works</font>
-					</h2>
+					<h2 align="center" id="part1b">How the Report Writer works</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Report Groups</font></h4>
+					<h4>Report Groups</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>The Report Writer works by recognizing that many reports take (more or less) the same shape.</p>
@@ -448,44 +431,42 @@ PrintSalaryReport.
 					<blockquote>
 						<p>
 							REPORT HEADING or RH group<br />
-							<font size="-1">- printed once at the beginning of the report</font>
+							- printed once at the beginning of the report
 						</p>
 					</blockquote>
 					<ol>
 						<blockquote>
 							<p>
 								PAGE HEADING of PH group<br />
-								<font size="-1">- printed at the top of each page</font>
+								- printed at the top of each page
 							</p>
 							<blockquote>
 								<p>
 									CONTROL HEADING or CH group<br />
-									<font size="-1">- printed at the beginning of each control break</font>
+									- printed at the beginning of each control break
 								</p>
 								<blockquote>
 									<p>
 										DETAIL or DE group<br />
-										<font size="-1"
-											>- printed each time the
-											<code class="language-cobol">GENERATE</code> statement is executed</font
-										>
+										- printed each time the
+										<code class="language-cobol">GENERATE</code> statement is executed
 									</p>
 								</blockquote>
 								<p>
 									CONTROL FOOTING or CF group<br />
-									<font size="-1">- printed at the end of each control break</font>
+									- printed at the end of each control break
 								</p>
 							</blockquote>
 							<p>
 								PAGE FOOTING or PF group<br />
-								<font size="-1">- printed at the bottom of each page</font>
+								- printed at the bottom of each page
 							</p>
 						</blockquote>
 					</ol>
 					<blockquote>
 						<p>
 							REPORT FOOTING or RF group<br />
-							<font size="-1">- printed once at the end of the report.</font>
+							- printed once at the end of the report.
 						</p>
 					</blockquote>
 					<p>
@@ -512,9 +493,7 @@ PrintSalaryReport.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="center">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Report writing made easy</font>
-					</h4>
+					<h4 align="center">Report writing made easy</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -546,16 +525,12 @@ PrintSalaryReport.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part2">
-						<font color="#FFFF00"
-							><font face="Arial, Helvetica, sans-serif">Let's write a Report Writer program!</font></font
-						>
-					</h2>
+					<h2 align="center" id="part2">Let's write a Report Writer program!</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font></h4>
+					<h4>Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -574,9 +549,7 @@ PrintSalaryReport.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Report Specification</font>
-					</h4>
+					<h4>Report Specification</h4>
 				</td>
 				<td valign="top" width="525">
 					<p align="left">
@@ -602,9 +575,7 @@ PrintSalaryReport.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">A simple report</font>
-					</h4>
+					<h4>A simple report</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -680,9 +651,7 @@ Programmer - Michael Coughlan               Page :  1
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Code & Commentary</font>
-					</h4>
+					<h4>Code & Commentary</h4>
 				</td>
 				<td valign="top" width="525">
 					<table border="1" width="100%">
@@ -703,16 +672,12 @@ Programmer - Michael Coughlan               Page :  1
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part3">
-						<font color="#FFFF00">Let's add some features to our Report Program</font>
-					</h2>
+					<h2 align="center" id="part3">Let's add some features to our Report Program</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Adding a city and a final total</font>
-					</h4>
+					<h4>Adding a city and a final total</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -727,9 +692,7 @@ Programmer - Michael Coughlan               Page :  1
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Printing the city total</font>
-					</h4>
+					<h4>Printing the city total</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -754,9 +717,7 @@ Programmer - Michael Coughlan               Page :  1
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Printing a Final Total</font>
-					</h4>
+					<h4>Printing a Final Total</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -774,9 +735,7 @@ Programmer - Michael Coughlan               Page :  1
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">REPORT SECTION changes</font>
-					</h4>
+					<h4>REPORT SECTION changes</h4>
 				</td>
 				<td valign="top" width="525">
 					<hr />
@@ -862,11 +821,7 @@ RD  SalesReport
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Changes to the Procedure Division</font
-						>
-					</h4>
+					<h4>Changes to the Procedure Division</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -880,14 +835,12 @@ RD  SalesReport
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top">
-					<h2 align="center" id="part4">
-						<font color="#FFFF00" face="Arial, Helvetica, sans-serif">Report Writer Declaratives</font>
-					</h2>
+					<h2 align="center" id="part4">Report Writer Declaratives</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font></h4>
+					<h4>Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -910,11 +863,7 @@ RD  SalesReport
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Calculating the salesperson's commission and salary</font
-						>
-					</h4>
+					<h4>Calculating the salesperson's commission and salary</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -948,9 +897,7 @@ RD  SalesReport
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Values of control break items</font>
-					</h4>
+					<h4>Values of control break items</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -981,11 +928,7 @@ RD  SalesReport
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>The full program and the report it produces</font
-						>
-					</h4>
+					<h4>The full program and the report it produces</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>Changes from the simple version are shown in red.</p>
@@ -1264,11 +1207,7 @@ Programmer - Michael Coughlan               Page :  1 </code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Summary of control break item reference</font
-						>
-					</h4>
+					<h4>Summary of control break item reference</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1292,15 +1231,12 @@ Programmer - Michael Coughlan               Page :  1 </code></pre>
 						<h3 align="center">Copyright Notice</h3>
 						<p align="left">These COBOL course materials are the copyright property of Michael Coughlan.</p>
 						<p align="left">
-							<font size="2"
-								>All rights reserved. No part of these course materials may be reproduced in any form or
-								by any means - graphic, electronic, mechanical, photocopying, printing, recording,
-								taping or stored in an information storage and retrieval system - without the written
-								permission of</font
-							>
-							<font size="2">the author.</font>
+							All rights reserved. No part of these course materials may be reproduced in any form or by
+							any means - graphic, electronic, mechanical, photocopying, printing, recording, taping or
+							stored in an information storage and retrieval system - without the written permission of
+							the author.
 						</p>
-						<p align="center"><font size="2">(c) Michael Coughlan</font></p>
+						<p align="center">(c) Michael Coughlan</p>
 					</div>
 				</td>
 			</tr>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -128,10 +128,23 @@
 			ul.toc > li {
 				padding-left: 0.4em;
 				margin-bottom: 0.6em;
+				font-size: smaller;
 			}
 
 			ul.toc a {
 				font-weight: bold;
+				font-size: larger;
+			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			td[bgcolor="#FFFFCC"] h3,
+			td[bgcolor="#FFFFCC"] h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
 			}
 		</style>
 	</head>
@@ -147,40 +160,29 @@
 					<ul class="toc">
 						<li>
 							<a href="#intro">Introduction</a><br />
-							<font size="-1">Unit aims, objectives and prerequisites.</font>
+							Unit aims, objectives and prerequisites.
 						</li>
 						<li>
 							<a href="#part1">Defining the Report - Report File entries</a><br />
-							<font size="-1"
-								>This section examines the <code class="language-cobol">ENVIRONMENT DIVISION</code> and
-								File Section entries required when we create<br />
-								a Report Writer program.</font
-							>
+							This section examines the <code class="language-cobol">ENVIRONMENT DIVISION</code> and File
+							Section entries required when we create<br />
+							a Report Writer program.
 						</li>
 						<li>
 							<a href="#part2">Defining the Report - Report Description (RD) entries</a><br />
-							<font size="-1"
-								>In this section we examine the Report Section and the Report Description (RD) entries
-								required to<br />
-								define a report.</font
-							>
+							In this section we examine the Report Section and the Report Description (RD) entries
+							required to<br />
+							define a report.
 						</li>
 						<li>
 							<a href="#part3">Defining the Report - Report Group entries</a><br />
-							<font size="-1"
-								>This section examines the entries required to define a report group record.</font
-							>
+							This section examines the entries required to define a report group record.
 						</li>
 						<li>
 							<a href="#part4">Defining the Report - Lines and Columns</a><br />
-							<font size="-1"
-								>This section examines the entries the vertical and horizontal placement of print
-								items.</font
-							>
-							<font size="-1"
-								>It examines<br />
-								clauses such as -</font
-							>
+							This section examines the entries the vertical and horizontal placement of print items. It
+							examines<br />
+							clauses such as -
 							<code class="language-cobol">LINE NUMBER</code>,
 							<code class="language-cobol">COLUMN NUMBER</code>,
 							<code class="language-cobol">GROUP INDICATE</code>,
@@ -188,41 +190,33 @@
 						</li>
 						<li>
 							<a href="#part5">Special Report Writer registers</a><br />
-							<font size="-1"
-								>In this section the <code class="language-cobol">LINE-COUNTER</code> and
-								<code class="language-cobol">PAGE-COUNTER</code> registers are examined.</font
-							>
+							In this section the <code class="language-cobol">LINE-COUNTER</code> and
+							<code class="language-cobol">PAGE-COUNTER</code> registers are examined.
 						</li>
 						<li>
 							<a href="#part6">The Procedure Division Verbs</a><br />
-							<font size="-1"
-								>This section introduces the <code class="language-cobol">INITIATE</code>,
-								<code class="language-cobol">GENERATE</code> and
-								<code class="language-cobol">TERMINATE</code> verbs.</font
-							>
+							This section introduces the <code class="language-cobol">INITIATE</code>,
+							<code class="language-cobol">GENERATE</code> and
+							<code class="language-cobol">TERMINATE</code> verbs.
 						</li>
 						<li>
 							<a href="#part7">Report Writer Declaratives</a><br />
-							<font size="-1"
-								>In this section elements of the Declaratives, such as
-								<code class="language-cobol">USE BEFORE REPORTING</code>,
-								<code class="language-cobol">SUPPRESS PRINTING</code> and<br />
-								control break registers, are examined.</font
-							>
+							In this section elements of the Declaratives, such as
+							<code class="language-cobol">USE BEFORE REPORTING</code>,
+							<code class="language-cobol">SUPPRESS PRINTING</code> and<br />
+							control break registers, are examined.
 						</li>
 					</ul>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="intro">
-						<font color="#FFFF00"><font face="Arial, Helvetica, sans-serif">Introduction</font></font>
-					</h2>
+					<h2 align="center" id="intro">Introduction</h2>
 				</td>
 			</tr>
 			<tr>
 				<td bgcolor="#FFFFCC" valign="top" width="160">
-					<h4><font color="#993300" face="Arial, Helvetica, sans-serif">Aims</font></h4>
+					<h4>Aims</h4>
 				</td>
 				<td width="540">
 					<p>
@@ -234,7 +228,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Objectives</font></h4>
+					<h4>Objectives</h4>
 				</td>
 				<td width="540">
 					<p>By the end of this unit you should -</p>
@@ -257,7 +251,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font></h4>
+					<h4>Prerequisites</h4>
 				</td>
 				<td width="525">
 					<p>You should be familiar with the material covered in the units;</p>
@@ -282,22 +276,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part1">
-						<font color="#FFFF00"
-							><font face="Arial, Helvetica, sans-serif"
-								>Defining the Report - Report File entries</font
-							></font
-						>
-					</h2>
+					<h2 align="center" id="part1">Defining the Report - Report File entries</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							><code class="language-cobol">ENVIRONMENT DIVISION</code> entries</font
-						>
-					</h4>
+					<h4><code class="language-cobol">ENVIRONMENT DIVISION</code> entries</h4>
 				</td>
 				<td valign="top" width="540">
 					<p>
@@ -312,10 +296,7 @@
 						For instance, in the program fragment below, the Select and Assign for the final example program
 						(given in the previous Report Writer unit) is shown.
 					</p>
-					<p>
-						When the Report Writer generates this report it will be stored in the file
-						<font size="-1">SALESREPORT.LPT</font>.
-					</p>
+					<p>When the Report Writer generates this report it will be stored in the file SALESREPORT.LPT.</p>
 					<table background="Resources/pics/code.gif" border="1" width="100%">
 						<tr>
 							<td>
@@ -360,9 +341,7 @@ RD  SalesReport
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">File Section entries</font>
-					</h4>
+					<h4 align="left">File Section entries</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -393,16 +372,12 @@ RD  SalesReport
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top">
-					<h2 align="center" id="part2">
-						<font color="#FFFF00" face="Arial, Helvetica, sans-serif"
-							>Defining the Report - Report Description (RD) Entries</font
-						>
-					</h2>
+					<h2 align="center" id="part2">Defining the Report - Report Description (RD) Entries</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font></h4>
+					<h4>Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -426,11 +401,7 @@ RD  SalesReport
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>The Report Description (RD) entries - Syntax</font
-						>
-					</h4>
+					<h4 align="left">The Report Description (RD) entries - Syntax</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>The syntax for the Report Description (RD) entries is shown below -</p>
@@ -440,11 +411,7 @@ RD  SalesReport
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>The Report Description (RD) entries - Semantics</font
-						>
-					</h4>
+					<h4 align="left">The Report Description (RD) entries - Semantics</h4>
 				</td>
 				<td valign="top" width="525">
 					<p align="center"><b>RD Rules</b></p>
@@ -510,19 +477,12 @@ RD  SalesReport
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top">
-					<h2 align="center" id="part3">
-						<font color="#FFFF00" face="Arial, Helvetica, sans-serif"></font>
-						<font color="#FFFF00"
-							><font face="Arial, Helvetica, sans-serif"
-								>Defining the Report - Report Group entries</font
-							></font
-						>
-					</h2>
+					<h2 align="center" id="part3">Defining the Report - Report Group entries</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font></h4>
+					<h4>Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -539,15 +499,11 @@ RD  SalesReport
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Defining a Report Group Record - Syntax</font
-						>
-					</h4>
+					<h4 align="left">Defining a Report Group Record - Syntax</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
-						<b><font size="+1">Report Group Definition</font></b>
+						<b>Report Group Definition</b>
 					</p>
 					<p><img height="512" src="Resources/pics/rwGroupType.gif" width="405" /></p>
 					<hr />
@@ -555,9 +511,7 @@ RD  SalesReport
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"><i>ReportGroupName</i> Rules</font>
-					</h4>
+					<h4 align="left"><i>ReportGroupName</i> Rules</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>The <i>ReportGroupName</i> is required only when the group -</p>
@@ -578,9 +532,7 @@ RD  SalesReport
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">The LINE NUMBER clause</font>
-					</h4>
+					<h4 align="left">The LINE NUMBER clause</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -627,9 +579,7 @@ RD  SalesReport
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">The NEXT GROUP clause</font>
-					</h4>
+					<h4 align="left">The NEXT GROUP clause</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -665,9 +615,7 @@ RD  SalesReport
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">The TYPE clause</font>
-					</h4>
+					<h4 align="left">The TYPE clause</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -678,8 +626,8 @@ RD  SalesReport
 					</p>
 					<p><b>Rules</b></p>
 					<p>
-						Most groups are defined once for each report but control groups (other than
-						<font size="-1">CONTROL ..FINAL</font> groups) are defined for each control break item.
+						Most groups are defined once for each report but control groups (other than CONTROL ..FINAL
+						groups) are defined for each control break item.
 					</p>
 					<p>
 						In <code class="language-cobol">REPORT FOOTING</code>, and
@@ -713,21 +661,12 @@ RD  SalesReport
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top">
-					<h2 align="center" id="part4">
-						<font color="#FFFF00" face="Arial, Helvetica, sans-serif"></font>
-						<font color="#FFFF00"
-							><font face="Arial, Helvetica, sans-serif"
-								>Defining the Report - Lines and Columns</font
-							></font
-						>
-					</h2>
+					<h2 align="center" id="part4">Defining the Report - Lines and Columns</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4 align="left">Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -741,9 +680,7 @@ RD  SalesReport
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Defining Report Lines</font>
-					</h4>
+					<h4 align="left">Defining Report Lines</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -759,11 +696,7 @@ RD  SalesReport
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="center">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Defining Elementary print items in a report group</font
-						>
-					</h4>
+					<h4 align="center">Defining Elementary print items in a report group</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -788,9 +721,7 @@ RD  SalesReport
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">The COLUMN NUMBER clause</font>
-					</h4>
+					<h4 align="left">The COLUMN NUMBER clause</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -808,9 +739,7 @@ RD  SalesReport
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">The GROUP INDICATE clause</font>
-					</h4>
+					<h4>The GROUP INDICATE clause</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -844,9 +773,7 @@ RD  SalesReport
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">The SOURCE clause</font>
-					</h4>
+					<h4>The SOURCE clause</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -860,7 +787,7 @@ RD  SalesReport
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">The SUM clause</font></h4>
+					<h4>The SUM clause</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -962,9 +889,7 @@ RD  SalesReport
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">The RESET ON clause</font>
-					</h4>
+					<h4>The RESET ON clause</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -976,23 +901,19 @@ RD  SalesReport
 					<ol>
 						<li>
 							The <i>ControlBreakItem#$i</i> must be one of the data items mentioned in the
-							<font size="-1">CONTROL/CONTROLS</font> clause in the Report Description.
+							CONTROL/CONTROLS clause in the Report Description.
 						</li>
 					</ol>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part5">
-						<font color="#FFFF00"
-							><font face="Arial, Helvetica, sans-serif">Special Report Writer registers</font></font
-						>
-					</h2>
+					<h2 align="center" id="part5">Special Report Writer registers</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font></h4>
+					<h4>Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -1010,9 +931,7 @@ RD  SalesReport
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">The LINE-COUNTER register</font>
-					</h4>
+					<h4>The LINE-COUNTER register</h4>
 				</td>
 				<td valign="top" width="525">
 					<p align="left">
@@ -1039,9 +958,7 @@ RD  SalesReport
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">The PAGE-COUNTER register</font>
-					</h4>
+					<h4>The PAGE-COUNTER register</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -1077,12 +994,12 @@ RD  SalesReport
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part6"><font color="#FFFF00">Procedure Division verbs</font></h2>
+					<h2 align="center" id="part6">Procedure Division verbs</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font></h4>
+					<h4>Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -1112,7 +1029,7 @@ RD  SalesReport
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Syntax</font></h4>
+					<h4>Syntax</h4>
 				</td>
 				<td valign="top" width="525">
 					<p><img height="144" src="Resources/pics/rwVerbs.gif" width="238" /></p>
@@ -1121,7 +1038,7 @@ RD  SalesReport
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">INITIATE</font></h4>
+					<h4>INITIATE</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1148,7 +1065,7 @@ RD  SalesReport
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">GENERATE</font></h4>
+					<h4>GENERATE</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1253,7 +1170,7 @@ Programmer - Michael Coughlan               Page :  1
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">TERMINATE</font></h4>
+					<h4>TERMINATE</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1272,14 +1189,12 @@ Programmer - Michael Coughlan               Page :  1
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top">
-					<h2 align="center" id="part7">
-						<font color="#FFFF00" face="Arial, Helvetica, sans-serif">Report Writer Declaratives</font>
-					</h2>
+					<h2 align="center" id="part7">Report Writer Declaratives</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font></h4>
+					<h4>Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1304,11 +1219,7 @@ Programmer - Michael Coughlan               Page :  1
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Using Declaratives with the Report Writer</font
-						>
-					</h4>
+					<h4>Using Declaratives with the Report Writer</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>When Declaratives are used they must appear as the first item in the Procedure Division.</p>
@@ -1332,9 +1243,7 @@ Programmer - Michael Coughlan               Page :  1
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Declaratives Example</font>
-					</h4>
+					<h4>Declaratives Example</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -1367,9 +1276,7 @@ Begin.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">The SUPPRESS PRINTING statement</font>
-					</h4>
+					<h4>The SUPPRESS PRINTING statement</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1408,9 +1315,7 @@ END DECLARATIVES.</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Control Break Registers</font>
-					</h4>
+					<h4>Control Break Registers</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -1452,15 +1357,12 @@ END DECLARATIVES.</code></pre>
 						<h3 align="center">Copyright Notice</h3>
 						<p align="left">These COBOL course materials are the copyright property of Michael Coughlan.</p>
 						<p align="left">
-							<font size="2"
-								>All rights reserved. No part of these course materials may be reproduced in any form or
-								by any means - graphic, electronic, mechanical, photocopying, printing, recording,
-								taping or stored in an information storage and retrieval system - without the written
-								permission of</font
-							>
-							<font size="2">the author.</font>
+							All rights reserved. No part of these course materials may be reproduced in any form or by
+							any means - graphic, electronic, mechanical, photocopying, printing, recording, taping or
+							stored in an information storage and retrieval system - without the written permission of
+							the author.
 						</p>
-						<p align="center"><font size="2">(c) Michael Coughlan</font></p>
+						<p align="center">(c) Michael Coughlan</p>
 					</div>
 				</td>
 			</tr>

--- a/course/Search.html
+++ b/course/Search.html
@@ -134,10 +134,23 @@
 			ul.toc > li {
 				padding-left: 0.4em;
 				margin-bottom: 0.6em;
+				font-size: smaller;
 			}
 
 			ul.toc a {
 				font-weight: bold;
+				font-size: larger;
+			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			td[bgcolor="#FFFFCC"] h3,
+			td[bgcolor="#FFFFCC"] h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
 			}
 		</style>
 	</head>
@@ -154,45 +167,34 @@
 					<ul class="toc">
 						<li>
 							<a href="#intro">Introduction</a><br />
-							<font size="-1">Unit aims, objectives, prerequisites.</font>
+							Unit aims, objectives, prerequisites.
 						</li>
 						<li>
 							<a href="#part1">OCCURS clause extensions</a><br />
-							<font size="-1"
-								>The <code class="language-cobol">SEARCH</code> and
-								<code class="language-cobol">SEARCH ALL</code> require that the description of the table
-								to be searched contain a number of new extensions to the
-								<code class="language-cobol">OCCURS</code> clause. In this section the syntax of these
-								new extensions is introduced</font
-							>
+							The <code class="language-cobol">SEARCH</code> and
+							<code class="language-cobol">SEARCH ALL</code> require that the description of the table to
+							be searched contain a number of new extensions to the
+							<code class="language-cobol">OCCURS</code> clause. In this section the syntax of these new
+							extensions is introduced
 						</li>
 						<li>
 							<a href="#part2">The SEARCH verb</a><br />
-							<font size="-1"
-								>This section demonstrates how the <code class="language-cobol">SEARCH</code> verb may
-								be used to search through a table sequentially.</font
-							>
+							This section demonstrates how the <code class="language-cobol">SEARCH</code> verb may be
+							used to search through a table sequentially.
 						</li>
 						<li>
 							<a href="#part3">Searching multi-dimension tables</a><br />
-							<font size="-1"
-								>The <code class="language-cobol">SEARCH</code> cannot be applied directly to search a
-								multi-dimension table. This section demonstrates how to overcome this restriction by
-								treating the multi-dimension table as a collection of single dimension tables and
-								applying the <code class="language-cobol">SEARCH</code> to each single dimension
-								table.</font
-							>
-							<font size="-1">.</font>
+							The <code class="language-cobol">SEARCH</code> cannot be applied directly to search a
+							multi-dimension table. This section demonstrates how to overcome this restriction by
+							treating the multi-dimension table as a collection of single dimension tables and applying
+							the <code class="language-cobol">SEARCH</code> to each single dimension table.
 						</li>
 						<li>
 							<a href="#part4">The SEARCH ALL verb</a><br />
-							<font size="-1"
-								>The <code class="language-cobol">SEARCH ALL</code> is used when a binary search is
-								required. This section introduces the syntax of the
-								<code class="language-cobol">SEARCH ALL</code>, demonstrates how a binary search works
-								and shows how the <code class="language-cobol">SEARCH ALL</code> can be used to search
-								an ordered table.</font
-							>
+							The <code class="language-cobol">SEARCH ALL</code> is used when a binary search is required.
+							This section introduces the syntax of the <code class="language-cobol">SEARCH ALL</code>,
+							demonstrates how a binary search works and shows how the
+							<code class="language-cobol">SEARCH ALL</code> can be used to search an ordered table.
 						</li>
 					</ul>
 					<hr />
@@ -200,18 +202,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top">
-					<h2 align="center" id="intro">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Introduction</font>
-						</font>
-					</h2>
+					<h2 align="center" id="intro">Introduction</h2>
 				</td>
 			</tr>
 			<tr>
 				<td bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#993300" face="Arial, Helvetica, sans-serif">Aims</font>
-					</h4>
+					<h4>Aims</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -245,9 +241,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Objectives</font>
-					</h4>
+					<h4>Objectives</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>By the end of this unit you should -</p>
@@ -274,9 +268,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font>
-					</h4>
+					<h4>Prerequisites</h4>
 				</td>
 				<td valign="top" width="525">
 					<ul>
@@ -308,18 +300,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top">
-					<h2 align="center" id="part1">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Occurs clause extensions</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part1">Occurs clause extensions</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4>Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<p align="left">
@@ -340,9 +326,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Full OCCURS clause syntax</font>
-					</h4>
+					<h4>Full OCCURS clause syntax</h4>
 				</td>
 				<td valign="top" width="525">
 					<p align="left"><img height="122" src="Resources/pics/Search1.gif" width="331" /></p>
@@ -350,9 +334,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">INDEXED BY phrase - notes</font>
-					</h4>
+					<h4>INDEXED BY phrase - notes</h4>
 				</td>
 				<td valign="top" width="525">
 					<p align="left">
@@ -394,9 +376,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">KEY IS phrase - notes</font>
-					</h4>
+					<h4>KEY IS phrase - notes</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -428,18 +408,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top">
-					<h2 align="center" id="part2">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">The SEARCH verb</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part2">The SEARCH verb</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4>Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -451,9 +425,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">SEARCH syntax</font>
-					</h4>
+					<h4>SEARCH syntax</h4>
 				</td>
 				<td valign="top" width="525">
 					<p><img height="152" src="Resources/pics/Search2.gif" width="374" /></p>
@@ -519,9 +491,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">The SET verb syntax</font>
-					</h4>
+					<h4>The SET verb syntax</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -549,9 +519,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">SEARCH example 1</font>
-					</h4>
+					<h4>SEARCH example 1</h4>
 					<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
 				</td>
 				<td valign="top" width="525">
@@ -630,9 +598,7 @@ Begin.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Example program 2</font>
-					</h4>
+					<h4>Example program 2</h4>
 					<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
 				</td>
 				<td valign="top" width="525">
@@ -774,18 +740,12 @@ DisplayCountyTaxes.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top">
-					<h2 align="center" id="part3">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Searching multi-dimension tables</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part3">Searching multi-dimension tables</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4>Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<p align="left">
@@ -918,11 +878,7 @@ LoadTable.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>The Race Results Example program</font
-						>
-					</h4>
+					<h4>The Race Results Example program</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1067,18 +1023,12 @@ END-SEARCH</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top">
-					<h2 align="center" id="part4">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">The SEARCH ALL verb</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part4">The SEARCH ALL verb</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4 align="left">Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1094,9 +1044,7 @@ END-SEARCH</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">SEARCH ALL syntax</font>
-					</h4>
+					<h4>SEARCH ALL syntax</h4>
 				</td>
 				<td valign="top" width="525">
 					<p align="left"><img height="302" src="Resources/pics/Search3.gif" width="492" /></p>
@@ -1145,9 +1093,7 @@ END-SEARCH</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">How a binary search works</font>
-					</h4>
+					<h4>How a binary search works</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1266,9 +1212,7 @@ Begin.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Example program</font>
-					</h4>
+					<h4>Example program</h4>
 					<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
 				</td>
 				<td valign="top" width="525">
@@ -1402,17 +1346,12 @@ DisplayCountyTaxes.
 							These COBOL course materials are the copyright property of Michael Coughlan.
 						</p>
 						<p align="left">
-							<font size="2"
-								>All rights reserved. No part of these course materials may be reproduced in any form or
-								by any means - graphic, electronic, mechanical, photocopying, printing, recording,
-								taping or stored in an information storage and retrieval system - without the written
-								permission of</font
-							>
-							<font size="2">the author.</font>
+							All rights reserved. No part of these course materials may be reproduced in any form or by
+							any means - graphic, electronic, mechanical, photocopying, printing, recording, taping or
+							stored in an information storage and retrieval system - without the written permission of
+							the author.
 						</p>
-						<p align="center">
-							<font size="2">(c) Michael Coughlan</font>
-						</p>
+						<p align="center">(c) Michael Coughlan</p>
 					</div>
 				</td>
 			</tr>

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -128,10 +128,23 @@
 			ul.toc > li {
 				padding-left: 0.4em;
 				margin-bottom: 0.6em;
+				font-size: smaller;
 			}
 
 			ul.toc a {
 				font-weight: bold;
+				font-size: larger;
+			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			td[bgcolor="#FFFFCC"] h3,
+			td[bgcolor="#FFFFCC"] h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
 			}
 		</style>
 	</head>
@@ -148,30 +161,26 @@
 					<ul class="toc">
 						<li>
 							<a href="#intro">Introduction</a><br />
-							<font size="-1">Unit aims, objectives, prerequisites.</font>
+							Unit aims, objectives, prerequisites.
 						</li>
 						<li>
 							<a href="#part1">Selection using IF</a><br />
-							<font size="-1"
-								>This section demonstrates selection using the IF statement. It introduces Relation
-								Conditions, Class Condition, Sign Condition and Complex Conditions. It also covers
-								Implied Subjects and Nested IFs.</font
-							>
+							This section demonstrates selection using the IF statement. It introduces Relation
+							Conditions, Class Condition, Sign Condition and Complex Conditions. It also covers Implied
+							Subjects and Nested IFs.
 						</li>
 						<li>
 							<a href="#part2">Condition Names</a><br />
-							<font size="-1">In this section the concept of a Condition Name is explained.</font>
+							In this section the concept of a Condition Name is explained.
 						</li>
 						<li>
 							<a href="#part3">Using the SET verb with Condition Names</a><br />
-							<font size="-1"
-								>This section demonstrates how the <code class="language-cobol">SET</code> verb may be
-								used to set a Condition Name to true.</font
-							>
+							This section demonstrates how the <code class="language-cobol">SET</code> verb may be used
+							to set a Condition Name to true.
 						</li>
 						<li>
 							<a href="#part4">The EVALUATE verb</a><br />
-							<font size="-1">In this section COBOL's version of Case/Switch is introduced.</font>
+							In this section COBOL's version of Case/Switch is introduced.
 						</li>
 					</ul>
 					<hr />
@@ -179,25 +188,18 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="intro">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Introduction</font>
-						</font>
-					</h2>
+					<h2 align="center" id="intro">Introduction</h2>
 				</td>
 			</tr>
 			<tr>
 				<td bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#993300" face="Arial, Helvetica, sans-serif">Aims</font>
-					</h4>
+					<h4>Aims</h4>
 				</td>
 				<td width="540">
 					<p>
-						In most procedural languages, <font size="-1"></font>If <font size="-1"></font>and Case/Switch
-						are the only selection constructs supported. COBOL supports advanced versions of both of these
-						constructs, but it also introduces the concept of Condition Names - a kind of abstract
-						condition.
+						In most procedural languages, If and Case/Switch are the only selection constructs supported.
+						COBOL supports advanced versions of both of these constructs, but it also introduces the concept
+						of Condition Names - a kind of abstract condition.
 					</p>
 					<p>
 						In this tutorial we will examine COBOL's selection constructs, the
@@ -209,9 +211,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Objectives</font>
-					</h4>
+					<h4>Objectives</h4>
 				</td>
 				<td valign="top" width="540">
 					<p>By the end of this unit you should -</p>
@@ -239,9 +239,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="77" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font>
-					</h4>
+					<h4>Prerequisites</h4>
 				</td>
 				<td height="77" valign="top" width="525">
 					<ul>
@@ -265,18 +263,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part1">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Selection using IF</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part1">Selection using IF</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4>Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -298,9 +290,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">IF syntax</font>
-					</h4>
+					<h4>IF syntax</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -323,9 +313,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Using the END-IF delimiter</font>
-					</h4>
+					<h4>Using the END-IF delimiter</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -380,9 +368,7 @@ Statement6.</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Condition Types</font>
-					</h4>
+					<h4>Condition Types</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -395,7 +381,7 @@ Statement6.</code></pre>
 							<th valign="top">
 								<div align="center">
 									<b>
-										<font color="#FF0000">Condition Types</font>
+										<span style="color: #ff0000">Condition Types</span>
 									</b>
 								</div>
 							</th>
@@ -425,9 +411,7 @@ Statement6.</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Relation Conditions</font>
-					</h4>
+					<h4>Relation Conditions</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -464,30 +448,21 @@ Statement6.</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Class Conditions</font>
-					</h4>
+					<h4>Class Conditions</h4>
 					<aside>
 						<p align="center">
 							<img height="44" src="Resources/pics/i-LightBulbTip.gif" width="42" />
 						</p>
 						<p align="left">
-							<font size="-1"
-								>Although this course will not cover the <font size="-2">SPECIAL-NAMES</font> paragraph
-								in detail it is useful to acquaint yourself with its clauses.</font
-							>
+							Although this course will not cover the SPECIAL-NAMES paragraph in detail it is useful to
+							acquaint yourself with its clauses.
 						</p>
 						<p align="left">
-							<font size="-1"
-								>As well as setting up a class name, the <font size="-2">SPECIAL-NAMES</font> paragraph
-								allows you to do such things as;<br
-							/></font>
-							<font size="-1"
-								>Specify the collating sequence - e.g. <font size="-2">ASCII</font> or
-								<font size="-2">EBCDIC</font><br />
-								Specify the currency sign<br />
-								Create User Defined Figurative constants.
-							</font>
+							As well as setting up a class name, the SPECIAL-NAMES paragraph allows you to do such things
+							as;<br />
+							Specify the collating sequence - e.g. ASCII or EBCDIC<br />
+							Specify the currency sign<br />
+							Create User Defined Figurative constants.
 						</p>
 					</aside>
 				</td>
@@ -498,8 +473,8 @@ Statement6.</code></pre>
 						classes, such as numeric or alphanumeric. A Class Condition may be used to determine whether the
 						value of data-item is a member of one these classes. For instance, a
 						<code class="language-cobol">NUMERIC</code> Class Condition might be used on an alphanumeric
-						(<font size="-1">PIC X</font>) or a numeric (<code class="language-cobol">PIC 9</code>)
-						data-item to see if it contained numeric data.
+						(PIC X) or a numeric (<code class="language-cobol">PIC 9</code>) data-item to see if it
+						contained numeric data.
 					</p>
 					<p>
 						The UserDefinedClassName is name that a programmer can assign to a set of characters. The
@@ -535,9 +510,7 @@ END-IF
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Sign Condition</font>
-					</h4>
+					<h4 align="left">Sign Condition</h4>
 				</td>
 				<td valign="top" width="525">
 					<p><img height="76" src="Resources/pics/Select4.gif" width="313" /></p>
@@ -550,25 +523,21 @@ END-IF
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Complex Conditions</font>
-					</h4>
+					<h4 align="left">Complex Conditions</h4>
 					<aside>
 						<p align="center">
 							<img height="44" src="Resources/pics/i-LightBulbTip.gif" width="42" />
 						</p>
 						<p align="left">
-							<font size="-1"
-								>You can see from the <code class="language-cobol">IF Amnt1</code> example, that
-								figuring out how a complex condition will be evaluated is not straightfoward.<br
-							/></font>
-							<font size="-1">Always use brackets to make the order of evaluation explicit.</font>
+							You can see from the <code class="language-cobol">IF Amnt1</code> example, that figuring out
+							how a complex condition will be evaluated is not straightfoward.<br />
+							Always use brackets to make the order of evaluation explicit.
 						</p>
 					</aside>
 				</td>
 				<td valign="top" width="525">
 					<p>
-						<font size="-1"><img height="52" src="Resources/pics/Select5.gif" width="228" /></font>
+						<img height="52" src="Resources/pics/Select5.gif" width="228" />
 					</p>
 					<p>
 						Complex Conditions are formed by combining two or more simple conditions using the conjunction
@@ -584,17 +553,17 @@ END-IF
 						<tr bgcolor="#FFFFCC">
 							<th valign="top" width="23%">
 								<p align="center">
-									<font color="#FF0000"><b>Precedence</b></font>
+									<span style="color: #ff0000"><b>Precedence</b></span>
 								</p>
 							</th>
 							<th valign="top" width="35%">
 								<p align="center">
-									<font color="#FF0000"><b>Condition Value</b></font>
+									<span style="color: #ff0000"><b>Condition Value</b></span>
 								</p>
 							</th>
 							<th valign="top" width="42%">
 								<p align="center">
-									<font color="#FF0000"><b>Arithmetic Equivalent</b></font>
+									<span style="color: #ff0000"><b>Arithmetic Equivalent</b></span>
 								</p>
 							</th>
 						</tr>
@@ -673,9 +642,7 @@ END-IF
 					<table align="center" border="1" width="94%">
 						<tr>
 							<th scope="row" bgcolor="#FFFFCC" width="16%">
-								<p align="center">
-									<font size="-1">Condition</font>
-								</p>
+								<p align="center">Condition</p>
 							</th>
 							<td bgcolor="#E1FFE1" width="84%">
 								<p align="center">
@@ -687,9 +654,7 @@ END-IF
 						</tr>
 						<tr>
 							<th scope="row" bgcolor="#FFFFCC" width="16%">
-								<p align="center">
-									<font size="-1">Expressed as</font>
-								</p>
+								<p align="center">Expressed as</p>
 							</th>
 							<td bgcolor="#E1FFE1" width="84%">
 								<pre
@@ -699,9 +664,7 @@ END-IF
 						</tr>
 						<tr>
 							<th scope="row" bgcolor="#FFFFCC" height="17" width="16%">
-								<div align="center">
-									<font size="-1">Evaluates to</font>
-								</div>
+								<div align="center">Evaluates to</div>
 							</th>
 							<td bgcolor="#E1FFE1" height="17" width="84%">
 								<pre
@@ -711,9 +674,7 @@ END-IF
 						</tr>
 						<tr>
 							<th scope="row" bgcolor="#FFFFCC" width="16%">
-								<div align="center">
-									<font size="-1">Evaluates to</font>
-								</div>
+								<div align="center">Evaluates to</div>
 							</th>
 							<td bgcolor="#E1FFE1" width="84%">
 								<pre
@@ -729,9 +690,7 @@ END-IF
 					<table align="center" border="1" width="93%">
 						<tr>
 							<th scope="row" bgcolor="#FFFFCC" width="16%">
-								<p align="center">
-									<font size="-1">Condition</font>
-								</p>
+								<p align="center">Condition</p>
 							</th>
 							<td bgcolor="#E1FFE1" width="84%">
 								<p align="center">
@@ -743,9 +702,7 @@ END-IF
 						</tr>
 						<tr>
 							<th scope="row" bgcolor="#FFFFCC" width="16%">
-								<p align="center">
-									<font size="-1">Expressed as</font>
-								</p>
+								<p align="center">Expressed as</p>
 							</th>
 							<td bgcolor="#E1FFE1" width="84%">
 								<pre
@@ -755,9 +712,7 @@ END-IF
 						</tr>
 						<tr>
 							<th scope="row" bgcolor="#FFFFCC" height="17" width="16%">
-								<div align="center">
-									<font size="-1">Evaluates to</font>
-								</div>
+								<div align="center">Evaluates to</div>
 							</th>
 							<td bgcolor="#E1FFE1" height="17" width="84%">
 								<pre
@@ -767,9 +722,7 @@ END-IF
 						</tr>
 						<tr>
 							<th scope="row" bgcolor="#FFFFCC" width="16%">
-								<div align="center">
-									<font size="-1">Evaluates to</font>
-								</div>
+								<div align="center">Evaluates to</div>
 							</th>
 							<td bgcolor="#E1FFE1" width="84%">
 								<pre
@@ -779,9 +732,7 @@ END-IF
 						</tr>
 						<tr>
 							<th scope="row" bgcolor="#FFFFCC" width="16%">
-								<div align="center">
-									<font size="-1">Evaluates to</font>
-								</div>
+								<div align="center">Evaluates to</div>
 							</th>
 							<td bgcolor="#E1FFE1" width="84%">
 								<pre
@@ -806,9 +757,7 @@ END-IF
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Implied Subjects</font>
-					</h4>
+					<h4 align="left">Implied Subjects</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -857,9 +806,7 @@ END-IF
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Nested Ifs</font>
-					</h4>
+					<h4 align="left">Nested Ifs</h4>
 					<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" /></p>
 				</td>
 				<td valign="top" width="525">
@@ -877,40 +824,39 @@ END-IF
 END-IF 
 </code></pre>
 					<p>
-						The table below contains representations of the variables used in the nested
-						<font size="-1">Ifs</font> above. In each instance, see if you can figure out which of the
-						messages will be displayed. To see the answer, move your cursor over the text "Answer" and the
-						correct answer should be shown.
+						The table below contains representations of the variables used in the nested Ifs above. In each
+						instance, see if you can figure out which of the messages will be displayed. To see the answer,
+						move your cursor over the text "Answer" and the correct answer should be shown.
 					</p>
 					<form action="Selection.html" method="post">
 						<table align="center" bgcolor="#E1FFE1" border="1" width="50%">
 							<tr bgcolor="#FFFFCC">
 								<th width="13%">
 									<div align="center">
-										<font color="#FF0000"><b>VarA</b></font>
+										<span style="color: #ff0000"><b>VarA</b></span>
 									</div>
 								</th>
 								<th width="13%">
 									<div align="center">
-										<font color="#FF0000"><b>VarB</b></font>
+										<span style="color: #ff0000"><b>VarB</b></span>
 									</div>
 								</th>
 								<th width="13%">
 									<div align="center">
-										<font color="#FF0000"><b>VarC</b></font>
+										<span style="color: #ff0000"><b>VarC</b></span>
 									</div>
 								</th>
 								<th width="12%">
 									<div align="center">
-										<font color="#FF0000"><b>VarG</b></font>
+										<span style="color: #ff0000"><b>VarG</b></span>
 									</div>
 								</th>
 								<th bgcolor="#FFFFCC" width="49%">
 									<div align="center">
-										<font color="#FF0000"
+										<span style="color: #ff0000"
 											><b>
 												<code class="language-cobol">DISPLAY</code>
-											</b></font
+											</b></span
 										>
 									</div>
 								</th>
@@ -1021,18 +967,12 @@ END-IF
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part2">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Condition Names</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part2">Condition Names</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="355" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4 align="left">Introduction</h4>
 				</td>
 				<td height="355" valign="top" width="525">
 					<p>
@@ -1055,9 +995,7 @@ END-IF
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Condition Name Syntax</font>
-					</h4>
+					<h4 align="left">Condition Name Syntax</h4>
 				</td>
 				<td valign="top" width="525">
 					<p align="left"><img height="76" src="Resources/pics/Select6.gif" width="501" /></p>
@@ -1134,9 +1072,7 @@ END-IF
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Condition Names examples</font>
-					</h4>
+					<h4 align="left">Condition Names examples</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1158,9 +1094,7 @@ END-IF
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="355" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Using Condition Names correctly</font>
-					</h4>
+					<h4 align="left">Using Condition Names correctly</h4>
 				</td>
 				<td height="355" valign="top" width="525">
 					<p>
@@ -1236,18 +1170,12 @@ END-IF
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part3">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Using the SET verb with Condition Names</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part3">Using the SET verb with Condition Names</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="188" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4 align="left">Introduction</h4>
 				</td>
 				<td height="188" valign="top" width="525">
 					<p>
@@ -1264,9 +1192,7 @@ END-IF
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="355" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">SET syntax</font>
-					</h4>
+					<h4 align="left">SET syntax</h4>
 				</td>
 				<td height="355" valign="top" width="525">
 					<p>SET {ConditionName} ... TO TRUE</p>
@@ -1292,9 +1218,7 @@ END-IF
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="355" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">SET verb example</font>
-					</h4>
+					<h4 align="left">SET verb example</h4>
 				</td>
 				<td height="355" valign="top" width="525">
 					<p>
@@ -1317,11 +1241,7 @@ END-IF
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="355" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Using the SET verb with Sequential Files
-						</font>
-					</h4>
+					<h4 align="left">Using the SET verb with Sequential Files</h4>
 					<p align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48" /></p>
 				</td>
 				<td height="355" valign="top" width="525">
@@ -1402,18 +1322,12 @@ Begin.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part4">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">The EVALUATE verb</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part4">The EVALUATE verb</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4 align="left">Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1431,14 +1345,12 @@ Begin.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="355" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Evaluate syntax</font>
-					</h4>
+					<h4 align="left">Evaluate syntax</h4>
 				</td>
 				<td height="355" valign="top" width="525">
 					<p><img height="453" src="Resources/pics/Select7.gif" width="523" /></p>
 					<p>
-						<font size="-1"><b>EVALUATE</b></font> <b>notes</b><br />
+						<b>EVALUATE notes</b><br />
 						The items immediately after the word <code class="language-cobol">EVALUATE</code> and before the
 						first <code class="language-cobol">WHEN</code> are called <i>subjects</i>.
 					</p>
@@ -1474,9 +1386,7 @@ Begin.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="355" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">EVALUATE example1</font>
-					</h4>
+					<h4 align="left">EVALUATE example1</h4>
 				</td>
 				<td height="355" valign="top" width="525">
 					<p>
@@ -1553,9 +1463,7 @@ END-EVALUATE
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="355" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">EVALUATE example2</font>
-					</h4>
+					<h4 align="left">EVALUATE example2</h4>
 				</td>
 				<td height="355" valign="top" width="525">
 					<p>
@@ -1910,17 +1818,12 @@ END-EVALUATE
 							These COBOL course materials are the copyright property of Michael Coughlan.
 						</p>
 						<p align="left">
-							<font size="2"
-								>All rights reserved. No part of these course materials may be reproduced in any form or
-								by any means - graphic, electronic, mechanical, photocopying, printing, recording,
-								taping or stored in an information storage and retrieval system - without the written
-								permission of</font
-							>
-							<font size="2">the author.</font>
+							All rights reserved. No part of these course materials may be reproduced in any form or by
+							any means - graphic, electronic, mechanical, photocopying, printing, recording, taping or
+							stored in an information storage and retrieval system - without the written permission of
+							the author.
 						</p>
-						<p align="center">
-							<font size="2">(c) Michael Coughlan</font>
-						</p>
+						<p align="center">(c) Michael Coughlan</p>
 					</div>
 				</td>
 			</tr>

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -128,10 +128,23 @@
 			ul.toc > li {
 				padding-left: 0.4em;
 				margin-bottom: 0.6em;
+				font-size: smaller;
 			}
 
 			ul.toc a {
 				font-weight: bold;
+				font-size: larger;
+			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			td[bgcolor="#FFFFCC"] h3,
+			td[bgcolor="#FFFFCC"] h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
 			}
 		</style>
 	</head>
@@ -148,29 +161,23 @@
 					<ul class="toc">
 						<li>
 							<a href="#intro">Introduction</a><br />
-							<font size="-1">Unit aims, objectives, prerequisites.</font>
+							Unit aims, objectives, prerequisites.
 						</li>
 						<li>
 							<a href="#part1">Introduction to record-based files</a><br />
-							<font size="-1"
-								>This section introduces record-based files, the concept of the record buffer and
-								defines terminology such as file, record and field.</font
-							>
+							This section introduces record-based files, the concept of the record buffer and defines
+							terminology such as file, record and field.
 						</li>
 						<li>
 							<a href="#part2">Declaring records and files</a><br />
-							<font size="-1"
-								>This section demonstrates how the FD entry is used to describe a files record buffer
-								and show how to use the SELECT and ASSIGN clause to connect an internal file name to an
-								external data repository.</font
-							>
+							This section demonstrates how the FD entry is used to describe a files record buffer and
+							show how to use the SELECT and ASSIGN clause to connect an internal file name to an external
+							data repository.
 						</li>
 						<li>
 							<a href="#part3">COBOL file handling verbs</a><br />
-							<font size="-1"
-								>The COBOL verbs for processing Sequential Files are introduced in this section. The
-								section ends with a full example program.</font
-							>
+							The COBOL verbs for processing Sequential Files are introduced in this section. The section
+							ends with a full example program.
 						</li>
 					</ul>
 					<hr />
@@ -178,26 +185,19 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="intro">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Introduction</font>
-						</font>
-					</h2>
+					<h2 align="center" id="intro">Introduction</h2>
 				</td>
 			</tr>
 			<tr>
 				<td bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#993300" face="Arial, Helvetica, sans-serif">Aims</font>
-					</h4>
+					<h4>Aims</h4>
 				</td>
 				<td valign="top" width="540">
 					<div align="center">
 						<p align="left">
 							Files are repositories of data that reside on backing storage (hard disk, magnetic tape or
-							<font size="-1">CD-ROM</font>). Nowadays, files are used to store a variety of different
-							types of information, such as programs, documents, spreadsheets, videos, sounds, pictures
-							and record-based data.
+							CD-ROM). Nowadays, files are used to store a variety of different types of information, such
+							as programs, documents, spreadsheets, videos, sounds, pictures and record-based data.
 						</p>
 						<p align="left">
 							Although COBOL can be used to process these other kinds of data file, it is generally used
@@ -234,9 +234,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Objectives</font>
-					</h4>
+					<h4>Objectives</h4>
 				</td>
 				<td valign="top" width="540">
 					<p>By the end of this unit you should -</p>
@@ -255,9 +253,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="77" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font>
-					</h4>
+					<h4>Prerequisites</h4>
 				</td>
 				<td height="77" valign="top" width="525">
 					<ul>
@@ -283,18 +279,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part1">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Introduction to record-based files</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part1">Introduction to record-based files</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4>Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -313,9 +303,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Files, Records, Fields</font>
-					</h4>
+					<h4>Files, Records, Fields</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -348,9 +336,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Record instance vs Record type</font>
-					</h4>
+					<h4>Record instance vs Record type</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -378,9 +364,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">The record buffer</font>
-					</h4>
+					<h4 align="left">The record buffer</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -411,9 +395,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Some implications of "buffers"</font>
-					</h4>
+					<h4>Some implications of "buffers"</h4>
 					<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
 				</td>
 				<td valign="top" width="525">
@@ -449,25 +431,17 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part2">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Declaring Records and Files</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part2">Declaring Records and Files</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4 align="left">Introduction</h4>
 					<aside>
 						<p align="center">
 							<img height="37" src="Resources/pics/i-Detail.gif" width="30" /><br />
-							<font size="-1"
-								>This is for demonstration only. In reality we would need to include far more items and
-								some of the fields would have to be considerably larger.</font
-							>
+							This is for demonstration only. In reality we would need to include far more items and some
+							of the fields would have to be considerably larger.
 						</p>
 					</aside>
 				</td>
@@ -494,9 +468,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="355" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Creating a record</font>
-					</h4>
+					<h4 align="left">Creating a record</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -568,11 +540,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="355" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Declaring a record buffer in your program
-						</font>
-					</h4>
+					<h4 align="left">Declaring a record buffer in your program</h4>
 					<p align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48" /></p>
 				</td>
 				<td height="355" valign="top" width="525">
@@ -614,9 +582,7 @@ FD StudentFile.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">The SELECT and ASSIGN clause</font>
-					</h4>
+					<h4 align="left">The SELECT and ASSIGN clause</h4>
 					<p align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48" /></p>
 				</td>
 				<td valign="top" width="525">
@@ -627,7 +593,7 @@ FD StudentFile.
 					</p>
 					<p>
 						The internal file name used in a file's <code class="language-cobol">FD</code> entry is
-						connected to an external file (on disk, tape or <font size="-1">CD-ROM</font>) by means of the
+						connected to an external file (on disk, tape or CD-ROM) by means of the
 						<code class="language-cobol">SELECT</code> and
 						<code class="language-cobol">ASSIGN</code> clause. The
 						<code class="language-cobol">SELECT</code> and <code class="language-cobol">ASSIGN</code> clause
@@ -641,7 +607,7 @@ FD StudentFile.
 								<pre class="language-cobol"><code class="language-cobol">ENVIRONMENT DIVISION.
 INPUT-OUTPUT SECTION.
 FILE-CONTROL.
-   SELECT StudentFile 
+   SELECT StudentFile
           ASSIGN TO "STUDENTS.DAT".
 DATA DIVISION.
 FILE SECTION.
@@ -664,27 +630,19 @@ FD StudentFile.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="551" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>SELECT and ASSIGN syntax for Sequential files</font
-						>
-					</h4>
+					<h4>SELECT and ASSIGN syntax for Sequential files</h4>
 					<aside>
 						<p align="center">
 							<img height="37" src="Resources/pics/i-Detail.gif" width="30" /><br />
-							<font size="-1"
-								>The Select and Assign clause has far more entries (even for Sequential files) than
-								those we show here; but we will examine the other entries in later tutorials.</font
-							>
+							The Select and Assign clause has far more entries (even for Sequential files) than those we
+							show here; but we will examine the other entries in later tutorials.
 						</p>
 					</aside>
 					<aside>
 						<p align="center">
 							<img height="37" src="Resources/pics/i-Detail.gif" width="30" /><br />
-							<font size="-1"
-								>We are only going to deal with statically assigned file names for the moment, but it is
-								possible to assign a file name to a file at run-time.</font
-							>
+							We are only going to deal with statically assigned file names for the moment, but it is
+							possible to assign a file name to a file at run-time.
 						</p>
 					</aside>
 				</td>
@@ -719,10 +677,10 @@ FD StudentFile.
 							could associate the StudentFile with an actual file using statements like:
 						</p>
 					</div>
-					<pre class="language-cobol" align="left"><code class="language-cobol">SELECT StudentFile 
+					<pre class="language-cobol" align="left"><code class="language-cobol">SELECT StudentFile
        ASSIGN TO "D:\Cobol\ExampleProgs\Students.Dat"
 
-SELECT StudentFile 
+SELECT StudentFile
        ASSIGN TO "A:\Students.Dat"
 </code></pre>
 					<div align="center">
@@ -732,11 +690,7 @@ SELECT StudentFile
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>What is the purpose of the SELECT and ASSIGN clause?</font
-						>
-					</h4>
+					<h4>What is the purpose of the SELECT and ASSIGN clause?</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -766,18 +720,12 @@ SELECT StudentFile
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part3">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">COBOL file handling verbs</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part3">COBOL file handling verbs</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4 align="left">Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -796,19 +744,15 @@ SELECT StudentFile
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">The OPEN verb</font>
-					</h4>
+					<h4 align="left">The OPEN verb</h4>
 					<aside>
 						<p align="center">
 							<img height="44" src="Resources/pics/i-LightBulbTip.gif" width="42" /><br />
-							<font size="-1"
-								>Although, as you can see from the ellipses in the syntax diagram, it is possible to
-								open a number of files with one OPEN statement it not advisable to do so. If an error is
-								detected on opening a file and you have used only one statement to open all the files,
-								the system probably won't be able to show you which particular file is causing the
-								problem. If you open all the files separately, it will.</font
-							>
+							Although, as you can see from the ellipses in the syntax diagram, it is possible to open a
+							number of files with one OPEN statement it not advisable to do so. If an error is detected
+							on opening a file and you have used only one statement to open all the files, the system
+							probably won't be able to show you which particular file is causing the problem. If you open
+							all the files separately, it will.
 						</p>
 					</aside>
 				</td>
@@ -849,9 +793,7 @@ SELECT StudentFile
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">The CLOSE verb</font>
-					</h4>
+					<h4 align="left">The CLOSE verb</h4>
 				</td>
 				<td valign="top" width="525">
 					<p><u>CLOSE</u> InternalFileName...</p>
@@ -865,9 +807,7 @@ SELECT StudentFile
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="355" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">The READ verb</font>
-					</h4>
+					<h4 align="left">The READ verb</h4>
 				</td>
 				<td height="355" valign="top" width="525">
 					<p><img height="101" src="Resources/pics/FileSeq5.gif" width="288" /></p>
@@ -898,9 +838,7 @@ SELECT StudentFile
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">How the READ works</font>
-					</h4>
+					<h4 align="left">How the READ works</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -935,17 +873,13 @@ SELECT StudentFile
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">The WRITE verb</font>
-					</h4>
+					<h4 align="left">The WRITE verb</h4>
 					<aside>
 						<p align="center">
 							<img height="37" src="Resources/pics/i-Detail.gif" width="30" /><br />
-							<font size="-1"
-								>The <code class="language-cobol">WRITE</code> format actually contains a number of
-								other entries but these relate to writing to print files and will be covered in
-								subsequent tutorials.</font
-							>
+							The <code class="language-cobol">WRITE</code> format actually contains a number of other
+							entries but these relate to writing to print files and will be covered in subsequent
+							tutorials.
 						</p>
 					</aside>
 				</td>
@@ -953,7 +887,7 @@ SELECT StudentFile
 					<p><u>WRITE</u> RecordName [<u>FROM</u> Identifier]</p>
 					<p>
 						The <code class="language-cobol">WRITE</code> verb is used to copy data from the record buffer
-						(RAM) to the file on backing storage (Disk, tape or <font size="-1">CD-ROM</font>).
+						(RAM) to the file on backing storage (Disk, tape or CD-ROM).
 					</p>
 					<p>
 						To <code class="language-cobol">WRITE</code> data to a file we must move the data to the record
@@ -973,9 +907,7 @@ SELECT StudentFile
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Read a file, Write a record</font>
-					</h4>
+					<h4 align="left">Read a file, Write a record</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1003,9 +935,7 @@ SELECT StudentFile
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Example Program</font>
-					</h4>
+					<h4 align="left">Example Program</h4>
 					<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
 				</td>
 				<td valign="top" width="525">
@@ -1026,7 +956,7 @@ AUTHOR.  Michael Coughlan.
 *&gt; using the ACCEPT and the WRITE verbs and then read and
 *&gt; display its records using the READ and DISPLAY.
 *&gt; Note: In this version of COBOL pressing the Carriage Return (CR)
-*&gt; without entering any data results in StudentDetails 
+*&gt; without entering any data results in StudentDetails
 *&gt; being filled with spaces.
 
 ENVIRONMENT DIVISION.
@@ -1102,17 +1032,12 @@ GetStudentRecord.
 							These COBOL course materials are the copyright property of Michael Coughlan.
 						</p>
 						<p align="left">
-							<font size="2"
-								>All rights reserved. No part of these course materials may be reproduced in any form or
-								by any means - graphic, electronic, mechanical, photocopying, printing, recording,
-								taping or stored in an information storage and retrieval system - without the written
-								permission of</font
-							>
-							<font size="2">the author.</font>
+							All rights reserved. No part of these course materials may be reproduced in any form or by
+							any means - graphic, electronic, mechanical, photocopying, printing, recording, taping or
+							stored in an information storage and retrieval system - without the written permission of
+							the author.
 						</p>
-						<p align="center">
-							<font size="2">(c) Michael Coughlan</font>
-						</p>
+						<p align="center">(c) Michael Coughlan</p>
 					</div>
 				</td>
 			</tr>

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -150,10 +150,23 @@
 			ul.toc > li {
 				padding-left: 0.4em;
 				margin-bottom: 0.6em;
+				font-size: smaller;
 			}
 
 			ul.toc a {
 				font-weight: bold;
+				font-size: larger;
+			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			td[bgcolor="#FFFFCC"] h3,
+			td[bgcolor="#FFFFCC"] h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
 			}
 		</style>
 	</head>
@@ -170,30 +183,24 @@
 					<ul class="toc">
 						<li>
 							<a href="#intro">Introduction</a><br />
-							<font size="-1">Unit aims, objectives, prerequisites.</font>
+							Unit aims, objectives, prerequisites.
 						</li>
 						<li>
 							<a href="#part1">Organization and Access</a><br />
-							<font size="-1"
-								>This section introduces the concepts of file organization and access. It describes how
-								Sequential files are organized and introduces the idea of ordered and unordered
-								Sequential files.</font
-							>
+							This section introduces the concepts of file organization and access. It describes how
+							Sequential files are organized and introduces the idea of ordered and unordered Sequential
+							files.
 						</li>
 						<li>
 							<a href="#part2">Processing unordered Sequential files</a><br />
-							<font size="-1"
-								>This section explores the processing restrictions of unordered Sequential files. It
-								demonstrates that, while records can be easily added to unordered files, deleting and
-								updating records is not really feasible.</font
-							>
+							This section explores the processing restrictions of unordered Sequential files. It
+							demonstrates that, while records can be easily added to unordered files, deleting and
+							updating records is not really feasible.
 						</li>
 						<li>
 							<a href="#part3">Processing ordered Sequential files</a><br />
-							<font size="-1"
-								>This section demonstrates how to use a file of batched transactions to insert (add),
-								delete and update records in an ordered Sequential file..</font
-							>
+							This section demonstrates how to use a file of batched transactions to insert (add), delete
+							and update records in an ordered Sequential file..
 						</li>
 					</ul>
 					<hr />
@@ -201,18 +208,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="intro">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Introduction</font>
-						</font>
-					</h2>
+					<h2 align="center" id="intro">Introduction</h2>
 				</td>
 			</tr>
 			<tr>
 				<td bgcolor="#FFFFCC" height="172" valign="top" width="175">
-					<h4>
-						<font color="#993300" face="Arial, Helvetica, sans-serif">Aims</font>
-					</h4>
+					<h4>Aims</h4>
 				</td>
 				<td height="172" valign="top" width="540">
 					<div align="center">
@@ -234,9 +235,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="135" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Objectives</font>
-					</h4>
+					<h4>Objectives</h4>
 				</td>
 				<td height="135" valign="top" width="540">
 					<p>By the end of this unit you should -</p>
@@ -250,9 +249,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="77" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font>
-					</h4>
+					<h4>Prerequisites</h4>
 				</td>
 				<td height="77" valign="top" width="525">
 					<ul>
@@ -279,18 +276,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part1">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Organization and Access</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part1">Organization and Access</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4>Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -329,9 +320,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Sequential Organization</font>
-					</h4>
+					<h4>Sequential Organization</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -355,9 +344,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Ordered and Unordered files</font>
-					</h4>
+					<h4>Ordered and Unordered files</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -415,18 +402,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part2">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Processing unordered Sequential Files</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part2">Processing unordered Sequential Files</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="97" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4 align="left">Introduction</h4>
 				</td>
 				<td height="97" valign="top" width="525">
 					<p>
@@ -442,11 +423,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="157" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Adding records to an unordered Sequential File</font
-						>
-					</h4>
+					<h4 align="left">Adding records to an unordered Sequential File</h4>
 				</td>
 				<td height="157" valign="top" width="525">
 					<p>
@@ -471,19 +448,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="173" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Problems with unordered Sequential files
-						</font>
-					</h4>
+					<h4 align="left">Problems with unordered Sequential files</h4>
 					<aside>
 						<p align="center">
 							<img height="37" src="Resources/pics/i-Detail.gif" width="30" /><br />
-							<font size="-1"
-								>Although it is true that in standard COBOL, Sequential files cannot be deleted or
-								updated "in situ", many vendors, including Microfocus, allow this for disk based
-								files.</font
-							>
+							Although it is true that in standard COBOL, Sequential files cannot be deleted or updated
+							"in situ", many vendors, including Microfocus, allow this for disk based files.
 						</p>
 					</aside>
 				</td>
@@ -504,9 +474,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="433" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Record matching</font>
-					</h4>
+					<h4 align="left">Record matching</h4>
 				</td>
 				<td height="433" valign="top" width="525">
 					<p>
@@ -539,11 +507,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="177" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Attempting to batch delete records in an unordered file.</font
-						>
-					</h4>
+					<h4>Attempting to batch delete records in an unordered file.</h4>
 				</td>
 				<td height="177" valign="top" width="525">
 					<div align="center">
@@ -582,18 +546,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part3">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Processing Ordered Sequential Files</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part3">Processing Ordered Sequential Files</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4 align="left">Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -607,11 +565,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="389" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Inserting records into an ordered Sequential file.</font
-						>
-					</h4>
+					<h4 align="left">Inserting records into an ordered Sequential file.</h4>
 				</td>
 				<td height="389" valign="top" width="525">
 					<p align="left">
@@ -637,9 +591,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="536" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Self Assessment questions</font>
-					</h4>
+					<h4 align="left">Self Assessment questions</h4>
 					<p align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48" /></p>
 					<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" /></p>
 				</td>
@@ -651,7 +603,7 @@
 					<table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="392">
 						<tr valign="top">
 							<td height="188">
-								<pre class="language-cobol"><code class="language-cobol">PERFORM UNTIL EndTF AND EndMF  
+								<pre class="language-cobol"><code class="language-cobol">PERFORM UNTIL EndTF AND EndMF
   IF TFKey &lt; MFKey
      MOVE TFRec TO NFRec
      WRITE NFRec
@@ -741,11 +693,7 @@ END-PERFORM
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="147" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Deleting records from an ordered Sequential file.</font
-						>
-					</h4>
+					<h4 align="left">Deleting records from an ordered Sequential file.</h4>
 				</td>
 				<td height="147" valign="top" width="525">
 					<p>The animation below demonstrates how to delete records from an ordered Sequential file.</p>
@@ -759,11 +707,7 @@ END-PERFORM
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="210" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Updating records in an ordered Sequential file.</font
-						>
-					</h4>
+					<h4 align="left">Updating records in an ordered Sequential file.</h4>
 				</td>
 				<td height="210" valign="top" width="525">
 					<p>
@@ -782,11 +726,7 @@ END-PERFORM
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Multiple record type transaction files
-						</font>
-					</h4>
+					<h4 align="left">Multiple record type transaction files</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -823,17 +763,12 @@ END-PERFORM
 							These COBOL course materials are the copyright property of Michael Coughlan.
 						</p>
 						<p align="left">
-							<font size="2"
-								>All rights reserved. No part of these course materials may be reproduced in any form or
-								by any means - graphic, electronic, mechanical, photocopying, printing, recording,
-								taping or stored in an information storage and retrieval system - without the written
-								permission of</font
-							>
-							<font size="2">the author.</font>
+							All rights reserved. No part of these course materials may be reproduced in any form or by
+							any means - graphic, electronic, mechanical, photocopying, printing, recording, taping or
+							stored in an information storage and retrieval system - without the written permission of
+							the author.
 						</p>
-						<p align="center">
-							<font size="2">(c) Michael Coughlan</font>
-						</p>
+						<p align="center">(c) Michael Coughlan</p>
 					</div>
 				</td>
 			</tr>

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -128,10 +128,23 @@
 			ul.toc > li {
 				padding-left: 0.4em;
 				margin-bottom: 0.6em;
+				font-size: smaller;
 			}
 
 			ul.toc a {
 				font-weight: bold;
+				font-size: larger;
+			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			td[bgcolor="#FFFFCC"] h3,
+			td[bgcolor="#FFFFCC"] h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
 			}
 		</style>
 	</head>
@@ -148,31 +161,25 @@
 					<ul class="toc">
 						<li>
 							<a href="#intro">Introduction</a><br />
-							<font size="-1">Unit aims, objectives, prerequisites.</font>
+							Unit aims, objectives, prerequisites.
 						</li>
 						<li>
 							<a href="#part1">Multiple record-type files</a><br />
-							<font size="-1"
-								>This section demonstrates how to declare and use files that contain multiple types of
-								record.</font
-							>
+							This section demonstrates how to declare and use files that contain multiple types of
+							record.
 						</li>
 						<li>
 							<a href="#part2">COBOL print files</a><br />
-							<font size="-1"
-								>This section introduces COBOL print files, demonstrates how a print file may be set up
-								and shows how a print file is used to print a report.</font
-							>
+							This section introduces COBOL print files, demonstrates how a print file may be set up and
+							shows how a print file is used to print a report.
 						</li>
 						<li>
 							<a href="#part3">Variable length records</a><br />
-							<font size="-1"
-								>This section introduces variable length records, demonstrates how variable length
-								records may be declared and shows how variable length records with the
-								<code class="language-cobol">DEPENDING ON</code> phrase may be processed. In addition,
-								this section demonstrates how a file name may be assigned to a file at run-time rather
-								than at compile-time.</font
-							>
+							This section introduces variable length records, demonstrates how variable length records
+							may be declared and shows how variable length records with the
+							<code class="language-cobol">DEPENDING ON</code> phrase may be processed. In addition, this
+							section demonstrates how a file name may be assigned to a file at run-time rather than at
+							compile-time.
 						</li>
 					</ul>
 					<hr />
@@ -180,18 +187,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="intro">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Introduction</font>
-						</font>
-					</h2>
+					<h2 align="center" id="intro">Introduction</h2>
 				</td>
 			</tr>
 			<tr>
 				<td bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#993300" face="Arial, Helvetica, sans-serif">Aims</font>
-					</h4>
+					<h4>Aims</h4>
 				</td>
 				<td valign="top" width="540">
 					<div align="center">
@@ -207,9 +208,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Objectives</font>
-					</h4>
+					<h4>Objectives</h4>
 				</td>
 				<td valign="top" width="540">
 					<p>By the end of this unit you should -</p>
@@ -239,9 +238,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font>
-					</h4>
+					<h4>Prerequisites</h4>
 				</td>
 				<td valign="top" width="525">
 					<ul>
@@ -269,18 +266,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part1">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Multiple record-type files</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part1">Multiple record-type files</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4>Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -303,11 +294,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Implications of multiple record types
-						</font>
-					</h4>
+					<h4>Implications of multiple record types</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -328,11 +315,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Declaring a multiple record-type file
-						</font>
-					</h4>
+					<h4>Declaring a multiple record-type file</h4>
 					<p align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48" /></p>
 				</td>
 				<td valign="top" width="525">
@@ -357,7 +340,7 @@
 								<pre class="language-cobol"><code class="language-cobol">ENVIRONMENT DIVISION.
 INPUT-OUTPUT SECTION.
 FILE-CONTROL.
-   SELECT TransFile 
+   SELECT TransFile
           ASSIGN TO "TRANS.DAT"
           ORGANIZATION IS LINE SEQUENTIAL.
 DATA DIVISION.
@@ -395,17 +378,11 @@ FD TransFile.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Multiple record-types - one record buffer
-						</font>
-					</h4>
+					<h4>Multiple record-types - one record buffer</h4>
 					<p align="center">
 						<img height="62" src="Resources/pics/i-Animation.gif" width="62" />
 					</p>
-					<p align="left">
-						<font size="-1">Click on the diagram opposite to see how the records map on to the buffer</font>
-					</p>
+					<p align="left">Click on the diagram opposite to see how the records map on to the buffer</p>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -432,17 +409,13 @@ FD TransFile.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Implications of record mappings</font>
-					</h4>
+					<h4>Implications of record mappings</h4>
 					<aside>
 						<p align="center">
 							<img height="37" src="Resources/pics/i-Detail.gif" width="30" /><br />
-							<font size="-1"
-								>Actually, in the NetExpress version of COBOL, when a record is smaller than the record
-								buffer the rest of the buffer is filled with spaces. So in the example opposite, the
-								NewCourseCode would display spaces.</font
-							>
+							Actually, in the NetExpress version of COBOL, when a record is smaller than the record
+							buffer the rest of the buffer is filled with spaces. So in the example opposite, the
+							NewCourseCode would display spaces.
 						</p>
 					</aside>
 				</td>
@@ -470,12 +443,8 @@ FD TransFile.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">The type-code.</font>
-					</h4>
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"></font>
-					</h4>
+					<h4>The type-code.</h4>
+					<h4></h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -501,14 +470,9 @@ FD TransFile.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>The revised record descriptions.</font
-						>
-					</h4>
+					<h4>The revised record descriptions.</h4>
 					<h4 align="center">
 						<img height="44" src="Resources/pics/ProgFrag.gif" width="48" />
-						<font color="#800000" face="Arial, Helvetica, sans-serif"></font>
 					</h4>
 				</td>
 				<td valign="top" width="525">
@@ -517,8 +481,7 @@ FD TransFile.
 							In the program fragment below, the revised record descriptions are shown. These record
 							descriptions now include a one character field, which stores the type-code inserted into
 							each transaction record to indicate the transaction type. Obviously the transaction file
-							(<font size="-1">TRANS.DAT</font>) must must also be altered so that its actual records
-							contain the type-code.
+							(TRANS.DAT) must must also be altered so that its actual records contain the type-code.
 						</p>
 						<table
 							align="center"
@@ -532,7 +495,7 @@ FD TransFile.
 									<pre class="language-cobol"><code class="language-cobol">ENVIRONMENT DIVISION.
 INPUT-OUTPUT SECTION.
 FILE-CONTROL.
-   SELECT TransFile 
+   SELECT TransFile
           ASSIGN TO "TRANS.DAT"
           ORGANIZATION IS LINE SEQUENTIAL.
 DATA DIVISION.
@@ -600,14 +563,9 @@ FD TransFile.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Using FILLER in the transaction records.
-						</font>
-					</h4>
+					<h4>Using FILLER in the transaction records.</h4>
 					<h4 align="center">
 						<img height="44" src="Resources/pics/ProgFrag.gif" width="48" />
-						<font color="#800000" face="Arial, Helvetica, sans-serif"></font>
 					</h4>
 				</td>
 				<td valign="top" width="525">
@@ -625,7 +583,7 @@ FD TransFile.
 								<pre class="language-cobol"><code class="language-cobol">ENVIRONMENT DIVISION.
 INPUT-OUTPUT SECTION.
 FILE-CONTROL.
-   SELECT TransFile 
+   SELECT TransFile
           ASSIGN TO "TRANS.DAT"
           ORGANIZATION IS LINE SEQUENTIAL.
 
@@ -677,16 +635,12 @@ FD TransFile.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part2">
-						<font color="#FFFF00">COBOL print files</font>
-					</h2>
+					<h2 align="center" id="part2">COBOL print files</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4 align="left">Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -701,9 +655,7 @@ FD TransFile.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Setting up a print file</font>
-					</h4>
+					<h4 align="left">Setting up a print file</h4>
 				</td>
 				<td valign="top" width="525">
 					<p align="left">
@@ -720,9 +672,7 @@ FD TransFile.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Declaring print lines</font>
-					</h4>
+					<h4 align="left">Declaring print lines</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -785,11 +735,7 @@ FD TransFile.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Problems multiple print records.</font
-						>
-					</h4>
+					<h4 align="left">Problems multiple print records.</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -814,9 +760,7 @@ FD TransFile.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Setting up a print file</font>
-					</h4>
+					<h4 align="left">Setting up a print file</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -836,9 +780,7 @@ FD TransFile.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">The WRITE format revisited.</font>
-					</h4>
+					<h4>The WRITE format revisited.</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -881,9 +823,7 @@ FD TransFile.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Bringing it all together.</font>
-					</h4>
+					<h4 align="left">Bringing it all together.</h4>
 					<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
 				</td>
 				<td valign="top" width="525">
@@ -904,11 +844,11 @@ AUTHOR.  Michael Coughlan.
 ENVIRONMENT DIVISION.
 INPUT-OUTPUT SECTION.
 FILE-CONTROL.
-   SELECT StudentDetailsReport 
+   SELECT StudentDetailsReport
           ASSIGN TO "StudRpt.Lpt"
           ORGANIZATION IS LINE SEQUENTIAL.
 
-   SELECT StudentFile 
+   SELECT StudentFile
           ASSIGN TO "STUDENTS.DAT"
           ORGANIZATION IS LINE SEQUENTIAL.
 
@@ -934,13 +874,13 @@ FD StudentDetailsReport.
 WORKING-STORAGE SECTION.
 01 Heading1.
    02 FILLER          PIC X(7)  VALUE SPACES.
-   02 FILLER          PIC X(25) 
+   02 FILLER          PIC X(25)
                       VALUE "UL Student Details Report".
 
-01 Heading2. 
-   02 FILLER          PIC X(21) 
+01 Heading2.
+   02 FILLER          PIC X(21)
                       VALUE "StudentId StudentName".
-   02 FILLER          PIC X(14) 
+   02 FILLER          PIC X(14)
                       VALUE " Gender Course".
 
 01 StudentDetailLine.
@@ -971,16 +911,16 @@ PrintStudentReport.
         AT END SET EndOfStudentFile TO TRUE
    END-READ
    PERFORM PrintReportBody UNTIL EndOfStudentFile
-   WRITE PrintLine FROM ReportFooting 
+   WRITE PrintLine FROM ReportFooting
          AFTER ADVANCING 3 LINES
    CLOSE StudentFile, StudentDetailsReport
    STOP RUN.
 
 PrintReportBody.
-   IF NewPageRequired 
+   IF NewPageRequired
       ADD 1 TO PageNum
       MOVE PageNum TO PrnPageNum
-      WRITE PrintLine FROM PageFooting 
+      WRITE PrintLine FROM PageFooting
             AFTER ADVANCING 3 LINES
       PERFORM PrintPageHeadings
    END-IF
@@ -996,12 +936,12 @@ PrintReportBody.
    END-READ.
 
 PrintPageHeadings.
-   WRITE PrintLine FROM Heading1 
+   WRITE PrintLine FROM Heading1
          AFTER ADVANCING PAGE
    WRITE PrintLine FROM Heading2
          AFTER ADVANCING 2 LINES
    MOVE 3 TO LineCount.
-    
+
 </code></pre>
 							</td>
 						</tr>
@@ -1022,18 +962,12 @@ PrintPageHeadings.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part3">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Variable length records</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part3">Variable length records</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4 align="left">Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1051,20 +985,14 @@ PrintPageHeadings.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>FD entries for variable length records
-						</font>
-					</h4>
+					<h4 align="left">FD entries for variable length records</h4>
 					<aside>
 						<p align="center">
 							<img height="37" src="Resources/pics/i-Detail.gif" width="30" /><br />
-							<font size="-1"
-								>The <code class="language-cobol">RECORD CONTAINS</code> clause does much the same as
-								the <code class="language-cobol">RECORD..VARYING</code> clause without the
-								<code class="language-cobol">DEPENDING ON</code> phrase, but the
-								<code class="language-cobol">RECORD..VARYING</code> clause is the more versatile.
-							</font>
+							The <code class="language-cobol">RECORD CONTAINS</code> clause does much the same as the
+							<code class="language-cobol">RECORD..VARYING</code> clause without the
+							<code class="language-cobol">DEPENDING ON</code> phrase, but the
+							<code class="language-cobol">RECORD..VARYING</code> clause is the more versatile.
 						</p>
 					</aside>
 				</td>
@@ -1095,7 +1023,7 @@ PrintPageHeadings.
 					</p>
 					<p align="left"><b>Examples</b></p>
 					<pre class="language-cobol" align="left"><code class="language-cobol">FD TransFile
-   RECORD IS VARYING IN SIZE 
+   RECORD IS VARYING IN SIZE
    FROM 8 TO 31 CHARACTERS.
 
 FD Stringfile
@@ -1107,11 +1035,7 @@ FD Stringfile
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>How variable-length records, declared with the DEPENDING ON phrase, work.</font
-						>
-					</h4>
+					<h4 align="left">How variable-length records, declared with the DEPENDING ON phrase, work.</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1131,9 +1055,7 @@ FD Stringfile
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Example program</font>
-					</h4>
+					<h4 align="left">Example program</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>The example program below introduces and number of new techniques and concepts;</p>
@@ -1168,8 +1090,8 @@ FD Stringfile
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  VarLenRecs.
 AUTHOR.  Michael Coughlan.
-*&gt; This program uses variable length records. 
-*&gt; It demonstrates how condition names may be used to 
+*&gt; This program uses variable length records.
+*&gt; It demonstrates how condition names may be used to
 *&gt; discover which type of record is in the record buffer.
 *&gt; It shows how a file name may be assigned to a file
 *&gt; at run time rather than compile time.
@@ -1183,7 +1105,7 @@ FILE-CONTROL.
           ASSIGN TO StringFileName
           ORGANIZATION IS LINE SEQUENTIAL.
 
-   SELECT TransFile 
+   SELECT TransFile
           ASSIGN TO "TRANS.DAT"
           ORGANIZATION IS LINE SEQUENTIAL.
 
@@ -1222,7 +1144,7 @@ FD Stringfile
    DEPENDING ON StringSize.
 01 StringRec            PIC X(80).
    88 EndOfStrings      VALUE HIGH-VALUES.
-   
+
 
 WORKING-STORAGE SECTION.
 01 StringSize           PIC 99.
@@ -1286,17 +1208,12 @@ DisplayTransactions.
 							These COBOL course materials are the copyright property of Michael Coughlan.
 						</p>
 						<p align="left">
-							<font size="2"
-								>All rights reserved. No part of these course materials may be reproduced in any form or
-								by any means - graphic, electronic, mechanical, photocopying, printing, recording,
-								taping or stored in an information storage and retrieval system - without the written
-								permission of</font
-							>
-							<font size="2">the author.</font>
+							All rights reserved. No part of these course materials may be reproduced in any form or by
+							any means - graphic, electronic, mechanical, photocopying, printing, recording, taping or
+							stored in an information storage and retrieval system - without the written permission of
+							the author.
 						</p>
-						<p align="center">
-							<font size="2">(c) Michael Coughlan</font>
-						</p>
+						<p align="center">(c) Michael Coughlan</p>
 					</div>
 				</td>
 			</tr>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -128,10 +128,23 @@
 			ul.toc > li {
 				padding-left: 0.4em;
 				margin-bottom: 0.6em;
+				font-size: smaller;
 			}
 
 			ul.toc a {
 				font-weight: bold;
+				font-size: larger;
+			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			td[bgcolor="#FFFFCC"] h3,
+			td[bgcolor="#FFFFCC"] h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
 			}
 		</style>
 	</head>
@@ -150,39 +163,30 @@
 					<ul class="toc">
 						<li>
 							<a href="#intro">Introduction</a><br />
-							<font size="-1">Unit aims, objectives, prerequisites.</font>
+							Unit aims, objectives, prerequisites.
 						</li>
 						<li>
 							<a href="#part1">Simple SORTing</a><br />
-							<font size="-1"
-								>This section introduces a simplified version of
-								<code class="language-cobol">SORT</code> verb syntax, and discusses why we might need to
-								sort a file as part of a solution to a programming problem..</font
-							>
+							This section introduces a simplified version of
+							<code class="language-cobol">SORT</code> verb syntax, and discusses why we might need to
+							sort a file as part of a solution to a programming problem..
 						</li>
 						<li>
 							<a href="#part2">Sorting with an INPUT PROCEDURE</a><br />
-							<font size="-1"
-								>This section introduces a <code class="language-cobol">SORT</code> with an
-								<code class="language-cobol">INPUT PROCEDURE</code> and demonstrates how an INPUT
-								PROCEDURE may be used to filter, or alter, records before they are supplied to the sort
-								process.</font
-							>
+							This section introduces a <code class="language-cobol">SORT</code> with an
+							<code class="language-cobol">INPUT PROCEDURE</code> and demonstrates how an INPUT PROCEDURE
+							may be used to filter, or alter, records before they are supplied to the sort process.
 						</li>
 						<li>
 							<a href="#part3">Sorting with an OUTPUT PROCEDURE</a><br />
-							<font size="-1"
-								>This section shows how an <code class="language-cobol">OUTPUT PROCEDURE</code> may be
-								used to filter, or alter, records after they have been sorted.</font
-							>
+							This section shows how an <code class="language-cobol">OUTPUT PROCEDURE</code> may be used
+							to filter, or alter, records after they have been sorted.
 						</li>
 						<li>
 							<a href="#part4">MERGEing files</a><br />
-							<font size="-1"
-								>In this section the <code class="language-cobol">MERGE</code> verb is introduced. The
-								<code class="language-cobol">MERGE</code> verb may be used to merge two or more ordered
-								files.</font
-							>
+							In this section the <code class="language-cobol">MERGE</code> verb is introduced. The
+							<code class="language-cobol">MERGE</code> verb may be used to merge two or more ordered
+							files.
 						</li>
 					</ul>
 					<hr />
@@ -190,18 +194,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="intro">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Introduction</font>
-						</font>
-					</h2>
+					<h2 align="center" id="intro">Introduction</h2>
 				</td>
 			</tr>
 			<tr>
 				<td bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#993300" face="Arial, Helvetica, sans-serif">Aims</font>
-					</h4>
+					<h4>Aims</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -231,9 +229,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Objectives</font>
-					</h4>
+					<h4>Objectives</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>By the end of this unit you should -</p>
@@ -272,9 +268,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font>
-					</h4>
+					<h4>Prerequisites</h4>
 				</td>
 				<td valign="top" width="525">
 					<ul>
@@ -303,18 +297,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part1">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Simple Sorting</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part1">Simple Sorting</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4>Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -341,9 +329,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Why sort the file?</font>
-					</h4>
+					<h4>Why sort the file?</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -365,9 +351,8 @@
 										it in the month in question).
 									</p>
 									<p>
-										The program will use as input, the file
-										<font size="-1">CALLS.DAT</font>. This file contains a record of all the calls
-										made that month. The cost per unit is 0.10.
+										The program will use as input, the file CALLS.DAT. This file contains a record
+										of all the calls made that month. The cost per unit is 0.10.
 									</p>
 									<p>
 										The calls file in an unordered Sequential file. The record description is as
@@ -401,11 +386,7 @@ Total value =  999,999,999.99</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Solving the problem without sorting the file?</font
-						>
-					</h4>
+					<h4>Solving the problem without sorting the file?</h4>
 				</td>
 				<td valign="top" width="525">
 					<p align="left">
@@ -459,17 +440,12 @@ END-IF</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Syntax of a simplified SORT</font>
-					</h4>
+					<h4>Syntax of a simplified SORT</h4>
 					<aside>
 						<p align="center">
 							<img height="37" src="Resources/pics/i-Detail.gif" width="30" /><br />
-							<font size="-1"
-								>Records in <font size="-2">LINE SEQUENTIAL</font> files are followed by the carriage
-								return and line feed characters, but <font size="-2">RECORD SEQUENTIAL</font> files are
-								organized as a simple stream of bytes.</font
-							>
+							Records in LINE SEQUENTIAL files are followed by the carriage return and line feed
+							characters, but RECORD SEQUENTIAL files are organized as a simple stream of bytes.
 						</p>
 					</aside>
 					<p align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48" /></p>
@@ -546,7 +522,7 @@ SORT WorkFile ON ASCENDING ProvinceCode
 							or 7 bit ), <code class="language-cobol">EBCDIC</code>,or user-defined.
 						</p>
 						<p align="left">
-							<font size="-1"><b>SORT</b></font> <b>rules</b>
+							<b>SORT rules</b>
 						</p>
 					</div>
 					<ol>
@@ -645,9 +621,7 @@ Begin.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">How a simple SORT works</font>
-					</h4>
+					<h4>How a simple SORT works</h4>
 				</td>
 				<td valign="top" width="525">
 					<p align="left">
@@ -659,7 +633,7 @@ Begin.
 					<p align="left">
 						Remember - the <code class="language-cobol">SORT</code> automatically opens the CallsFile and
 						the SortedCallsFile. These files must not be open when the
-						<code class="language-cobol">SORT</code> executes or it<font size="-1"></font> will fail.
+						<code class="language-cobol">SORT</code> executes or it will fail.
 					</p>
 					<p align="center"><img height="270" src="Resources/pics/Sort2.gif" width="470" /></p>
 					<pre
@@ -674,12 +648,7 @@ Begin.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Using multiple keys.</font>
-					</h4>
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"></font>
-					</h4>
+					<h4>Using multiple keys.</h4>
 				</td>
 				<td valign="top" width="525">
 					<p align="left">
@@ -707,33 +676,27 @@ Begin.
 						<tr bgcolor="#FFFFCC">
 							<td valign="top" width="58">
 								<p align="center">
-									<font size="-1"
-										><b
-											>Ascending<br />
-											Province<br />
-											Cod</b
-										></font
-									><b>e</b>
+									<b
+										>Ascending<br />
+										Province<br />
+										Code</b
+									>
 								</p>
 							</td>
 							<td valign="top" width="64">
 								<div align="center">
-									<font size="-1"
-										><b
-											>Descending<br />
-											Vendor<br />
-											Number</b
-										></font
+									<b
+										>Descending<br />
+										Vendor<br />
+										Number</b
 									>
 								</div>
 							</td>
 							<td valign="top" width="45">
 								<div align="center">
-									<font size="-1"
-										><b
-											>Remaining<br />
-											Record</b
-										></font
+									<b
+										>Remaining<br />
+										Record</b
 									>
 								</div>
 							</td>
@@ -843,18 +806,12 @@ etc.</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part2">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">SORTing with an INPUT PROCEDURE</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part2">SORTing with an INPUT PROCEDURE</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4 align="left">Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -873,11 +830,7 @@ etc.</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>SORT syntax with INPUT PROCEDURE</font
-						>
-					</h4>
+					<h4 align="left">SORT syntax with INPUT PROCEDURE</h4>
 				</td>
 				<td valign="top" width="525">
 					<p align="left"><img height="274" src="Resources/pics/Sort3.gif" width="486" /></p>
@@ -896,7 +849,7 @@ SORT WorkFile ON ASCENDING CountryNameWF, CustomerNameWF
               GIVING SortedSubscriptionsFile. 
 </code></pre>
 					<p align="left">
-						<font size="-1"><b>INPUT PROCEDURE</b></font> <b>notes</b><br />
+						<b>INPUT PROCEDURE notes</b><br />
 						When an <code class="language-cobol">INPUT PROCEDURE</code> is used, it replaces the
 						<code class="language-cobol">USING</code> phrase. The <i>ProcName</i> in the
 						<code class="language-cobol">INPUT PROCEDURE</code> phrase, identifies a block of code, that
@@ -941,11 +894,7 @@ SORT WorkFile ON ASCENDING CountryNameWF, CustomerNameWF
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>How a SORT with and INPUT PROCEDURE works.
-						</font>
-					</h4>
+					<h4 align="left">How a SORT with and INPUT PROCEDURE works.</h4>
 				</td>
 				<td valign="top" width="525">
 					<p align="left">
@@ -976,9 +925,8 @@ SORT WorkFile ON ASCENDING CountryNameWF, CustomerNameWF
 					</p>
 					<p align="left">
 						In the example below, an <code class="language-cobol">INPUT PROCEDURE</code> is used to select
-						only the records of foreign guests, for sorting. The diagram shows how an
-						<font size="-1">INPUT PROCEDURE,</font> is used to sit between the input file and the sort
-						process, to filter the records.
+						only the records of foreign guests, for sorting. The diagram shows how an INPUT PROCEDURE, is
+						used to sit between the input file and the sort process, to filter the records.
 					</p>
 					<p align="center"><img height="240" src="Resources/pics/Sort5.gif" width="435" /></p>
 					<pre class="language-cobol"><code class="language-cobol">SORT WorkFile ON ASCENDING CountryNameWF
@@ -990,9 +938,7 @@ SORT WorkFile ON ASCENDING CountryNameWF, CustomerNameWF
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Creating an INPUT PROCEDURE</font>
-					</h4>
+					<h4 align="left">Creating an INPUT PROCEDURE</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1035,18 +981,12 @@ CLOSE InFileName</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>The Foreign Guests Report - example program</font
-						>
-					</h4>
+					<h4 align="left">The Foreign Guests Report - example program</h4>
 					<aside>
 						<p align="center">
 							<img height="37" src="Resources/pics/i-Detail.gif" width="30" /><br />
-							<font size="-1"
-								>In this instance, since the number of countries in the world is fairly static, a
-								table-based solution might also be viable.</font
-							>
+							In this instance, since the number of countries in the world is fairly static, a table-based
+							solution might also be viable.
 						</p>
 					</aside>
 					<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
@@ -1206,11 +1146,7 @@ PrintReportBody.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Feeding the SORT from the keyboard - example program</font
-						>
-					</h4>
+					<h4>Feeding the SORT from the keyboard - example program</h4>
 					<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
 				</td>
 				<td valign="top" width="525">
@@ -1322,18 +1258,12 @@ GetStudentDetails.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part3">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Sorting with an OUTPUT PROCEDURE</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part3">Sorting with an OUTPUT PROCEDURE</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4 align="left">Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1367,10 +1297,7 @@ GetStudentDetails.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">SORT syntax with OUTPUT<br /></font>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">PROCEDURE</font>
-					</h4>
+					<h4 align="left">SORT syntax with OUTPUT PROCEDURE</h4>
 				</td>
 				<td valign="top" width="525">
 					<p align="left">
@@ -1388,7 +1315,7 @@ SORT WorkFile ON ASCENDING KEY SalespersonNumWF
      OUTPUT PROCEDURE IS SummariseSales.
              </code></pre>
 					<p>
-						<font size="-1"><b>OUTPUT PROCEDURE</b></font> <b>notes</b><br />
+						<b>OUTPUT PROCEDURE notes</b><br />
 						An <code class="language-cobol">OUTPUT PROCEDURE</code> is used to retrieve sorted records from
 						the work file using the <code class="language-cobol">RETURN</code> verb.
 					</p>
@@ -1414,9 +1341,7 @@ SORT WorkFile ON ASCENDING KEY SalespersonNumWF
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">How the OUTPUT PROCEDURE works</font>
-					</h4>
+					<h4 align="left">How the OUTPUT PROCEDURE works</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1453,16 +1378,13 @@ SORT WorkFile ON ASCENDING KEY SalespersonNumWF
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Creating an OUTPUT PROCEDURE</font>
-					</h4>
+					<h4 align="left">Creating an OUTPUT PROCEDURE</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
 						An <code class="language-cobol">OUTPUT PROCEDURE</code> uses the RETURN verb to read sorted
-						records from the work file declared in the <font size="-1">Sort's</font>
-						<code class="language-cobol">SD</code> entry. The syntax of the
-						<code class="language-cobol">RETURN</code> verb is;
+						records from the work file declared in the Sort's <code class="language-cobol">SD</code> entry.
+						The syntax of the <code class="language-cobol">RETURN</code> verb is;
 					</p>
 					<blockquote>
 						<p>
@@ -1505,11 +1427,7 @@ CLOSE OutFile
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Sales summary file - example program
-						</font>
-					</h4>
+					<h4 align="left">Sales summary file - example program</h4>
 					<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
 				</td>
 				<td valign="top" width="525">
@@ -1598,11 +1516,7 @@ SummariseSales.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Revised Foreign Guests Report - example program</font
-						>
-					</h4>
+					<h4 align="left">Revised Foreign Guests Report - example program</h4>
 					<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
 				</td>
 				<td valign="top" width="525">
@@ -1747,18 +1661,12 @@ PrintReportBody.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part4">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">MERGEing files</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part4">MERGEing files</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4 align="left">Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1780,9 +1688,7 @@ PrintReportBody.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">MERGE syntax</font>
-					</h4>
+					<h4 align="left">MERGE syntax</h4>
 				</td>
 				<td valign="top" width="525">
 					<p><img height="229" src="Resources/pics/Sort8.gif" width="494" /></p>
@@ -1806,8 +1712,8 @@ PrintReportBody.
 						temporary file, with an <code class="language-cobol">SD</code> entry in the
 						<code class="language-cobol">FILE SECTION</code>, a
 						<code class="language-cobol">SELECT</code> and <code class="language-cobol">ASSIGN</code> entry
-						in the <code class="language-cobol">INPUT-OUTPUT SECTION</code>, and an organization of
-						<font size="-1">RECORD SEQUENTIAL.</font>
+						in the <code class="language-cobol">INPUT-OUTPUT SECTION</code>, and an organization of RECORD
+						SEQUENTIAL.
 					</p>
 					<p align="left">
 						Each <i>MergeKeyIdentifier</i> identifies a field in the record of the work file. The sorted
@@ -1847,9 +1753,7 @@ PrintReportBody.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">MERGE example</font>
-					</h4>
+					<h4 align="left">MERGE example</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1928,17 +1832,12 @@ Begin.
 							These COBOL course materials are the copyright property of Michael Coughlan.
 						</p>
 						<p align="left">
-							<font size="2"
-								>All rights reserved. No part of these course materials may be reproduced in any form or
-								by any means - graphic, electronic, mechanical, photocopying, printing, recording,
-								taping or stored in an information storage and retrieval system - without the written
-								permission of</font
-							>
-							<font size="2">the author.</font>
+							All rights reserved. No part of these course materials may be reproduced in any form or by
+							any means - graphic, electronic, mechanical, photocopying, printing, recording, taping or
+							stored in an information storage and retrieval system - without the written permission of
+							the author.
 						</p>
-						<p align="center">
-							<font size="2">(c) Michael Coughlan</font>
-						</p>
+						<p align="center">(c) Michael Coughlan</p>
 					</div>
 				</td>
 			</tr>

--- a/course/String.html
+++ b/course/String.html
@@ -16,10 +16,23 @@
 			ul.toc > li {
 				padding-left: 0.4em;
 				margin-bottom: 0.6em;
+				font-size: smaller;
 			}
 
 			ul.toc a {
 				font-weight: bold;
+				font-size: larger;
+			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			td[bgcolor="#FFFFCC"] h3,
+			td[bgcolor="#FFFFCC"] h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
 			}
 		</style>
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
@@ -207,59 +220,52 @@
 						<ul class="toc">
 							<li>
 								<a href="#intro">Introduction</a><br />
-								<font size="-1">Unit aims, objectives and prerequisites.</font>
+								Unit aims, objectives and prerequisites.
 							</li>
 							<li>
 								<a href="#verb">The STRING verb</a><br />
-								<font size="-1"
-									>This section examines the syntax, functioning and rules of the STRING verb</font
-								>
+								This section examines the syntax, functioning and rules of the STRING verb
 							</li>
 							<li>
 								<a href="#examples">STRING examples</a><br />
-								<font size="-1"
-									>This section starts with some animated examples and ends with some examples that
-									take the form of Self Assessment Questions (SAQ).</font
-								>
+								This section starts with some animated examples and ends with some examples that take
+								the form of Self Assessment Questions (SAQ).
 							</li>
 						</ul>
 						<table border="0" cellpadding="4" cellspacing="0" width="710">
 							<tr>
 								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="intro"><font color="#FFFF00">Introduction</font></h2>
+									<h2 align="center" id="intro">Introduction</h2>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#993300">Aims</font></h3>
+									<h3>Aims</h3>
 								</td>
 								<td width="525">
 									<p>
 										The aim of this unit is to provide to provide you with a solid understanding of
-										the <font size="2">STRING</font> verb.
+										the STRING verb.
 									</p>
 									<hr />
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Objectives</font></h3>
+									<h3>Objectives</h3>
 								</td>
 								<td width="525">
 									<p>By the end of this unit you should:By the end of this unit you should:</p>
 									<ol>
-										<li>Understand how the <font size="2">STRING</font> verb works.</li>
-										<li>
-											Be able to use the <font size="2">STRING</font> to concatenate text strings
-											in your programs
-										</li>
+										<li>Understand how the STRING verb works.</li>
+										<li>Be able to use the STRING to concatenate text strings in your programs</li>
 									</ol>
 									<hr />
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Prerequisites</font></h3>
+									<h3>Prerequisites</h3>
 								</td>
 								<td width="525">
 									<p>You should be familiar with the material covered in the unit;</p>
@@ -289,20 +295,20 @@
 						<table border="0" cellpadding="4" cellspacing="0" width="710">
 							<tr>
 								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="verb"><font color="#FFFF00">The STRING verb</font></h2>
+									<h2 align="center" id="verb">The STRING verb</h2>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="left"><font color="#800000">Introduction</font></h3>
+									<h3 align="left">Introduction</h3>
 								</td>
 								<td width="525">
 									<p>
-										The <font size="2">STRING</font> verb is used for string concatenation. That is,
-										it is used to join together the contents of two or more source strings or
-										partial source string to create a single destination string.
+										The STRING verb is used for string concatenation. That is, it is used to join
+										together the contents of two or more source strings or partial source string to
+										create a single destination string.
 									</p>
-									<p>The examples below show how the <font size="2">STRING</font> is used.</p>
+									<p>The examples below show how the STRING is used.</p>
 									<p>
 										The first example concatenates the entire contents of the identifiers Indent1
 										and Ident2 with the literal "10" and puts the resulting sting into DestString.
@@ -329,7 +335,7 @@ END-STRING.</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">STRING syntax</font></h3>
+									<h3>STRING syntax</h3>
 								</td>
 								<td width="525">
 									<p><img src="Resources/pics/I-String.gif" /></p>
@@ -356,21 +362,20 @@ END-STRING.</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">How the STRING works</font></h3>
+									<h3>How the STRING works</h3>
 								</td>
 								<td width="525">
 									<p>
-										The <font size="2">STRING</font> statement moves characters from the source
-										string to the destination string according to the rules for alphanumeric to
-										alphanumeric moves.
+										The STRING statement moves characters from the source string to the destination
+										string according to the rules for alphanumeric to alphanumeric moves.
 									</p>
 									<p>
 										However, no space filling occurs and unless characters in the destination string
 										are explicitly overwritten they remain undisturbed.
 									</p>
 									<p>
-										As usual with alphanumeric to alphanumeric <font size="2">MOVE</font>s, data
-										movement is from left to right.
+										As usual with alphanumeric to alphanumeric MOVEs, data movement is from left to
+										right.
 									</p>
 									<p>
 										The leftmost character of the source is moved to the leftmost position of the
@@ -382,19 +387,19 @@ END-STRING.</code></pre>
 										leftmost source string first.
 									</p>
 									<p>
-										When a <font size="2">WITH POINTER</font> phrase is used, its value determines
-										the starting character position for insertion into the destination string.
+										When a WITH POINTER phrase is used, its value determines the starting character
+										position for insertion into the destination string.
 									</p>
 									<p>
-										The <font size="2">ON OVERFLOW</font> clause executes if there are still valid
-										characters left in the source strings but the destination string is full.
+										The ON OVERFLOW clause executes if there are still valid characters left in the
+										source strings but the destination string is full.
 									</p>
 									<hr />
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Data movement termination</font></h3>
+									<h3>Data movement termination</h3>
 								</td>
 								<td width="525">
 									<p>Data movement from a particular source string ends when either;</p>
@@ -408,10 +413,10 @@ END-STRING.</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">STRING termination</font></h3>
+									<h3>STRING termination</h3>
 								</td>
 								<td width="525">
-									<p>The <font size="2">STRING</font> statement ends when either;</p>
+									<p>The STRING statement ends when either;</p>
 									<ul>
 										<li>all the source strings have been processed</li>
 										<li>the destination string is full</li>
@@ -422,13 +427,13 @@ END-STRING.</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">STRING rules</font></h3>
+									<h3>STRING rules</h3>
 								</td>
 								<td width="525">
 									<ol>
 										<li>
-											Where a literal can be use, a Figurative Constant can be used except the
-											<font size="2">ALL</font> (literal).<br />
+											Where a literal can be use, a Figurative Constant can be used except the ALL
+											(literal).<br />
 											<br />
 										</li>
 										<li>
@@ -437,7 +442,7 @@ END-STRING.</code></pre>
 										</li>
 										<li>
 											The destination item Dest$i must be an elementary data item without editing
-											symbols or the <font size="2">JUSTIFIED</font> clause.<br />
+											symbols or the JUSTIFIED clause.<br />
 											<br />
 										</li>
 										<li>
@@ -452,34 +457,33 @@ END-STRING.</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">STRING clauses</font></h3>
+									<h3>STRING clauses</h3>
 								</td>
 								<td width="525">
 									<p>
-										<font size="2"><b>ON OVERFLOW</b></font> <b></b><br />
-										If the <font size="2">ON OVERFLOW</font> clause is used then the statement
-										following it will be executed if there are still characters left to pass across
-										in the source field(s) but the destination field has been filled.
+										<b>ON OVERFLOW</b> <b></b><br />
+										If the ON OVERFLOW clause is used then the statement following it will be
+										executed if there are still characters left to pass across in the source
+										field(s) but the destination field has been filled.
 									</p>
 									<p>
-										<font size="2"><b>WITH POINTER</b></font> <b></b><br />
-										The <font size="2">WITH POINTER</font> phrase allows an identifier/dataname to
-										be kept which holds the position in the Destination String where the next
-										character will go.
+										<b>WITH POINTER</b> <b></b><br />
+										The WITH POINTER phrase allows an identifier/dataname to be kept which holds the
+										position in the Destination String where the next character will go.
 									</p>
 									<p>
-										When the <font size="2">WITH POINTER</font> phrase is used, the program must set
-										the pointer to an initial value greater than 0 and less than the length of the
-										destination string before the <font size="2">STRING</font> statement executes.
+										When the WITH POINTER phrase is used, the program must set the pointer to an
+										initial value greater than 0 and less than the length of the destination string
+										before the STRING statement executes.
 									</p>
 									<p>
-										If the <font size="2">WITH POINTER</font> phrase is <b>not</b> used, operation
-										on the destination field starts from the leftmost position.
+										If the WITH POINTER phrase is <b>not</b> used, operation on the destination
+										field starts from the leftmost position.
 									</p>
 									<p>
-										<font size="2"><b>DELIMITED BY SIZE</b></font> <b></b><br />
-										The <font size="2">DELIMITED BY SIZE</font> clause means that the whole of the
-										sending field will be added to the destination string.
+										<b>DELIMITED BY SIZE</b> <b></b><br />
+										The DELIMITED BY SIZE clause means that the whole of the sending field will be
+										added to the destination string.
 									</p>
 								</td>
 							</tr>
@@ -499,12 +503,12 @@ END-STRING.</code></pre>
 						<table border="0" cellpadding="4" cellspacing="0" width="710">
 							<tr>
 								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="examples"><font color="#FFFF00">STRING examples</font></h2>
+									<h2 align="center" id="examples">STRING examples</h2>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#993300">Introduction</font></h3>
+									<h3>Introduction</h3>
 								</td>
 								<td width="525">
 									<p>
@@ -518,16 +522,14 @@ END-STRING.</code></pre>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
 									<h3>
-										<font color="#800000"
-											>Example 1<br />
-											(animation)</font
-										>
+										Example 1<br />
+										(animation)
 									</h3>
 								</td>
 								<td width="525">
 									<p>
 										The animation in this example shows how the STRING works by stepping though each
-										clause in the <font size="2">STRING</font> statement.
+										clause in the STRING statement.
 									</p>
 									<p>
 										<iframe
@@ -538,11 +540,9 @@ END-STRING.</code></pre>
 										></iframe>
 									</p>
 									<p align="center">
-										<font size="2"
-											>Click on the diagram below to step through the animation. Left click or
-											PageDown to go to the next step and right click or press PageUp to go to the
-											previous step.</font
-										>
+										Click on the diagram below to step through the animation. Left click or PageDown
+										to go to the next step and right click or press PageUp to go to the previous
+										step.
 									</p>
 									<hr />
 								</td>
@@ -550,29 +550,25 @@ END-STRING.</code></pre>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
 									<h3>
-										<font color="#800000"
-											>Example 2<br />
-											(animation)</font
-										>
+										Example 2<br />
+										(animation)
 									</h3>
 								</td>
 								<td width="525">
 									<p>
-										The <font size="2">WITH POINTER</font> phrase is often very useful because it
-										means that we don't have to <font size="2">STRING</font> all the source strings
-										together in one go.
+										The WITH POINTER phrase is often very useful because it means that we don't have
+										to STRING all the source strings together in one go.
 									</p>
 									<p>
-										Using the <font size="2">WITH POINTER</font> we can build the destination string
-										by executing a number of separate STRING statements or by executing a
-										<font size="2">STRING</font> statement a number of times.
+										Using the WITH POINTER we can build the destination string by executing a number
+										of separate STRING statements or by executing a STRING statement a number of
+										times.
 									</p>
 									<p>
 										In this example we show how a destination string may be built a piece at a time
-										by executing several separate <font size="2">STRING</font> statements. At the
-										end of this unit in the combined example you will see how a
-										<font size="2">STRING</font> statement may be used within a loop to build a
-										destination string.
+										by executing several separate STRING statements. At the end of this unit in the
+										combined example you will see how a STRING statement may be used within a loop
+										to build a destination string.
 									</p>
 									<p>
 										<iframe
@@ -583,35 +579,31 @@ END-STRING.</code></pre>
 										></iframe>
 									</p>
 									<p align="center">
-										<font size="2"
-											>Click on the diagram below to step through the animation. Left click or
-											PageDown to go to the next step and right click or press PageUp to go to the
-											previous step.</font
-										>
+										Click on the diagram below to step through the animation. Left click or PageDown
+										to go to the next step and right click or press PageUp to go to the previous
+										step.
 									</p>
 									<hr />
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="left">
-										<font color="#800000">Self assessment questions/examples</font>
-									</h3>
+									<h3 align="left">Self assessment questions/examples</h3>
 								</td>
 								<td width="525">
 									<p>
-										The examples below consist of data delarations and a number of
-										<font size="2">STRING</font> statements.
+										The examples below consist of data delarations and a number of STRING
+										statements.
 									</p>
 									<p>
-										For each <font size="2">STRING</font> example, write out the text that would be
-										displayed by the <font size="2">DISPLAY</font> statement. Assume that the data
-										starts off fresh for each <font size="2">STRING</font> statement.
+										For each STRING example, write out the text that would be displayed by the
+										DISPLAY statement. Assume that the data starts off fresh for each STRING
+										statement.
 									</p>
 									<p>
-										Treat the examples as an opportunity to test your understanding of the
-										<font size="2">STRING</font> verb. Before you click on the answers in the frame
-										below write down your own answer.
+										Treat the examples as an opportunity to test your understanding of the STRING
+										verb. Before you click on the answers in the frame below write down your own
+										answer.
 									</p>
 									<p><b>Data Declarations.</b></p>
 									<pre class="language-cobol"><code class="language-cobol">01 StringFields.
@@ -666,7 +658,7 @@ END-STRING.</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Answers to SAQs</font></h3>
+									<h3>Answers to SAQs</h3>
 								</td>
 								<td width="525">
 									<p align="center">
@@ -676,10 +668,8 @@ END-STRING.</code></pre>
 											style="border: 1px solid #ccc; width: 100%; aspect-ratio: 520/208"
 											width="520"
 										></iframe>
-										<font size="2"
-											>Left click or PageDown to go to the next answer and right click or press
-											PageUp to go to the previous answer.&nbsp;</font
-										>
+										Left click or PageDown to go to the next answer and right click or press PageUp
+										to go to the previous answer.&nbsp;
 									</p>
 								</td>
 							</tr>
@@ -705,15 +695,12 @@ END-STRING.</code></pre>
 										These COBOL course materials are the copyright property of Michael Coughlan.
 									</p>
 									<p>
-										<font size="2"
-											>All rights reserved. No part of these course materials may be reproduced in
-											any form or by any means - graphic, electronic, mechanical, photocopying,
-											printing, recording, taping or stored in an information storage and
-											retrieval system - without the written permission of</font
-										>
-										<font size="2">the author.</font>
+										All rights reserved. No part of these course materials may be reproduced in any
+										form or by any means - graphic, electronic, mechanical, photocopying, printing,
+										recording, taping or stored in an information storage and retrieval system -
+										without the written permission of the author.
 									</p>
-									<p align="center"><font size="2">(c) Michael Coughlan</font></p>
+									<p align="center">(c) Michael Coughlan</p>
 								</td>
 							</tr>
 						</table>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -128,10 +128,23 @@
 			ul.toc > li {
 				padding-left: 0.4em;
 				margin-bottom: 0.6em;
+				font-size: smaller;
 			}
 
 			ul.toc a {
 				font-weight: bold;
+				font-size: larger;
+			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			td[bgcolor="#FFFFCC"] h3,
+			td[bgcolor="#FFFFCC"] h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
 			}
 		</style>
 	</head>
@@ -150,22 +163,17 @@
 					<ul class="toc">
 						<li>
 							<a href="#intro">Introduction</a><br />
-							<font size="-1">Unit aims, objectives, prerequisites.</font>
+							Unit aims, objectives, prerequisites.
 						</li>
 						<li>
 							<a href="#part1">The CALL verb</a><br />
-							<font size="-1"
-								>Subprograms, the syntax and semantics of the CALL verb and parameter passing
-								mechanisms. State memory, the IS INITIAL clause and the CANCEL command.</font
-							>
+							Subprograms, the syntax and semantics of the CALL verb and parameter passing mechanisms.
+							State memory, the IS INITIAL clause and the CANCEL command.
 						</li>
 						<li>
 							<a href="#part2">Contained Subprograms</a><br />
-							<font size="-1">C</font>
-							<font size="-1"
-								>ontained subprogram defined. Sharing data with the IS GLOBAL and IS EXTERNAL clause.
-								Using the IS COMMON PROGRAM clause. Measuring the quality of subprograms.</font
-							>
+							Contained subprogram defined. Sharing data with the IS GLOBAL and IS EXTERNAL clause. Using
+							the IS COMMON PROGRAM clause. Measuring the quality of subprograms.
 						</li>
 					</ul>
 					<hr />
@@ -173,18 +181,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top">
-					<h2 align="center" id="intro">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Introduction</font>
-						</font>
-					</h2>
+					<h2 align="center" id="intro">Introduction</h2>
 				</td>
 			</tr>
 			<tr>
 				<td bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#993300" face="Arial, Helvetica, sans-serif">Aims</font>
-					</h4>
+					<h4>Aims</h4>
 					<h4><img height="1" src="Resources/pics/PanelLine.gif" width="175" /></h4>
 				</td>
 				<td valign="top" width="525">
@@ -221,9 +223,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Objectives</font>
-					</h4>
+					<h4>Objectives</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>By the end of this unit you should -</p>
@@ -260,9 +260,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font>
-					</h4>
+					<h4>Prerequisites</h4>
 				</td>
 				<td valign="top" width="525">
 					<ul>
@@ -301,25 +299,19 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top">
-					<h2 align="center" id="part1">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">The CALL verb</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part1">The CALL verb</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
 					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"><b>Introduction</b></font>
+						<b>Introduction</b>
 					</h4>
 					<aside>
 						<p align="center">
 							<img height="37" src="Resources/pics/i-Detail.gif" width="30" /><br />
-							<font size="-1"
-								>Your vendor will have supplied a Linker with your COBOL development system. You will
-								have to read the vendor manual for the specifics of how it works.</font
-							>
+							Your vendor will have supplied a Linker with your COBOL development system. You will have to
+							read the vendor manual for the specifics of how it works.
 						</p>
 					</aside>
 				</td>
@@ -354,11 +346,7 @@
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
 					<h4>
-						<font color="#800000"
-							><b>
-								<font face="Arial, Helvetica, sans-serif">CALL verb semantics</font>
-							</b></font
-						>
+						<b>CALL verb semantics</b>
 					</h4>
 				</td>
 				<td valign="top" width="525">
@@ -377,22 +365,17 @@
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
 					<p>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"><b>CALL syntax and notes</b></font>
+						<b>CALL syntax and notes</b>
 					</p>
 					<aside>
 						<p align="center">
 							<img height="62" src="Resources/pics/i-BugAlert.gif" width="56" />
 						</p>
 						<p align="center">
-							<font size="-1"
-								>Passing parameters of incorrect types to a called program is a frequent source of
-								program failure (crashes).<br
-							/></font>
-							<font size="-1"
-								>Always double check to make sure that the types of the parameters passed by the caller
-								program are in agreement with those declared in the LINKAGE SECTION of the called
-								program.</font
-							>
+							Passing parameters of incorrect types to a called program is a frequent source of program
+							failure (crashes).<br />
+							Always double check to make sure that the types of the parameters passed by the caller
+							program are in agreement with those declared in the LINKAGE SECTION of the called program.
 						</p>
 					</aside>
 				</td>
@@ -459,7 +442,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<font color="#800000" face="Arial, Helvetica, sans-serif"><b>Parameter passing mechanisms</b></font>
+					<b>Parameter passing mechanisms</b>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -503,7 +486,7 @@
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
 					<p>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"><b>CALL example</b></font>
+						<b>CALL example</b>
 					</p>
 				</td>
 				<td valign="top" width="525">
@@ -607,9 +590,7 @@ Begin.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<font color="#800000" face="Arial, Helvetica, sans-serif"
-						><b>State memory and the IS INITIAL clause</b>
-					</font>
+					<b>State memory and the IS INITIAL clause</b>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -693,55 +674,34 @@ Begin.
 								<div align="left">
 									<div align="center">
 										<b>Example Runs<br /></b>
-										<font size="-1">The parameter</font>
-										<font size="-1"
-											>value is shown in <font color="#0000FF">blue</font> and the result
-											displayed is shown in <font color="#FF0000">red</font>.<br
-										/></font>
+										The parameter value is shown in <span style="color: #0000ff">blue</span> and the
+										result displayed is shown in <span style="color: #ff0000">red</span>.<br />
 									</div>
 									<hr />
-									<div align="center"><font size="-2">First Run</font><br /></div>
+									<div align="center">First Run<br /></div>
 									<div align="center">
-										<font color="#0000FF"
-											><b>
-												<font face="Arial, Helvetica, sans-serif">12</font>
-											</b></font
-										>
-										<b>
-											<font face="Arial, Helvetica, sans-serif"
-												><br />
-												<font color="#FF0000">Total = 62</font>
-											</font>
+										<span style="color: #0000ff"><b>12</b></span>
+										<b
+											><br />
+											<span style="color: #ff0000">Total = 62</span>
 										</b>
 									</div>
 									<hr align="center" />
-									<div align="center"><font size="-2">Second Run</font><br /></div>
+									<div align="center">Second Run<br /></div>
 									<div align="center">
-										<font color="#0000FF"
-											><b>
-												<font face="Arial, Helvetica, sans-serif">5</font>
-											</b></font
-										>
-										<b>
-											<font face="Arial, Helvetica, sans-serif"
-												><br />
-												<font color="#FF0000">Total = 55</font>
-											</font>
+										<span style="color: #0000ff"><b>5</b></span>
+										<b
+											><br />
+											<span style="color: #ff0000">Total = 55</span>
 										</b>
 									</div>
 									<hr align="center" />
-									<div align="center"><font size="-2">Third Run</font><br /></div>
+									<div align="center">Third Run<br /></div>
 									<div align="center">
-										<font color="#0000FF"
-											><b>
-												<font face="Arial, Helvetica, sans-serif">12</font>
-											</b></font
-										>
-										<b>
-											<font face="Arial, Helvetica, sans-serif"
-												><br />
-												<font color="#FF0000">Total = 62</font>
-											</font>
+										<span style="color: #0000ff"><b>12</b></span>
+										<b
+											><br />
+											<span style="color: #ff0000">Total = 62</span>
 										</b>
 									</div>
 								</div>
@@ -780,59 +740,35 @@ Begin.
 								<div align="left">
 									<div align="center">
 										<b>Example Runs<br /></b>
-										<font size="-1">The parameter</font>
-										<font size="-1"
-											>value is shown in <font color="#0000FF">blue</font> and the result
-											displayed is shown in <font color="#FF0000">red</font>.<br
-										/></font>
+										The parameter value is shown in <span style="color: #0000ff">blue</span> and the
+										result displayed is shown in <span style="color: #ff0000">red</span>.<br />
 									</div>
 									<hr />
+									<div align="center">First Run<br /></div>
 									<div align="center">
-										<font size="-2">First Run</font><br />
-										<font size="-1"></font>
-									</div>
-									<div align="center">
-										<font color="#0000FF"
-											><b>
-												<font face="Arial, Helvetica, sans-serif">12</font>
-											</b></font
-										>
-										<b>
-											<font face="Arial, Helvetica, sans-serif"
-												><br />
-												<font color="#FF0000">Total = 62</font>
-											</font>
+										<span style="color: #0000ff"><b>12</b></span>
+										<b
+											><br />
+											<span style="color: #ff0000">Total = 62</span>
 										</b>
 									</div>
 									<hr align="center" />
-									<div align="center"><font size="-2">Second Run</font><br /></div>
+									<div align="center">Second Run<br /></div>
 									<div align="center">
 										<div>
-											<font color="#0000FF"
-												><b>
-													<font face="Arial, Helvetica, sans-serif">5</font>
-												</b></font
-											>
-											<b>
-												<font face="Arial, Helvetica, sans-serif"
-													><br />
-													<font color="#FF0000">Total = 67</font>
-												</font>
+											<span style="color: #0000ff"><b>5</b></span>
+											<b
+												><br />
+												<span style="color: #ff0000">Total = 67</span>
 											</b>
 										</div>
 										<hr />
-										<font size="-2">Third Run</font><br />
+										Third Run<br />
 										<div align="center">
-											<font color="#0000FF"
-												><b>
-													<font face="Arial, Helvetica, sans-serif">12</font>
-												</b></font
-											>
-											<b>
-												<font face="Arial, Helvetica, sans-serif"
-													><br />
-													<font color="#FF0000">Total = 79</font>
-												</font>
+											<span style="color: #0000ff"><b>12</b></span>
+											<b
+												><br />
+												<span style="color: #ff0000">Total = 79</span>
 											</b>
 										</div>
 									</div>
@@ -854,9 +790,7 @@ Begin.
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
 					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							><b>State memory and the CANCEL verb</b>
-						</font>
+						<b>State memory and the CANCEL verb</b>
 					</h4>
 				</td>
 				<td valign="top" width="525">
@@ -887,11 +821,7 @@ CALL "Fickle" USING BY CONTENT IncValue.</code></pre>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
 					<h4>
-						<b>
-							<font color="#800000" face="Arial, Helvetica, sans-serif"
-								>Subprogram clauses and verbs</font
-							>
-						</b>
+						<b>Subprogram clauses and verbs</b>
 					</h4>
 				</td>
 				<td valign="top" width="525">
@@ -948,18 +878,12 @@ CALL "Fickle" USING BY CONTENT IncValue.</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top">
-					<h2 align="center" id="part2">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Contained Subprograms</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part2">Contained Subprograms</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4>Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<p align="left">
@@ -989,9 +913,7 @@ CALL "Fickle" USING BY CONTENT IncValue.</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<font color="#800000" face="Arial, Helvetica, sans-serif"
-						><b>Defining a contained subprogram</b></font
-					>
+					<b>Defining a contained subprogram</b>
 				</td>
 				<td valign="top" width="525">
 					<p align="left">
@@ -1000,13 +922,9 @@ CALL "Fickle" USING BY CONTENT IncValue.</code></pre>
 						<code class="language-cobol">END PROGRAM</code> statement. This has the format:
 					</p>
 					<p align="center">
-						<b>
-							<font face="Arial, Helvetica, sans-serif">END PROGRAM ProgramIdName.</font>
-						</b>
+						<b>END PROGRAM ProgramIdName.</b>
 					</p>
-					<b>
-						<font face="Arial, Helvetica, sans-serif">Contained subprogram restrictions</font>
-					</b>
+					<b>Contained subprogram restrictions</b>
 					<b><br /></b> Contained subprograms have the following restrictions:<br />
 					<ol>
 						<li>
@@ -1027,7 +945,7 @@ CALL "Fickle" USING BY CONTENT IncValue.</code></pre>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
 					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"><b>The IS GLOBAL clause</b></font>
+						<b>The IS GLOBAL clause</b>
 					</h4>
 				</td>
 				<td valign="top" width="525">
@@ -1095,19 +1013,15 @@ END-PROGRAM ContainerProgram.</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Information Hiding using the IS GLOBAL clause and contained subprograms</font
-						>
-					</h4>
+					<h4>Information Hiding using the IS GLOBAL clause and contained subprograms</h4>
 				</td>
 				<td valign="top" width="525">
 					<p align="left">
 						Contained subprograms. seem to offer us the opportunity to create some form of Information
 						Hiding. For instance, it looks as though we could create an Informational Strength module as
-						defined by Myres (<font size="-1">Myres, G.J. <i>Composite/Structured Design.</i> 1979</font>)
-						by hiding a table declaration within a containing program and then allowing access to it through
-						the contained subprograms. (see diagram below).
+						defined by Myres (Myres, G.J. <i>Composite/Structured Design.</i> 1979) by hiding a table
+						declaration within a containing program and then allowing access to it through the contained
+						subprograms. (see diagram below).
 					</p>
 					<p align="center"><img height="206" src="Resources/pics/call6.gif" width="401" /></p>
 					<p align="left">
@@ -1129,10 +1043,10 @@ END-PROGRAM ContainerProgram.</code></pre>
 						more significant data needs it could prove a serious drawback.
 					</p>
 					<p align="left">
-						Glenford Myres (<font size="-1">Myres, G.J. <i>Composite/Structured Design.</i> 1979</font>) has
-						produced criteria for deciding whether a module (i.e. a subprogram) is good or bad. Module
-						Coupling (i.e. the data connections between modules) is one of the criteria he considers.
-						According to his criteria the ContainerProgram below exhibits both Stamp and Control coupling.
+						Glenford Myres (Myres, G.J. <i>Composite/Structured Design.</i> 1979) has produced criteria for
+						deciding whether a module (i.e. a subprogram) is good or bad. Module Coupling (i.e. the data
+						connections between modules) is one of the criteria he considers. According to his criteria the
+						ContainerProgram below exhibits both Stamp and Control coupling.
 					</p>
 					<p align="center"><img height="286" src="Resources/pics/call7.gif" width="406" /></p>
 					<hr size="1" width="100%" />
@@ -1140,9 +1054,7 @@ END-PROGRAM ContainerProgram.</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<b>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">The IS COMMON PROGRAM clause</font>
-					</b>
+					<b>The IS COMMON PROGRAM clause</b>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1178,11 +1090,9 @@ END-PROGRAM ContainerProgram.</code></pre>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
 					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							><b
-								>Example program using contained subprograms. and the IS COMMON PROGRAM and IS GLOBAL
-								clauses</b
-							></font
+						<b
+							>Example program using contained subprograms. and the IS COMMON PROGRAM and IS GLOBAL
+							clauses</b
 						>
 					</h4>
 				</td>
@@ -1242,11 +1152,7 @@ END PROGRAM MainProgram.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Example program using the IS INITIAL and IS COMMON clauses and the CANCEL command.</font
-						>
-					</h4>
+					<h4>Example program using the IS INITIAL and IS COMMON clauses and the CANCEL command.</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1356,11 +1262,9 @@ END PROGRAM Counter.</code></pre>
 								<div align="center">
 									<h3><b>Example Run</b></h3>
 									<p>
-										<font size="-1"
-											>Numeric values entered by the user are shown in
-											<font color="#0000FF">blue</font> and values output by the computer are
-											shown in <font color="#FF0000">red</font>.
-										</font>
+										Numeric values entered by the user are shown in
+										<span style="color: #0000ff">blue</span> and values output by the computer are
+										shown in <span style="color: #ff0000">red</span>.
 									</p>
 								</div>
 								<pre class="language-cobol" align="left"><code class="language-cobol">Enter value - 13
@@ -1398,9 +1302,7 @@ Value - 0</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">The IS EXTERNAL clause</font>
-					</h4>
+					<h4>The IS EXTERNAL clause</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1442,18 +1344,15 @@ Value - 0</code></pre>
 					<p>
 						The kind of hidden data communication between subprograms that is supported by the
 						<code class="language-cobol">IS EXTERNAL</code> clause is generally regarded as very poor
-						practice. Myres (<font size="-1">Myres, G.J. <i>Composite/Structured Design.</i> 1979</font>),
-						for instance, indicates that this "Common Coupling" is nearly the worst kind of module coupling
-						possible.
+						practice. Myres (Myres, G.J. <i>Composite/Structured Design.</i> 1979), for instance, indicates
+						that this "Common Coupling" is nearly the worst kind of module coupling possible.
 					</p>
 					<hr size="1" width="100%" />
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Designing a modular system</font>
-					</h4>
+					<h4>Designing a modular system</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1482,11 +1381,7 @@ Value - 0</code></pre>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
 					<h4>
-						<font color="#800000"
-							><b>
-								<font face="Arial, Helvetica, sans-serif">Criteria for module goodness</font>
-							</b></font
-						>
+						<b>Criteria for module goodness</b>
 					</h4>
 				</td>
 				<td valign="top" width="525">
@@ -1528,17 +1423,12 @@ Value - 0</code></pre>
 							These COBOL course materials are the copyright property of Michael Coughlan.
 						</p>
 						<p align="left">
-							<font size="2"
-								>All rights reserved. No part of these course materials may be reproduced in any form or
-								by any means - graphic, electronic, mechanical, photocopying, printing, recording,
-								taping or stored in an information storage and retrieval system - without the written
-								permission of</font
-							>
-							<font size="2">the author.</font>
+							All rights reserved. No part of these course materials may be reproduced in any form or by
+							any means - graphic, electronic, mechanical, photocopying, printing, recording, taping or
+							stored in an information storage and retrieval system - without the written permission of
+							the author.
 						</p>
-						<p align="center">
-							<font size="2">(c) Michael Coughlan</font>
-						</p>
+						<p align="center">(c) Michael Coughlan</p>
 					</div>
 				</td>
 			</tr>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -128,10 +128,23 @@
 			ul.toc > li {
 				padding-left: 0.4em;
 				margin-bottom: 0.6em;
+				font-size: smaller;
 			}
 
 			ul.toc a {
 				font-weight: bold;
+				font-size: larger;
+			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			td[bgcolor="#FFFFCC"] h3,
+			td[bgcolor="#FFFFCC"] h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
 			}
 		</style>
 	</head>
@@ -150,34 +163,25 @@
 					<ul class="toc">
 						<li>
 							<a href="#intro">Introduction</a><br />
-							<font size="-1">Unit aims, objectives, prerequisites.</font>
+							Unit aims, objectives, prerequisites.
 						</li>
 						<li>
 							<a href="#part1">Why use tables?</a><br />
-							<font size="-1"
-								>This section starts with a problem specification, explores possible solutions and ends
-								with the realisation that a table-based solution is probably best.</font
-							>
+							This section starts with a problem specification, explores possible solutions and ends with
+							the realisation that a table-based solution is probably best.
 						</li>
 						<li>
 							<a href="#part2">Using a CountyTax table</a><br />
-							<font size="-1"
-								>This section explores how the table-based solution may be implemented.</font
-							>
+							This section explores how the table-based solution may be implemented.
 						</li>
 						<li>
 							<a href="#part3">Displaying the CountyName</a><br />
-							<font size="-1"
-								>In this section we explore how we might deal with an extension to the problem
-								specification that requires us to display a county name instead of a county code.</font
-							>
+							In this section we explore how we might deal with an extension to the problem specification
+							that requires us to display a county name instead of a county code.
 						</li>
 						<li>
 							<a href="#part4">Using one table to index into another</a><br />
-							<font size="-1"
-								>In this section we show how the subscript of one table may be used to index into
-								another.</font
-							>
+							In this section we show how the subscript of one table may be used to index into another.
 						</li>
 					</ul>
 					<hr />
@@ -185,18 +189,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" height="27" valign="top">
-					<h2 align="center" id="intro">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Introduction</font>
-						</font>
-					</h2>
+					<h2 align="center" id="intro">Introduction</h2>
 				</td>
 			</tr>
 			<tr>
 				<td bgcolor="#FFFFCC" height="138" valign="top" width="175">
-					<h4>
-						<font color="#993300" face="Arial, Helvetica, sans-serif">Aims</font>
-					</h4>
+					<h4>Aims</h4>
 				</td>
 				<td height="138" valign="top" width="525">
 					<div align="center">
@@ -214,9 +212,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="156" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Objectives</font>
-					</h4>
+					<h4>Objectives</h4>
 				</td>
 				<td height="156" valign="top" width="525">
 					<p>By the end of this unit you should -</p>
@@ -236,9 +232,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="77" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font>
-					</h4>
+					<h4>Prerequisites</h4>
 				</td>
 				<td height="77" valign="top" width="525">
 					<ul>
@@ -268,18 +262,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top">
-					<h2 align="center" id="part1">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Why use tables?</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part1">Why use tables?</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="195" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4>Introduction</h4>
 					<p align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48" /></p>
 				</td>
 				<td height="195" valign="top" width="525">
@@ -348,9 +336,7 @@ Begin.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="749" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Exploring the problem</font>
-					</h4>
+					<h4>Exploring the problem</h4>
 				</td>
 				<td height="749" valign="top" width="525">
 					<div align="center">
@@ -445,18 +431,12 @@ DISPLAY "County 3 total is ", County3TaxTotal
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top">
-					<h2 align="center" id="part2">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Using a CountyTax table</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part2">Using a CountyTax table</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="294" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4>Introduction</h4>
 				</td>
 				<td height="294" valign="top" width="525">
 					<p>
@@ -484,18 +464,14 @@ DISPLAY "County 3 total is ", County3TaxTotal
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="483" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Declaring the CountyTax table</font>
-					</h4>
+					<h4>Declaring the CountyTax table</h4>
 					<h4 align="center">
 						<a href="Resources/ppz/TC-Tables1.html"
 							><img border="0" height="62" src="Resources/pics/i-Animation.gif" width="62"
 						/></a>
 					</h4>
-					<font size="-1"
-						>If TaxPaid has a value of 74.75 what do you think each of the program statements opposite will
-						do when they execute. Click on the diagram or the icon to see an animated answer.</font
-					>
+					If TaxPaid has a value of 74.75 what do you think each of the program statements opposite will do
+					when they execute. Click on the diagram or the icon to see an animated answer.
 				</td>
 				<td height="483" valign="top" width="525">
 					<p align="left">
@@ -530,9 +506,7 @@ ADD TaxPaid TO CountyTax(CountyCode - 2)</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="551" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">The County Tax Report program</font>
-					</h4>
+					<h4>The County Tax Report program</h4>
 					<p align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48" /></p>
 				</td>
 				<td height="551" valign="top" width="525">
@@ -590,18 +564,12 @@ Begin.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top">
-					<h2 align="center" id="part3">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Displaying the County Name</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part3">Displaying the County Name</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="150" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4>Introduction</h4>
 				</td>
 				<td height="150" valign="top" width="525">
 					<div align="center">
@@ -618,9 +586,7 @@ Begin.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="679" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">A table-based solution</font>
-					</h4>
+					<h4>A table-based solution</h4>
 					<p align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48" /></p>
 				</td>
 				<td height="679" valign="top" width="525">
@@ -676,11 +642,7 @@ Begin.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="206" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>A diagrammatic representation of the CountyName table</font
-						>
-					</h4>
+					<h4>A diagrammatic representation of the CountyName table</h4>
 				</td>
 				<td height="206" valign="top" width="525">
 					<div align="center">
@@ -715,18 +677,12 @@ Begin.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top">
-					<h2 align="center" id="part4">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Using one table to index into another</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part4">Using one table to index into another</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="381" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4 align="left">Introduction</h4>
 				</td>
 				<td height="381" valign="top" width="525">
 					<p>
@@ -762,9 +718,7 @@ Begin.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="206" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">An EVALUATE based solution</font>
-					</h4>
+					<h4>An EVALUATE based solution</h4>
 				</td>
 				<td height="206" valign="top" width="525">
 					<p align="left">
@@ -790,11 +744,7 @@ ADD TaxPaid TO CountyTax(CountyNum)</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" height="206" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Using the subscript from one table as the index into another</font
-						>
-					</h4>
+					<h4>Using the subscript from one table as the index into another</h4>
 					<p align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48" /></p>
 				</td>
 				<td height="206" valign="top" width="525">
@@ -873,17 +823,12 @@ Begin.
 							These COBOL course materials are the copyright property of Michael Coughlan.
 						</p>
 						<p align="left">
-							<font size="2"
-								>All rights reserved. No part of these course materials may be reproduced in any form or
-								by any means - graphic, electronic, mechanical, photocopying, printing, recording,
-								taping or stored in an information storage and retrieval system - without the written
-								permission of</font
-							>
-							<font size="2">the author.</font>
+							All rights reserved. No part of these course materials may be reproduced in any form or by
+							any means - graphic, electronic, mechanical, photocopying, printing, recording, taping or
+							stored in an information storage and retrieval system - without the written permission of
+							the author.
 						</p>
-						<p align="center">
-							<font size="2">(c) Michael Coughlan</font>
-						</p>
+						<p align="center">(c) Michael Coughlan</p>
 					</div>
 				</td>
 			</tr>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -150,10 +150,23 @@
 			ul.toc > li {
 				padding-left: 0.4em;
 				margin-bottom: 0.6em;
+				font-size: smaller;
 			}
 
 			ul.toc a {
 				font-weight: bold;
+				font-size: larger;
+			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			td[bgcolor="#FFFFCC"] h3,
+			td[bgcolor="#FFFFCC"] h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
 			}
 		</style>
 	</head>
@@ -172,39 +185,29 @@
 					<ul class="toc">
 						<li>
 							<a href="#intro">Introduction</a><br />
-							<font size="-1">Unit aims, objectives, prerequisites.</font>
+							Unit aims, objectives, prerequisites.
 						</li>
 						<li>
 							<a href="#part1">Declaring a single dimension table</a><br />
-							<font size="-1"
-								>In this section we demonstrate how the
-								<code class="language-cobol">OCCURS</code> clause is used to declare a single dimension
-								table. We also show how it may be used to declare a variable length table.</font
-							>
+							In this section we demonstrate how the
+							<code class="language-cobol">OCCURS</code> clause is used to declare a single dimension
+							table. We also show how it may be used to declare a variable length table.
 						</li>
 						<li>
 							<a href="#part2">Group items as elements</a><br />
-							<font size="-1"
-								>The elements of a table do not have to be elementary items - they can be group items.
-								This section demonstrates how to create a table, the elements of which, are group
-								items.</font
-							>
+							The elements of a table do not have to be elementary items - they can be group items. This
+							section demonstrates how to create a table, the elements of which, are group items.
 						</li>
 						<li>
 							<a href="#part3">Declaring multi-dimension tables</a><br />
-							<font size="-1"
-								>This section demonstrates how nested <code class="language-cobol">OCCURS</code> clauses
-								are used to create multi-dimension tables</font
-							>
-							<font size="-1">.</font>
+							This section demonstrates how nested <code class="language-cobol">OCCURS</code> clauses are
+							used to create multi-dimension tables.
 						</li>
 						<li>
 							<a href="#part4">Creating pre-filled tables with the REDEFINES clause.</a><br />
-							<font size="-1"
-								>This section first demonstrates non-table related uses for the REDEFINES clause and
-								then shows how it may be used to create pre-filled tables. The new COBOL'85 approaches
-								to creating pre-filled tables and to initialising tables are also demonstrated.</font
-							>
+							This section first demonstrates non-table related uses for the REDEFINES clause and then
+							shows how it may be used to create pre-filled tables. The new COBOL'85 approaches to
+							creating pre-filled tables and to initialising tables are also demonstrated.
 						</li>
 					</ul>
 					<hr />
@@ -212,18 +215,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top">
-					<h2 align="center" id="intro">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Introduction</font>
-						</font>
-					</h2>
+					<h2 align="center" id="intro">Introduction</h2>
 				</td>
 			</tr>
 			<tr>
 				<td bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#993300" face="Arial, Helvetica, sans-serif">Aims</font>
-					</h4>
+					<h4>Aims</h4>
 				</td>
 				<td valign="top" width="525">
 					<div align="center">
@@ -242,9 +239,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Objectives</font>
-					</h4>
+					<h4>Objectives</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>By the end of this unit you should -</p>
@@ -273,9 +268,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font>
-					</h4>
+					<h4>Prerequisites</h4>
 				</td>
 				<td valign="top" width="525">
 					<ul>
@@ -306,18 +299,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top">
-					<h2 align="center" id="part1">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Declaring a single dimension table</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part1">Declaring a single dimension table</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4>Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<p align="left">
@@ -333,9 +320,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Tables - general notes</font>
-					</h4>
+					<h4>Tables - general notes</h4>
 				</td>
 				<td valign="top" width="525">
 					<p align="left">
@@ -370,11 +355,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Using the <code class="language-cobol">OCCURS</code> clause to declare a table
-						</font>
-					</h4>
+					<h4>Using the <code class="language-cobol">OCCURS</code> clause to declare a table</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -425,9 +406,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">OCCURS clause syntax and rules</font>
-					</h4>
+					<h4>OCCURS clause syntax and rules</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -487,9 +466,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Table examples and some SAQ's</font>
-					</h4>
+					<h4>Table examples and some SAQ's</h4>
 					<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" /></p>
 				</td>
 				<td valign="top" width="525">
@@ -601,11 +578,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Declaring a variable length table.</font
-						>
-					</h4>
+					<h4>Declaring a variable length table.</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -652,18 +625,12 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top">
-					<h2 align="center" id="part2">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Group items as elements</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part2">Group items as elements</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4>Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -674,9 +641,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Setting up a combined table</font>
-					</h4>
+					<h4>Setting up a combined table</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -721,11 +686,7 @@
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Self Assessment Questions and animated example</font
-						>
-					</h4>
+					<h4>Self Assessment Questions and animated example</h4>
 					<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" /></p>
 				</td>
 				<td valign="top" width="525">
@@ -776,9 +737,7 @@ MOVE ZEROS TO CountyTaxTable</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Example program</font>
-					</h4>
+					<h4>Example program</h4>
 					<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
 				</td>
 				<td valign="top" width="525">
@@ -888,18 +847,12 @@ DisplayCountyTaxes.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top">
-					<h2 align="center" id="part3">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif">Declaring multi-dimension tables</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part3">Declaring multi-dimension tables</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4>Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<p align="left">
@@ -967,9 +920,7 @@ DisplayCountyTaxes.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Problem discussion</font>
-					</h4>
+					<h4>Problem discussion</h4>
 				</td>
 				<td valign="top" width="525">
 					<p align="left">
@@ -1029,9 +980,7 @@ END-EVALUATE.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">A two dimension table</font>
-					</h4>
+					<h4>A two dimension table</h4>
 				</td>
 				<td valign="top" width="525">
 					<p align="left">
@@ -1069,11 +1018,7 @@ END-EVALUATE.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Self Assessment Questions and examples
-						</font>
-					</h4>
+					<h4>Self Assessment Questions and examples</h4>
 					<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" /></p>
 				</td>
 				<td valign="top" width="525">
@@ -1097,11 +1042,7 @@ MOVE ZEROS TO Age(3)</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Displaying the population report for each county</font
-						>
-					</h4>
+					<h4>Displaying the population report for each county</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1137,11 +1078,7 @@ MOVE ZEROS TO Age(3)</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Creating a three dimension table</font
-						>
-					</h4>
+					<h4>Creating a three dimension table</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1163,11 +1100,7 @@ MOVE ZEROS TO Age(3)</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Self Assessment Questions and examples
-						</font>
-					</h4>
+					<h4>Self Assessment Questions and examples</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1191,11 +1124,7 @@ MOVE ZEROS TO PopulationTable</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>One last tweak to the problem specification.</font
-						>
-					</h4>
+					<h4>One last tweak to the problem specification.</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1286,20 +1215,12 @@ ADD 56 TO PopTotal(12,3,2)</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#993300" colspan="2" valign="top">
-					<h2 align="center" id="part4">
-						<font color="#FFFF00">
-							<font face="Arial, Helvetica, sans-serif"
-								>Creating pre-filled tables with the REDEFINES clause
-							</font>
-						</font>
-					</h2>
+					<h2 align="center" id="part4">Creating pre-filled tables with the REDEFINES clause</h2>
 				</td>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-					</h4>
+					<h4 align="left">Introduction</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1327,19 +1248,15 @@ ADD 56 TO PopTotal(12,3,2)</code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Non-tables uses for the REDEFINES clause - some examples</font
-						>
-					</h4>
+					<h4>Non-tables uses for the REDEFINES clause - some examples</h4>
 				</td>
 				<td valign="top" width="525">
 					<p align="left">
-						<b>Example 1<br /></b> Some COBOL statements, like the <font size="-1">UNSTRING,</font> require
-						their receiving fields to be alphanumeric (PIC X) data-items. This is inconvenient if the value
-						of the data-item is actually numeric because then a <code class="language-cobol">MOVE</code> is
-						required to place the value into a numeric item. If the value contains a decimal point then this
-						creates even more difficulties.
+						<b>Example 1<br /></b> Some COBOL statements, like the UNSTRING, require their receiving fields
+						to be alphanumeric (PIC X) data-items. This is inconvenient if the value of the data-item is
+						actually numeric because then a <code class="language-cobol">MOVE</code> is required to place
+						the value into a numeric item. If the value contains a decimal point then this creates even more
+						difficulties.
 					</p>
 					<p align="left">
 						For example, suppose an <code class="language-cobol">UNSTRING</code> statement has just
@@ -1434,15 +1351,11 @@ END-EVALUATE </code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">REDEFINES syntax and rules</font>
-					</h4>
+					<h4>REDEFINES syntax and rules</h4>
 				</td>
 				<td valign="top" width="525">
 					<p><img height="48" src="Resources/pics/Redefines.gif" width="358" /></p>
-					<p>
-						<font size="-1"><b>REDEFINES</b></font> <b>rules</b>
-					</p>
+					<p><b>REDEFINES</b> <b>rules</b></p>
 					<ol>
 						<li>
 							The <code class="language-cobol">REDEFINES</code> clause must immediately follow Identifier1
@@ -1478,11 +1391,7 @@ END-EVALUATE </code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Using the REDEFINES clause to create a pre-filled table.</font
-						>
-					</h4>
+					<h4>Using the REDEFINES clause to create a pre-filled table.</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1526,9 +1435,7 @@ END-EVALUATE </code></pre>
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif">Example program</font>
-					</h4>
+					<h4>Example program</h4>
 					<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
 				</td>
 				<td valign="top" width="525">
@@ -1650,11 +1557,7 @@ DisplayCountyTaxes.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>Creating pre-filled tables without using the REDEFINES clause.</font
-						>
-					</h4>
+					<h4>Creating pre-filled tables without using the REDEFINES clause.</h4>
 				</td>
 				<td valign="top" width="525">
 					<p>
@@ -1686,11 +1589,7 @@ DisplayCountyTaxes.
 			</tr>
 			<tr>
 				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>
-						<font color="#800000" face="Arial, Helvetica, sans-serif"
-							>COBOL'85 table initialisation changes
-						</font>
-					</h4>
+					<h4>COBOL'85 table initialisation changes</h4>
 				</td>
 				<td valign="top" width="525">
 					<p align="left">
@@ -1743,17 +1642,12 @@ DisplayCountyTaxes.
 							These COBOL course materials are the copyright property of Michael Coughlan.
 						</p>
 						<p align="left">
-							<font size="2"
-								>All rights reserved. No part of these course materials may be reproduced in any form or
-								by any means - graphic, electronic, mechanical, photocopying, printing, recording,
-								taping or stored in an information storage and retrieval system - without the written
-								permission of</font
-							>
-							<font size="2">the author.</font>
+							All rights reserved. No part of these course materials may be reproduced in any form or by
+							any means - graphic, electronic, mechanical, photocopying, printing, recording, taping or
+							stored in an information storage and retrieval system - without the written permission of
+							the author.
 						</p>
-						<p align="center">
-							<font size="2">(c) Michael Coughlan</font>
-						</p>
+						<p align="center">(c) Michael Coughlan</p>
 					</div>
 				</td>
 			</tr>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -16,10 +16,23 @@
 			ul.toc > li {
 				padding-left: 0.4em;
 				margin-bottom: 0.6em;
+				font-size: smaller;
 			}
 
 			ul.toc a {
 				font-weight: bold;
+				font-size: larger;
+			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			td[bgcolor="#FFFFCC"] h3,
+			td[bgcolor="#FFFFCC"] h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
 			}
 		</style>
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
@@ -207,68 +220,59 @@
 						<ul class="toc">
 							<li>
 								<a href="#intro">Introduction</a><br />
-								<font size="-1">Unit aims, objectives and prerequisites.</font>
+								Unit aims, objectives and prerequisites.
 							</li>
 							<li>
 								<a href="#verb">The UNSTRING verb</a><br />
-								<font size="-1"
-									>This section examines the syntax, functioning and rules of the
-									<code class="language-cobol">UNSTRING</code>.</font
-								>
+								This section examines the syntax, functioning and rules of the
+								<code class="language-cobol">UNSTRING</code>.
 							</li>
 							<li>
 								<a href="#examples">UNSTRING examples</a><br />
-								<font size="-1"
-									>This section starts with some abstract examples, goes on to a more practical
-									example and ends with a example program</font
-								>
+								This section starts with some abstract examples, goes on to a more practical example and
+								ends with a example program
 							</li>
 							<li>
 								<a href="#combined">A combined example</a><br />
-								<font size="-1"
-									>The unit ends with a practical example that uses the
-									<code class="language-cobol">STRING</code> and
-									<code class="language-cobol">UNSTRING</code> verbs in combination.</font
-								>
+								The unit ends with a practical example that uses the
+								<code class="language-cobol">STRING</code> and
+								<code class="language-cobol">UNSTRING</code> verbs in combination.
 							</li>
 						</ul>
 						<table border="0" cellpadding="4" cellspacing="0" width="710">
 							<tr>
 								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="intro"><font color="#FFFF00">Introduction</font></h2>
+									<h2 align="center" id="intro">Introduction</h2>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#993300">Aims</font></h3>
+									<h3>Aims</h3>
 								</td>
 								<td width="525">
 									<p>
 										The aim of this unit is to provide to provide you with a solid understanding of
-										the <font size="2">UNSTRING</font> verb.
+										the UNSTRING verb.
 									</p>
 									<hr />
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Objectives</font></h3>
+									<h3>Objectives</h3>
 								</td>
 								<td width="525">
 									<p>By the end of this unit you should:By the end of this unit you should:</p>
 									<ol>
-										<li>Understand how the <font size="2">UNSTRING</font> works</li>
-										<li>
-											Be able to use the <font size="2">UNSTRING</font> to divide a string into
-											sub-strings
-										</li>
+										<li>Understand how the UNSTRING works</li>
+										<li>Be able to use the UNSTRING to divide a string into sub-strings</li>
 									</ol>
 									<hr />
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Prerequisites</font></h3>
+									<h3>Prerequisites</h3>
 								</td>
 								<td width="525">
 									<p>You should be familiar with the material covered in the unit;</p>
@@ -278,8 +282,8 @@
 										<li>Selection</li>
 										<li>Tables</li>
 										<li>Edited Pictures</li>
-										<li>The <font size="2">INSPECT</font> verb</li>
-										<li>The <font size="2">STRING</font> verb</li>
+										<li>The INSPECT verb</li>
+										<li>The STRING verb</li>
 									</ul>
 								</td>
 							</tr>
@@ -299,18 +303,16 @@
 						<table border="0" cellpadding="4" cellspacing="0" width="710">
 							<tr>
 								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="verb"><font color="#FFFF00">The UNSTRING verb</font></h2>
+									<h2 align="center" id="verb">The UNSTRING verb</h2>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="left"><font color="#800000">Introduction</font></h3>
+									<h3 align="left">Introduction</h3>
 								</td>
 								<td width="525">
-									<p>
-										The <font size="2">UNSTRING</font> is used to divide a string into sub-strings.
-									</p>
-									<p>The examples below show how the <font size="2">UNSTRING</font> is used.</p>
+									<p>The UNSTRING is used to divide a string into sub-strings.</p>
+									<p>The examples below show how the UNSTRING is used.</p>
 									<p>
 										The first example breaks a name string into its three constituent part - the
 										first name , second name and surname. For instance the string "John Joseph Ryan"
@@ -322,8 +324,8 @@
 										lines are stored in a six element table.
 									</p>
 									<p>
-										Since not all addresses will have six parts exactly, we use the
-										<font size="2">TALLYING</font> clause to discover how many parts there are.
+										Since not all addresses will have six parts exactly, we use the TALLYING clause
+										to discover how many parts there are.
 									</p>
 									<pre
 										class="language-cobol"
@@ -341,7 +343,7 @@ END-UNSTRING.</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">UNSTRING syntax</font></h3>
+									<h3>UNSTRING syntax</h3>
 								</td>
 								<td width="525">
 									<p><img src="Resources/pics/I-UnString.gif" /></p>
@@ -379,7 +381,7 @@ END-UNSTRING.</code></pre>
 												<td width="21%">DestCounter#i</td>
 												<td width="79%">
 													Holds the count of the number of destination strings affected by the
-													<font size="2">UNSTRING</font> operation.
+													UNSTRING operation.
 												</td>
 											</tr>
 										</table>
@@ -389,13 +391,12 @@ END-UNSTRING.</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">How the UNSTRING works</font></h3>
+									<h3>How the UNSTRING works</h3>
 								</td>
 								<td width="525">
 									<p>
-										The <font size="2">UNSTRING</font> copies characters from the source string, to
-										the destination string, until a condition is encountered that terminates data
-										movement.
+										The UNSTRING copies characters from the source string, to the destination
+										string, until a condition is encountered that terminates data movement.
 									</p>
 									<p>
 										When data movement ends for a particular destination string, the next
@@ -411,20 +412,20 @@ END-UNSTRING.</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Data movement termination</font></h3>
+									<h3>Data movement termination</h3>
 								</td>
 								<td width="525">
 									<p>
-										When the <font size="2">DELIMITED BY</font> clause is used data movement from
-										the source string to the current destination string ends when either ;
+										When the DELIMITED BY clause is used data movement from the source string to the
+										current destination string ends when either ;
 									</p>
 									<ul>
 										<li>a delimiter is encountered in the source string</li>
 										<li>the end of the source string is reached.</li>
 									</ul>
 									<p>
-										When the <font size="2">DELIMITED BY</font> clause is not used, data movement
-										from the source string to the current destination string ends when either;
+										When the DELIMITED BY clause is not used, data movement from the source string
+										to the current destination string ends when either;
 									</p>
 									<ul>
 										<li>the destination string is full</li>
@@ -435,10 +436,10 @@ END-UNSTRING.</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">UNSTRING termination</font></h3>
+									<h3>UNSTRING termination</h3>
 								</td>
 								<td width="525">
-									<p>The <font size="2">UNSTRING</font> statement terminates when either;</p>
+									<p>The UNSTRING statement terminates when either;</p>
 									<ul>
 										<li>All the characters in the source string have been examined</li>
 										<li>All the destination strings have been processed</li>
@@ -452,13 +453,13 @@ END-UNSTRING.</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">UNSTRING rules</font></h3>
+									<h3>UNSTRING rules</h3>
 								</td>
 								<td width="525">
 									<ol>
 										<li>
 											Where a literal can be used any figurative constant can be used except the
-											<font size="2">ALL</font> (literal).<br />
+											ALL (literal).<br />
 											<br />
 										</li>
 										<li>
@@ -467,19 +468,17 @@ END-UNSTRING.</code></pre>
 										</li>
 										<li>
 											Characters are moved from the source string to the destination strings
-											according to the rules for the <font size="2">MOVE</font>, with space
-											filling if required.<br />
+											according to the rules for the MOVE, with space filling if required.<br />
 											<br />
 										</li>
 										<li>
 											The delimiter is moved into HoldDelim$i according to the rules for the
-											<font size="2">MOVE</font>.<br />
+											MOVE.<br />
 											<br />
 										</li>
 										<li>
-											The <font size="2">DELIMITER IN</font> and
-											<font size="2">COUNT IN</font> phrases may be specified only if the
-											<font size="2">DELIMITED BY</font> phrase is used.
+											The DELIMITER IN and COUNT IN phrases may be specified only if the DELIMITED
+											BY phrase is used.
 										</li>
 									</ol>
 									<hr />
@@ -487,18 +486,17 @@ END-UNSTRING.</code></pre>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">UNSTRING clauses</font></h3>
+									<h3>UNSTRING clauses</h3>
 								</td>
 								<td width="525">
 									<p>
-										<font size="2"><b>ON OVERFLOW</b></font
-										><br />
-										The <font size="2">ON OVERFLOW</font> is activated if :-
+										<b>ON OVERFLOW</b><br />
+										The ON OVERFLOW is activated if :-
 									</p>
 									<ul>
 										<li>
 											The unstring pointer (Pointer#i) is not pointing to a character position
-											within the source string when the <font size="2">UNSTRING</font> executes.
+											within the source string when the UNSTRING executes.
 										</li>
 										<li>
 											All the destination strings have been processed but there are still valid
@@ -506,68 +504,52 @@ END-UNSTRING.</code></pre>
 										</li>
 									</ul>
 									<p>
-										The statements following the <font size="2">NOT ON OVERFLOW</font> are executed
-										if the <font size="2">UNSTRING</font> is about to terminate successfully.
+										The statements following the NOT ON OVERFLOW are executed if the UNSTRING is
+										about to terminate successfully.
 									</p>
 									<p>
-										<font size="2"><b>COUNT IN</b></font
-										><br />
-										The <font size="2">COUNT IN</font> clause is associated with a particular
-										destination string and holds a count of the number of characters passed to the
-										destination string.
+										<b>COUNT IN</b><br />
+										The COUNT IN clause is associated with a particular destination string and holds
+										a count of the number of characters passed to the destination string.
 									</p>
 									<p>
-										<font size="2"><b>TALLYING IN</b></font
-										><br />
-										Only one <font size="2">TALLYING</font> clause can be used with each
-										<font size="2">UNSTRING</font> . It holds a count of the number of destination
-										strings affected by the <font size="2">UNSTRING</font> operation.
+										<b>TALLYING IN</b><br />
+										Only one TALLYING clause can be used with each UNSTRING . It holds a count of
+										the number of destination strings affected by the UNSTRING operation.
 									</p>
 									<p>
-										<font size="2"><b>WITH POINTER</b></font
-										><br />
-										When the <font size="2">WITH POINTER</font> clause is used the Pointer#i holds
-										the position of the next non-delimiter character to be examined in the source
-										string.
+										<b>WITH POINTER</b><br />
+										When the WITH POINTER clause is used the Pointer#i holds the position of the
+										next non-delimiter character to be examined in the source string.
 									</p>
 									<p>
 										Pointer#i must be large enough to hold a value one greater than the size of the
 										source string.
 									</p>
 									<p>
-										<font size="2"
-											><b>ALL<br /></b
-										></font>
+										<b>ALL<br /></b>
 										When the ALL phrase is used, contiguous delimiters are treated as if only one
 										delimiter had been encountered. <b></b>
-										<font size="2"
-											><b><br /></b
-										></font>
+										<b><br /></b>
 									</p>
 									<p>
 										If the ALL is not used, contiguous delimiters will result in spaces being sent
 										to some of the destination strings
 									</p>
 									<p>
-										<font size="2"><b>DELIMITER IN</b></font
-										><br />
-										A <font size="2">DELIMITER IN</font> clause is associated with a particular
-										destination string. HoldDelim$i holds the delimiter that was encountered in the
-										source string.
+										<b>DELIMITER IN</b><br />
+										A DELIMITER IN clause is associated with a particular destination string.
+										HoldDelim$i holds the delimiter that was encountered in the source string.
 									</p>
 									<p>
-										If the <font size="2">DELIMITER IN</font> phrase is used with the
-										<font size="2">ALL</font> phrase then only one occurrence of the delimiter will
-										be moved to HoldDelim$i.
+										If the DELIMITER IN phrase is used with the ALL phrase then only one occurrence
+										of the delimiter will be moved to HoldDelim$i.
 									</p>
 									<p>
-										<font size="2"
-											><b>DELIMITED BY<br /></b
-										></font>
-										When the <font size="2">DELIMITED BY</font> phrase is used, characters are
-										examined in the source string and transferred to the current destination string
-										until one of the specified delimiters is encountered or the end the source
-										string is reached.
+										<b>DELIMITED BY<br /></b>
+										When the DELIMITED BY phrase is used, characters are examined in the source
+										string and transferred to the current destination string until one of the
+										specified delimiters is encountered or the end the source string is reached.
 									</p>
 									<p>
 										If there is not enough room in the destination string to take all the characters
@@ -598,12 +580,12 @@ END-UNSTRING.</code></pre>
 						<table border="0" cellpadding="4" cellspacing="0" width="710">
 							<tr>
 								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="examples"><font color="#FFFF00">UNSTRING examples</font></h2>
+									<h2 align="center" id="examples">UNSTRING examples</h2>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#993300">Introduction</font></h3>
+									<h3>Introduction</h3>
 								</td>
 								<td width="525">
 									<p>
@@ -611,27 +593,22 @@ END-UNSTRING.</code></pre>
 										UNSTRING.
 									</p>
 									<p>Example 7 is a longer and more practical example</p>
-									<p>
-										Finally the section ends with an example program that uses the
-										<font size="2">UNSTRING</font>.
-									</p>
+									<p>Finally the section ends with an example program that uses the UNSTRING.</p>
 									<hr />
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
 									<h3>
-										<font color="#800000"
-											>Examples 1 - 6<br />
-											(animation)</font
-										>
+										Examples 1 - 6<br />
+										(animation)
 									</h3>
 								</td>
 								<td width="525">
 									<p>
-										When you view these examples start by carefully examining the
-										<font size="2">UNSTRING</font> statement. See if you can figure out what it's
-										going to do (you may need to review the material above for this).
+										When you view these examples start by carefully examining the UNSTRING
+										statement. See if you can figure out what it's going to do (you may need to
+										review the material above for this).
 									</p>
 									<p>
 										When you are happy with your prediction step through the example and see if you
@@ -648,10 +625,8 @@ END-UNSTRING.</code></pre>
 											style="border: 1px solid #ccc; width: 100%; aspect-ratio: 520/416"
 											width="520"
 										></iframe>
-										<font size="2"
-											>Left click or PageDown to go to the next frame and right click or press
-											PageUp to go to the previous frame.</font
-										>
+										Left click or PageDown to go to the next frame and right click or press PageUp
+										to go to the previous frame.
 									</center>
 									<hr />
 								</td>
@@ -659,16 +634,14 @@ END-UNSTRING.</code></pre>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
 									<h3>
-										<font color="#800000"
-											>Example 7<br />
-											(animation)</font
-										>
+										Example 7<br />
+										(animation)
 									</h3>
 								</td>
 								<td width="525">
 									<p>
-										The <font size="2">WITH POINTER</font> phrase is often very useful because it
-										means that we don't have to unpack the whole source string in one go..
+										The WITH POINTER phrase is often very useful because it means that we don't have
+										to unpack the whole source string in one go..
 									</p>
 									<p>
 										In this example, we unpack a full name, any number of Christian names followed
@@ -681,18 +654,16 @@ END-UNSTRING.</code></pre>
 											style="border: 1px solid #ccc; width: 100%; aspect-ratio: 520/416"
 											width="520"
 										></iframe>
-										<font size="2"
-											>Click on the diagram below to step through the animation. Left click or
-											PageDown to go to the next step and right click or press PageUp to go to the
-											previous step.</font
-										>
+										Click on the diagram below to step through the animation. Left click or PageDown
+										to go to the next step and right click or press PageUp to go to the previous
+										step.
 									</center>
 									<hr />
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Example program</font></h3>
+									<h3>Example program</h3>
 								</td>
 								<td width="525">
 									<p>
@@ -809,12 +780,12 @@ Begin.
 						<table border="0" cellpadding="4" cellspacing="0" width="710">
 							<tr>
 								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="combined"><font color="#FFFF00">Combined example</font></h2>
+									<h2 align="center" id="combined">Combined example</h2>
 								</td>
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#993300">Introduction</font></h3>
+									<h3>Introduction</h3>
 								</td>
 								<td width="525">
 									<p>
@@ -827,7 +798,7 @@ Begin.
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Data items used in the example</font></h3>
+									<h3>Data items used in the example</h3>
 								</td>
 								<td width="525">
 									<pre class="language-cobol"><code class="language-cobol">01 OldName  PIC X(80).
@@ -847,7 +818,7 @@ Begin.
 							</tr>
 							<tr>
 								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3><font color="#800000">Animation</font></h3>
+									<h3>Animation</h3>
 								</td>
 								<td width="525">
 									<center>
@@ -859,11 +830,9 @@ Begin.
 										></iframe>
 									</center>
 									<div align="center">
-										<font size="2"
-											>Click on the diagram below to step through the animation. Left click or
-											PageDown to go to the next step and right click or press PageUp to go to the
-											previous step.</font
-										>
+										Click on the diagram below to step through the animation. Left click or PageDown
+										to go to the next step and right click or press PageUp to go to the previous
+										step.
 									</div>
 								</td>
 							</tr>
@@ -889,15 +858,12 @@ Begin.
 										These COBOL course materials are the copyright property of Michael Coughlan.
 									</p>
 									<p>
-										<font size="2"
-											>All rights reserved. No part of these course materials may be reproduced in
-											any form or by any means - graphic, electronic, mechanical, photocopying,
-											printing, recording, taping or stored in an information storage and
-											retrieval system - without the written permission of</font
-										>
-										<font size="2">the author.</font>
+										All rights reserved. No part of these course materials may be reproduced in any
+										form or by any means - graphic, electronic, mechanical, photocopying, printing,
+										recording, taping or stored in an information storage and retrieval system -
+										without the written permission of the author.
 									</p>
-									<p align="center"><font size="2">(c) Michael Coughlan</font></p>
+									<p align="center">(c) Michael Coughlan</p>
 								</td>
 							</tr>
 						</table>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -167,10 +167,23 @@
 			ul.toc > li {
 				padding-left: 0.4em;
 				margin-bottom: 0.6em;
+				font-size: smaller;
 			}
 
 			ul.toc a {
 				font-weight: bold;
+				font-size: larger;
+			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			td[bgcolor="#FFFFCC"] h3,
+			td[bgcolor="#FFFFCC"] h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
 			}
 		</style>
 	</head>
@@ -192,17 +205,14 @@
 								<ul class="toc">
 									<li>
 										<a href="#intro">Introduction</a><br />
-										<font size="-1">Unit aims, objectives, prerequisites.</font>
+										Unit aims, objectives, prerequisites.
 									</li>
 									<li>
 										<a href="#part1">The USAGE clause</a><br />
-										<font size="-1"
-											>Subprograms, the syntax and semantics of the
-											<code class="language-cobol">CALL</code> verb and parameter passing
-											mechanisms. State memory, the
-											<code class="language-cobol">IS INITIAL</code> clause and the
-											<code class="language-cobol">CANCEL</code> command.</font
-										>
+										Subprograms, the syntax and semantics of the
+										<code class="language-cobol">CALL</code> verb and parameter passing mechanisms.
+										State memory, the <code class="language-cobol">IS INITIAL</code> clause and the
+										<code class="language-cobol">CANCEL</code> command.
 									</li>
 								</ul>
 								<hr />
@@ -210,18 +220,12 @@
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#993300" colspan="2" valign="top">
-								<h2 align="center" id="intro">
-									<font color="#FFFF00">
-										<font face="Arial, Helvetica, sans-serif">Introduction</font>
-									</font>
-								</h2>
+								<h2 align="center" id="intro">Introduction</h2>
 							</td>
 						</tr>
 						<tr>
 							<td bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#993300" face="Arial, Helvetica, sans-serif">Aims</font>
-								</h4>
+								<h4>Aims</h4>
 								<h4><img height="1" src="Resources/pics/PanelLine.gif" width="175" /></h4>
 							</td>
 							<td valign="top" width="525">
@@ -251,9 +255,7 @@
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#800000" face="Arial, Helvetica, sans-serif">Objectives</font>
-								</h4>
+								<h4>Objectives</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>By the end of this unit you should -</p>
@@ -281,9 +283,7 @@
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font>
-								</h4>
+								<h4>Prerequisites</h4>
 							</td>
 							<td valign="top" width="525">
 								<ul>
@@ -313,44 +313,30 @@
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#993300" colspan="2" valign="top">
-								<h2 align="center" id="part1">
-									<font color="#FFFF00">
-										<font face="Arial, Helvetica, sans-serif">The USAGE clause</font>
-									</font>
-								</h2>
+								<h2 align="center" id="part1">The USAGE clause</h2>
 							</td>
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#800000" face="Arial, Helvetica, sans-serif"><b>Introduction</b></font>
-								</h4>
+								<h4><b>Introduction</b></h4>
 								<div align="center">
 									<img height="37" src="Resources/pics/i-Detail.gif" width="30" />
 								</div>
 								<div align="center">
 									<p>
-										<font size="-1"><br /></font>
-										<font size="-1"
-											><b>ASCII</b><br />
-											<b>A</b>merican <b>S</b>tandard <b>C</b>ode for <b>I</b>nformation
-											<b>I</b>nterchange
-										</font>
+										<br />
+										<b>ASCII</b><br />
+										<b>A</b>merican <b>S</b>tandard <b>C</b>ode for <b>I</b>nformation
+										<b>I</b>nterchange
 									</p>
 									<p>
-										<font size="-1"
-											><b>EBCDIC<br /></b
-										></font>
-										<font size="-1"
-											><b>E</b>xtended <b>B</b>inary <b>C</b>oded <b>D</b>ecimal
-											<b>I</b>nterchange <b>C</b>ode
-										</font>
+										<b>EBCDIC<br /></b>
+										<b>E</b>xtended <b>B</b>inary <b>C</b>oded <b>D</b>ecimal <b>I</b>nterchange
+										<b>C</b>ode
 									</p>
 									<p>
-										<font size="-1"
-											><b>BCD</b><br />
-											<b>B</b>inary <b>C</b>oded <b>D</b>ecimal
-										</font>
+										<b>BCD</b><br />
+										<b>B</b>inary <b>C</b>oded <b>D</b>ecimal
 									</p>
 								</div>
 							</td>
@@ -387,15 +373,7 @@
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#800000"
-										><b>
-											<font face="Arial, Helvetica, sans-serif"
-												>Problems with USAGE IS DISPLAY</font
-											>
-										</b></font
-									>
-								</h4>
+								<h4><b>Problems with USAGE IS DISPLAY</b></h4>
 								<p align="center">
 									<img height="44" src="Resources/pics/aa-ProgFrag.gif" width="48" />
 								</p>
@@ -404,28 +382,22 @@
 										<img height="44" src="Resources/pics/aai-LightBulbTip.gif" width="42" />
 									</p>
 									<p>
-										<font size="-1"
-											>The speed of modern computers means that it is hardly worth the effort of
-											using the USAGE clause unless the data item is going to be used in thousands
-											of computations.</font
-										>
+										The speed of modern computers means that it is hardly worth the effort of using
+										the USAGE clause unless the data item is going to be used in thousands of
+										computations.
 									</p>
 									<p>
-										<font size="-1"
-											>For reasons of portability the
-											<code class="language-cobol">USAGE</code> clause should never be used in
-											record descriptions.<br />
-											If the file is read on a different make of computer we have no guarantee
-											that the data will be interpreted correctly.</font
-										>
+										For reasons of portability the
+										<code class="language-cobol">USAGE</code> clause should never be used in record
+										descriptions.<br />
+										If the file is read on a different make of computer we have no guarantee that
+										the data will be interpreted correctly.
 									</p>
 									<p>
-										<font size="-1"
-											>Even on the same make of computer, using the
-											<code class="language-cobol">USAGE</code> clause in record descriptions
-											means that the data in the file will probably not be understood by other
-											programming languages or by utility programs or by text editors.</font
-										>
+										Even on the same make of computer, using the
+										<code class="language-cobol">USAGE</code> clause in record descriptions means
+										that the data in the file will probably not be understood by other programming
+										languages or by utility programs or by text editors.
 									</p>
 								</aside>
 							</td>
@@ -483,15 +455,15 @@ Begin.
 									If you examine the ASCII table below you will see that the digit 4 (the value in
 									Num1) is encoded as
 									<b>
-										<font color="#FF0000">00110100</font>
+										<span style="color: #ff0000">00110100</span>
 									</b>
-									and the digit 1 is encoded as <font color="#FF0000"><b>00110001</b></font
+									and the digit 1 is encoded as <span style="color: #ff0000"><b>00110001</b></span
 									>.
 								</p>
 								<p>
 									When these these binary numbers are added together the result is
 									<b>
-										<font color="#FF0000">01100101</font>
+										<span style="color: #ff0000">01100101</span>
 									</b>
 									which is the ASCII code for the lower case letter "e".
 								</p>
@@ -1208,28 +1180,28 @@ Begin.
 											<td width="114">
 												<p align="center">
 													<b>
-														<font color="#FF0000">1</font>
+														<span style="color: #ff0000">1</span>
 													</b>
 												</p>
 											</td>
 											<td width="66">
 												<p align="center">
 													<b>
-														<font color="#FF0000">49</font>
+														<span style="color: #ff0000">49</span>
 													</b>
 												</p>
 											</td>
 											<td width="60">
 												<p align="center">
 													<b>
-														<font color="#FF0000">31</font>
+														<span style="color: #ff0000">31</span>
 													</b>
 												</p>
 											</td>
 											<td width="108">
 												<p align="center">
 													<b>
-														<font color="#FF0000">00110001</font>
+														<span style="color: #ff0000">00110001</span>
 													</b>
 												</p>
 											</td>
@@ -1266,28 +1238,28 @@ Begin.
 											<td width="114">
 												<p align="center">
 													<b>
-														<font color="#FF0000">4</font>
+														<span style="color: #ff0000">4</span>
 													</b>
 												</p>
 											</td>
 											<td width="66">
 												<p align="center">
 													<b>
-														<font color="#FF0000">52</font>
+														<span style="color: #ff0000">52</span>
 													</b>
 												</p>
 											</td>
 											<td width="60">
 												<p align="center">
 													<b>
-														<font color="#FF0000">34</font>
+														<span style="color: #ff0000">34</span>
 													</b>
 												</p>
 											</td>
 											<td width="108">
 												<p align="center">
 													<b>
-														<font color="#FF0000">00110100</font>
+														<span style="color: #ff0000">00110100</span>
 													</b>
 												</p>
 											</td>
@@ -1968,28 +1940,28 @@ Begin.
 											<td width="114">
 												<p align="center">
 													<b>
-														<font color="#FF0000">e</font>
+														<span style="color: #ff0000">e</span>
 													</b>
 												</p>
 											</td>
 											<td width="66">
 												<p align="center">
 													<b>
-														<font color="#FF0000">101</font>
+														<span style="color: #ff0000">101</span>
 													</b>
 												</p>
 											</td>
 											<td width="60">
 												<p align="center">
 													<b>
-														<font color="#FF0000">65</font>
+														<span style="color: #ff0000">65</span>
 													</b>
 												</p>
 											</td>
 											<td width="108">
 												<p align="center">
 													<b>
-														<font color="#FF0000">01100101</font>
+														<span style="color: #ff0000">01100101</span>
 													</b>
 												</p>
 											</td>
@@ -2366,9 +2338,7 @@ Begin.
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
 								<p>
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										><b>USAGE syntax and notes</b>
-									</font>
+									<b>USAGE syntax and notes</b>
 								</p>
 								<p align="center">
 									<img height="44" src="Resources/pics/aa-ProgFrag.gif" width="48" />
@@ -2378,27 +2348,20 @@ Begin.
 										<img height="62" src="Resources/pics/aai-BugAlert.gif" width="56" />
 									</p>
 									<p align="center">
-										<font size="-1"
-											>Group items are always treated as alphanumeric and this can cause problems
-											when there are subordinate COMP items.</font
-										>
+										Group items are always treated as alphanumeric and this can cause problems when
+										there are subordinate COMP items.
 									</p>
 									<p align="center">
-										<font size="-1"
-											>For instance, suppose we had a statement like -<br />
-											<code class="language-cobol">MOVE ZEROS TO GROUP2</code>.<br />
-											in the program opposite.</font
-										>
-										<font size="-1"
-											><br />
-											<br />
-											On the surface it looks as if this statement is moving the numeric value 0
-											to NumItem1 and NumItem2 but what is actually moved into these items is the
-											ASCII digit "0".<br />
-											<br />
-											When an attempt is made to use NumItem1 or NumItem2 in a calculation the
-											program will crash because these data-items contain non-numeric data.
-										</font>
+										For instance, suppose we had a statement like -<br />
+										<code class="language-cobol">MOVE ZEROS TO GROUP2</code>.<br />
+										in the program opposite.<br />
+										<br />
+										On the surface it looks as if this statement is moving the numeric value 0 to
+										NumItem1 and NumItem2 but what is actually moved into these items is the ASCII
+										digit "0".<br />
+										<br />
+										When an attempt is made to use NumItem1 or NumItem2 in a calculation the program
+										will crash because these data-items contain non-numeric data.
 									</p>
 								</aside>
 							</td>
@@ -2551,9 +2514,7 @@ Begin.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<font color="#800000" face="Arial, Helvetica, sans-serif"
-									><b>The SYNCHRONIZED clause</b>
-								</font>
+								<b>The SYNCHRONIZED clause</b>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -2628,17 +2589,12 @@ Begin.
 										These COBOL course materials are the copyright property of Michael Coughlan.
 									</p>
 									<p align="left">
-										<font size="2"
-											>All rights reserved. No part of these course materials may be reproduced in
-											any form or by any means - graphic, electronic, mechanical, photocopying,
-											printing, recording, taping or stored in an information storage and
-											retrieval system - without the written permission of</font
-										>
-										<font size="2">the author.</font>
+										All rights reserved. No part of these course materials may be reproduced in any
+										form or by any means - graphic, electronic, mechanical, photocopying, printing,
+										recording, taping or stored in an information storage and retrieval system -
+										without the written permission of the author.
 									</p>
-									<p align="center">
-										<font size="2">(c) Michael Coughlan</font>
-									</p>
+									<p align="center">(c) Michael Coughlan</p>
 								</div>
 							</td>
 						</tr>

--- a/course/index.html
+++ b/course/index.html
@@ -69,7 +69,7 @@
 				<td width="350" height="105">
 					<h1>
 						<img src="../pics/T-Dept.gif" width="297" height="36" /><br />
-						<font size="5"><font color="#000000">&nbsp;COBOL Programming Course</font></font>
+						&nbsp;COBOL Programming Course
 					</h1>
 					<p align="center">
 						<b
@@ -89,7 +89,7 @@
 							<td width="14%" height="15">
 								<img src="Resources/pics/i-Tuts.gif" width="22" height="21" vspace="1" hspace="2" />
 							</td>
-							<td width="86%" height="15"><font size="-1">COBOL tutorial</font></td>
+							<td width="86%" height="15">COBOL tutorial</td>
 						</tr>
 						<tr>
 							<td width="14%">
@@ -101,11 +101,11 @@
 									vspace="1"
 								/>
 							</td>
-							<td width="86%"><font size="-1">COBOL programming exercise</font></td>
+							<td width="86%">COBOL programming exercise</td>
 						</tr>
 						<tr valign="middle">
 							<td width="14%" height="8"><img src="Resources/pics/i-SAQ.gif" vspace="0" hspace="2" /></td>
-							<td width="86%" height="8"><font size="-1">Self assessement questions</font></td>
+							<td width="86%" height="8">Self assessement questions</td>
 						</tr>
 					</table>
 				</td>

--- a/examples/default.html
+++ b/examples/default.html
@@ -160,6 +160,17 @@
 				padding-left: 0.4em;
 				margin-bottom: 0.4em;
 			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			td[bgcolor="#FFFFCC"] h3,
+			td[bgcolor="#FFFFCC"] h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
+			}
 		</style>
 	</head>
 
@@ -174,21 +185,17 @@
 			<tr>
 				<td>
 					<p>
-						<font size="-1"
-							>These pages contain a large number of example COBOL programs. The programs may be
-							downloaded, or viewed in your browser. Test data for the example COBOL programs is also
-							provided where appropriate.</font
-						>
+						These pages contain a large number of example COBOL programs. The programs may be downloaded, or
+						viewed in your browser. Test data for the example COBOL programs is also provided where
+						appropriate.
 					</p>
 					<p>
-						<font size="-1"
-							>The programs have been compiled and tested using Microfocus NetExpress but they should work
-							on any COBOL-85 complient compiler with very few changes.<br />
-							You may have to reformat the programs if your compiler does not have the equivalent of the $
-							SET SOURCEFORMAT"FREE". This compiler directive frees Microfocus COBOL programs from the
-							normal COBOL formatting conventions.<br />
-							You may also have to remove the</font
-						>
+						The programs have been compiled and tested using Microfocus NetExpress but they should work on
+						any COBOL-85 complient compiler with very few changes.<br />
+						You may have to reformat the programs if your compiler does not have the equivalent of the $ SET
+						SOURCEFORMAT"FREE". This compiler directive frees Microfocus COBOL programs from the normal
+						COBOL formatting conventions.<br />
+						You may also have to remove the
 						<code class="language-cobol">ORGANIZATION IS LINE SEQUENTIAL</code> phrase in the
 						<code class="language-cobol">SELECT</code> and <code class="language-cobol">ASSIGN</code> clause
 						of sequential files. In Microfocus COBOL,
@@ -196,14 +203,12 @@
 						return and line feed.
 					</p>
 					<p align="center">
-						<font size="-1"><b>Copyright Notice</b></font>
+						<b>Copyright Notice</b>
 					</p>
 					<p align="left">
-						<font size="-1"
-							>These programs are the copyright property of Michael Coughlan. You have permission to use
-							these programs for your own personal use but you may not reproduce them in any published
-							work without written permission from the author.</font
-						>
+						These programs are the copyright property of Michael Coughlan. You have permission to use these
+						programs for your own personal use but you may not reproduce them in any published work without
+						written permission from the author.
 					</p>
 				</td>
 			</tr>
@@ -212,58 +217,44 @@
 		<a id="pagetop"></a>
 		<ul class="toc">
 			<li>
-				<a href="#SimplePrograms">Beginners Programs</a> -
-				<font size="-1"
-					>Simple programs using <code class="language-cobol">ACCEPT</code>,
-					<code class="language-cobol">DISPLAY</code> and some arithmetic verbs.</font
-				>
+				<a href="#SimplePrograms">Beginners Programs</a> - Simple programs using
+				<code class="language-cobol">ACCEPT</code>, <code class="language-cobol">DISPLAY</code> and some
+				arithmetic verbs.
 			</li>
 			<li>
 				<a href="#Selection">Selection and Iteration</a>
-				<font size="-1"
-					>- Selection (<code class="language-cobol">IF</code>, <code class="language-cobol">EVALUATE</code>)
-					and Iteration (<code class="language-cobol">PERFORM</code>) example programs.</font
-				>
+				- Selection (<code class="language-cobol">IF</code>, <code class="language-cobol">EVALUATE</code>) and
+				Iteration (<code class="language-cobol">PERFORM</code>) example programs.
 			</li>
 			<li>
-				<a href="#SequentialFiles">Sequential Files</a>&nbsp; -
-				<font size="-1">Programs that demonstrate how to process sequential files.</font>
+				<a href="#SequentialFiles">Sequential Files</a>&nbsp; - Programs that demonstrate how to process
+				sequential files.
 			</li>
 			<li>
-				<a href="#Sort">Sorting and Merging</a> -
-				<font size="-1"
-					>Examples that use <code class="language-cobol">INPUT PROCEDURE</code>'s and the
-					<code class="language-cobol">SORT</code> and <code class="language-cobol">MERGE</code> verbs</font
-				>
+				<a href="#Sort">Sorting and Merging</a> - Examples that use
+				<code class="language-cobol">INPUT PROCEDURE</code>'s and the
+				<code class="language-cobol">SORT</code> and <code class="language-cobol">MERGE</code> verbs
 			</li>
 			<li>
-				<a href="#Direct">Direct Access Files</a> -
-				<font size="-1">Example programs that show how to process Indexed and Relative files.</font>
+				<a href="#Direct">Direct Access Files</a> - Example programs that show how to process Indexed and
+				Relative files.
 			</li>
 			<li>
-				<a href="#Call">CALLing sub-programs</a> -
-				<font size="-1">Example programs that Demonstrate contained, and external, sub-programs.</font>
+				<a href="#Call">CALLing sub-programs</a> - Example programs that Demonstrate contained, and external,
+				sub-programs.
 			</li>
 			<li>
-				<a href="#Strings">String handling</a> -
-				<font size="-1"
-					>Example programs that show how to use Reference Modification,
-					<code class="language-cobol">INSPECT</code> and <code class="language-cobol">UNSTRING</code>.</font
-				>
+				<a href="#Strings">String handling</a> - Example programs that show how to use Reference Modification,
+				<code class="language-cobol">INSPECT</code> and <code class="language-cobol">UNSTRING</code>.
 			</li>
-			<li>
-				<a href="#Reports">The COBOL Report Writer</a> -
-				<font size="-1">Example programs using the COBOL Report Writer.</font>
-			</li>
-			<li><a href="#Tables">COBOL Tables</a> - <font size="-1">Example programs using tables.</font></li>
+			<li><a href="#Reports">The COBOL Report Writer</a> - Example programs using the COBOL Report Writer.</li>
+			<li><a href="#Tables">COBOL Tables</a> - Example programs using tables.</li>
 		</ul>
 		<table border="0" bordercolordark="#000000" bordercolorlight="#FFFFFF" width="725">
 			<tr bgcolor="#990000" valign="top">
 				<td colspan="4">
 					<h2 align="center" id="SimplePrograms">
-						<b>
-							<font color="#FFFF00">Beginners programs</font>
-						</b>
+						<b> Beginners programs </b>
 					</h2>
 				</td>
 			</tr>
@@ -286,10 +277,8 @@
 					<div align="center">Shortest.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>This example program is almost the shortest COBOL program we can have. We could make it shorter
-						still by leaving out the STOP RUN.</font
-					>
+					This example program is almost the shortest COBOL program we can have. We could make it shorter
+					still by leaving out the STOP RUN.
 				</td>
 				<td width="189">
 					<div align="center">
@@ -308,10 +297,8 @@
 					<p align="center">Accept.cbl</p>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>The program accepts a simple student record from the user and displays the individual fields.
-						Also shows how the ACCEPT may be used to get and DISPLAY the system time and date.</font
-					>
+					The program accepts a simple student record from the user and displays the individual fields. Also
+					shows how the ACCEPT may be used to get and DISPLAY the system time and date.
 				</td>
 				<td width="189">
 					<div align="center">
@@ -333,10 +320,7 @@
 					<div align="center">Multiplier.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>Accepts two single digit numbers from the user, multiplies them together and displays the
-						result.</font
-					>
+					Accepts two single digit numbers from the user, multiplies them together and displays the result.
 				</td>
 				<td width="189">
 					<div align="center">
@@ -365,9 +349,7 @@
 			<tr bgcolor="#990000" valign="top">
 				<td colspan="4">
 					<h2 align="center" id="Selection">
-						<b>
-							<font color="#FFFF00">Selection and Interation</font>
-						</b>
+						<b> Selection and Interation </b>
 					</h2>
 				</td>
 			</tr>
@@ -391,10 +373,8 @@
 				</td>
 				<td align="left" height="49" width="298">
 					<p>
-						<font size="-1"
-							>An example program that implements a primative calculator. The calculator only does
-							additions and multiplications.<br
-						/></font>
+						An example program that implements a primative calculator. The calculator only does additions
+						and multiplications.<br />
 						&nbsp;
 					</p>
 				</td>
@@ -416,10 +396,8 @@
 					<div align="center">Conditions.cbl</div>
 				</td>
 				<td align="left" height="24" width="298">
-					<font size="-1"
-						>An example program demonstrating the use of Condition Names (level 88's).<br />
-						&nbsp;</font
-					>
+					An example program demonstrating the use of Condition Names (level 88's).<br />
+					&nbsp;
 				</td>
 				<td height="24" width="189">
 					<div align="center">
@@ -439,11 +417,9 @@
 					<div align="center">Perform1.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>An example program demonstrating how the first format of the PERFORM may be used to change the
-						flow of control through a program.<br />
-						&nbsp;<br
-					/></font>
+					An example program demonstrating how the first format of the PERFORM may be used to change the flow
+					of control through a program.<br />
+					&nbsp;<br />
 				</td>
 				<td width="189">
 					<div align="center">
@@ -462,11 +438,9 @@
 					<div align="center">Perform2.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>Demonstrates the second format of the PERFORM. The PERFORM..TIMES may be used to execute a
-						block of code x number of times.<br />
-						&nbsp;</font
-					>
+					Demonstrates the second format of the PERFORM. The PERFORM..TIMES may be used to execute a block of
+					code x number of times.<br />
+					&nbsp;
 				</td>
 				<td width="189">
 					<div align="center">
@@ -485,11 +459,9 @@
 					<div align="center">Perform3.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values
-						where the length of the stream cannot be determined in advance (although in this case there is a
-						set maximum number of values in the stream).</font
-					><br />
+					Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values where
+					the length of the stream cannot be determined in advance (although in this case there is a set
+					maximum number of values in the stream).<br />
 					&nbsp;<br />
 				</td>
 				<td width="189">
@@ -511,12 +483,9 @@
 					<div align="center">Perform4.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be
-						used for counting iteration. Also introduces the WITH TEST BEFORE and WITH TEST AFTER
-						phrases.<br />
-						&nbsp;</font
-					>
+					Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used
+					for counting iteration. Also introduces the WITH TEST BEFORE and WITH TEST AFTER phrases.<br />
+					&nbsp;
 				</td>
 				<td width="189">
 					<div align="center">
@@ -534,11 +503,9 @@
 					<div align="center">MileageCount.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be
-						used to simulate a mileage counter.<br />
-						&nbsp;</font
-					>
+					Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used to
+					simulate a mileage counter.<br />
+					&nbsp;
 				</td>
 				<td width="189">
 					<div align="center">
@@ -567,9 +534,7 @@
 			<tr bgcolor="#990000" valign="top">
 				<td colspan="4">
 					<h2 align="center" id="SequentialFiles">
-						<b>
-							<font color="#FFFF00">Sequential Files</font>
-						</b>
+						<b> Sequential Files </b>
 					</h2>
 				</td>
 			</tr>
@@ -592,10 +557,8 @@
 					<div align="center">SeqWrite.cbl</div>
 				</td>
 				<td align="left" height="31" width="298">
-					<font size="-1"
-						>Example program demonstrating how to create a sequential file from data input by the user.<br />
-						&nbsp;</font
-					>
+					Example program demonstrating how to create a sequential file from data input by the user.<br />
+					&nbsp;
 				</td>
 				<td height="31" width="189">
 					<div align="center">
@@ -616,11 +579,9 @@
 					<div align="center">SeqReadno88.cbl</div>
 				</td>
 				<td align="left" height="21" width="298">
-					<font size="-1"
-						>An example program that reads a sequential file and displays the records. This version does not
-						use level 88's to signal when the end of the file has been reached.<br />
-						To test the program download this<a href="SeqRead/STUDENTS.DAT">testdata file</a>.</font
-					><br />
+					An example program that reads a sequential file and displays the records. This version does not use
+					level 88's to signal when the end of the file has been reached.<br />
+					To test the program download this<a href="SeqRead/STUDENTS.DAT">testdata file</a>.<br />
 					&nbsp;
 				</td>
 				<td height="21" width="189">
@@ -642,16 +603,12 @@
 					<div align="center">SeqRead.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>An example program that reads a sequential file and displays the records. This is the correct
-						version which uses the Condition Name (level 88) "EndOfFile"to signal when the end of the file
-						has been reached.<br />
-						To test the program download this</font
-					>
-					<font size="-1"
-						><a href="SeqRead/STUDENTS.DAT">testdata file</a>.<br />
-						&nbsp;</font
-					>
+					An example program that reads a sequential file and displays the records. This is the correct
+					version which uses the Condition Name (level 88) "EndOfFile"to signal when the end of the file has
+					been reached.<br />
+					To test the program download this
+					<a href="SeqRead/STUDENTS.DAT">testdata file</a>.<br />
+					&nbsp;
 				</td>
 				<td width="189">
 					<div align="center">
@@ -672,14 +629,12 @@
 					<div align="center">SeqInsert.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>Demonstrates how to insert records into a sequential file from a file of transaction records. A
-						new file is created which contains the inserted records.<br />
-						To test this program you will need to download Student Masterfile -
-						<a href="SeqIns/STUDENTS.DAT">Students.Dat</a> and the Transaction file
-						<a href="SeqIns/TRANSINS.DAT">Transins.dat</a>
-					</font>
-					<font size="-1">.</font><br />
+					Demonstrates how to insert records into a sequential file from a file of transaction records. A new
+					file is created which contains the inserted records.<br />
+					To test this program you will need to download Student Masterfile -
+					<a href="SeqIns/STUDENTS.DAT">Students.Dat</a> and the Transaction file
+					<a href="SeqIns/TRANSINS.DAT">Transins.dat</a>
+					.<br />
 					&nbsp;
 				</td>
 				<td width="189">
@@ -700,16 +655,10 @@
 					<div align="center">SeqRpt.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>This program reads records from the student file, counts the total number of student records in
-						the file and the number records for females and males. Prints the results in a very short
-						report.</font
-					>
-					<font size="-1"
-						><br />
-						To test the program download <a href="SeqIns/STUDENTS.DAT">Students.Dat</a><br />
-						&nbsp;</font
-					>
+					This program reads records from the student file, counts the total number of student records in the
+					file and the number records for females and males. Prints the results in a very short report.<br />
+					To test the program download <a href="SeqIns/STUDENTS.DAT">Students.Dat</a><br />
+					&nbsp;
 				</td>
 				<td width="189">
 					<div align="center">
@@ -738,9 +687,7 @@
 			<tr bgcolor="#990000" valign="top">
 				<td colspan="4">
 					<h2 align="center" id="Sort">
-						<b>
-							<font color="#FFFF00">Sorting and Merging</font>
-						</b>
+						<b> Sorting and Merging </b>
 					</h2>
 				</td>
 			</tr>
@@ -763,11 +710,9 @@
 					<div align="center">InputSort.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>Uses the SORT and an INPUT PROCEDURE to accept records from the user and sort them on ascending
-						StudentId.<br />
-						&nbsp;</font
-					>
+					Uses the SORT and an INPUT PROCEDURE to accept records from the user and sort them on ascending
+					StudentId.<br />
+					&nbsp;
 				</td>
 				<td width="189">
 					<div align="center"><code class="language-cobol">SORT</code>, Input Procedure</div>
@@ -784,15 +729,10 @@
 					<div align="center">MaleSort.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>Sorts the student masterfile (sorted on ascending Student Id) and produces a new file, sorted
-						on ascending student name, containing only the records of male students.</font
-					>
-					<font size="-1"
-						><br />
-						To test the program download <a href="SeqIns/STUDENTS.DAT">Students.Dat</a><br />
-						&nbsp;</font
-					>
+					Sorts the student masterfile (sorted on ascending Student Id) and produces a new file, sorted on
+					ascending student name, containing only the records of male students.<br />
+					To test the program download <a href="SeqIns/STUDENTS.DAT">Students.Dat</a><br />
+					&nbsp;
 				</td>
 				<td width="189">
 					<div align="center"><code class="language-cobol">SORT</code>, Input Procedure</div>
@@ -809,16 +749,11 @@
 					<div align="center">Merge.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>Uses the MERGE to insert records from a transaction file into a sequential master file.
-					</font>
-					<font size="-1"
-						>.<br />
-						To test this program you will need to download Student Masterfile -
-						<a href="SeqIns/STUDENTS.DAT">Students.Dat</a> and the Transaction file
-						<a href="SeqIns/TRANSINS.DAT">Transins.dat</a>
-					</font>
-					<font size="-1">.</font><br />
+					Uses the MERGE to insert records from a transaction file into a sequential master file. .<br />
+					To test this program you will need to download Student Masterfile -
+					<a href="SeqIns/STUDENTS.DAT">Students.Dat</a> and the Transaction file
+					<a href="SeqIns/TRANSINS.DAT">Transins.dat</a>
+					.<br />
 					&nbsp;
 				</td>
 				<td width="189">
@@ -838,15 +773,13 @@
 					<div align="center">AromaSalesRpt.Cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>Exam paper model answer. A program is required to produce a summary sales report from an
-						unsorted sequential file containing the details of sales of essential and base oils to Aromamora
-						customers.<br />
-						Read the
-						<a href="../exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html">program specification</a>
-						first. The required data files may be downloaded from there.<br />
-						&nbsp;<br />
-					</font>
+					Exam paper model answer. A program is required to produce a summary sales report from an unsorted
+					sequential file containing the details of sales of essential and base oils to Aromamora
+					customers.<br />
+					Read the
+					<a href="../exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html">program specification</a>
+					first. The required data files may be downloaded from there.<br />
+					&nbsp;<br />
 				</td>
 				<td width="189">
 					<div align="center">
@@ -865,16 +798,12 @@
 				<td height="75" width="135">CSISEmailDomain.Cbl</td>
 				<td align="left" height="75" width="298">
 					<p>
-						<font size="-1"
-							>Exam paper model answer. A program is required which will produce a file, sorted on
-							ascending email domain, from the unsorted GraduateInfo file.<br />
-							Read the
-							<a href="../exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html"
-								>program specification</a
-							>
-							first. The required data files may be downloaded from there.<br />
-							&nbsp;
-						</font>
+						Exam paper model answer. A program is required which will produce a file, sorted on ascending
+						email domain, from the unsorted GraduateInfo file.<br />
+						Read the
+						<a href="../exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html">program specification</a>
+						first. The required data files may be downloaded from there.<br />
+						&nbsp;
 					</p>
 				</td>
 				<td height="75" width="189">
@@ -895,20 +824,16 @@
 					<div align="center">BestSellers.Cbl</div>
 				</td>
 				<td align="left" height="75" width="298">
-					<font size="-1"
-						>Exam paper model answer. The Folio Society is a Book Club that sells fine books to customers
-						all over the world. A program is required to print a list of the ten best selling books (by
-						copies sold) in the Book Club.<br />
-						Read the
-						<a href="../exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html">program specification</a>
-						first. The required data files may be downloaded from there.<br />
-						&nbsp;<br />
-					</font>
+					Exam paper model answer. The Folio Society is a Book Club that sells fine books to customers all
+					over the world. A program is required to print a list of the ten best selling books (by copies sold)
+					in the Book Club.<br />
+					Read the
+					<a href="../exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html">program specification</a>
+					first. The required data files may be downloaded from there.<br />
+					&nbsp;<br />
 				</td>
 				<td height="75" width="189">
-					<font size="-1"
-						>(Sequential Files, Print Files, SORT with Input Procedure and Output Procedure, Tables)
-					</font>
+					(Sequential Files, Print Files, SORT with Input Procedure and Output Procedure, Tables)
 				</td>
 				<td height="75" width="71">
 					<div align="center">
@@ -922,14 +847,12 @@
 					<div align="center">DueSubRpt.Cbl</div>
 				</td>
 				<td align="left" height="116" width="298">
-					<font size="-1"
-						>Exam paper model answer. NetNews is a company which runs an NNTP server carrying the complete
-						USENET news feed with over 15,000 news groups. Access to this server is available to internet
-						users all over the world. Users of the system pay a subscription fee for access. A program is
-						required to produce a report showing the subscriptions which are now due. The report will be
-						based on the Due Subscriptions file.<br />
-						&nbsp;</font
-					>
+					Exam paper model answer. NetNews is a company which runs an NNTP server carrying the complete USENET
+					news feed with over 15,000 news groups. Access to this server is available to internet users all
+					over the world. Users of the system pay a subscription fee for access. A program is required to
+					produce a report showing the subscriptions which are now due. The report will be based on the Due
+					Subscriptions file.<br />
+					&nbsp;
 				</td>
 				<td height="116" width="189">
 					(Sequential Files, Print Files, <code class="language-cobol">SORT</code> with Input Procedure,
@@ -956,9 +879,7 @@
 			<tr bgcolor="#990000" valign="top">
 				<td colspan="4">
 					<h2 align="center" id="Direct">
-						<b>
-							<font color="#FFFF00">Direct Access Files</font>
-						</b>
+						<b> Direct Access Files </b>
 					</h2>
 				</td>
 			</tr>
@@ -981,12 +902,10 @@
 					<div align="center">Seq2Rel.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>Creates a direct access Relative file from a Sequential File. Note that Relative files are not
-						standard ASCII files and so cannot be created with an editor as Sequential files can.<br />
-						To create the Relative file you will need to download the supplier file
-						<a href="Relative/SEQSUPP.dat">SEQSUPP.DAT</a> </font
-					><br />
+					Creates a direct access Relative file from a Sequential File. Note that Relative files are not
+					standard ASCII files and so cannot be created with an editor as Sequential files can.<br />
+					To create the Relative file you will need to download the supplier file
+					<a href="Relative/SEQSUPP.dat">SEQSUPP.DAT</a><br />
 					&nbsp;
 				</td>
 				<td width="189">
@@ -1009,12 +928,10 @@
 					<div align="center">ReadRel.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>Reads the Relative file - RELSUPP.DAT - created in the previous example program and displays
-						the records. Allows the user to choose to read through and display all the records in the file
-						sequentially, or to use a key to read just one record directly.<br />
-						&nbsp;</font
-					>
+					Reads the Relative file - RELSUPP.DAT - created in the previous example program and displays the
+					records. Allows the user to choose to read through and display all the records in the file
+					sequentially, or to use a key to read just one record directly.<br />
+					&nbsp;
 				</td>
 				<td width="189">
 					<div align="center">
@@ -1037,15 +954,11 @@
 					<div align="center">Seq2Index.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>Creates a direct access Indexed file from a Sequential file. Note that Microfocus Indexed files
-						actually consist of two files - the data file and the index file (.idx).<br
-					/></font>
-					<font size="-1"
-						>To create the Indexed file you will need to download the supplier file
-						<a href="Indexed/SEQVIDEO.dat">SEQVIDEO.DAT</a><br />
-						&nbsp;
-					</font>
+					Creates a direct access Indexed file from a Sequential file. Note that Microfocus Indexed files
+					actually consist of two files - the data file and the index file (.idx).<br />
+					To create the Indexed file you will need to download the supplier file
+					<a href="Indexed/SEQVIDEO.dat">SEQVIDEO.DAT</a><br />
+					&nbsp;
 				</td>
 				<td width="189">
 					<div align="center">
@@ -1067,11 +980,9 @@
 					<div align="center">DirectReadIdx.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>Does a direct read on the Indexed file created by the previous example program. Allows the user
-						to choose which of the keys to use for the direct read.<br />
-						&nbsp;</font
-					>
+					Does a direct read on the Indexed file created by the previous example program. Allows the user to
+					choose which of the keys to use for the direct read.<br />
+					&nbsp;
 				</td>
 				<td width="189">
 					<div align="center">Indexed files, <code class="language-cobol">READ..KEY IS</code>.</div>
@@ -1088,11 +999,9 @@
 					<div align="center">SeqReadIdx.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>Reads the Indexed file sequentially on whichever key is chosen by the user. Displays all the
-						records in the file.<br />
-						&nbsp;</font
-					>
+					Reads the Indexed file sequentially on whichever key is chosen by the user. Displays all the records
+					in the file.<br />
+					&nbsp;
 				</td>
 				<td width="189">
 					<div align="center">
@@ -1113,14 +1022,12 @@
 				</td>
 				<td align="left" height="87" width="298">
 					<p>
-						<font size="-1"
-							>Exam paper model answer. A program which applies a transaction file of student payments to
-							a Student Master File and which then produces a report showing those students whose fees are
-							partially or wholly outstanding. Read the
-							<a href="../exercises/Exm-StudFeesRpt/Exm-StudPay.html">program specification</a> first. The
-							required data files may be downloaded from there.<br />
-							&nbsp;
-						</font>
+						Exam paper model answer. A program which applies a transaction file of student payments to a
+						Student Master File and which then produces a report showing those students whose fees are
+						partially or wholly outstanding. Read the
+						<a href="../exercises/Exm-StudFeesRpt/Exm-StudPay.html">program specification</a> first. The
+						required data files may be downloaded from there.<br />
+						&nbsp;
 					</p>
 				</td>
 				<td height="87" width="189">
@@ -1144,20 +1051,16 @@
 					<div align="center">Aroma96.cbl</div>
 				</td>
 				<td align="left" height="87" width="298">
-					<font size="-1"
-						>Exam paper model answer. A program is required which will apply a file of sorted, validated
-						transactions to the Oil-Stock-File and then produce a report based on the contents of both the
-						Oil-Details-File and the Oil-Stock-File. The report writer must be used to produce the report
-						which must be printed sequenced on ascending Oil-Name.</font
-					><br />
-					<font size="-1"
-						>Read the
-						<a href="../exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html"
-							>program specification</a
-						>
-						first. The required data files may be downloaded from there.<br />
-						&nbsp; </font
-					><br />
+					Exam paper model answer. A program is required which will apply a file of sorted, validated
+					transactions to the Oil-Stock-File and then produce a report based on the contents of both the
+					Oil-Details-File and the Oil-Stock-File. The report writer must be used to produce the report which
+					must be printed sequenced on ascending Oil-Name.<br />
+					Read the
+					<a href="../exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html"
+						>program specification</a
+					>
+					first. The required data files may be downloaded from there.<br />
+					&nbsp;<br />
 				</td>
 				<td height="87" width="189">
 					<div align="center">
@@ -1182,18 +1085,16 @@
 				</td>
 				<td align="left" height="131" width="298">
 					<p>
-						<font size="-1"
-							>Exam paper model answer. A program is required to produce a Purchase Requirements Report
-							from the Publisher, Book and Purchase Requirements files. The report should be sequenced on
-							ascending Publisher Name and should only detail the purchase requirements for the semester
-							under scrutiny.<br />
-							Read the
-							<a href="../exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html"
-								>program specification</a
-							>
-							first. The required data files may be downloaded from there.<br />
-							&nbsp;
-						</font>
+						Exam paper model answer. A program is required to produce a Purchase Requirements Report from
+						the Publisher, Book and Purchase Requirements files. The report should be sequenced on ascending
+						Publisher Name and should only detail the purchase requirements for the semester under
+						scrutiny.<br />
+						Read the
+						<a href="../exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html"
+							>program specification</a
+						>
+						first. The required data files may be downloaded from there.<br />
+						&nbsp;
 					</p>
 				</td>
 				<td height="131" width="189">
@@ -1216,17 +1117,15 @@
 					<div align="center">LibRoyaltyRpt.Cbl</div>
 				</td>
 				<td align="left" height="159" width="298">
-					<font size="-1"
-						>Exam paper model answer. Each time a book is borrowed, the Pascal Memorial Library pays the
-						author a small sum of money as royalty. Royalties are paid to authors through their agents. A
-						report is required which processes the Authors file and the Books File to produce a report which
-						shows the amount to be sent to each agent, shows the breakdown of the agent payment into author
-						payments, and shows the breakdown of each author payment into royalty payments per book.<br />
-						Read the
-						<a href="../exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html">program specification</a>
-						first. The required data files may be downloaded from there.<br />
-						&nbsp;
-					</font>
+					Exam paper model answer. Each time a book is borrowed, the Pascal Memorial Library pays the author a
+					small sum of money as royalty. Royalties are paid to authors through their agents. A report is
+					required which processes the Authors file and the Books File to produce a report which shows the
+					amount to be sent to each agent, shows the breakdown of the agent payment into author payments, and
+					shows the breakdown of each author payment into royalty payments per book.<br />
+					Read the
+					<a href="../exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html">program specification</a>
+					first. The required data files may be downloaded from there.<br />
+					&nbsp;
 				</td>
 				<td height="159" width="189">
 					<div align="center">
@@ -1246,16 +1145,13 @@
 			<tr valign="top">
 				<td height="138" width="135">TopSuppliersRpt.Cbl</td>
 				<td align="left" height="138" width="298">
-					<font size="-1">Exam paper model answer.</font>
-					<font size="-1"
-						>The manager of Metropolis Videos has asked you to write a program to produce a report showing
-						the top three Video Suppliers (by total store video earnings) and for each of the top three the
-						most popular video title (by average earnings) must be shown.<br />
-						Read the
-						<a href="../exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html">program specification</a>
-						first. The required data files may be downloaded from there.<br />
-						&nbsp;
-					</font>
+					Exam paper model answer. The manager of Metropolis Videos has asked you to write a program to
+					produce a report showing the top three Video Suppliers (by total store video earnings) and for each
+					of the top three the most popular video title (by average earnings) must be shown.<br />
+					Read the
+					<a href="../exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html">program specification</a>
+					first. The required data files may be downloaded from there.<br />
+					&nbsp;
 				</td>
 				<td height="138" width="189">
 					<div align="center">
@@ -1284,9 +1180,7 @@
 			<tr bgcolor="#990000" valign="top">
 				<td colspan="4">
 					<h2 align="center" id="Call">
-						<b>
-							<font color="#FFFF00">CALLing sub-programs</font>
-						</b>
+						<b> CALLing sub-programs </b>
 					</h2>
 				</td>
 			</tr>
@@ -1309,14 +1203,12 @@
 					<div align="center">DriverProg.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>This program demonstrates the CALL verb by calling three external sub-programs.<br />
-						The "MultiplyNums" sub-program demonstrates flow of control - from caller to called and back
-						again - and the use of parameters.<br />
-						The "Fickle" sub-program demonstrates State Memory.<br />
-						The "Steadfast" sub-program shows how a sub-program can use the IS INITIAL phrase to avoid State
-						Memory</font
-					>.<br />
+					This program demonstrates the CALL verb by calling three external sub-programs.<br />
+					The "MultiplyNums" sub-program demonstrates flow of control - from caller to called and back again -
+					and the use of parameters.<br />
+					The "Fickle" sub-program demonstrates State Memory.<br />
+					The "Steadfast" sub-program shows how a sub-program can use the IS INITIAL phrase to avoid State
+					Memory.<br />
 					&nbsp;
 				</td>
 				<td width="189">
@@ -1338,12 +1230,10 @@
 					<div align="center">MultiplyNums.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>The "MultiplyNums" sub-program, called from the driver program above, demonstrates the flow of
-						control from the driver program to the called sub-program and back again. It uses numeric and
-						string parameters and demonstrates the BY REFERENCE (the default) and BY CONTENT parameter
-						passing mechanisms.</font
-					><br />
+					The "MultiplyNums" sub-program, called from the driver program above, demonstrates the flow of
+					control from the driver program to the called sub-program and back again. It uses numeric and string
+					parameters and demonstrates the BY REFERENCE (the default) and BY CONTENT parameter passing
+					mechanisms.<br />
 					&nbsp;
 				</td>
 				<td width="189">
@@ -1364,11 +1254,9 @@
 					<div align="center">Fickle.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>Fickle is a sub-program called from DriverProg.cbl above. Fickle is a program that demonstrates
-						State Memory. Each time the program is called it remembers its state from the previous call.<br />
-						&nbsp;</font
-					>
+					Fickle is a sub-program called from DriverProg.cbl above. Fickle is a program that demonstrates
+					State Memory. Each time the program is called it remembers its state from the previous call.<br />
+					&nbsp;
 				</td>
 				<td width="189">
 					<div align="center">
@@ -1388,11 +1276,9 @@
 					<div align="center">Steadfast.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>Steadfast is a sub-program called from DriverProg.cbl above. Steadfast is identical to Fickle
-						except that it uses the IS INITIAL phrase to avoid State Memory.<br />
-						&nbsp;</font
-					>
+					Steadfast is a sub-program called from DriverProg.cbl above. Steadfast is identical to Fickle except
+					that it uses the IS INITIAL phrase to avoid State Memory.<br />
+					&nbsp;
 				</td>
 				<td width="189">
 					<div align="center">
@@ -1413,11 +1299,9 @@
 					<div align="center">DateDriver.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>A driver program for the date validation sub-program below. Accepts a date from the user,
-						passes it to the date validation sub-program and interprets and displays the result.<br />
-						&nbsp;</font
-					>
+					A driver program for the date validation sub-program below. Accepts a date from the user, passes it
+					to the date validation sub-program and interprets and displays the result.<br />
+					&nbsp;
 				</td>
 				<td width="189">
 					<div align="center">
@@ -1438,11 +1322,9 @@
 					<div align="center">ValiDate.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a code
-						indicating if the date was valid or not. If not valid, the code indicates why the date was not
-						valid (e.g. day to great for month).</font
-					>
+					A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a code
+					indicating if the date was valid or not. If not valid, the code indicates why the date was not valid
+					(e.g. day to great for month).
 				</td>
 				<td width="189">
 					<div align="center">
@@ -1466,13 +1348,11 @@
 					<div align="center">DayDiffDriver.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>A driver program that accepts two dates from the user and displays the difference in days
-						between them. This program uses the
-						<a href="SubProg/DateValid/ValiDate.cbl">ValiDate.cbl</a> sub-program above and also contains a
-						number of contained sub-programs.<br />
-						&nbsp;
-					</font>
+					A driver program that accepts two dates from the user and displays the difference in days between
+					them. This program uses the
+					<a href="SubProg/DateValid/ValiDate.cbl">ValiDate.cbl</a> sub-program above and also contains a
+					number of contained sub-programs.<br />
+					&nbsp;
 				</td>
 				<td width="189">
 					<div align="center">
@@ -1496,19 +1376,15 @@
 				</td>
 				<td align="left" height="157" width="298">
 					<p>
-						<font size="-1"
-							>Exam paper model answer. A program is required which will process the Stock and
-							Manufacturer files to create an Orders file containing ordering information for all the
-							parts that need to be re-ordered (i.e. where the QtyInStock is less than the ReorderLevel).
-							For EU countries only, the COSTOFITEMS and POSTAGE fields of each Orders file record must be
-							calculated. The Postage rate is obtained by calling an existing program.<br />
-							Read the
-							<a href="../exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html"
-								>program specification</a
-							>
-							first. The required data files may be downloaded from there.<br />
-							&nbsp;
-						</font>
+						Exam paper model answer. A program is required which will process the Stock and Manufacturer
+						files to create an Orders file containing ordering information for all the parts that need to be
+						re-ordered (i.e. where the QtyInStock is less than the ReorderLevel). For EU countries only, the
+						COSTOFITEMS and POSTAGE fields of each Orders file record must be calculated. The Postage rate
+						is obtained by calling an existing program.<br />
+						Read the
+						<a href="../exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html">program specification</a>
+						first. The required data files may be downloaded from there.<br />
+						&nbsp;
 					</p>
 				</td>
 				<td height="157" width="189">
@@ -1532,22 +1408,17 @@
 					<div align="center">SFbyMail.cbl</div>
 				</td>
 				<td align="left" height="157" width="298">
-					<font size="-1">Exam paper model answer.</font>
-					<font size="-1"
-						>A program is required to apply the Orders file (containing customer orders) to the indexed Book
-						Stock file and to produce the Processed Orders file.<br />
-						Read the <a href="../exercises/Exm-SFbyMail/Exm-SFbyMai.html">program specification</a> first.
-						The required data files may be downloaded from there.<br
-					/></font>
+					Exam paper model answer. A program is required to apply the Orders file (containing customer orders)
+					to the indexed Book Stock file and to produce the Processed Orders file.<br />
+					Read the <a href="../exercises/Exm-SFbyMail/Exm-SFbyMai.html">program specification</a> first. The
+					required data files may be downloaded from there.<br />
 				</td>
 				<td height="157" width="189">
 					<div align="center">
-						<font size="-1"
-							><code class="language-cobol">CALL</code>, subprograms, Sequential files, Indexed files,
-							<code class="language-cobol">READ</code>, <code class="language-cobol">WRITE</code>,
-							<code class="language-cobol">REWRITE</code>, <code class="language-cobol">COMPUTE</code>,
-							<code class="language-cobol">UNSTRING</code>
-						</font>
+						<code class="language-cobol">CALL</code>, subprograms, Sequential files, Indexed files,
+						<code class="language-cobol">READ</code>, <code class="language-cobol">WRITE</code>,
+						<code class="language-cobol">REWRITE</code>, <code class="language-cobol">COMPUTE</code>,
+						<code class="language-cobol">UNSTRING</code>
 					</div>
 				</td>
 				<td height="157" width="71">
@@ -1571,9 +1442,7 @@
 			<tr bgcolor="#990000" valign="top">
 				<td colspan="4">
 					<h2 align="center" id="Strings">
-						<b>
-							<font color="#FFFF00">String handling</font>
-						</b>
+						<b> String handling </b>
 					</h2>
 				</td>
 			</tr>
@@ -1596,15 +1465,13 @@
 					<div align="center">RefMod.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>Solves a number of string handling tasks such as : - Extracting a substring from a string given
-						the start position and length of the substring.<br />
-						Extracting the first x number of chars from a string.<br />
-						Extracting the last x number of chars from a string.<br />
-						Removing trailing blanks from a string.<br />
-						Removing leading blanks from a string.<br />
-						Finding the location of the first occurrence of any of a substring's chars in a string</font
-					><br />
+					Solves a number of string handling tasks such as : - Extracting a substring from a string given the
+					start position and length of the substring.<br />
+					Extracting the first x number of chars from a string.<br />
+					Extracting the last x number of chars from a string.<br />
+					Removing trailing blanks from a string.<br />
+					Removing leading blanks from a string.<br />
+					Finding the location of the first occurrence of any of a substring's chars in a string<br />
 					&nbsp;
 				</td>
 				<td width="189">
@@ -1625,12 +1492,10 @@
 					<div align="center">UnstringFileEg.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>An example showing the unpacking of comma separated records and the size validation of the
-						unpacked fields.<br />
-						To test this program use the data file <a href="Strings/varlen.dat">VarLen.dat</a>.<br />
-						&nbsp;</font
-					>
+					An example showing the unpacking of comma separated records and the size validation of the unpacked
+					fields.<br />
+					To test this program use the data file <a href="Strings/varlen.dat">VarLen.dat</a>.<br />
+					&nbsp;
 				</td>
 				<td width="189">
 					<div align="center">
@@ -1650,26 +1515,22 @@
 					<div align="center">FileConv.Cbl</div>
 				</td>
 				<td align="left" height="154" width="298">
-					<font size="-1"
-						>Exam paper model answer. A program is required to convert the unsorted Client-Names file of
-						free-format, variable length, records into a sorted file of fixed length records. The sorted
-						file must be sorted into ascending Client-Name within ascending County-Name. In addition to
-						converting and sorting the file, the program must ensure that the county name is valid and must
-						convert it to a county number.<br />
-						Read the
-						<a href="../exercises/Exm-FileConversion/Exm-FileConversion.html">program specification</a>
-						first. The required data files may be downloaded from there.<br />
-					</font>
+					Exam paper model answer. A program is required to convert the unsorted Client-Names file of
+					free-format, variable length, records into a sorted file of fixed length records. The sorted file
+					must be sorted into ascending Client-Name within ascending County-Name. In addition to converting
+					and sorting the file, the program must ensure that the county name is valid and must convert it to a
+					county number.<br />
+					Read the
+					<a href="../exercises/Exm-FileConversion/Exm-FileConversion.html">program specification</a>
+					first. The required data files may be downloaded from there.<br />
 					&nbsp; &nbsp;
 				</td>
 				<td height="154" width="189">
 					<div align="center">
-						<font size="-1"
-							>Sequential files, <code class="language-cobol">SORT</code> with Input Procedure,
-							Pre-Defined Table of values, <code class="language-cobol">STRING</code>,
-							<code class="language-cobol">UNSTRING</code>, <code class="language-cobol">INSPECT</code>,
-							<code class="language-cobol">SEARCH ALL</code>
-						</font>
+						Sequential files, <code class="language-cobol">SORT</code> with Input Procedure, Pre-Defined
+						Table of values, <code class="language-cobol">STRING</code>,
+						<code class="language-cobol">UNSTRING</code>, <code class="language-cobol">INSPECT</code>,
+						<code class="language-cobol">SEARCH ALL</code>
 					</div>
 				</td>
 				<td height="154" width="71">
@@ -1693,9 +1554,7 @@
 			<tr bgcolor="#990000" valign="top">
 				<td colspan="4">
 					<h2 align="center" id="Reports">
-						<b>
-							<font color="#FFFF00">The COBOL Report Writer</font>
-						</b>
+						<b> The COBOL Report Writer </b>
 					</h2>
 				</td>
 			</tr>
@@ -1718,12 +1577,10 @@
 					<div align="center">RepWriteA.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>A simplified version of RepWriteFull.cbl using only one control break.<br />
-						All four of these Report Writer programs use the
-						<a href="ReportWriter/GBSALES.DAT.dat">GBsales.dat</a> data file.<br />
-						&nbsp;
-					</font>
+					A simplified version of RepWriteFull.cbl using only one control break.<br />
+					All four of these Report Writer programs use the
+					<a href="ReportWriter/GBSALES.DAT.dat">GBsales.dat</a> data file.<br />
+					&nbsp;
 				</td>
 				<td width="189">
 					<div align="center">
@@ -1743,13 +1600,11 @@
 					<div align="center">RepWriteB.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>A simplified version of RepWriteFull.cbl containing all the control breaks but not using
-						Declaratives.<br />
-						All four of these Report Writer programs use the
-						<a href="ReportWriter/GBSALES.DAT.dat">GBsales.dat</a> data file.<br />
-						&nbsp;
-					</font>
+					A simplified version of RepWriteFull.cbl containing all the control breaks but not using
+					Declaratives.<br />
+					All four of these Report Writer programs use the
+					<a href="ReportWriter/GBSALES.DAT.dat">GBsales.dat</a> data file.<br />
+					&nbsp;
 				</td>
 				<td width="189">
 					<div align="center">
@@ -1769,13 +1624,11 @@
 					<div align="center">RepWriteFull.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>The full version of the report program containing all the control breaks and using Declaratives
-						to calculate the salesperson salary and commission.<br />
-						All four of these Report Writer programs use the
-						<a href="ReportWriter/GBSALES.DAT.dat">GBsales.dat</a> data file.<br />
-						&nbsp;
-					</font>
+					The full version of the report program containing all the control breaks and using Declaratives to
+					calculate the salesperson salary and commission.<br />
+					All four of these Report Writer programs use the
+					<a href="ReportWriter/GBSALES.DAT.dat">GBsales.dat</a> data file.<br />
+					&nbsp;
 				</td>
 				<td width="189">
 					<div align="center">
@@ -1796,13 +1649,11 @@
 					<div align="center">RepWriteSumm.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>The summary version of the full report program containing all the control breaks and using
-						Declaratives to calculate the salesperson salary and commission.<br />
-						All four of these Report Writer programs use the
-						<a href="ReportWriter/GBSALES.DAT.dat">GBsales.dat</a> data file.<br />
-						&nbsp;
-					</font>
+					The summary version of the full report program containing all the control breaks and using
+					Declaratives to calculate the salesperson salary and commission.<br />
+					All four of these Report Writer programs use the
+					<a href="ReportWriter/GBSALES.DAT.dat">GBsales.dat</a> data file.<br />
+					&nbsp;
 				</td>
 				<td width="189">
 					<div align="center">
@@ -1832,9 +1683,7 @@
 			<tr bgcolor="#990000" valign="top">
 				<td colspan="4">
 					<h2 align="center" id="Tables">
-						<b>
-							<font color="#FFFF00">COBOL Tables</font>
-						</b>
+						<b> COBOL Tables </b>
 					</h2>
 				</td>
 			</tr>
@@ -1858,13 +1707,11 @@
 				</td>
 				<td align="left" width="298">
 					<p>
-						<font size="-1"
-							>This program counts the number of students born in each month and displays the result.<br />
-							The program uses a pre-filled table of month names.<br />
-							This program is the solution to one of the programming exercises.<br />
-							Read the <a href="../exercises/MonthTable.html">program specification</a> first.<br />
-							&nbsp;</font
-						>
+						This program counts the number of students born in each month and displays the result.<br />
+						The program uses a pre-filled table of month names.<br />
+						This program is the solution to one of the programming exercises.<br />
+						Read the <a href="../exercises/MonthTable.html">program specification</a> first.<br />
+						&nbsp;
 					</p>
 				</td>
 				<td width="189">
@@ -1887,22 +1734,18 @@
 					<div align="center">FlyByNight.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>Exam paper model answer. A program is required which will read the Booking Master file to
-						produce a Summary file sequenced upon ascending Destination-Name.<br />
-						Read the
-						<a href="../exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html">program specification</a> first.
-						The required data files may be downloaded from there.<br />
-						&nbsp;<br />
-					</font>
+					Exam paper model answer. A program is required which will read the Booking Master file to produce a
+					Summary file sequenced upon ascending Destination-Name.<br />
+					Read the
+					<a href="../exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html">program specification</a> first. The
+					required data files may be downloaded from there.<br />
+					&nbsp;<br />
 				</td>
 				<td width="189">
 					<div align="center">
-						<font size="-1"
-							>Pre-Filled Tables, Sequential Files, <code class="language-cobol">SORT</code> with Input
-							Procedure, <code class="language-cobol">SEARCH</code>,
-							<code class="language-cobol">INSPECT</code>
-						</font>
+						Pre-Filled Tables, Sequential Files, <code class="language-cobol">SORT</code> with Input
+						Procedure, <code class="language-cobol">SEARCH</code>,
+						<code class="language-cobol">INSPECT</code>
 					</div>
 				</td>
 				<td width="71">
@@ -1917,25 +1760,18 @@
 					<div align="center">USSRship.cbl</div>
 				</td>
 				<td align="left" width="298">
-					<font size="-1"
-						>Exam paper model answer. A program is required to produce a report detailing the major vessels
-						(Vessels of tonnage 3,500 or greater and all submarines) in each of oceans and major seas of the
-						world.</font
-					>
-					<font size="-1"
-						><br />
-						Read the
-						<a href="../exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html">program specification</a> first.
-						The required data files may be downloaded from there. </font
-					><br />
-					<font size="-1">&nbsp;</font><br />
+					Exam paper model answer. A program is required to produce a report detailing the major vessels
+					(Vessels of tonnage 3,500 or greater and all submarines) in each of oceans and major seas of the
+					world.<br />
+					Read the
+					<a href="../exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html">program specification</a> first. The
+					required data files may be downloaded from there.<br />
+					&nbsp;<br />
 				</td>
 				<td width="189">
 					<div align="center">
-						<font size="-1"
-							>Sequential files, <code class="language-cobol">SORT</code> with Input Procedure, Print
-							Files, Pre-defined tables, Condition Names</font
-						>
+						Sequential files, <code class="language-cobol">SORT</code> with Input Procedure, Print Files,
+						Pre-defined tables, Condition Names
 					</div>
 				</td>
 				<td width="71">

--- a/exercises/COBOLExams/COBOLExams.html
+++ b/exercises/COBOLExams/COBOLExams.html
@@ -143,7 +143,7 @@
 				<td bgcolor="#990000">
 					<div align="center">
 						<h1>
-							<b><font color="#FFFF00">COBOL Programming Exams</font></b>
+							<b style="color: #ffff00">COBOL Programming Exams</b>
 						</h1>
 					</div>
 				</td>

--- a/exercises/CountDown.html
+++ b/exercises/CountDown.html
@@ -135,6 +135,17 @@
 					margin: 0.2em 0;
 				}
 			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			td[bgcolor="#FFFFCC"] h3,
+			td[bgcolor="#FFFFCC"] h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
+			}
 		</style>
 	</head>
 	<body text="#000000" bgcolor="#FFFFFF" link="#0000FF" vlink="#FF0000" alink="#009B00">
@@ -196,30 +207,23 @@
 		<ul>
 			<ul>
 				<ul>
-					<u><font size="+2">Example run</font></u>
+					<u>Example run</u>
 				</ul>
-				<tt
-					>Enter the number of calcs required :- <font size="+1"><b>2</b></font></tt
+				<tt>Enter the number of calcs required :- <b>2</b></tt
 				><br />
-				<tt
-					>Enter First Number : <b><font size="+1">3</font></b></tt
+				<tt>Enter First Number : <b>3</b></tt
 				><br />
-				<tt
-					>Enter Second Number : <b><font size="+1">3</font></b></tt
+				<tt>Enter Second Number : <b>3</b></tt
 				><br />
-				<tt
-					>Enter operator (+ or *) : <b><font size="+1">*</font></b></tt
+				<tt>Enter operator (+ or *) : <b>*</b></tt
 				><br />
 				<tt>Result is = 9</tt
 				><br />
-				<tt
-					>Enter First Number : <b><font size="+1">3</font></b></tt
+				<tt>Enter First Number : <b>3</b></tt
 				><br />
-				<tt
-					>Enter Second Number : <font size="+1"><b>3</b></font></tt
+				<tt>Enter Second Number : <b>3</b></tt
 				><br />
-				<tt
-					>Enter operator (+ or *) : <b><font size="+1">+</font></b></tt
+				<tt>Enter operator (+ or *) : <b>+</b></tt
 				><br />
 				<tt>Result is = 6</tt
 				><br />
@@ -236,13 +240,11 @@
 		<ul>
 			<ul>
 				<ul>
-					<u><font size="+2">Example run</font></u>
+					<u>Example run</u>
 				</ul>
-				<tt
-					>Enter your name :- <b><font size="+1">Mike Ryan</font></b></tt
+				<tt>Enter your name :- <b>Mike Ryan</b></tt
 				><br />
-				<tt
-					>Enter the count-down start value :- <b><font size="+1">05</font></b></tt
+				<tt>Enter the count-down start value :- <b>05</b></tt
 				><br />
 				<tt>Getting ready to display your name.</tt
 				><br />
@@ -282,7 +284,7 @@
 							height="52"
 							width="52"
 					/></a>
-					<font size="-2">To COBOL Exercises</font>
+					To COBOL Exercises
 				</td>
 			</tr>
 		</table>

--- a/exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html
+++ b/exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html
@@ -142,10 +142,8 @@
 			<tr>
 				<td bgcolor="#990000" colspan="3" height="48" valign="middle">
 					<h2 align="center">
-						<font color="#FFFF00"
-							>The ACME<br />
-							Stock Reorder System</font
-						>
+						The ACME<br />
+						Stock Reorder System
 					</h2>
 				</td>
 			</tr>
@@ -197,13 +195,11 @@
 			<tr valign="top">
 				<td bgcolor="#FFFFFF" colspan="2" height="23"><b>Major Constructs</b></td>
 				<td bgcolor="#FFFFFF" height="23" width="78%">
-					<font size="-1"
-						>Indexed files, Relative Files, SubPrograms, <code class="language-cobol">CALL..USING</code>,
-						<code class="language-cobol">READ</code>, <code class="language-cobol">WRITE</code>,
-						<code class="language-cobol">REWRITE</code>, Condition Names (level 88s),
-						<code class="language-cobol">EVALUATE</code>, <code class="language-cobol">UNSTRING</code>,
-						<code class="language-cobol">MULTIPLY..ON SIZE ERROR</code>.</font
-					>
+					Indexed files, Relative Files, SubPrograms, <code class="language-cobol">CALL..USING</code>,
+					<code class="language-cobol">READ</code>, <code class="language-cobol">WRITE</code>,
+					<code class="language-cobol">REWRITE</code>, Condition Names (level 88s),
+					<code class="language-cobol">EVALUATE</code>, <code class="language-cobol">UNSTRING</code>,
+					<code class="language-cobol">MULTIPLY..ON SIZE ERROR</code>.
 				</td>
 			</tr>
 			<tr>
@@ -914,14 +910,12 @@
 					</p>
 					<hr />
 					<p align="center">
-						<font size="-1"><b>Copyright Notice</b></font>
+						<b>Copyright Notice</b>
 					</p>
 					<p align="left">
-						<font size="-1"
-							>This COBOL project specification is the copyright property of Michael Coughlan. You have
-							permission to use this material for your own personal use but you may not reproduce it in
-							any published work without written permission from the author.</font
-						>
+						This COBOL project specification is the copyright property of Michael Coughlan. You have
+						permission to use this material for your own personal use but you may not reproduce it in any
+						published work without written permission from the author.
 					</p>
 				</td>
 			</tr>

--- a/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html
+++ b/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html
@@ -141,10 +141,8 @@
 			<tr>
 				<td bgcolor="#990000" colspan="3" height="27" valign="middle">
 					<h3 align="center">
-						<font color="#FFFF00"
-							>Aromamora<br />
-							Oil Stock File Maintenance and Report</font
-						>
+						Aromamora<br />
+						Oil Stock File Maintenance and Report
 					</h3>
 				</td>
 			</tr>
@@ -189,12 +187,10 @@
 			<tr valign="top">
 				<td bgcolor="#FFFFFF" colspan="2" height="2"><b>Major Constructs</b></td>
 				<td bgcolor="#FFFFFF" height="2" width="78%">
-					<font size="-1"
-						>Indexed files, Relative Files, Sequential Files, Report Writer,
-						<code class="language-cobol">EVALUATE</code>, <code class="language-cobol">COMPUTE</code>,
-						<code class="language-cobol">READ</code>, <code class="language-cobol">WRITE</code>,
-						<code class="language-cobol">REWRITE</code>, <code class="language-cobol">START</code></font
-					>
+					Indexed files, Relative Files, Sequential Files, Report Writer,
+					<code class="language-cobol">EVALUATE</code>, <code class="language-cobol">COMPUTE</code>,
+					<code class="language-cobol">READ</code>, <code class="language-cobol">WRITE</code>,
+					<code class="language-cobol">REWRITE</code>, <code class="language-cobol">START</code>
 				</td>
 			</tr>
 			<tr>
@@ -576,14 +572,12 @@
 					</p>
 					<hr />
 					<p align="center">
-						<font size="-1"><b>Copyright Notice</b></font>
+						<b>Copyright Notice</b>
 					</p>
 					<p align="left">
-						<font size="-1"
-							>This COBOL project specification is the copyright property of Michael Coughlan. You have
-							permission to use this material for your own personal use but you may not reproduce it in
-							any published work without written permission from the author.</font
-						>
+						This COBOL project specification is the copyright property of Michael Coughlan. You have
+						permission to use this material for your own personal use but you may not reproduce it in any
+						published work without written permission from the author.
 					</p>
 				</td>
 			</tr>

--- a/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html
+++ b/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html
@@ -141,10 +141,8 @@
 			<tr>
 				<td bgcolor="#990000" colspan="3" height="27" valign="middle">
 					<h3 align="center">
-						<font color="#FFFF00"
-							>Aromamora<br />
-							Summary Sales Report</font
-						>
+						Aromamora<br />
+						Summary Sales Report
 					</h3>
 				</td>
 			</tr>
@@ -349,14 +347,12 @@
 					</p>
 					<hr />
 					<p align="center">
-						<font size="-1"><b>Copyright Notice</b></font>
+						<b>Copyright Notice</b>
 					</p>
 					<p align="left">
-						<font size="-1"
-							>This COBOL project specification is the copyright property of Michael Coughlan. You have
-							permission to use this material for your own personal use but you may not reproduce it in
-							any published work without written permission from the author.</font
-						>
+						This COBOL project specification is the copyright property of Michael Coughlan. You have
+						permission to use this material for your own personal use but you may not reproduce it in any
+						published work without written permission from the author.
 					</p>
 				</td>
 			</tr>

--- a/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html
+++ b/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html
@@ -183,10 +183,8 @@
 			<tr>
 				<td bgcolor="#990000" colspan="3" height="27" valign="middle">
 					<h3 align="center">
-						<font color="#FFFF00"
-							>Folio Society<br />
-							Best Sellers List Report</font
-						>
+						Folio Society<br />
+						Best Sellers List Report
 					</h3>
 				</td>
 			</tr>
@@ -231,9 +229,7 @@
 			<tr valign="top">
 				<td bgcolor="#FFFFFF" colspan="2" height="18"><b>Major Constructs</b></td>
 				<td bgcolor="#FFFFFF" height="18" width="78%">
-					<font size="-1"
-						>Sequential Files, Print Files, SORT with Input Procedure and Output Procedure, Tables</font
-					>
+					Sequential Files, Print Files, SORT with Input Procedure and Output Procedure, Tables
 				</td>
 			</tr>
 			<tr>
@@ -459,14 +455,12 @@
 					</div>
 					<hr />
 					<p align="center">
-						<font size="-1"><b>Copyright Notice</b></font>
+						<b>Copyright Notice</b>
 					</p>
 					<p align="left">
-						<font size="-1"
-							>This COBOL project specification is the copyright property of Michael Coughlan. You have
-							permission to use this material for your own personal use but you may not reproduce it in
-							any published work without written permission from the author.</font
-						>
+						This COBOL project specification is the copyright property of Michael Coughlan. You have
+						permission to use this material for your own personal use but you may not reproduce it in any
+						published work without written permission from the author.
 					</p>
 				</td>
 			</tr>

--- a/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html
+++ b/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html
@@ -141,10 +141,8 @@
 			<tr>
 				<td bgcolor="#990000" colspan="3" height="27" valign="middle">
 					<h3 align="center">
-						<font color="#FFFF00"
-							>Campus Bookshop<br />
-							Purchase Requirements Report</font
-						>
+						Campus Bookshop<br />
+						Purchase Requirements Report
 					</h3>
 				</td>
 			</tr>
@@ -177,9 +175,9 @@
 						indexed files -
 					</p>
 					<ul>
-						<li>The Purchase Requirements File (<font size="-1">PRFILE.DAT</font>)</li>
-						<li>The Book File (<font size="-1">BOOKFILE.DAT</font>)</li>
-						<li>The Publisher File (<font size="-1">PUBFILE.DAT</font>)</li>
+						<li>The Purchase Requirements File (PRFILE.DAT)</li>
+						<li>The Book File (BOOKFILE.DAT)</li>
+						<li>The Publisher File (PUBFILE.DAT)</li>
 					</ul>
 					<p>using <a href="SETUPIdxFiles.Cbl">this program</a>.</p>
 					<p>
@@ -191,10 +189,8 @@
 			<tr valign="top">
 				<td bgcolor="#FFFFFF" colspan="2" height="23"><b>Major Constructs</b></td>
 				<td bgcolor="#FFFFFF" height="23" width="78%">
-					<font size="-1"
-						>Indexed files, Report Writer, Report Section, INITIATE, GENERATE, TERMINATE, READ, WRITE,
-						REWRITE, START</font
-					>
+					Indexed files, Report Writer, Report Section, INITIATE, GENERATE, TERMINATE, READ, WRITE, REWRITE,
+					START
 				</td>
 			</tr>
 			<tr>
@@ -526,14 +522,12 @@
 					</p>
 					<hr />
 					<p align="center">
-						<font size="-1"><b>Copyright Notice</b></font>
+						<b>Copyright Notice</b>
 					</p>
 					<p align="left">
-						<font size="-1"
-							>This COBOL project specification is the copyright property of Michael Coughlan. You have
-							permission to use this material for your own personal use but you may not reproduce it in
-							any published work without written permission from the author.</font
-						>
+						This COBOL project specification is the copyright property of Michael Coughlan. You have
+						permission to use this material for your own personal use but you may not reproduce it in any
+						published work without written permission from the author.
 					</p>
 				</td>
 			</tr>

--- a/exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html
+++ b/exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html
@@ -183,10 +183,8 @@
 			<tr>
 				<td bgcolor="#990000" colspan="3" height="27" valign="middle">
 					<h3 align="center">
-						<font color="#FFFF00"
-							>CSIS Web Site<br />
-							Email Domain File</font
-						>
+						CSIS Web Site<br />
+						Email Domain File
 					</h3>
 				</td>
 			</tr>
@@ -243,10 +241,8 @@
 			<tr valign="top">
 				<td bgcolor="#FFFFFF" colspan="2" height="2"><b>Major Constructs</b></td>
 				<td bgcolor="#FFFFFF" height="2" width="78%">
-					<font size="-1"
-						>SORT with Input Procedure and Output Procedure, Sequential Files, Pre-Defined Tables, Run time
-						filled tables, SEARCH</font
-					>
+					SORT with Input Procedure and Output Procedure, Sequential Files, Pre-Defined Tables, Run time
+					filled tables, SEARCH
 				</td>
 			</tr>
 			<tr>
@@ -611,14 +607,12 @@
 					</div>
 					<hr />
 					<p align="center">
-						<font size="-1"><b>Copyright Notice</b></font>
+						<b>Copyright Notice</b>
 					</p>
 					<p align="left">
-						<font size="-1"
-							>This COBOL project specification is the copyright property of Michael Coughlan. You have
-							permission to use this material for your own personal use but you may not reproduce it in
-							any published work without written permission from the author.</font
-						>
+						This COBOL project specification is the copyright property of Michael Coughlan. You have
+						permission to use this material for your own personal use but you may not reproduce it in any
+						published work without written permission from the author.
 					</p>
 				</td>
 			</tr>

--- a/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html
+++ b/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html
@@ -142,10 +142,8 @@
 			<tr>
 				<td bgcolor="#990000" colspan="3" height="27" valign="middle">
 					<h3 align="center">
-						<font color="#FFFF00"
-							>NetNews<br />
-							Due Subscriptions Report</font
-						>
+						NetNews<br />
+						Due Subscriptions Report
 					</h3>
 				</td>
 			</tr>
@@ -196,9 +194,7 @@
 			<tr valign="top">
 				<td bgcolor="#FFFFFF" colspan="2" height="2"><b>Major Constructs</b></td>
 				<td bgcolor="#FFFFFF" height="2" width="78%">
-					<font size="-1"
-						>Sequential Files, Print Files, SORT with Input Procedure, Tables, SEARCH ALL, EVALUATE</font
-					>
+					Sequential Files, Print Files, SORT with Input Procedure, Tables, SEARCH ALL, EVALUATE
 				</td>
 			</tr>
 			<tr>
@@ -492,14 +488,12 @@
 					</p>
 					<hr />
 					<p align="center">
-						<font size="-1"><b>Copyright Notice</b></font>
+						<b>Copyright Notice</b>
 					</p>
 					<p align="left">
-						<font size="-1"
-							>This COBOL project specification is the copyright property of Michael Coughlan. You have
-							permission to use this material for your own personal use but you may not reproduce it in
-							any published work without written permission from the author.</font
-						>
+						This COBOL project specification is the copyright property of Michael Coughlan. You have
+						permission to use this material for your own personal use but you may not reproduce it in any
+						published work without written permission from the author.
 					</p>
 				</td>
 			</tr>

--- a/exercises/Exm-FileConversion/Exm-FileConversion.html
+++ b/exercises/Exm-FileConversion/Exm-FileConversion.html
@@ -141,10 +141,8 @@
 			<tr>
 				<td bgcolor="#990000" colspan="3" height="38" valign="middle">
 					<h3 align="center">
-						<font color="#FFFF00"
-							>File Conversion<br />
-							Program</font
-						>
+						File Conversion<br />
+						Program
 					</h3>
 				</td>
 			</tr>
@@ -175,10 +173,8 @@
 			<tr valign="top">
 				<td bgcolor="#FFFFFF" colspan="2" height="23"><b>Major Constructs</b></td>
 				<td bgcolor="#FFFFFF" height="23" width="78%">
-					<font size="-1"
-						>Sequential files, SORT with Input Procedure, Pre-Defined Table of values, STRING, UNSTRING,
-						INSPECT, SEARCH ALL</font
-					>
+					Sequential files, SORT with Input Procedure, Pre-Defined Table of values, STRING, UNSTRING, INSPECT,
+					SEARCH ALL
 				</td>
 			</tr>
 			<tr>
@@ -595,14 +591,12 @@ Ryan Michael Terence          34 Winchester Drive Dubline 7 Co. Dublin    090123
 					</div>
 					<hr />
 					<p align="center">
-						<font size="-1"><b>Copyright Notice</b></font>
+						<b>Copyright Notice</b>
 					</p>
 					<p align="left">
-						<font size="-1"
-							>This COBOL project specification is the copyright property of Michael Coughlan. You have
-							permission to use this material for your own personal use but you may not reproduce it in
-							any published work without written permission from the author.</font
-						>
+						This COBOL project specification is the copyright property of Michael Coughlan. You have
+						permission to use this material for your own personal use but you may not reproduce it in any
+						published work without written permission from the author.
 					</p>
 				</td>
 			</tr>

--- a/exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html
+++ b/exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html
@@ -182,11 +182,8 @@
 			<tr>
 				<td bgcolor="#990000" colspan="3" height="27" valign="middle">
 					<h3 align="center">
-						<font color="#FFFF00">Fly By Night Travel Agency</font>
-						<font color="#FFFF00"
-							><br />
-							Sorted Summary File</font
-						>
+						Fly By Night Travel Agency<br />
+						Sorted Summary File
 					</h3>
 				</td>
 			</tr>
@@ -226,10 +223,10 @@
 					<h3>Introduction</h3>
 					<p>
 						The FlyByNight travel agency sends its customers all over the world. For each booking a record
-						is created in the Booking Master file (<font size="-1">BOOKING.DAT</font>). Each customer
-						booking is assigned (as part of the record) a category indicating the primary reason for the
-						booking (i.e. Sport, Tourism, Business, Personal and Other). The file is unsorted and each
-						record has the following description;
+						is created in the Booking Master file (BOOKING.DAT). Each customer booking is assigned (as part
+						of the record) a category indicating the primary reason for the booking (i.e. Sport, Tourism,
+						Business, Personal and Other). The file is unsorted and each record has the following
+						description;
 					</p>
 					<div align="center">
 						<table border="1" cellpadding="0" cellspacing="0" height="60" width="432">
@@ -480,14 +477,12 @@
 					</blockquote>
 					<hr />
 					<p align="center">
-						<font size="-1"><b>Copyright Notice</b></font>
+						<b>Copyright Notice</b>
 					</p>
 					<p align="left">
-						<font size="-1"
-							>This COBOL project specification is the copyright property of Michael Coughlan. You have
-							permission to use this material for your own personal use but you may not reproduce it in
-							any published work without written permission from the author.</font
-						>
+						This COBOL project specification is the copyright property of Michael Coughlan. You have
+						permission to use this material for your own personal use but you may not reproduce it in any
+						published work without written permission from the author.
 					</p>
 				</td>
 			</tr>

--- a/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html
+++ b/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html
@@ -183,10 +183,8 @@
 			<tr>
 				<td bgcolor="#990000" colspan="3" height="27" valign="middle">
 					<h3 align="center">
-						<font color="#FFFF00"
-							>Pascal Memorial Library<br />
-							Royalty Payments Report Program</font
-						>
+						Pascal Memorial Library<br />
+						Royalty Payments Report Program
 					</h3>
 				</td>
 			</tr>
@@ -228,10 +226,7 @@
 			<tr valign="top">
 				<td bgcolor="#FFFFFF" colspan="2" height="41"><b>Major Constructs</b></td>
 				<td bgcolor="#FFFFFF" height="41" width="78%">
-					<font size="-1"
-						>Indexed Files, Print Files, READ..NEXT RECORD, READ..KEY IS, START, REWRITE, WRITE, MULTIPLY,
-						SET</font
-					>
+					Indexed Files, Print Files, READ..NEXT RECORD, READ..KEY IS, START, REWRITE, WRITE, MULTIPLY, SET
 				</td>
 			</tr>
 			<tr>
@@ -544,14 +539,12 @@
 					</div>
 					<hr />
 					<p align="center">
-						<font size="-1"><b>Copyright Notice</b></font>
+						<b>Copyright Notice</b>
 					</p>
 					<p align="left">
-						<font size="-1"
-							>This COBOL project specification is the copyright property of Michael Coughlan. You have
-							permission to use this material for your own personal use but you may not reproduce it in
-							any published work without written permission from the author.</font
-						>
+						This COBOL project specification is the copyright property of Michael Coughlan. You have
+						permission to use this material for your own personal use but you may not reproduce it in any
+						published work without written permission from the author.
 					</p>
 				</td>
 			</tr>

--- a/exercises/Exm-SFbyMail/Exm-SFbyMai.html
+++ b/exercises/Exm-SFbyMail/Exm-SFbyMai.html
@@ -183,10 +183,8 @@
 			<tr>
 				<td bgcolor="#990000" colspan="3" height="27" valign="middle">
 					<h3 align="center">
-						<font color="#FFFF00"
-							>Science Fiction by Mail<br />
-							Order Processing Program</font
-						>
+						Science Fiction by Mail<br />
+						Order Processing Program
 					</h3>
 				</td>
 			</tr>
@@ -278,10 +276,7 @@
 			<tr valign="top">
 				<td bgcolor="#FFFFFF" colspan="2" height="23"><b>Major Constructs</b></td>
 				<td bgcolor="#FFFFFF" height="23" width="78%">
-					<font size="-1"
-						>CALL, subprograms, Sequential files, Indexed files, READ, WRITE, REWRITE, COMPUTE,
-						UNSTRING</font
-					>
+					CALL, subprograms, Sequential files, Indexed files, READ, WRITE, REWRITE, COMPUTE, UNSTRING
 				</td>
 			</tr>
 			<tr>
@@ -292,8 +287,8 @@
 						<i>Science Fiction by Mail</i> is a company which sells Science Fiction and Fantasy books
 						through the Internet. Customers view the book catalogues and place orders by connecting to the
 						companys web site. When an order is placed, an Order-Number is assigned, and the details of the
-						order are written to an Orders file (<font size="-1">ORDERS.DAT</font>). Only already registered
-						customers can place an order.
+						order are written to an Orders file (ORDERS.DAT). Only already registered customers can place an
+						order.
 					</p>
 					<p>
 						At the end of the day, the Orders file is processed, applying it to the Book Stock file and
@@ -678,14 +673,12 @@
 					</blockquote>
 					<hr />
 					<p align="center">
-						<font size="-1"><b>Copyright Notice</b></font>
+						<b>Copyright Notice</b>
 					</p>
 					<p align="left">
-						<font size="-1"
-							>This COBOL project specification is the copyright property of Michael Coughlan. You have
-							permission to use this material for your own personal use but you may not reproduce it in
-							any published work without written permission from the author.</font
-						>
+						This COBOL project specification is the copyright property of Michael Coughlan. You have
+						permission to use this material for your own personal use but you may not reproduce it in any
+						published work without written permission from the author.
 					</p>
 				</td>
 			</tr>

--- a/exercises/Exm-StudFeesRpt/Exm-StudPay.html
+++ b/exercises/Exm-StudFeesRpt/Exm-StudPay.html
@@ -141,10 +141,8 @@
 			<tr>
 				<td bgcolor="#990000" colspan="3" height="27" valign="middle">
 					<h3 align="center">
-						<font color="#FFFF00"
-							>Student Fee Payment<br />
-							Update and Report</font
-						>
+						Student Fee Payment<br />
+						Update and Report
 					</h3>
 				</td>
 			</tr>
@@ -410,18 +408,16 @@
 						<a href="Exm-StudFeePaymentRpt.gif"
 							><img border="1" height="210" src="Exm-StudFeePaymentRpts.gif" width="314" /></a
 						><br />
-						<font size="-1">Click for full size version</font>
+						Click for full size version
 					</p>
 					<hr />
 					<p align="center">
-						<font size="-1"><b>Copyright Notice</b></font>
+						<b>Copyright Notice</b>
 					</p>
 					<p align="left">
-						<font size="-1"
-							>This COBOL project specification is the copyright property of Michael Coughlan. You have
-							permission to use this material for your own personal use but you may not reproduce it in
-							any published work without written permission from the author.</font
-						>
+						This COBOL project specification is the copyright property of Michael Coughlan. You have
+						permission to use this material for your own personal use but you may not reproduce it in any
+						published work without written permission from the author.
 					</p>
 				</td>
 			</tr>

--- a/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html
+++ b/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html
@@ -183,10 +183,8 @@
 			<tr>
 				<td bgcolor="#990000" colspan="3" height="27" valign="middle">
 					<h3 align="center">
-						<font color="#FFFF00"
-							>Top Video Suppliers<br />
-							Report</font
-						>
+						Top Video Suppliers<br />
+						Report
 					</h3>
 				</td>
 			</tr>
@@ -503,14 +501,12 @@
 					</p>
 					<hr />
 					<p align="center">
-						<font size="-1"><b>Copyright Notice</b></font>
+						<b>Copyright Notice</b>
 					</p>
 					<p align="left">
-						<font size="-1"
-							>This COBOL project specification is the copyright property of Michael Coughlan. You have
-							permission to use this material for your own personal use but you may not reproduce it in
-							any published work without written permission from the author.</font
-						>
+						This COBOL project specification is the copyright property of Michael Coughlan. You have
+						permission to use this material for your own personal use but you may not reproduce it in any
+						published work without written permission from the author.
 					</p>
 				</td>
 			</tr>

--- a/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html
+++ b/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html
@@ -122,10 +122,8 @@
 			<tr>
 				<td bgcolor="#990000" colspan="3" height="27" valign="middle">
 					<h3 align="center">
-						<font color="#FFFF00"
-							>USSR Naval Vessel<br />
-							Inventory Report</font
-						>
+						USSR Naval Vessel<br />
+						Inventory Report
 					</h3>
 				</td>
 			</tr>
@@ -253,16 +251,11 @@
 						<blockquote>
 							<blockquote>
 								<p>
-									The <b><font size="+1">P</font></b
-									>acific,<br />
-									The <b><font size="+1">A</font></b
-									>tlantic<br />
-									The <b><font size="+1">M</font></b
-									>editerranean<br />
-									The <b><font size="+1">I</font></b
-									>ndian Ocean<br />
-									The <b><font size="+1e">O</font></b
-									>ther Seas
+									The <b>P</b>acific,<br />
+									The <b>A</b>tlantic<br />
+									The <b>M</b>editerranean<br />
+									The <b>I</b>ndian Ocean<br />
+									The <b>O</b>ther Seas
 								</p>
 							</blockquote>
 						</blockquote>
@@ -286,16 +279,14 @@
 									<div align="center">
 										<br />
 										<b
-											><font size="-1"
-												>L<br />
-												O<br />
-												C<br />
-												A<br />
-												T<br />
-												I<br />
-												O<br />
-												N</font
-											></b
+											>L<br />
+											O<br />
+											C<br />
+											A<br />
+											T<br />
+											I<br />
+											O<br />
+											N</b
 										>
 									</div>
 								</td>
@@ -726,14 +717,12 @@
 					</p>
 					<hr />
 					<p align="center">
-						<font size="-1"><b>Copyright Notice</b></font>
+						<b>Copyright Notice</b>
 					</p>
 					<p align="left">
-						<font size="-1"
-							>This COBOL project specification is the copyright property of Michael Coughlan. You have
-							permission to use this material for your own personal use but you may not reproduce it in
-							any published work without written permission from the author.</font
-						>
+						This COBOL project specification is the copyright property of Michael Coughlan. You have
+						permission to use this material for your own personal use but you may not reproduce it in any
+						published work without written permission from the author.
 					</p>
 				</td>
 			</tr>

--- a/exercises/GettingStarted.html
+++ b/exercises/GettingStarted.html
@@ -310,7 +310,7 @@
 							height="52"
 							width="52"
 					/></a>
-					<font size="-2">To COBOL Exercises</font>
+					To COBOL Exercises
 				</td>
 			</tr>
 		</table>

--- a/exercises/MonthTable.html
+++ b/exercises/MonthTable.html
@@ -288,7 +288,7 @@
 		<ul>
 			<ul>
 				<ul>
-					<u><font size="+2">Example Run</font></u
+					<u>Example Run</u
 					><br />
 					<tt>&nbsp;Month&nbsp;&nbsp;&nbsp; StudCount</tt
 					><br />
@@ -333,7 +333,7 @@
 		</p>
 		<p align="center">
 			<b
-				><u><font color="#FF0000">WARNING</font></u></b
+				><u><span style="color: #ff0000">WARNING</span></u></b
 			>
 		</p>
 		<p align="left">
@@ -353,7 +353,7 @@
 							src="../pics/B-BackArrow.gif"
 							width="52"
 					/></a>
-					<font size="-2">To COBOL Exercises</font>
+					To COBOL Exercises
 				</td>
 			</tr>
 		</table>

--- a/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html
+++ b/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html
@@ -161,11 +161,9 @@
 			<tr>
 				<td bgcolor="#990000" colspan="2" height="55" valign="middle">
 					<h2 align="center">
-						<font color="#FFFF00"
-							><b
-								>Aromamora<br />
-								Outstanding Invoices Report</b
-							></font
+						<b
+							>Aromamora<br />
+							Outstanding Invoices Report</b
 						>
 					</h2>
 				</td>
@@ -485,14 +483,12 @@
 					</p>
 					<hr />
 					<p align="center">
-						<font size="-1"><b>Copyright Notice</b></font>
+						<b>Copyright Notice</b>
 					</p>
 					<p align="left">
-						<font size="-1"
-							>This COBOL project specification is the copyright property of Michael Coughlan. You have
-							permission to use this material for your own personal use but you may not reproduce it in
-							any published work without written permission from the author.</font
-						>
+						This COBOL project specification is the copyright property of Michael Coughlan. You have
+						permission to use this material for your own personal use but you may not reproduce it in any
+						published work without written permission from the author.
 					</p>
 				</td>
 			</tr>

--- a/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html
+++ b/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html
@@ -161,11 +161,9 @@
 			<tr>
 				<td bgcolor="#990000" colspan="2" height="59" valign="middle">
 					<h2 align="center">
-						<font color="#FFFF00"
-							><b
-								>Aromamora Essential Oils<br />
-								Sales Report</b
-							></font
+						<b
+							>Aromamora Essential Oils<br />
+							Sales Report</b
 						>
 					</h2>
 				</td>
@@ -523,14 +521,12 @@
 					</p>
 					<hr />
 					<p align="center">
-						<font size="-1"><b>Copyright Notice</b></font>
+						<b>Copyright Notice</b>
 					</p>
 					<p align="left">
-						<font size="-1"
-							>This COBOL project specification is the copyright property of Michael Coughlan. You have
-							permission to use this material for your own personal use but you may not reproduce it in
-							any published work without written permission from the author.</font
-						>
+						This COBOL project specification is the copyright property of Michael Coughlan. You have
+						permission to use this material for your own personal use but you may not reproduce it in any
+						published work without written permission from the author.
 					</p>
 				</td>
 			</tr>

--- a/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html
+++ b/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html
@@ -161,10 +161,8 @@
 			<tr>
 				<td bgcolor="#990000" colspan="2" height="59" valign="middle">
 					<h2 align="center">
-						<font color="#FFFF00"
-							><b>UL CAO points calculator<br /></b
-						></font>
-						<font color="#FFFF00"><b>and Report</b></font>
+						<b>UL CAO points calculator<br /></b>
+						<b>and Report</b>
 					</h2>
 				</td>
 			</tr>
@@ -680,7 +678,7 @@
 							<tr bgcolor="#CCFFFF">
 								<td class="Normal" colspan="2" height="27" valign="top" width="518">
 									<div align="center">
-										<b><font size="+1">UL Courses and Course Codes</font></b>
+										<b>UL Courses and Course Codes</b>
 									</div>
 								</td>
 							</tr>
@@ -1512,14 +1510,12 @@
 					</div>
 					<hr />
 					<p align="center">
-						<font size="-1"><b>Copyright Notice</b></font>
+						<b>Copyright Notice</b>
 					</p>
 					<p align="left">
-						<font size="-1"
-							>This COBOL project specification is the copyright property of Michael Coughlan. You have
-							permission to use this material for your own personal use but you may not reproduce it in
-							any published work without written permission from the author.</font
-						>
+						This COBOL project specification is the copyright property of Michael Coughlan. You have
+						permission to use this material for your own personal use but you may not reproduce it in any
+						published work without written permission from the author.
 					</p>
 				</td>
 			</tr>

--- a/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html
+++ b/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html
@@ -161,11 +161,9 @@
 			<tr>
 				<td bgcolor="#990000" colspan="2" height="59" valign="middle">
 					<h2 align="center">
-						<font color="#FFFF00"
-							><b
-								>Munster<br />
-								Surnames FrequencyReport</b
-							></font
+						<b
+							>Munster<br />
+							Surnames FrequencyReport</b
 						>
 					</h2>
 				</td>
@@ -302,14 +300,12 @@
 					</p>
 					<hr />
 					<p align="center">
-						<font size="-1"><b>Copyright Notice</b></font>
+						<b>Copyright Notice</b>
 					</p>
 					<p align="left">
-						<font size="-1"
-							>This COBOL project specification is the copyright property of Michael Coughlan. You have
-							permission to use this material for your own personal use but you may not reproduce it in
-							any published work without written permission from the author.</font
-						>
+						This COBOL project specification is the copyright property of Michael Coughlan. You have
+						permission to use this material for your own personal use but you may not reproduce it in any
+						published work without written permission from the author.
 					</p>
 				</td>
 			</tr>

--- a/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html
+++ b/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html
@@ -161,11 +161,9 @@
 			<tr>
 				<td bgcolor="#990000" colspan="2" height="59" valign="middle">
 					<h2 align="center">
-						<font color="#FFFF00"
-							><b
-								>Newtronics Plc.<br />
-								File Maintenance Program</b
-							></font
+						<b
+							>Newtronics Plc.<br />
+							File Maintenance Program</b
 						>
 					</h2>
 				</td>
@@ -1249,14 +1247,12 @@ Check Digit       =            4</pre
 					</p>
 					<hr />
 					<p align="center">
-						<font size="-1"><b>Copyright Notice</b></font>
+						<b>Copyright Notice</b>
 					</p>
 					<p align="left">
-						<font size="-1"
-							>This COBOL project specification is the copyright property of Michael Coughlan. You have
-							permission to use this material for your own personal use but you may not reproduce it in
-							any published work without written permission from the author.</font
-						>
+						This COBOL project specification is the copyright property of Michael Coughlan. You have
+						permission to use this material for your own personal use but you may not reproduce it in any
+						published work without written permission from the author.
 					</p>
 				</td>
 			</tr>

--- a/exercises/Proj-CSISEvalform/CSISEvalForm.html
+++ b/exercises/Proj-CSISEvalform/CSISEvalForm.html
@@ -139,10 +139,8 @@
 			<tr>
 				<td bgcolor="#990000" colspan="2" height="59" valign="middle">
 					<h2 align="center">
-						<font color="#FFFF00"
-							><b>CSIS WebSite<br /></b
-						></font>
-						<font color="#FFFF00"><b>Evaluation Form Report</b></font>
+						<b>CSIS WebSite<br /></b>
+						<b>Evaluation Form Report</b>
 					</h2>
 				</td>
 			</tr>
@@ -489,26 +487,24 @@
 						placement of items is left to the discretion of the programmer.
 					</p>
 					<p><span>&nbsp;</span></p>
-					<pre><span><font color="#000099">     <font color="#000000">  <b>                                       </b></font></font></span><font color="#000000"><b>CSIS Web Site<br></b></font><font color="#000000"><b><span>                                       </span>Evaluation Form Report</b></font></pre>
-					<pre><font color="#000000"><b>CountryName                         Visitors    Occupation                                             Evaluation </b></font></pre>
-					<pre><font color="#000000"><b>XXXXXXXXXXXXXXXXXXXX  XX,XXX  XXXXXXXXXXXXXXXXXXXXXXX           XXXXXXXXX</b></font></pre>
-					<pre><font color="#000000"><b>XXXXXXXXXXXXXXXXXXXX  XX,XXX  XXXXXXXXXXXXXXXXXXXXXXX           XXXXXXXXX</b></font></pre>
-					<pre><font color="#000000"><b>XXXXXXXXXXXXXXXXXXXX  XX,XXX  XXXXXXXXXXXXXXXXXXXXXXX           XXXXXXXXX</b></font></pre>
-					<pre><font color="#000000"><b>XXXXXXXXXXXXXXXXXXXX  XX,XXX  XXXXXXXXXXXXXXXXXXXXXXX           XXXXXXXXX</b></font></pre>
-					<pre><font color="#000000"><b>XXXXXXXXXXXXXXXXXXXX  XX,XXX  XXXXXXXXXXXXXXXXXXXXXXX           XXXXXXXXX</b></font></pre>
-					<pre><font color="#000000"><b><span style="font-size:10.0pt;font-family:&quot;Courier New&quot;,&quot;Times New Roman&quot;">-----------------------------------------------------------------</span></b></font></pre>
-					<pre><font color="#000000"><b>Total Visitors           -      XXX,XXX    </b></font></pre>
-					<pre><font color="#000000"><b>Overall Evaluation  - XXXXXXXXX</b></font></pre>
+					<pre><span>     <b>                                       </b></span><b>CSIS Web Site<br></b><b><span>                                       </span>Evaluation Form Report</b></pre>
+					<pre><b>CountryName                         Visitors    Occupation                                             Evaluation </b></pre>
+					<pre><b>XXXXXXXXXXXXXXXXXXXX  XX,XXX  XXXXXXXXXXXXXXXXXXXXXXX           XXXXXXXXX</b></pre>
+					<pre><b>XXXXXXXXXXXXXXXXXXXX  XX,XXX  XXXXXXXXXXXXXXXXXXXXXXX           XXXXXXXXX</b></pre>
+					<pre><b>XXXXXXXXXXXXXXXXXXXX  XX,XXX  XXXXXXXXXXXXXXXXXXXXXXX           XXXXXXXXX</b></pre>
+					<pre><b>XXXXXXXXXXXXXXXXXXXX  XX,XXX  XXXXXXXXXXXXXXXXXXXXXXX           XXXXXXXXX</b></pre>
+					<pre><b>XXXXXXXXXXXXXXXXXXXX  XX,XXX  XXXXXXXXXXXXXXXXXXXXXXX           XXXXXXXXX</b></pre>
+					<pre><b><span style="font-size:10.0pt;font-family:&quot;Courier New&quot;,&quot;Times New Roman&quot;">-----------------------------------------------------------------</span></b></pre>
+					<pre><b>Total Visitors           -      XXX,XXX    </b></pre>
+					<pre><b>Overall Evaluation  - XXXXXXXXX</b></pre>
 					<hr />
 					<p align="center">
-						<font size="-1"><b>Copyright Notice</b></font>
+						<b>Copyright Notice</b>
 					</p>
 					<p align="left">
-						<font size="-1"
-							>This COBOL project sprecification is the copyright property of Michael Coughlan. You have
-							permission to use this material for your own personal use but you may not reproduce it in
-							any published work without written permission from the author.</font
-						>
+						This COBOL project sprecification is the copyright property of Michael Coughlan. You have
+						permission to use this material for your own personal use but you may not reproduce it in any
+						published work without written permission from the author.
 					</p>
 				</td>
 			</tr>

--- a/exercises/SeqInsert.html
+++ b/exercises/SeqInsert.html
@@ -316,9 +316,7 @@
 		the example run below:
 		<ul>
 			<ul>
-				<u>
-					<font size="+2">Example Run</font>
-				</u>
+				<u> Example Run </u>
 			</ul>
 			<tt>&nbsp;&nbsp;&nbsp;&nbsp; Stud-Id Surname</tt>
 			<ul>
@@ -379,7 +377,7 @@
 		&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 		<b
 			><u>
-				<font color="#FF0000">WARNING</font>
+				<span style="color: #ff0000">WARNING</span>
 			</u></b
 		><br />
 		Do not look at the solution until you have finished your own or at least have made a substantial effort to
@@ -415,7 +413,7 @@
 							height="52"
 							width="52"
 					/></a>
-					<font size="-2">To COBOL Exercises</font>
+					To COBOL Exercises
 				</td>
 			</tr>
 		</table>

--- a/exercises/SeqRead.html
+++ b/exercises/SeqRead.html
@@ -332,7 +332,7 @@
 		<ul>
 			<ul>
 				<ul>
-					<u><font size="+2">Example Run</font></u>
+					<u>Example Run</u>
 				</ul>
 				<tt>------ STUDENT REPORT ------</tt>
 				<p><tt>MS. COUGHLAN DOB = 10-08-1985</tt></p>
@@ -353,7 +353,7 @@
 							height="52"
 							width="52"
 					/></a>
-					<font size="-2">To COBOL Exercises</font>
+					To COBOL Exercises
 				</td>
 			</tr>
 		</table>

--- a/exercises/SeqReadIf.html
+++ b/exercises/SeqReadIf.html
@@ -307,9 +307,8 @@
 		<ul>
 			<ul>
 				<ul>
-					<u><font size="+2">Example Run</font></u>
+					<u>Example Run</u>
 				</ul>
-				<u><font size="+2"></font></u>
 				<p><tt>STUDENT NUMBERS :- SUMMARY REPORT</tt><tt></tt></p>
 				<p><tt>Number of Males = 20</tt><tt></tt></p>
 				<p><tt>Number of Females = 15</tt></p>
@@ -329,7 +328,7 @@
 							height="52"
 							width="52"
 					/></a>
-					<font size="-2">To COBOL Exercises</font>
+					To COBOL Exercises
 				</td>
 			</tr>
 		</table>

--- a/exercises/SeqUpdate.html
+++ b/exercises/SeqUpdate.html
@@ -419,7 +419,7 @@
 		<a href="../examples/SeqUpd/SeqUpdate.cbl">sample solution</a>.<br />
 		&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 		<b
-			><u><font color="#FF0000">WARNING</font></u></b
+			><u><span style="color: #ff0000">WARNING</span></u></b
 		><br />
 		As always please do not look at the solution until you have finished your own program.&nbsp;&nbsp; At the very
 		least you should make a substantial effort to complete your own attempt at the program before examining the
@@ -436,7 +436,7 @@
 							height="52"
 							width="52"
 					/></a>
-					<font size="-2">To COBOL Exercises</font>
+					To COBOL Exercises
 				</td>
 			</tr>
 		</table>

--- a/exercises/SeqWrite.html
+++ b/exercises/SeqWrite.html
@@ -239,7 +239,7 @@
 		<ul>
 			<ul>
 				<ul>
-					<u><font size="+2">Example Run</font></u>
+					<u>Example Run</u>
 				</ul>
 				<tt>Please enter the student record using the template below.</tt
 				><br />
@@ -271,7 +271,7 @@
 		<ul>
 			<ul>
 				<ul>
-					<u><font size="+2">Example Run</font></u>
+					<u>Example Run</u>
 				</ul>
 				<tt>Stud-Id&nbsp; Student Name Gender</tt
 				><br />
@@ -295,9 +295,7 @@
 		<tt></tt>&nbsp;<tt></tt>
 		<center>
 			<tt
-				><b
-					><font color="#FF0000"><font size="+1">WARNING</font></font></b
-				></tt
+				><b><span style="color: #ff0000">WARNING</span></b></tt
 			>
 			<tt
 				>Do not look at the solution until you have finished your own or at least have made a substantial effort
@@ -316,7 +314,7 @@
 							height="52"
 							width="52"
 					/></a>
-					<font size="-2">To COBOL Exercises</font>
+					To COBOL Exercises
 				</td>
 			</tr>
 		</table>

--- a/exercises/SortIP.html
+++ b/exercises/SortIP.html
@@ -300,10 +300,10 @@
 		</p>
 		<p>
 			So the solution you are going to adopt in this exercise is to create a new file with the records sorted on
-			ascending CourseCode by&nbsp; using the <font size="2">SORT</font> verb to sort the Students File.&nbsp; To
-			make the <font size="2">SORT</font> as efficient as possible (by reducing the amount of data that needs to
-			be processed) records of the sorted file should only contain the fields that are needed for this program. An
-			Input Procedure should be used to create the appropriate Sort Records.
+			ascending CourseCode by&nbsp; using the SORT verb to sort the Students File.&nbsp; To make the SORT as
+			efficient as possible (by reducing the amount of data that needs to be processed) records of the sorted file
+			should only contain the fields that are needed for this program. An Input Procedure should be used to create
+			the appropriate Sort Records.
 		</p>
 		<p>
 			When the sorted file has been produced it is a simple matter to process it to calculate the required totals
@@ -355,9 +355,7 @@
 			<ul>
 				<ul>
 					<ul>
-						<u>
-							<font size="+2">Example Run</font>
-						</u>
+						<u> Example Run </u>
 					</ul>
 					<tt>CourseCode Females Males</tt
 					><br />
@@ -378,7 +376,7 @@
 			&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 			<b
 				><u>
-					<font color="#FF0000">WARNING</font>
+					<span style="color: #ff0000">WARNING</span>
 				</u></b
 			><br />
 			As always please do not look at the solution until you have finished your own program.&nbsp;&nbsp; At the
@@ -397,7 +395,7 @@
 							height="52"
 							width="52"
 					/></a>
-					<font size="-2">To COBOL Exercises</font>
+					To COBOL Exercises
 				</td>
 			</tr>
 		</table>

--- a/exercises/index.html
+++ b/exercises/index.html
@@ -157,6 +157,17 @@
 				padding-left: 0.4em;
 				margin-bottom: 0.4em;
 			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			td[bgcolor="#FFFFCC"] h3,
+			td[bgcolor="#FFFFCC"] h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
+			}
 		</style>
 	</head>
 	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
@@ -175,53 +186,40 @@
 				<tr>
 					<td width="50">&nbsp;</td>
 					<td width="698">
-						<p><font size="-1">These pages contain -</font></p>
+						<p>These pages contain -</p>
 						<ul>
-							<li><font size="-1">Simple COBOL programming exercises with sample answers.</font></li>
-							<li><font size="-1">Programming exam specifications with sample answers.</font></li>
-							<li>
-								<font size="-1">Programming p</font>
-								<font size="-1">roject specifications with no answers provided.</font>
-							</li>
+							<li>Simple COBOL programming exercises with sample answers.</li>
+							<li>Programming exam specifications with sample answers.</li>
+							<li>Programming project specifications with no answers provided.</li>
 						</ul>
-						<p><font size="-1">Where required, test data files are also supplied.</font></p>
+						<p>Where required, test data files are also supplied.</p>
 						<p>
-							<font size="-1"
-								>The simple programming exercises are normally given as lab exercises. Good students
-								should be able to do these in little more than one or two hours.</font
-							>
+							The simple programming exercises are normally given as lab exercises. Good students should
+							be able to do these in little more than one or two hours.
 						</p>
 						<p>
-							<font size="-1"
-								>The specifications for the programming exams are actually old
-								<a href="COBOLExams/COBOLExams.html">exam papers</a>. Good students should be able to
-								produce a working program in four to six hours.</font
-							>
+							The specifications for the programming exams are actually old
+							<a href="COBOLExams/COBOLExams.html">exam papers</a>. Good students should be able to
+							produce a working program in four to six hours.
 						</p>
 						<p>
-							<font size="-1"
-								>Unlike the exercises described above, the programming project specifications require
-								programs that can not be written in one sitting. For each project, an estimate of the
-								number of hours it should take to complete the project has been given.</font
-							>
+							Unlike the exercises described above, the programming project specifications require
+							programs that can not be written in one sitting. For each project, an estimate of the number
+							of hours it should take to complete the project has been given.
 						</p>
 						<p>
-							<font size="-1"
-								>In our course we normally allow students about one week for every 5 hours of the
-								completion estimate. In other words if we estimate that a programming project will take
-								20 hours to complete, we allow the students 4 weeks to do it.</font
-							>
+							In our course we normally allow students about one week for every 5 hours of the completion
+							estimate. In other words if we estimate that a programming project will take 20 hours to
+							complete, we allow the students 4 weeks to do it.
 						</p>
 						<p align="center">
-							<font size="-1"><b>Copyright Notice</b></font>
+							<b>Copyright Notice</b>
 						</p>
 						<p align="left">
-							<font size="-1"
-								>These COBOL programming exercises, program specifications, and sample programs are the
-								copyright property of Michael Coughlan. You have permission to use these materials for
-								your own personal use but you may not reproduce them in any published work without
-								written permission from the author.</font
-							>
+							These COBOL programming exercises, program specifications, and sample programs are the
+							copyright property of Michael Coughlan. You have permission to use these materials for your
+							own personal use but you may not reproduce them in any published work without written
+							permission from the author.
 						</p>
 					</td>
 				</tr>
@@ -286,18 +284,15 @@
 					</td>
 					<td height="37" valign="top" width="73%">
 						<p>
-							<font size="-1"
-								>Write a program to apply a transaction file of student payments to a Student Master
-								File and then produce a report showing those students whose fees are partially or wholly
-								outstanding.<br />
-								(Indexed files, Print files, <code class="language-cobol">READ..NEXT RECORD</code>,
-								<code class="language-cobol">START</code>, <code class="language-cobol">WRITE</code>,
-								<code class="language-cobol">REWRITE</code>,
-								<code class="language-cobol">IF</code>,<br />
-								<code class="language-cobol">PERFORM</code>, <code class="language-cobol">ADD</code>,
-								<code class="language-cobol">SUBTRACT</code>)<br />
-								&nbsp;</font
-							>
+							Write a program to apply a transaction file of student payments to a Student Master File and
+							then produce a report showing those students whose fees are partially or wholly
+							outstanding.<br />
+							(Indexed files, Print files, <code class="language-cobol">READ..NEXT RECORD</code>,
+							<code class="language-cobol">START</code>, <code class="language-cobol">WRITE</code>,
+							<code class="language-cobol">REWRITE</code>, <code class="language-cobol">IF</code>,<br />
+							<code class="language-cobol">PERFORM</code>, <code class="language-cobol">ADD</code>,
+							<code class="language-cobol">SUBTRACT</code>)<br />
+							&nbsp;
 						</p>
 					</td>
 				</tr>
@@ -310,13 +305,10 @@
 					</td>
 					<td height="47" valign="top" width="73%">
 						<p>
-							<font size="-1"
-								>A program is required to produce a summary sales report from an unsorted sequential
-								file containing the details of sales of essential and base oils to Aromamora
-								customers.<br />
-								(<code class="language-cobol">SORT</code> with Input Procedure and Output Procedure,
-								Print Files, Sequential Files, <code class="language-cobol">COMPUTE</code>)</font
-							><br />
+							A program is required to produce a summary sales report from an unsorted sequential file
+							containing the details of sales of essential and base oils to Aromamora customers.<br />
+							(<code class="language-cobol">SORT</code> with Input Procedure and Output Procedure, Print
+							Files, Sequential Files, <code class="language-cobol">COMPUTE</code>)<br />
 							&nbsp;
 						</p>
 					</td>
@@ -330,15 +322,11 @@
 					</td>
 					<td height="62" valign="top" width="73%">
 						<p>
-							<font size="-1"
-								>A program is required which will read the tourist bookings master filee to produce a
-								summary file sequenced upon ascending Destination-Name.<br
-							/></font>
-							<font size="-1"
-								>(Pre-Filled Tables, Sequential Files, <code class="language-cobol">SORT</code> with
-								Input Procedure, <code class="language-cobol">SEARCH</code>,
-								<code class="language-cobol">INSPECT</code>)</font
-							><br />
+							A program is required which will read the tourist bookings master filee to produce a summary
+							file sequenced upon ascending Destination-Name.<br />
+							(Pre-Filled Tables, Sequential Files, <code class="language-cobol">SORT</code> with Input
+							Procedure, <code class="language-cobol">SEARCH</code>,
+							<code class="language-cobol">INSPECT</code>)<br />
 							&nbsp;
 						</p>
 					</td>
@@ -352,19 +340,15 @@
 					</td>
 					<td height="103" valign="top" width="73%">
 						<p>
-							<font size="-1"
-								>A program is required which will apply a file of sorted, validated transactions to the
-								Oil-Stock-File and then produce a report based on the contents of both the
-								Oil-Details-File and the Oil-Stock-File. The report writer must be used to produce the
-								report which must be printed sequenced on ascending Oil-Name.</font
-							><br />
-							(<font size="-1"
-								>Indexed files, Relative Files, Sequential Files, Report Writer,
-								<code class="language-cobol">EVALUATE</code>,
-								<code class="language-cobol">COMPUTE</code>, <code class="language-cobol">READ</code>,
-								<code class="language-cobol">WRITE</code>, <code class="language-cobol">REWRITE</code>,
-								<code class="language-cobol">START</code></font
-							>
+							A program is required which will apply a file of sorted, validated transactions to the
+							Oil-Stock-File and then produce a report based on the contents of both the Oil-Details-File
+							and the Oil-Stock-File. The report writer must be used to produce the report which must be
+							printed sequenced on ascending Oil-Name.<br />
+							(Indexed files, Relative Files, Sequential Files, Report Writer,
+							<code class="language-cobol">EVALUATE</code>, <code class="language-cobol">COMPUTE</code>,
+							<code class="language-cobol">READ</code>, <code class="language-cobol">WRITE</code>,
+							<code class="language-cobol">REWRITE</code>,
+							<code class="language-cobol">START</code>
 							)<br />
 							&nbsp;
 						</p>
@@ -379,20 +363,14 @@
 					</td>
 					<td height="2" valign="top" width="73%">
 						<p>
-							<font size="-1"
-								>A program is required to produce a Purchase Requirements Report from the Publisher,
-								Book and Purchase Requirements files. The report should be sequenced on ascending
-								Publisher Name and should only detail the purchase requirements for the semester under
-								scrutiny.<br
-							/></font>
-							<font size="-1"
-								>(Indexed files, Report Writer, Report Section,
-								<code class="language-cobol">INITIATE</code>,
-								<code class="language-cobol">GENERATE</code>,
-								<code class="language-cobol">TERMINATE</code>, <code class="language-cobol">READ</code>,
-								<code class="language-cobol">WRITE</code>, <code class="language-cobol">REWRITE</code>,
-								<code class="language-cobol">START</code></font
-							>
+							A program is required to produce a Purchase Requirements Report from the Publisher, Book and
+							Purchase Requirements files. The report should be sequenced on ascending Publisher Name and
+							should only detail the purchase requirements for the semester under scrutiny.<br />
+							(Indexed files, Report Writer, Report Section,
+							<code class="language-cobol">INITIATE</code>, <code class="language-cobol">GENERATE</code>,
+							<code class="language-cobol">TERMINATE</code>, <code class="language-cobol">READ</code>,
+							<code class="language-cobol">WRITE</code>, <code class="language-cobol">REWRITE</code>,
+							<code class="language-cobol">START</code>
 							)<br />
 							&nbsp;
 						</p>
@@ -407,21 +385,18 @@
 					</td>
 					<td height="93" valign="top" width="73%">
 						<p>
-							<font size="-1"
-								>A program is required which will process the Stock and Manufacturer files to create an
-								Orders file containing ordering information for all the parts that need to be re-ordered
-								(i.e. where the QtyInStock is less than the ReorderLevel). For EU countries only, the
-								COSTOFITEMS and POSTAGE fields of each Orders file record must be calculated. The
-								Postage rate is obtained by calling an existing program.<br />
-								(Indexed files, Relative Files, SubPrograms,
-								<code class="language-cobol">CALL..USING</code>,
-								<code class="language-cobol">READ</code>, <code class="language-cobol">WRITE</code>,
-								<code class="language-cobol">REWRITE</code>, Condition Names (level 88s),
-								<code class="language-cobol">EVALUATE</code>,
-								<code class="language-cobol">UNSTRING</code>,
-								<code class="language-cobol">MULTIPLY..ON SIZE ERROR</code>)<br />
-								&nbsp;</font
-							>
+							A program is required which will process the Stock and Manufacturer files to create an
+							Orders file containing ordering information for all the parts that need to be re-ordered
+							(i.e. where the QtyInStock is less than the ReorderLevel). For EU countries only, the
+							COSTOFITEMS and POSTAGE fields of each Orders file record must be calculated. The Postage
+							rate is obtained by calling an existing program.<br />
+							(Indexed files, Relative Files, SubPrograms,
+							<code class="language-cobol">CALL..USING</code>, <code class="language-cobol">READ</code>,
+							<code class="language-cobol">WRITE</code>, <code class="language-cobol">REWRITE</code>,
+							Condition Names (level 88s), <code class="language-cobol">EVALUATE</code>,
+							<code class="language-cobol">UNSTRING</code>,
+							<code class="language-cobol">MULTIPLY..ON SIZE ERROR</code>)<br />
+							&nbsp;
 						</p>
 					</td>
 				</tr>
@@ -433,18 +408,16 @@
 						>
 					</td>
 					<td height="93" valign="top" width="73%">
-						<font size="-1"
-							>A program is required to convert the unsorted Client-Names file of free-format, variable
-							length, records into a sorted file of fixed length records. The sorted file must be sorted
-							into ascending Client-Name within ascending County-Name. In addition to converting and
-							sorting the file, the program must ensure that the county name is valid and must convert it
-							to a county number.<br />
-							(Sequential files, <code class="language-cobol">SORT</code> with Input Procedure,
-							Pre-Defined Table of values, <code class="language-cobol">STRING</code>,
-							<code class="language-cobol">UNSTRING</code>, <code class="language-cobol">INSPECT</code>,
-							<code class="language-cobol">SEARCH ALL</code>)<br />
-							&nbsp;</font
-						>
+						A program is required to convert the unsorted Client-Names file of free-format, variable length,
+						records into a sorted file of fixed length records. The sorted file must be sorted into
+						ascending Client-Name within ascending County-Name. In addition to converting and sorting the
+						file, the program must ensure that the county name is valid and must convert it to a county
+						number.<br />
+						(Sequential files, <code class="language-cobol">SORT</code> with Input Procedure, Pre-Defined
+						Table of values, <code class="language-cobol">STRING</code>,
+						<code class="language-cobol">UNSTRING</code>, <code class="language-cobol">INSPECT</code>,
+						<code class="language-cobol">SEARCH ALL</code>)<br />
+						&nbsp;
 					</td>
 				</tr>
 				<tr>
@@ -456,16 +429,11 @@
 					</td>
 					<td height="29" valign="top" width="73%">
 						<p>
-							<font size="-1"
-								>A program is required to produce a report detailing the major vessels (Vessels of
-								tonnage 3,500 or greater and all submarines) in each of oceans and major seas of the
-								world.</font
-							><br />
-							<font size="-1"
-								>(Sequential files, <code class="language-cobol">SORT</code> with Input Procedure, Print
-								Files, Pre-defined tables, Condition Names)<br />
-								&nbsp;</font
-							>
+							A program is required to produce a report detailing the major vessels (Vessels of tonnage
+							3,500 or greater and all submarines) in each of oceans and major seas of the world.<br />
+							(Sequential files, <code class="language-cobol">SORT</code> with Input Procedure, Print
+							Files, Pre-defined tables, Condition Names)<br />
+							&nbsp;
 						</p>
 					</td>
 				</tr>
@@ -477,15 +445,13 @@
 						>
 					</td>
 					<td height="57" valign="top" width="73%">
-						<font size="-1"
-							>A program is required to apply the Orders file (containing customer orders) to the Book
-							Stock file and to produce the Processed Orders file.<br />
-							(<code class="language-cobol">CALL</code>, subprograms, Sequential files, Indexed files,
-							<code class="language-cobol">READ</code>, <code class="language-cobol">WRITE</code>,
-							<code class="language-cobol">REWRITE</code>, <code class="language-cobol">COMPUTE</code>,
-							<code class="language-cobol">UNSTRING</code>)<br />
-							&nbsp;</font
-						>
+						A program is required to apply the Orders file (containing customer orders) to the Book Stock
+						file and to produce the Processed Orders file.<br />
+						(<code class="language-cobol">CALL</code>, subprograms, Sequential files, Indexed files,
+						<code class="language-cobol">READ</code>, <code class="language-cobol">WRITE</code>,
+						<code class="language-cobol">REWRITE</code>, <code class="language-cobol">COMPUTE</code>,
+						<code class="language-cobol">UNSTRING</code>)<br />
+						&nbsp;
 					</td>
 				</tr>
 				<tr>
@@ -497,16 +463,12 @@
 					</td>
 					<td height="65" valign="top" width="73%">
 						<p>
-							<font size="-1"
-								>A program is required which will produce a file, sorted on ascending email domain, from
-								the unsorted GraduateInfo file.<br
-							/></font>
-							<font size="-1"
-								>(<code class="language-cobol">SORT</code> with Input Procedure and Output Procedure,
-								Sequential Files, Pre-Defined Tables, Run time filled tables,
-								<code class="language-cobol">SEARCH</code>)<br />
-								&nbsp;</font
-							>
+							A program is required which will produce a file, sorted on ascending email domain, from the
+							unsorted GraduateInfo file.<br />
+							(<code class="language-cobol">SORT</code> with Input Procedure and Output Procedure,
+							Sequential Files, Pre-Defined Tables, Run time filled tables,
+							<code class="language-cobol">SEARCH</code>)<br />
+							&nbsp;
 						</p>
 					</td>
 				</tr>
@@ -519,20 +481,16 @@
 					</td>
 					<td height="110" valign="top" width="73%">
 						<p>
-							<font size="-1"
-								>Each time a book is borrowed, the Pascal Memorial Library pays the author a small sum
-								of money as royalty. Royalties are paid to authors through their agents. A report is
-								required which processes the Authors file and the Books File to produce a report which
-								shows the amount to be sent to each agent, shows the breakdown of the agent payment into
-								author payments, and shows the breakdown of each author payment into royalty payments
-								per book.<br />
-								(Indexed Files, Print Files, <code class="language-cobol">READ..NEXT RECORD</code>,
-								<code class="language-cobol">READ..KEY IS</code>,
-								<code class="language-cobol">START</code>, <code class="language-cobol">REWRITE</code>,
-								<code class="language-cobol">WRITE</code>, <code class="language-cobol">MULTIPLY</code>,
-								<code class="language-cobol">SET</code>)<br />
-								&nbsp;</font
-							>
+							Each time a book is borrowed, the Pascal Memorial Library pays the author a small sum of
+							money as royalty. Royalties are paid to authors through their agents. A report is required
+							which processes the Authors file and the Books File to produce a report which shows the
+							amount to be sent to each agent, shows the breakdown of the agent payment into author
+							payments, and shows the breakdown of each author payment into royalty payments per book.<br />
+							(Indexed Files, Print Files, <code class="language-cobol">READ..NEXT RECORD</code>,
+							<code class="language-cobol">READ..KEY IS</code>, <code class="language-cobol">START</code>,
+							<code class="language-cobol">REWRITE</code>, <code class="language-cobol">WRITE</code>,
+							<code class="language-cobol">MULTIPLY</code>, <code class="language-cobol">SET</code>)<br />
+							&nbsp;
 						</p>
 					</td>
 				</tr>
@@ -545,15 +503,13 @@
 					</td>
 					<td height="49" valign="top" width="73%">
 						<p>
-							<font size="-1"
-								>The manager of Metropolis Videos has asked you to write a program to produce a report
-								showing the top three Video Suppliers (by total store video earnings) and for each of
-								the top three the most popular video title (by average earnings) must be shown.<br />
-								(Indexed Files, Relative Files, Print Files, <code class="language-cobol">READ</code>,
-								<code class="language-cobol">START</code>, Tables,
-								<code class="language-cobol">DIVIDE</code>)<br />
-								&nbsp;</font
-							>
+							The manager of Metropolis Videos has asked you to write a program to produce a report
+							showing the top three Video Suppliers (by total store video earnings) and for each of the
+							top three the most popular video title (by average earnings) must be shown.<br />
+							(Indexed Files, Relative Files, Print Files, <code class="language-cobol">READ</code>,
+							<code class="language-cobol">START</code>, Tables,
+							<code class="language-cobol">DIVIDE</code>)<br />
+							&nbsp;
 						</p>
 					</td>
 				</tr>
@@ -565,13 +521,11 @@
 						>
 					</td>
 					<td height="56" valign="top" width="73%">
-						<font size="-1"
-							>The Folio Society is a Book Club that sells fine books to customers all over the world. A
-							program is required to print a list of the ten best selling books (by copies sold) in the
-							Book Club.<br />
-							(Sequential Files, Print Files, SORT with Input Procedure and Output Procedure, Tables)<br />
-							&nbsp;</font
-						>
+						The Folio Society is a Book Club that sells fine books to customers all over the world. A
+						program is required to print a list of the ten best selling books (by copies sold) in the Book
+						Club.<br />
+						(Sequential Files, Print Files, SORT with Input Procedure and Output Procedure, Tables)<br />
+						&nbsp;
 					</td>
 				</tr>
 				<tr>
@@ -582,19 +536,14 @@
 						>
 					</td>
 					<td height="56" valign="top" width="73%">
-						<font size="-1"
-							>NetNews is a company which runs an NNTP server carrying the complete USENET news feed with
-							over 15,000 news groups. Access to this server is available to internet users all over the
-							world. Users of the system pay a subscription fee for access. The fee may be paid monthly
-							($20), half-yearly ($100) or yearly ($180). A program is required to produce a report
-							showing the subscriptions which are now due. The report will be based on the Due
-							Subscriptions file.</font
-						><br />
-						<font size="-1"
-							>(Sequential Files, Print Files, <code class="language-cobol">SORT</code> with Input
-							Procedure, Tables, <code class="language-cobol">SEARCH ALL</code>)<br />
-							&nbsp;</font
-						>
+						NetNews is a company which runs an NNTP server carrying the complete USENET news feed with over
+						15,000 news groups. Access to this server is available to internet users all over the world.
+						Users of the system pay a subscription fee for access. The fee may be paid monthly ($20),
+						half-yearly ($100) or yearly ($180). A program is required to produce a report showing the
+						subscriptions which are now due. The report will be based on the Due Subscriptions file.<br />
+						(Sequential Files, Print Files, <code class="language-cobol">SORT</code> with Input Procedure,
+						Tables, <code class="language-cobol">SEARCH ALL</code>)<br />
+						&nbsp;
 					</td>
 				</tr>
 			</table>
@@ -615,29 +564,23 @@
 					</td>
 					<td height="156" width="73%">
 						<p>
-							<font size="-1"
-								>A program is required which will produce a report from the file produced by the
-								Evaluation Form on the CSIS web site. For each country from which the site has been
-								visited the report should show-</font
-							>
+							A program is required which will produce a report from the file produced by the Evaluation
+							Form on the CSIS web site. For each country from which the site has been visited the report
+							should show-
 						</p>
 						<ul>
-							<li><font size="-1">The name of the country</font></li>
-							<li><font size="-1">The number of visitors from this country.</font></li>
-							<li><font size="-1">Most common occupation of visitors from this country</font></li>
+							<li>The name of the country</li>
+							<li>The number of visitors from this country.</li>
+							<li>Most common occupation of visitors from this country</li>
 							<li>
-								<font size="-1"
-									>The average evaluation of the web site by visitors from this country.<br />
-									<br
-								/></font>
+								The average evaluation of the web site by visitors from this country.<br />
+								<br />
 							</li>
 						</ul>
 						<p>
-							<font size="-1"
-								>The report must be implemented as an HTML web page and the information on the page
-								should appear in ascending country name sequence.<br />
-								&nbsp;</font
-							>
+							The report must be implemented as an HTML web page and the information on the page should
+							appear in ascending country name sequence.<br />
+							&nbsp;
 						</p>
 					</td>
 				</tr>
@@ -651,13 +594,11 @@
 						</p>
 					</td>
 					<td height="68" valign="top" width="73%">
-						<font size="-1"
-							>Aromamora PLC is a company which sells essential oils to Aromatherapists, Health Shops,
-							Chemists and other mass users of essential oils. Every month, details of sales to these
-							customers are gathered together into a Sales File . A program is required that will produce
-							a report from this file showing the quantities and values of essential oils purchased.<br />
-							&nbsp;</font
-						>
+						Aromamora PLC is a company which sells essential oils to Aromatherapists, Health Shops, Chemists
+						and other mass users of essential oils. Every month, details of sales to these customers are
+						gathered together into a Sales File . A program is required that will produce a report from this
+						file showing the quantities and values of essential oils purchased.<br />
+						&nbsp;
 					</td>
 				</tr>
 				<tr>

--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
 			<div>
 				<h1>
 					<img src="pics/T-Dept.gif" width="297" height="36" /><br />
-					<font size="5">COBOL programming - tutorials, lectures, exercises, examples</font>
+					COBOL programming - tutorials, lectures, exercises, examples
 				</h1>
 			</div>
 		</div>
@@ -103,13 +103,11 @@
 		<hr />
 		<ul class="toc">
 			<li>
-				<a href="course/index.html"
-					>COBOL programming course <font size="-1">(comprehensive COBOL tutorials)</font></a
-				>
+				<a href="course/index.html">COBOL programming course (comprehensive COBOL tutorials)</a>
 			</li>
 			<li>
 				<a href="lectures/CS4312Topics.html#ReportWriter1"
-					>Report Writer Tutorials <font size="-1">(part of the COBOL course)</font></a
+					>Report Writer Tutorials (part of the COBOL course)</a
 				>
 			</li>
 			<li><a href="exercises/index.html">COBOL programming exercises</a></li>

--- a/lectures/CS4312Topics.html
+++ b/lectures/CS4312Topics.html
@@ -1048,7 +1048,7 @@
 							src="../pics/B-BackArrow.gif"
 							width="52"
 					/></a>
-					<font size="-2">To contents page</font>
+					To contents page
 				</td>
 				<td width="53">
 					<a href="#"
@@ -1059,7 +1059,7 @@
 							src="../pics/B-CSISHome.gif"
 							width="52"
 					/></a>
-					<font size="-2">To the CSIS HomePage</font>
+					To the CSIS HomePage
 				</td>
 				<td width="68">
 					<a href="#"
@@ -1070,7 +1070,7 @@
 							src="../pics/B-Evaluation.gif"
 							width="52"
 					/></a>
-					<font size="-2">Evaluation Form</font>
+					Evaluation Form
 				</td>
 			</tr>
 		</table>

--- a/lectures/ReportWriterSSWeb.html
+++ b/lectures/ReportWriterSSWeb.html
@@ -150,6 +150,17 @@
 			ul.toc a {
 				font-weight: bold;
 			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			td[bgcolor="#FFFFCC"] h3,
+			td[bgcolor="#FFFFCC"] h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
+			}
 		</style>
 	</head>
 	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
@@ -178,83 +189,56 @@
 								<ul class="toc">
 									<li>
 										<a href="#intro">Introduction</a><br />
-										<font size="-1">Unit aims, objectives and prerequisites.</font>
+										Unit aims, objectives and prerequisites.
 									</li>
 									<li>
 										<a href="#part1">Defining the Report - Report File entries</a><br />
-										<font size="-1"
-											>This section examines the
-											<code class="language-cobol">ENVIRONMENT DIVISION</code> and File Section
-											entries required when we create<br />
-											a Report Writer program.</font
-										>
+										This section examines the
+										<code class="language-cobol">ENVIRONMENT DIVISION</code> and File Section
+										entries required when we create<br />
+										a Report Writer program.
 									</li>
 									<li>
 										<a href="#part2">Defining the Report - Report Description (RD) entries</a><br />
-										<font size="-1"
-											>In this section we examine the Report Section and the Report Description
-											(RD) entries required to<br />
-											define a report.</font
-										>
+										In this section we examine the Report Section and the Report Description (RD)
+										entries required to<br />
+										define a report.
 									</li>
 									<li>
 										<a href="#part3">Defining the Report - Report Group entries</a><br />
-										<font size="-1"
-											>This section examines the entries required to define a report group
-											record.</font
-										>
+										This section examines the entries required to define a report group record.
 									</li>
 									<li>
 										<a href="#part4">Defining the Report - Lines and Columns</a><br />
-										<font size="-1"
-											>This section examines the entries the vertical and horizontal placement of
-											print items.</font
-										>
-										<font size="-1"
-											>It examines<br />
-											clauses such as -</font
-										>
-										<font size="-1"
-											>LINE NUMBER, COLUMN NUMBER, GROUP INDICATE , SOURCE and SUM</font
-										>
-										<font size="-1">.</font>
+										This section examines the entries the vertical and horizontal placement of print
+										items. It examines<br />
+										clauses such as - LINE NUMBER, COLUMN NUMBER, GROUP INDICATE , SOURCE and SUM.
 									</li>
 									<li>
 										<a href="#part5">Special Report Writer registers</a><br />
-										<font size="-1"
-											>In this section the LINE-COUNTER and PAGE-COUNTER registers are
-											examined.</font
-										>
+										In this section the LINE-COUNTER and PAGE-COUNTER registers are examined.
 									</li>
 									<li>
 										<a href="#part6">The Procedure Division Verbs</a><br />
-										<font size="-1"
-											>This section introduces the INITIATE, GENERATE and TERMINATE verbs.</font
-										>
+										This section introduces the INITIATE, GENERATE and TERMINATE verbs.
 									</li>
 									<li>
 										<a href="#part7">Report Writer Declaratives</a><br />
-										<font size="-1"
-											>In this section elements of the Declaratives, such as USE BEFORE REPORTING,
-											SUPPRESS PRINTING and<br />
-											control break registers, are examined.</font
-										>
+										In this section elements of the Declaratives, such as USE BEFORE REPORTING,
+										SUPPRESS PRINTING and<br />
+										control break registers, are examined.
 									</li>
 								</ul>
 							</td>
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-								<h2 align="center" id="intro">
-									<font color="#FFFF00"
-										><font face="Arial, Helvetica, sans-serif">Introduction</font></font
-									>
-								</h2>
+								<h2 align="center" id="intro">Introduction</h2>
 							</td>
 						</tr>
 						<tr>
 							<td bgcolor="#FFFFCC" valign="top" width="160">
-								<h4><font color="#993300" face="Arial, Helvetica, sans-serif">Aims</font></h4>
+								<h4>Aims</h4>
 							</td>
 							<td width="540">
 								<p>
@@ -266,7 +250,7 @@
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-								<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Objectives</font></h4>
+								<h4>Objectives</h4>
 							</td>
 							<td width="540">
 								<p>By the end of this unit you should -</p>
@@ -293,7 +277,7 @@
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-								<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font></h4>
+								<h4>Prerequisites</h4>
 							</td>
 							<td width="525">
 								<p>You should be familiar with the material covered in the units;</p>
@@ -318,22 +302,12 @@
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-								<h2 align="center" id="part1">
-									<font color="#FFFF00"
-										><font face="Arial, Helvetica, sans-serif"
-											>Defining the Report - Report File entries</font
-										></font
-									>
-								</h2>
+								<h2 align="center" id="part1">Defining the Report - Report File entries</h2>
 							</td>
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-								<h4>
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										><code class="language-cobol">ENVIRONMENT DIVISION</code> entries</font
-									>
-								</h4>
+								<h4><code class="language-cobol">ENVIRONMENT DIVISION</code> entries</h4>
 							</td>
 							<td valign="top" width="540">
 								<p>
@@ -351,7 +325,7 @@
 								</p>
 								<p>
 									When the Report Writer generates this report it will be stored in the file
-									<font size="-1">SALESREPORT.LPT</font>.
+									SALESREPORT.LPT.
 								</p>
 								<table background="lectures/cobol/pics/code.gif" border="1" width="100%">
 									<tr>
@@ -361,7 +335,7 @@ INPUT-OUTPUT SECTION.
 FILE-CONTROL.
     SELECT SalesFile ASSIGN TO "GBPAY.DAT"
            ORGANIZATION IS LINE SEQUENTIAL.
-   <font color="#FF0000"><b> SELECT PrintFile ASSIGN TO "SALESREPORT.LPT".</b></font>
+   <span style="color: #FF0000"><b> SELECT PrintFile ASSIGN TO "SALESREPORT.LPT".</b></span>
 
 
 DATA DIVISION.
@@ -373,23 +347,23 @@ FD  SalesFile.
     02 SalesPersonNum   PIC 9.
     02 ValueOfSale      PIC 9(4)V99.
 
-<b><font color="#FF0000">FD  PrintFile
+<b><span style="color: #FF0000">FD  PrintFile
     REPORT IS SalesReport.
 
-</font></b><font color="#FF0000"><font color="#000000">    : intervening entries :
-    : intervening entries :</font></font><b><font color="#FF0000">
+</span></b>    : intervening entries :
+    : intervening entries :
 
-</font></b><font color="#FF0000"><font color="#000000">REPORT SECTION.</font></font><b><font color="#FF0000"><font color="#000000">
-<b><font color="#FF3300">RD  SalesReport</font></b>
-</font></font></b><font color="#FF0000"><font color="#000000">    CONTROLS ARE FINAL
+REPORT SECTION.
+<b><span style="color: #FF3300">RD  SalesReport</span></b>
+    CONTROLS ARE FINAL
                  CityCode
-                 SalesPersonNum 
+                 SalesPersonNum
     PAGE LIMIT IS 66
     HEADING 1
     FIRST DETAIL 6
     LAST DETAIL 42
-    FOOTING 52.</font></font><b><font color="#FF0000"><font color="#000000">
-</font></font></b></pre>
+    FOOTING 52.
+</pre>
 										</td>
 									</tr>
 								</table>
@@ -398,11 +372,7 @@ FD  SalesFile.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4 align="left">
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>File Section entries</font
-									>
-								</h4>
+								<h4 align="left">File Section entries</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -433,16 +403,12 @@ FD  SalesFile.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#993300" colspan="2" valign="top">
-								<h2 align="center" id="part2">
-									<font color="#FFFF00" face="Arial, Helvetica, sans-serif"
-										>Defining the Report - Report Description (RD) Entries</font
-									>
-								</h2>
+								<h2 align="center" id="part2">Defining the Report - Report Description (RD) Entries</h2>
 							</td>
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font></h4>
+								<h4>Introduction</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -467,11 +433,7 @@ FD  SalesFile.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4 align="left">
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>The Report Description (RD) entries - Syntax</font
-									>
-								</h4>
+								<h4 align="left">The Report Description (RD) entries - Syntax</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>The syntax for the Report Description (RD) entries is shown below -</p>
@@ -481,11 +443,7 @@ FD  SalesFile.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4 align="left">
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>The Report Description (RD) entries - Semantics</font
-									>
-								</h4>
+								<h4 align="left">The Report Description (RD) entries - Semantics</h4>
 							</td>
 							<td valign="top" width="525">
 								<p align="center"><b>RD Rules</b></p>
@@ -557,19 +515,12 @@ FD  SalesFile.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#993300" colspan="2" valign="top">
-								<h2 align="center" id="part3">
-									<font color="#FFFF00" face="Arial, Helvetica, sans-serif"></font>
-									<font color="#FFFF00"
-										><font face="Arial, Helvetica, sans-serif"
-											>Defining the Report - Report Group entries</font
-										></font
-									>
-								</h2>
+								<h2 align="center" id="part3">Defining the Report - Report Group entries</h2>
 							</td>
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font></h4>
+								<h4>Introduction</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -587,15 +538,11 @@ FD  SalesFile.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4 align="left">
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>Defining a Report Group Record - Syntax</font
-									>
-								</h4>
+								<h4 align="left">Defining a Report Group Record - Syntax</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
-									<b><font size="+1">Report Group Definition</font></b>
+									<b>Report Group Definition</b>
 								</p>
 								<p><img height="512" src="rwGroupType.gif" width="405" /></p>
 								<hr />
@@ -603,11 +550,7 @@ FD  SalesFile.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4 align="left">
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										><i>ReportGroupName</i> Rules</font
-									>
-								</h4>
+								<h4 align="left"><i>ReportGroupName</i> Rules</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>The <i>ReportGroupName</i> is required only when the group -</p>
@@ -630,11 +573,7 @@ FD  SalesFile.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4 align="left">
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>The LINE NUMBER clause</font
-									>
-								</h4>
+								<h4 align="left">The LINE NUMBER clause</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -681,11 +620,7 @@ FD  SalesFile.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4 align="left">
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>The NEXT GROUP clause</font
-									>
-								</h4>
+								<h4 align="left">The NEXT GROUP clause</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -722,9 +657,7 @@ FD  SalesFile.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4 align="left">
-									<font color="#800000" face="Arial, Helvetica, sans-serif">The TYPE clause</font>
-								</h4>
+								<h4 align="left">The TYPE clause</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -735,9 +668,8 @@ FD  SalesFile.
 								</p>
 								<p><b>Rules</b></p>
 								<p>
-									Most groups are defined once for each report but control groups (other than
-									<font size="-1">CONTROL ..FINAL</font> groups) are defined for each control break
-									item.
+									Most groups are defined once for each report but control groups (other than CONTROL
+									..FINAL groups) are defined for each control break item.
 								</p>
 								<p>
 									In <code class="language-cobol">REPORT FOOTING</code>, and
@@ -771,21 +703,12 @@ FD  SalesFile.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#993300" colspan="2" valign="top">
-								<h2 align="center" id="part4">
-									<font color="#FFFF00" face="Arial, Helvetica, sans-serif"></font>
-									<font color="#FFFF00"
-										><font face="Arial, Helvetica, sans-serif"
-											>Defining the Report - Lines and Columns</font
-										></font
-									>
-								</h2>
+								<h2 align="center" id="part4">Defining the Report - Lines and Columns</h2>
 							</td>
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4 align="left">
-									<font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font>
-								</h4>
+								<h4 align="left">Introduction</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -799,11 +722,7 @@ FD  SalesFile.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4 align="left">
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>Defining Report Lines</font
-									>
-								</h4>
+								<h4 align="left">Defining Report Lines</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -823,11 +742,7 @@ FD  SalesFile.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4 align="center">
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>Defining Elementary print items in a report group</font
-									>
-								</h4>
+								<h4 align="center">Defining Elementary print items in a report group</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -854,11 +769,7 @@ FD  SalesFile.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4 align="left">
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>The COLUMN NUMBER clause</font
-									>
-								</h4>
+								<h4 align="left">The COLUMN NUMBER clause</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -876,11 +787,7 @@ FD  SalesFile.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>The GROUP INDICATE clause</font
-									>
-								</h4>
+								<h4>The GROUP INDICATE clause</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -898,9 +805,9 @@ FD  SalesFile.
 											<pre>01  DetailLine TYPE IS DETAIL.
     02 LINE IS PLUS 1.
        03 COLUMN 1      PIC X(9)
-                        SOURCE CityName(CityCode) <font color="#FF0000"><b>GROUP INDICATE</b></font>.
+                        SOURCE CityName(CityCode) <span style="color: #FF0000"><b>GROUP INDICATE</b></span>.
        03 COLUMN 15     PIC 9
-                        SOURCE SalesPersonNum  <b><font color="#FF0000">GROUP INDICATE</font></b>.
+                        SOURCE SalesPersonNum  <b><span style="color: #FF0000">GROUP INDICATE</span></b>.
        03 COLUMN 25     PIC $$,$$$.99 SOURCE ValueOfSale.</pre>
 										</td>
 									</tr>
@@ -914,9 +821,7 @@ FD  SalesFile.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#800000" face="Arial, Helvetica, sans-serif">The SOURCE clause</font>
-								</h4>
+								<h4>The SOURCE clause</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -930,7 +835,7 @@ FD  SalesFile.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4><font color="#800000" face="Arial, Helvetica, sans-serif">The SUM clause</font></h4>
+								<h4>The SUM clause</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -980,21 +885,21 @@ FD  SalesFile.
     TYPE IS CONTROL FOOTING SalesPersonNum  NEXT GROUP PLUS 2.
                       :<i> other entries</i> :
                       :<i> other entries</i> :
-       03 <font color="#FF0000"><b>SMS</b></font> COLUMN 45 PIC $$$$$,$$$.99 <font color="#FF0000"><b>SUM ValueOfSale</b></font>.
+       03 <span style="color: #FF0000"><b>SMS</b></span> COLUMN 45 PIC $$$$$,$$$.99 <span style="color: #FF0000"><b>SUM ValueOfSale</b></span>.
 
 
 
 01  CityGrp TYPE IS CONTROL FOOTING CityCode NEXT GROUP PLUS 2.
                       :<i> other entries</i> :
                       :<i> other entries</i> :
-       03 <b><font color="#FF0000">CS</font></b> COLUMN 45  PIC $$$$$,$$$.99 <font color="#FF0000"><b>SUM SMS</b></font>.
+       03 <b><span style="color: #FF0000">CS</span></b> COLUMN 45  PIC $$$$$,$$$.99 <span style="color: #FF0000"><b>SUM SMS</b></span>.
 
 
 
 01  TotalSalesGrp TYPE IS CONTROL FOOTING FINAL.
                       :<i> other entries</i> :
                       :<i> other entries</i> :
-       03 COLUMN 45     PIC $$$$$,$$$.99 <b><font color="#FF0000">SUM CS</font></b>.</pre>
+       03 COLUMN 45     PIC $$$$$,$$$.99 <b><span style="color: #FF0000">SUM CS</span></b>.</pre>
 										</td>
 									</tr>
 								</table>
@@ -1015,9 +920,9 @@ FD  SalesFile.
     TYPE IS CONTROL FOOTING ShopNum  NEXT GROUP PLUS 2.
                       :<i> other entries</i> :
                       :<i> other entries</i> :
-       03 <font color="#FF0000"><b>SPS</b></font> COLUMN 20 PIC $$$,$$$.99  <font color="#FF0000"><b>SUM SalesPersonSale</b></font>.
-       03 <font color="#FF0000"><b>SCS</b></font> COLUMN 40 PIC $$$,$$$.99  <font color="#FF0000"><b>SUM CounterSale</b></font>.
-       03     COLUMN 60 PIC $$$$,$$$.99 <font color="#FF0000"><b>SUM SPS, SCS</b></font>.
+       03 <span style="color: #FF0000"><b>SPS</b></span> COLUMN 20 PIC $$$,$$$.99  <span style="color: #FF0000"><b>SUM SalesPersonSale</b></span>.
+       03 <span style="color: #FF0000"><b>SCS</b></span> COLUMN 40 PIC $$$,$$$.99  <span style="color: #FF0000"><b>SUM CounterSale</b></span>.
+       03     COLUMN 60 PIC $$$$,$$$.99 <span style="color: #FF0000"><b>SUM SPS, SCS</b></span>.
 </pre>
 										</td>
 									</tr>
@@ -1042,9 +947,7 @@ FD  SalesFile.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#800000" face="Arial, Helvetica, sans-serif">The RESET ON clause</font>
-								</h4>
+								<h4>The RESET ON clause</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -1057,25 +960,19 @@ FD  SalesFile.
 								<ol>
 									<li>
 										The <i>ControlBreakItem#$i</i> must be one of the data items mentioned in the
-										<font size="-1">CONTROL/CONTROLS</font> clause in the Report Description.
+										CONTROL/CONTROLS clause in the Report Description.
 									</li>
 								</ol>
 							</td>
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-								<h2 align="center" id="part5">
-									<font color="#FFFF00"
-										><font face="Arial, Helvetica, sans-serif"
-											>Special Report Writer registers</font
-										></font
-									>
-								</h2>
+								<h2 align="center" id="part5">Special Report Writer registers</h2>
 							</td>
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font></h4>
+								<h4>Introduction</h4>
 							</td>
 							<td valign="top" width="525">
 								<div align="center">
@@ -1101,11 +998,7 @@ FD  SalesFile.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>The LINE-COUNTER register</font
-									>
-								</h4>
+								<h4>The LINE-COUNTER register</h4>
 							</td>
 							<td valign="top" width="525">
 								<p align="left">
@@ -1134,11 +1027,7 @@ FD  SalesFile.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>The PAGE-COUNTER register</font
-									>
-								</h4>
+								<h4>The PAGE-COUNTER register</h4>
 							</td>
 							<td valign="top" width="525">
 								<div align="center">
@@ -1165,7 +1054,7 @@ FD  SalesFile.
        03 COLUMN 1      PIC X(29) 
                         VALUE "Programmer - Michael Coughlan".
        03 COLUMN 45     PIC X(6) VALUE "Page :".
-       03 COLUMN 52     PIC Z9 SOURCE<b><font color="#FF0000"> PAGE-COUNTER.</font></b></pre>
+       03 COLUMN 52     PIC Z9 SOURCE<b><span style="color: #FF0000"> PAGE-COUNTER.</span></b></pre>
 											</td>
 										</tr>
 									</table>
@@ -1175,12 +1064,12 @@ FD  SalesFile.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-								<h2 align="center" id="part6"><font color="#FFFF00">Procedure Division verbs</font></h2>
+								<h2 align="center" id="part6">Procedure Division verbs</h2>
 							</td>
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font></h4>
+								<h4>Introduction</h4>
 							</td>
 							<td valign="top" width="525">
 								<div align="center">
@@ -1218,7 +1107,7 @@ FD  SalesFile.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Syntax</font></h4>
+								<h4>Syntax</h4>
 							</td>
 							<td valign="top" width="525">
 								<p><img height="144" src="rwVerbs.gif" width="238" /></p>
@@ -1227,7 +1116,7 @@ FD  SalesFile.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4><font color="#800000" face="Arial, Helvetica, sans-serif">INITIATE</font></h4>
+								<h4>INITIATE</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -1255,7 +1144,7 @@ FD  SalesFile.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4><font color="#800000" face="Arial, Helvetica, sans-serif">GENERATE</font></h4>
+								<h4>GENERATE</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -1371,7 +1260,7 @@ Programmer - Michael Coughlan               Page :  1
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4><font color="#800000" face="Arial, Helvetica, sans-serif">TERMINATE</font></h4>
+								<h4>TERMINATE</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -1392,16 +1281,12 @@ Programmer - Michael Coughlan               Page :  1
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#993300" colspan="2" valign="top">
-								<h2 align="center" id="part7">
-									<font color="#FFFF00" face="Arial, Helvetica, sans-serif"
-										>Report Writer Declaratives</font
-									>
-								</h2>
+								<h2 align="center" id="part7">Report Writer Declaratives</h2>
 							</td>
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font></h4>
+								<h4>Introduction</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -1428,11 +1313,7 @@ Programmer - Michael Coughlan               Page :  1
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>Using Declaratives with the Report Writer</font
-									>
-								</h4>
+								<h4>Using Declaratives with the Report Writer</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -1467,11 +1348,7 @@ Programmer - Michael Coughlan               Page :  1
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>Declaratives Example</font
-									>
-								</h4>
+								<h4>Declaratives Example</h4>
 							</td>
 							<td valign="top" width="525">
 								<div align="center">
@@ -1479,7 +1356,7 @@ Programmer - Michael Coughlan               Page :  1
 										<tr>
 											<td>
 												<pre>PROCEDURE DIVISION.
-<b><font color="#FF0000">DECLARATIVES.
+<b><span style="color: #FF0000">DECLARATIVES.
 Calc SECTION.
     USE BEFORE REPORTING SalesPersonGrp.
 Calculate-Salary.
@@ -1487,7 +1364,7 @@ Calculate-Salary.
           GIVING Commission ROUNDED.
     ADD Commission, FixedRate(CityCode,SalesPersonNum)
           GIVING Salary.
-END DECLARATIVES.</font></b>
+END DECLARATIVES.</span></b>
 
 Main SECTION.
 Begin.
@@ -1504,11 +1381,7 @@ Begin.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>The SUPPRESS PRINTING statement</font
-									>
-								</h4>
+								<h4>The SUPPRESS PRINTING statement</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -1531,15 +1404,15 @@ Begin.
 								<table background="lectures/cobol/pics/code.gif" border="1" width="91%">
 									<tr>
 										<td>
-											<pre><font color="#000000">PROCEDURE DIVISION.
+											<pre>PROCEDURE DIVISION.
 DECLARATIVES.
 CheckShopSales SECTION.
     USE BEFORE REPORTING ShopTotalGrp.
 PrintMajorShopsOnly.
     IF SalesTotal &lt; 10000<b>
-       <font color="#FF3300">SUPPRESS PRINTING</font>
+       <span style="color: #FF3300">SUPPRESS PRINTING</span>
 </b>    END-IF.
-END DECLARATIVES.</font></pre>
+END DECLARATIVES.</pre>
 										</td>
 									</tr>
 								</table>
@@ -1548,11 +1421,7 @@ END DECLARATIVES.</font></pre>
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>Control Break Registers</font
-									>
-								</h4>
+								<h4>Control Break Registers</h4>
 							</td>
 							<td valign="top" width="525">
 								<div align="center">
@@ -1597,15 +1466,12 @@ END DECLARATIVES.</font></pre>
 										These COBOL course materials are the copyright property of Michael Coughlan.
 									</p>
 									<p align="left">
-										<font size="2"
-											>All rights reserved. No part of these course materials may be reproduced in
-											any form or by any means - graphic, electronic, mechanical, photocopying,
-											printing, recording, taping or stored in an information storage and
-											retrieval system - without the written permission of</font
-										>
-										<font size="2">the author.</font>
+										All rights reserved. No part of these course materials may be reproduced in any
+										form or by any means - graphic, electronic, mechanical, photocopying, printing,
+										recording, taping or stored in an information storage and retrieval system -
+										without the written permission of the author.
 									</p>
-									<p align="center"><font size="2">(c) Michael Coughlan</font></p>
+									<p align="center">(c) Michael Coughlan</p>
 								</div>
 							</td>
 						</tr>

--- a/lectures/ReportWriterWeb.html
+++ b/lectures/ReportWriterWeb.html
@@ -150,6 +150,17 @@
 			ul.toc a {
 				font-weight: bold;
 			}
+
+			td[bgcolor="#993300"] h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			td[bgcolor="#FFFFCC"] h3,
+			td[bgcolor="#FFFFCC"] h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
+			}
 		</style>
 	</head>
 	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
@@ -178,64 +189,46 @@
 								<ul class="toc">
 									<li>
 										<a href="#intro">Introduction</a><br />
-										<font size="-1">Unit aims, objectives and prerequisites.</font>
+										Unit aims, objectives and prerequisites.
 									</li>
 									<li>
 										<a href="#part1">The Report Writer in action</a><br />
-										<font size="-1"
-											>This section examines a report produced by a Report Writer program and then
-											examines the Procedure Division of the program that produced the
-											report.</font
-										>
+										This section examines a report produced by a Report Writer program and then
+										examines the Procedure Division of the program that produced the report.
 									</li>
 									<li>
 										<a href="#part1b">How the Report Writer works</a><br />
-										<font size="-1"
-											>This section explains how the Report Writer works. It examines the seven
-											report groups a report produced by a Report Writer program and then examines
-											the Procedure Division of the program that produced the report.</font
-										>
+										This section explains how the Report Writer works. It examines the seven report
+										groups a report produced by a Report Writer program and then examines the
+										Procedure Division of the program that produced the report.
 									</li>
 									<li>
 										<a href="#part2">Let's write a Report Writer p</a><a href="#part2">rogram</a
 										><br />
-										<font size="-1"
-											>This section uses learning by doing as its mode of instruction. We learn
-											how to write a simple version of the report program shown in the previous
-											section.</font
-										>
+										This section uses learning by doing as its mode of instruction. We learn how to
+										write a simple version of the report program shown in the previous section.
 									</li>
 									<li>
 										<a href="#part3">Let's add some features to our Report Program</a><br />
-										<font size="-1"
-											>In this section we amend the report program to include more
-											functionality</font
-										>
-										<font size="-1">.</font>
+										In this section we amend the report program to include more functionality.
 									</li>
 									<li>
 										<a href="#part4">Report Writer Declaratives</a><br />
-										<font size="-1"
-											>When the requirements of the report do not coincide with the way the Report
-											Writer works Declaratives can be used to extend the functionality of the
-											Report Writer.</font
-										>
+										When the requirements of the report do not coincide with the way the Report
+										Writer works Declaratives can be used to extend the functionality of the Report
+										Writer.
 									</li>
 								</ul>
 							</td>
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-								<h2 align="center" id="intro">
-									<font color="#FFFF00"
-										><font face="Arial, Helvetica, sans-serif">Introduction</font></font
-									>
-								</h2>
+								<h2 align="center" id="intro">Introduction</h2>
 							</td>
 						</tr>
 						<tr>
 							<td bgcolor="#FFFFCC" valign="top" width="160">
-								<h4><font color="#993300" face="Arial, Helvetica, sans-serif">Aims</font></h4>
+								<h4>Aims</h4>
 							</td>
 							<td width="540">
 								<p>
@@ -265,7 +258,7 @@
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-								<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Objectives</font></h4>
+								<h4>Objectives</h4>
 							</td>
 							<td width="540">
 								<p>By the end of this unit you should -</p>
@@ -288,7 +281,7 @@
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-								<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Prerequisites</font></h4>
+								<h4>Prerequisites</h4>
 							</td>
 							<td width="525">
 								<p>You should be familiar with the material covered in the unit;</p>
@@ -319,18 +312,12 @@
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-								<h2 align="center" id="part1">
-									<font color="#FFFF00"
-										><font face="Arial, Helvetica, sans-serif"
-											>The Report Writer in Action</font
-										></font
-									>
-								</h2>
+								<h2 align="center" id="part1">The Report Writer in Action</h2>
 							</td>
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-								<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font></h4>
+								<h4>Introduction</h4>
 							</td>
 							<td valign="top" width="540">
 								<p>
@@ -341,21 +328,15 @@
 									Report Writer.
 								</p>
 								<p>
-									The COBOL Report Writer is very large. It includes many new
-									<font size="2">DATA DIVISION</font> entries, including a
-									<font size="2">REPORT SECTION</font>, and a number of new
-									<font size="2">PROCEDURE DIVISION</font> verbs.
+									The COBOL Report Writer is very large. It includes many new DATA DIVISION entries,
+									including a REPORT SECTION, and a number of new PROCEDURE DIVISION verbs.
 								</p>
 								<hr />
 							</td>
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4 align="center">
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>An example report - with animated commentary.</font
-									>
-								</h4>
+								<h4 align="center">An example report - with animated commentary.</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -386,11 +367,7 @@
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4 align="center">
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>The Procedure Division that produces the sales report</font
-									>
-								</h4>
+								<h4 align="center">The Procedure Division that produces the sales report</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -435,11 +412,7 @@ PrintSalaryReport.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4 align="center">
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>So much work, so little Procedure Division code</font
-									>
-								</h4>
+								<h4 align="center">So much work, so little Procedure Division code</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -470,16 +443,12 @@ PrintSalaryReport.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#993300" colspan="2" valign="top">
-								<h2 align="center" id="part1b">
-									<font color="#FFFF00" face="Arial, Helvetica, sans-serif"
-										>How the Report Writer works</font
-									>
-								</h2>
+								<h2 align="center" id="part1b">How the Report Writer works</h2>
 							</td>
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Report Groups</font></h4>
+								<h4>Report Groups</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -507,43 +476,41 @@ PrintSalaryReport.
 								<blockquote>
 									<p>
 										REPORT HEADING or RH group<br />
-										<font size="-1">- printed once at the beginning of the report</font>
+										- printed once at the beginning of the report
 									</p>
 								</blockquote>
 								<ol>
 									<blockquote>
 										<p>
 											PAGE HEADING of PH group<br />
-											<font size="-1">- printed at the top of each page</font>
+											- printed at the top of each page
 										</p>
 										<blockquote>
 											<p>
 												CONTROL HEADING or CH group<br />
-												<font size="-1">- printed at the beginning of each control break</font>
+												- printed at the beginning of each control break
 											</p>
 											<blockquote>
 												<p>
 													DETAIL or DE group<br />
-													<font size="-1"
-														>- printed each time the GENERATE statement is executed</font
-													>
+													- printed each time the GENERATE statement is executed
 												</p>
 											</blockquote>
 											<p>
 												CONTROL FOOTING or CF group<br />
-												<font size="-1">- printed at the end of each control break</font>
+												- printed at the end of each control break
 											</p>
 										</blockquote>
 										<p>
 											PAGE FOOTING or PF group<br />
-											<font size="-1">- printed at the bottom of each page</font>
+											- printed at the bottom of each page
 										</p>
 									</blockquote>
 								</ol>
 								<blockquote>
 									<p>
 										REPORT FOOTING or RF group<br />
-										<font size="-1">- printed once at the end of the report.</font>
+										- printed once at the end of the report.
 									</p>
 								</blockquote>
 								<p>
@@ -554,8 +521,8 @@ PrintSalaryReport.
 									instance, in the example program, control footings are defined on the
 									SalesPersonNumber, the CityCode and <code class="language-cobol">FINAL</code>.
 									<code class="language-cobol">FINAL</code> is a special control group that is invoked
-									before the normal control groups (<font size="-1">CONTROL HEADING FINAL</font>) and
-									after the normal control groups (<font size="-1">CONTROL FOOTING FINAL</font>).
+									before the normal control groups (CONTROL HEADING FINAL) and after the normal
+									control groups (CONTROL FOOTING FINAL).
 								</p>
 								<p>
 									An ordinary control group is defined on some control break data-item. The Report
@@ -569,11 +536,7 @@ PrintSalaryReport.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4 align="center">
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>Report writing made easy</font
-									>
-								</h4>
+								<h4 align="center">Report writing made easy</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -606,18 +569,12 @@ PrintSalaryReport.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-								<h2 align="center" id="part2">
-									<font color="#FFFF00"
-										><font face="Arial, Helvetica, sans-serif"
-											>Let's write a Report Writer program!</font
-										></font
-									>
-								</h2>
+								<h2 align="center" id="part2">Let's write a Report Writer program!</h2>
 							</td>
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font></h4>
+								<h4>Introduction</h4>
 							</td>
 							<td valign="top" width="525">
 								<div align="center">
@@ -636,11 +593,7 @@ PrintSalaryReport.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>Report Specification</font
-									>
-								</h4>
+								<h4>Report Specification</h4>
 							</td>
 							<td valign="top" width="525">
 								<p align="left">
@@ -666,9 +619,7 @@ PrintSalaryReport.
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#800000" face="Arial, Helvetica, sans-serif">A simple report</font>
-								</h4>
+								<h4>A simple report</h4>
 							</td>
 							<td valign="top" width="525">
 								<div align="center">
@@ -745,9 +696,7 @@ Programmer - Michael Coughlan               Page :  1
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#800000" face="Arial, Helvetica, sans-serif">Code & Commentary</font>
-								</h4>
+								<h4>Code &amp; Commentary</h4>
 							</td>
 							<td valign="top" width="525">
 								<table border="1" width="100%">
@@ -768,18 +717,12 @@ Programmer - Michael Coughlan               Page :  1
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-								<h2 align="center" id="part3">
-									<font color="#FFFF00">Let's add some features to our Report Program</font>
-								</h2>
+								<h2 align="center" id="part3">Let's add some features to our Report Program</h2>
 							</td>
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>Adding a city and a final total</font
-									>
-								</h4>
+								<h4>Adding a city and a final total</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -798,11 +741,7 @@ Programmer - Michael Coughlan               Page :  1
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>Printing the city total</font
-									>
-								</h4>
+								<h4>Printing the city total</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -828,11 +767,7 @@ Programmer - Michael Coughlan               Page :  1
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>Printing a Final Total</font
-									>
-								</h4>
+								<h4>Printing a Final Total</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -852,11 +787,7 @@ Programmer - Michael Coughlan               Page :  1
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>REPORT SECTION changes</font
-									>
-								</h4>
+								<h4>REPORT SECTION changes</h4>
 							</td>
 							<td valign="top" width="525">
 								<hr />
@@ -865,8 +796,8 @@ Programmer - Michael Coughlan               Page :  1
 										<td valign="top">
 											<pre>REPORT SECTION.
 RD  SalesReport
-    CONTROLS ARE <b><font color="#FF0000">FINAL
-                 CityCode</font></b>
+    CONTROLS ARE <b><span style="color: #FF0000">FINAL
+                 CityCode</span></b>
                  SalesPersonNum 
     PAGE LIMIT IS 66
     HEADING 1
@@ -911,9 +842,9 @@ RD  SalesReport
        03 COLUMN 15     PIC X(21) VALUE "Sales for salesperson".
        03 COLUMN 37     PIC 9 SOURCE SalesPersonNum.
        03 COLUMN 43     PIC X VALUE "=".
-       03 <b><font color="#FF0000">SMS</font></b> COLUMN 45 PIC $$$$$,$$$.99 SUM ValueOfSale.
+       03 <b><span style="color: #FF0000">SMS</span></b> COLUMN 45 PIC $$$$$,$$$.99 SUM ValueOfSale.
 
-<b><font color="#FF0000">
+<b><span style="color: #FF0000">
 01  CityGrp TYPE IS CONTROL FOOTING CityCode NEXT GROUP PLUS 2.
     02 LINE IS PLUS 2.
        03 COLUMN 15     PIC X(9) VALUE "Sales for".
@@ -927,7 +858,7 @@ RD  SalesReport
        03 COLUMN 15     PIC X(11)
                         VALUE "Total sales".
        03 COLUMN 43     PIC X VALUE "=".
-       03 COLUMN 45     PIC $$$$$,$$$.99 SUM CS.</font></b>
+       03 COLUMN 45     PIC $$$$$,$$$.99 SUM CS.</span></b>
 
 
 01  TYPE IS PAGE FOOTING.
@@ -946,11 +877,7 @@ RD  SalesReport
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>Changes to the Procedure Division</font
-									>
-								</h4>
+								<h4>Changes to the Procedure Division</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -964,16 +891,12 @@ RD  SalesReport
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#993300" colspan="2" valign="top">
-								<h2 align="center" id="part4">
-									<font color="#FFFF00" face="Arial, Helvetica, sans-serif"
-										>Report Writer Declaratives</font
-									>
-								</h2>
+								<h2 align="center" id="part4">Report Writer Declaratives</h2>
 							</td>
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4><font color="#800000" face="Arial, Helvetica, sans-serif">Introduction</font></h4>
+								<h4>Introduction</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -998,11 +921,7 @@ RD  SalesReport
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>Calculating the salesperson's commission and salary</font
-									>
-								</h4>
+								<h4>Calculating the salesperson's commission and salary</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -1038,11 +957,7 @@ RD  SalesReport
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>Values of control break items</font
-									>
-								</h4>
+								<h4>Values of control break items</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -1076,11 +991,7 @@ RD  SalesReport
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>The full program and the report it produces</font
-									>
-								</h4>
+								<h4>The full program and the report it produces</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>Changes from the simple version are shown in red.</p>
@@ -1205,7 +1116,7 @@ RD  SalesReport
        03 COLUMN 43     PIC X VALUE "=".
        03 SMS COLUMN 45 PIC $$$$$,$$$.99 SUM ValueOfSale.
 
-<b><font color="#FF0000">    02 LINE IS PLUS 1.
+<b><span style="color: #FF0000">    02 LINE IS PLUS 1.
        03 COLUMN 15     PIC X(19) VALUE "Sales commission is".
        03 COLUMN 43     PIC X VALUE "=".
        03 COLUMN 45     PIC $$$$$,$$$.99 SOURCE Commission.
@@ -1223,7 +1134,7 @@ RD  SalesReport
     02 LINE IS PLUS 1.
        03 COLUMN 15     PIC X(30)
                         VALUE "Previous salesperson number = ".
-       03 COLUMN 45     PIC 9 SOURCE SalesPersonNum.</font></b>
+       03 COLUMN 45     PIC 9 SOURCE SalesPersonNum.</span></b>
 
 
 
@@ -1234,7 +1145,7 @@ RD  SalesReport
        03 COLUMN 43     PIC X VALUE "=".
        03 CS COLUMN 45  PIC $$$$$,$$$.99 SUM SMS.
 
-<b><font color="#FF0000">    02 LINE IS PLUS 1.
+<b><span style="color: #FF0000">    02 LINE IS PLUS 1.
        03 COLUMN 15     PIC X(12)
                         VALUE "Current city".
        03 COLUMN 43     PIC X VALUE "=".
@@ -1244,7 +1155,7 @@ RD  SalesReport
        03 COLUMN 15     PIC X(13)
                         VALUE "Previous city".
        03 COLUMN 43     PIC X VALUE "=".
-       03 COLUMN 45     PIC 9   SOURCE CityCode.</font></b>
+       03 COLUMN 45     PIC 9   SOURCE CityCode.</span></b>
 
 
 01  TotalSalesGrp TYPE IS CONTROL FOOTING FINAL.
@@ -1264,7 +1175,7 @@ RD  SalesReport
 
 
 PROCEDURE DIVISION.
-<b><font color="#FF0000">DECLARATIVES.
+<b><span style="color: #FF0000">DECLARATIVES.
 Calc SECTION.
     USE BEFORE REPORTING SalesPersonGrp.
 Calculate-Salary.
@@ -1272,7 +1183,7 @@ Calculate-Salary.
           GIVING Commission ROUNDED.
     ADD Commission, FixedRate(CityCode,SalesPersonNum)
           GIVING Salary.
-END DECLARATIVES.</font></b>
+END DECLARATIVES.</span></b>
 
 Main SECTION.
 Begin.
@@ -1290,8 +1201,8 @@ Begin.
 
 
 PrintSalaryReport.
-<b><font color="#FF0000">    MOVE CityCode TO CityNow.
-    MOVE SalesPersonNum  TO SalesPersonNow.</font></b>
+<b><span style="color: #FF0000">    MOVE CityCode TO CityNow.
+    MOVE SalesPersonNum  TO SalesPersonNow.</span></b>
     GENERATE DetailLine.
     READ SalesFile
           AT END SET EndOfFile TO TRUE
@@ -1366,11 +1277,7 @@ Programmer - Michael Coughlan               Page :  1 </pre
 						</tr>
 						<tr>
 							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>
-									<font color="#800000" face="Arial, Helvetica, sans-serif"
-										>Referencing control break items - summary</font
-									>
-								</h4>
+								<h4>Referencing control break items - summary</h4>
 							</td>
 							<td valign="top" width="525">
 								<p>
@@ -1396,15 +1303,12 @@ Programmer - Michael Coughlan               Page :  1 </pre
 										These COBOL course materials are the copyright property of Michael Coughlan.
 									</p>
 									<p align="left">
-										<font size="2"
-											>All rights reserved. No part of these course materials may be reproduced in
-											any form or by any means - graphic, electronic, mechanical, photocopying,
-											printing, recording, taping or stored in an information storage and
-											retrieval system - without the written permission of</font
-										>
-										<font size="2">the author.</font>
+										All rights reserved. No part of these course materials may be reproduced in any
+										form or by any means - graphic, electronic, mechanical, photocopying, printing,
+										recording, taping or stored in an information storage and retrieval system -
+										without the written permission of the author.
 									</p>
-									<p align="center"><font size="2">(c) Michael Coughlan</font></p>
+									<p align="center">(c) Michael Coughlan</p>
 								</div>
 							</td>
 						</tr>

--- a/lectures/index.html
+++ b/lectures/index.html
@@ -340,7 +340,7 @@
 							src="../pics/B-BackArrow.gif"
 							width="52" /></a
 					>&nbsp;<br />
-					<font size="-2">To COBOL resources</font>
+					To COBOL resources
 				</td>
 				<td>
 					<a href="#"
@@ -351,7 +351,7 @@
 							src="../pics/B-CSISHome.gif"
 							width="52" /></a
 					>&nbsp;<br />
-					<font size="-2">To the CSIS HomePage</font>
+					To the CSIS HomePage
 				</td>
 				<td>
 					<a href="#"
@@ -362,7 +362,7 @@
 							src="../pics/B-Evaluation.gif"
 							width="52"
 					/></a>
-					<font size="-2">Evaluation Form</font>
+					Evaluation Form
 				</td>
 			</tr>
 		</table>


### PR DESCRIPTION
## Summary

- Replaces all remaining `<font>` tags across course, exercises, lectures, and examples pages with semantic HTML and CSS
- Section heading colors/fonts (`h2`, `h3`, `h4`) previously applied via nested `<font color face>` attributes are now driven by scoped CSS rules (`td[bgcolor="#993300"] h2`, `td[bgcolor="#FFFFCC"] h3/h4`)
- TOC description text was inadvertently upsized when `<font size="-1">` tags were removed; restored with `font-size: smaller` on `ul.toc > li` and `font-size: larger` on `ul.toc a` to preserve the original visual hierarchy

## Test plan

- [x] Visually compared local build against https://bushidocodes.github.io/limerick-cobol/ across multiple course pages (COBOLIntro, COBOLcommands, DataDeclaration, Selection, Iteration)
- [x] Verified inline COBOL keyword highlighting (teal monospace) is identical to live site
- [x] Verified section h2 headers render as yellow Arial on dark-red backgrounds (same as before)
- [x] Verified TOC description font size matches live site after CSS fix
- [x] Ran `npx prettier --write "**/*.html"` — no formatting changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)