### PR TITLE
Refactor Inspect.html layout tables to CSS Grid

### DIFF
--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -25,13 +25,13 @@
 				margin-top: 0.6em;
 			}
 
-			td[bgcolor="#993300"] h2 {
+			.course-section-header h2 {
 				color: #ffff00;
 				font-family: Arial, Helvetica, sans-serif;
 			}
 
-			td[bgcolor="#FFFFCC"] h3,
-			td[bgcolor="#FFFFCC"] h4 {
+			.course-section-label h3,
+			.course-section-label h4 {
 				color: #800000;
 				font-family: Arial, Helvetica, sans-serif;
 			}
@@ -43,16 +43,6 @@
 				height: auto;
 			}
 
-			table {
-				max-width: 100%;
-			}
-
-			body > table,
-			body > hr {
-				margin-left: auto;
-				margin-right: auto;
-			}
-
 			pre {
 				overflow-x: auto;
 				max-width: 100%;
@@ -62,6 +52,56 @@
 				-webkit-text-size-adjust: 100%;
 			}
 
+			.page-wrapper {
+				border: 1px solid;
+				max-width: 715px;
+				margin: 0 auto;
+				box-sizing: border-box;
+			}
+
+			.course-section {
+				max-width: 710px;
+				margin: 0 auto;
+			}
+
+			.course-section-header {
+				background-color: #993300;
+				padding: 4px;
+				text-align: center;
+			}
+
+			.course-section-header h2 {
+				margin: 0;
+			}
+
+			.course-section-full {
+				padding: 4px;
+			}
+
+			.course-section-row {
+				display: grid;
+				grid-template-columns: 175px 1fr;
+				align-items: start;
+			}
+
+			.course-section-label {
+				background-color: #FFFFCC;
+				padding: 4px;
+			}
+
+			.course-section-content {
+				padding: 4px;
+			}
+
+			.page-top-link {
+				max-width: 710px;
+				margin: 0 auto;
+			}
+
+			.page-top-link p {
+				text-align: center;
+			}
+
 			@media (max-width: 600px) {
 				body {
 					margin: 4px;
@@ -69,31 +109,24 @@
 					word-wrap: break-word;
 				}
 
-				table[width] {
-					width: 100% !important;
-					height: auto !important;
-				}
-
-				td[width],
-				th[width],
-				td[height],
-				th[height] {
-					width: auto !important;
-					height: auto !important;
-				}
-
-				td[bgcolor="#993300"] > h2,
-				td[bgcolor="#993300"] > h3 {
+				.course-section-header h2,
+				.course-section-header h3 {
 					margin: 0.3em 0;
+				}
+
+				.course-section-row {
+					grid-template-columns: 1fr;
+				}
+
+				.course-section-label h3,
+				.course-section-label h4,
+				.course-section-label p {
+					margin: 0.2em 0;
 				}
 
 				blockquote {
 					margin-left: 12px;
 					margin-right: 12px;
-				}
-
-				hr[width] {
-					width: 100% !important;
 				}
 
 				img,
@@ -124,312 +157,225 @@
 					padding: 0.6em;
 					overflow-x: auto;
 				}
-
-				table[width="715"],
-				table[width="725"],
-				table[width="715"] > tbody,
-				table[width="725"] > tbody,
-				table[width="715"] > tbody > tr,
-				table[width="725"] > tbody > tr,
-				table[width="715"] > tbody > tr > td,
-				table[width="725"] > tbody > tr > td,
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])),
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])) > tbody,
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])) > tbody > tr,
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])) > tbody > tr > td {
-					display: block;
-					width: auto !important;
-				}
-
-				table[width="710"]:has(> tbody > tr > td[width="93%"]),
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody {
-					display: block;
-					width: 100% !important;
-				}
-
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr {
-					display: flex;
-					align-items: baseline;
-					gap: 0.4em;
-					margin: 0.4em 0;
-				}
-
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr > td[width="3%"] {
-					display: none;
-				}
-
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr > td[width="4%"] {
-					display: block;
-					flex: 0 0 auto;
-					width: auto !important;
-					padding: 0;
-				}
-
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr > td[width="93%"] {
-					display: block;
-					flex: 1 1 auto;
-					width: auto !important;
-					padding: 0;
-				}
-
-				td[width="175"] > h4:not(:first-child):not(:has(img)),
-				td[width="160"] > h4:not(:first-child):not(:has(img)),
-				h4:has(> img[src*="PanelLine"]) {
-					display: none;
-				}
-
-				td[width="175"] > h3,
-				td[width="175"] > h4,
-				td[width="175"] > p,
-				td[width="160"] > h3,
-				td[width="160"] > h4,
-				td[width="160"] > p {
-					margin: 0.2em 0;
-				}
 			}
 		</style>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
-		<table border="1" width="715">
-			<tbody>
-				<tr>
-					<td>
-						<center>
-							<div align="left">
-								<table border="0" width="710">
-									<tr>
-										<td>
-											<center>
-												<p id="top">
-													<img
-														alt=""
-														height="59"
-														src="Resources/pics/t-CobolTut.gif"
-														width="173"
-													/>
-												</p>
-											</center>
-											<center>
-												<h1>The INSPECT verb</h1>
-												<hr align="left" />
-											</center>
-										</td>
-									</tr>
-								</table>
-							</div>
-						</center>
-						<ul class="toc">
+		<div class="page-wrapper">
+			<div>
+				<center>
+					<p id="top">
+						<img
+							alt=""
+							height="59"
+							src="Resources/pics/t-CobolTut.gif"
+							width="173"
+						/>
+					</p>
+				</center>
+				<center>
+					<h1>The INSPECT verb</h1>
+					<hr align="left" />
+				</center>
+			</div>
+			<ul class="toc">
+				<li>
+					<a href="#intro">Introduction</a><br />
+					Unit aims, objectives, prerequisites and a legend for this unit's syntax diagrams.
+				</li>
+				<li>
+					<a href="#inspect">Using the INSPECT</a><br />
+					The <code class="language-cobol">INSPECT</code> is introduced by looking at an example
+					program. The way the <code class="language-cobol">INSPECT</code> works is explained and
+					its modifying phrases are explored.
+				</li>
+				<li>
+					<a href="#count">The counting format</a><br />
+					Presents the syntax and rules of the counting format of the
+					<code class="language-cobol">INSPECT</code>.
+				</li>
+				<li>
+					<a href="#replace">The replacing format</a><br />
+					Presents the syntax and rules of the replacing format of the
+					<code class="language-cobol">INSPECT</code>
+				</li>
+				<li>
+					<a href="#combine">The combined format</a><br />
+					This version combines the syntax and rules of the other two formats. The syntax of this
+					combined format is presented.
+				</li>
+				<li>
+					<a href="#convert">The converting format</a><br />
+					Presents the syntax and rules of the converting format of the
+					<code class="language-cobol">INSPECT</code>.
+				</li>
+			</ul>
+			<div class="course-section">
+				<div class="course-section-header">
+					<h2 id="intro">Introduction</h2>
+				</div>
+				<div class="course-section-row">
+					<div class="course-section-label">
+						<h3>Aims</h3>
+					</div>
+					<div class="course-section-content">
+						<p>
+							Many programming languages rely on library functions for string handling. COBOL
+							too, uses Intrinsic Functions for some tasks but most string manipulation is
+							done using Reference Modification and the three string handling verbs : INSPECT,
+							STRING and UNSTRING.
+						</p>
+						<p>
+							This unit examines the first of three string handling verbs and aims to provide
+							you with a solid understanding of its various formats and modifying phrases.
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="course-section-row">
+					<div class="course-section-label">
+						<h3>Objectives</h3>
+					</div>
+					<div class="course-section-content">
+						<p>By the end of this unit you should:</p>
+						<ol>
+							<li>Understand how the INSPECT verb works.</li>
 							<li>
-								<a href="#intro">Introduction</a><br />
-								Unit aims, objectives, prerequisites and a legend for this unit's syntax diagrams.
+								Have a good knowledge of the different formats and modifying phrases of the
+								INSPECT verb.
 							</li>
 							<li>
-								<a href="#inspect">Using the INSPECT</a><br />
-								The <code class="language-cobol">INSPECT</code> is introduced by looking at an example
-								program. The way the <code class="language-cobol">INSPECT</code> works is explained and
-								its modifying phrases are explored.
+								Be able to use the INSPECT to count, replace and convert characters in a
+								string.
+							</li>
+						</ol>
+						<hr />
+					</div>
+				</div>
+				<div class="course-section-row">
+					<div class="course-section-label">
+						<h3>Prerequisites</h3>
+					</div>
+					<div class="course-section-content">
+						<p>You should be familiar with the following material;</p>
+						<ul>
+							<li>Data Declaration</li>
+							<li>Iteration</li>
+							<li>Selection</li>
+							<li>Tables</li>
+							<li>Edited Pictures</li>
+						</ul>
+						<hr />
+					</div>
+				</div>
+				<div class="course-section-row">
+					<div class="course-section-label">
+						<h3>Syntax legend</h3>
+					</div>
+					<div class="course-section-content">
+						<p>
+							To simplify the syntax diagrams and reduce the number of rules that must be
+							explained, special operand endings are used in this unit's syntax diagrams.
+						</p>
+						<p>These operand endings have the following meaning:</p>
+						<div align="center">
+							<table bgcolor="#D2FFD2" border="1" cellpadding="4" cellspacing="0" width="67%">
+								<tr>
+									<td width="9%">$i</td>
+									<td width="91%">uses an alphanumeric data item</td>
+								</tr>
+								<tr>
+									<td width="9%">$il</td>
+									<td width="91%">uses an alphanumeric data item or a string literal</td>
+								</tr>
+								<tr>
+									<td width="9%">#i</td>
+									<td width="91%">uses a numeric data item</td>
+								</tr>
+								<tr>
+									<td width="9%">#il</td>
+									<td width="91%">uses a numeric data item or numeric literal</td>
+								</tr>
+								<tr>
+									<td width="9%">$#i</td>
+									<td width="91%">uses a numeric or an alphanumeric data item</td>
+								</tr>
+							</table>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="page-top-link">
+				<hr />
+				<p align="center">
+					<a href="#top"
+						><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
+					/></a>
+				</p>
+			</div>
+			<div class="course-section">
+				<div class="course-section-header">
+					<h2 id="inspect">Using the INSPECT</h2>
+				</div>
+				<div class="course-section-row">
+					<div class="course-section-label">
+						<h3>Introduction</h3>
+					</div>
+					<div class="course-section-content">
+						<p>The INSPECT has four formats;</p>
+						<ol class="spaced">
+							<li>The first format is used for counting characters in a string.</li>
+							<li>
+								The second replaces a group of characters in a string with another group of
+								characters.
+							</li>
+							<li>The third combines both operations in one statement.</li>
+							<li>
+								The fourth format converts each of a set of characters to its corresponding
+								character in another set of characters.
+							</li>
+						</ol>
+						<hr />
+					</div>
+				</div>
+				<div class="course-section-row">
+					<div class="course-section-label">
+						<h3>Example program Counting letter occurences using the INSPECT</h3>
+					</div>
+					<div class="course-section-content">
+						<p>
+							We'll start by looking at the PROCEDURE DIVISION of an example
+							program that uses the INSPECT verb. This program reads through a
+							file, counts how many times each letter of the alphabet occurs and
+							displays the results
+						</p>
+						<p>To do this the program;</p>
+						<ul>
+							<li>Reads in a line of text</li>
+							<li>
+								Converts all the characters to upper case using the
+								INSPECT..CONVERTING
 							</li>
 							<li>
-								<a href="#count">The counting format</a><br />
-								Presents the syntax and rules of the counting format of the
-								<code class="language-cobol">INSPECT</code>.
+								Counts the number of times each letter appears in the line using
+								the INSPECT..TALLYING and increments the count in LetterCount.
+								It gets the letters from inspection from a pre-defined table of
+								letters (see the unit on tables for the definition of this
+								letter table)
 							</li>
 							<li>
-								<a href="#replace">The replacing format</a><br />
-								Presents the syntax and rules of the replacing format of the
-								<code class="language-cobol">INSPECT</code>
-							</li>
-							<li>
-								<a href="#combine">The combined format</a><br />
-								This version combines the syntax and rules of the other two formats. The syntax of this
-								combined format is presented.
-							</li>
-							<li>
-								<a href="#convert">The converting format</a><br />
-								Presents the syntax and rules of the converting format of the
-								<code class="language-cobol">INSPECT</code>.
+								Uses a PERFORM..VARYING to display the counts after they have
+								been accumulated.
 							</li>
 						</ul>
-						<table border="0" cellpadding="4" cellspacing="0" width="710">
-							<tr>
-								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="intro">Introduction</h2>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Aims</h3>
-								</td>
-								<td width="525">
-									<p>
-										Many programming languages rely on library functions for string handling. COBOL
-										too, uses Intrinsic Functions for some tasks but most string manipulation is
-										done using Reference Modification and the three string handling verbs : INSPECT,
-										STRING and UNSTRING.
-									</p>
-									<p>
-										This unit examines the first of three string handling verbs and aims to provide
-										you with a solid understanding of its various formats and modifying phrases.
-									</p>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Objectives</h3>
-								</td>
-								<td width="525">
-									<p>By the end of this unit you should:</p>
-									<ol>
-										<li>Understand how the INSPECT verb works.</li>
-										<li>
-											Have a good knowledge of the different formats and modifying phrases of the
-											INSPECT verb.
-										</li>
-										<li>
-											Be able to use the INSPECT to count, replace and convert characters in a
-											string.
-										</li>
-									</ol>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Prerequisites</h3>
-								</td>
-								<td width="525">
-									<p>You should be familiar with the following material;</p>
-									<ul>
-										<li>Data Declaration</li>
-										<li>Iteration</li>
-										<li>Selection</li>
-										<li>Tables</li>
-										<li>Edited Pictures</li>
-									</ul>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Syntax legend</h3>
-								</td>
-								<td width="525">
-									<p>
-										To simplify the syntax diagrams and reduce the number of rules that must be
-										explained, special operand endings are used in this unit's syntax diagrams.
-									</p>
-									<p>These operand endings have the following meaning:</p>
-									<div align="center">
-										<table bgcolor="#D2FFD2" border="1" cellpadding="4" cellspacing="0" width="67%">
-											<tr>
-												<td width="9%">$i</td>
-												<td width="91%">uses an alphanumeric data item</td>
-											</tr>
-											<tr>
-												<td width="9%">$il</td>
-												<td width="91%">uses an alphanumeric data item or a string literal</td>
-											</tr>
-											<tr>
-												<td width="9%">#i</td>
-												<td width="91%">uses a numeric data item</td>
-											</tr>
-											<tr>
-												<td width="9%">#il</td>
-												<td width="91%">uses a numeric data item or numeric literal</td>
-											</tr>
-											<tr>
-												<td width="9%">$#i</td>
-												<td width="91%">uses a numeric or an alphanumeric data item</td>
-											</tr>
-										</table>
-									</div>
-								</td>
-							</tr>
-						</table>
-						<table border="0" width="710">
-							<tr>
-								<td>
-									<hr />
-									<p align="center">
-										<a href="#top"
-											><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-										/></a>
-									</p>
-								</td>
-							</tr>
-						</table>
-						<table border="0" cellpadding="4" cellspacing="0" width="710">
-							<tr>
-								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="inspect">Using the INSPECT</h2>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="left">Introduction</h3>
-								</td>
-								<td width="525">
-									<p>The INSPECT has four formats;</p>
-									<ol class="spaced">
-										<li>The first format is used for counting characters in a string.</li>
-										<li>
-											The second replaces a group of characters in a string with another group of
-											characters.
-										</li>
-										<li>The third combines both operations in one statement.</li>
-										<li>
-											The fourth format converts each of a set of characters to its corresponding
-											character in another set of characters.
-										</li>
-									</ol>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="left">Example program Counting letter occurences using the INSPECT</h3>
-								</td>
-								<td width="525">
-									<table border="0" width="100%">
-										<tr>
-											<td height="43" width="525">
-												<p>
-													We'll start by looking at the PROCEDURE DIVISION of an example
-													program that uses the INSPECT verb. This program reads through a
-													file, counts how many times each letter of the alphabet occurs and
-													displays the results
-												</p>
-												<p>To do this the program;</p>
-												<ul>
-													<li>Reads in a line of text</li>
-													<li>
-														Converts all the characters to upper case using the
-														INSPECT..CONVERTING
-													</li>
-													<li>
-														Counts the number of times each letter appears in the line using
-														the INSPECT..TALLYING and increments the count in LetterCount.
-														It gets the letters from inspection from a pre-defined table of
-														letters (see the unit on tables for the definition of this
-														letter table)
-													</li>
-													<li>
-														Uses a PERFORM..VARYING to display the counts after they have
-														been accumulated.
-													</li>
-												</ul>
-											</td>
-										</tr>
-										<tr>
-											<td background="Resources/pics/code.gif" width="525">
-												<pre
-													class="language-cobol"
-												><code class="language-cobol">PROCEDURE DIVISION.
+						<div style="background-image: url('Resources/pics/code.gif');">
+							<pre
+								class="language-cobol"
+							><code class="language-cobol">PROCEDURE DIVISION.
 Begin.
     OPEN INPUT TextFile
-    READ TextFile 
+    READ TextFile
       AT END SET EndOfFile TO TRUE
     END-READ
     PERFORM UNTIL EndOfFile
@@ -440,189 +386,171 @@ Begin.
           INSPECT TextLine TALLYING LetterCount(idx)
                      FOR ALL Letter(idx)
        END-PERFORM
-       READ TextFile 
+       READ TextFile
           AT END SET EndOfFile TO TRUE
        END-READ
     END-PERFORM
     PERFORM VARYING idx FROM 1 BY 1 UNTIL idx &gt; 26
-       DISPLAY "Letter " Letter(idx) 
-            " occurs " LetterCount(idx) " times" 
+       DISPLAY "Letter " Letter(idx)
+            " occurs " LetterCount(idx) " times"
     END-PERFORM
     CLOSE TextFile
     STOP RUN.
 </code></pre>
-											</td>
-										</tr>
-									</table>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>How the INSPECT works.</h3>
-								</td>
-								<td width="525">
-									<p>
-										The INSPECT scans the source string from left to right counting, replacing or
-										converting characters under the control of the TALLYING, REPLACING or CONVERTING
-										phrases.
-									</p>
-									<p>
-										The behavior of the INSPECT is modified by using the LEADING, FIRST, BEFORE and
-										AFTER phrases.
-									</p>
-									<p>
-										An ALL, LEADING, CHARACTERS, FIRST or CONVERTING phrase may only be followed by
-										one BEFORE and one AFTER phrase.
-									</p>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>The modifying phrases</h3>
-								</td>
-								<td width="525">
-									<p>
-										The <b>LEADING</b> phrase causes counting/replacement of all Compare$il
-										characters from the first valid one encountered to the first invalid one.
-									</p>
-									<p>The <b>FIRST</b> phrase causes only the first valid character to be replaced.</p>
-									<p>
-										The <b>BEFORE</b> phrase designates as valid those characters to the left of the
-										delimiter associated with it.
-									</p>
-									<p>
-										The <b>AFTER</b> phrase designates as valid those characters to the right of the
-										delimiter associated with it.
-									</p>
-									<p>
-										If the delimiter is not present in the SourceStr$i then using the BEFORE phrase
-										implies the whole string and using the AFTER phrase implies no characters at
-										all.
-									</p>
-								</td>
-							</tr>
-						</table>
-						<table border="0" width="710">
-							<tr>
-								<td>
-									<hr />
-									<p align="center">
-										<a href="#top"
-											><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-										/></a>
-									</p>
-								</td>
-							</tr>
-						</table>
-						<table border="0" cellpadding="4" cellspacing="0" width="710">
-							<tr>
-								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="count">The counting INSPECT</h2>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" colspan="2" valign="top" width="175">
-									<h3>Syntax</h3>
-									<p><img src="Resources/pics/CntInspect.gif" /></p>
-									<p align="left">
-										This format of the Inspect is used to count characters in a string.
-									</p>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Notes</h3>
-								</td>
-								<td width="525">
-									<p>If Compare$il or Delim$il is a figurative constant it is 1 character in size.</p>
-									<p>
-										An ALL, LEADING or CHARACTERS phrase can have not more than one BEFORE and one
-										AFTER phrase following it.
-									</p>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Examples</h3>
-								</td>
-								<td width="525">
-									<pre
-										class="language-cobol"
-									><code class="language-cobol">INSPECT FullName TALLYING UnstrPtr FOR LEADING SPACES.
+						</div>
+						<hr />
+					</div>
+				</div>
+				<div class="course-section-row">
+					<div class="course-section-label">
+						<h3>How the INSPECT works.</h3>
+					</div>
+					<div class="course-section-content">
+						<p>
+							The INSPECT scans the source string from left to right counting, replacing or
+							converting characters under the control of the TALLYING, REPLACING or CONVERTING
+							phrases.
+						</p>
+						<p>
+							The behavior of the INSPECT is modified by using the LEADING, FIRST, BEFORE and
+							AFTER phrases.
+						</p>
+						<p>
+							An ALL, LEADING, CHARACTERS, FIRST or CONVERTING phrase may only be followed by
+							one BEFORE and one AFTER phrase.
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="course-section-row">
+					<div class="course-section-label">
+						<h3>The modifying phrases</h3>
+					</div>
+					<div class="course-section-content">
+						<p>
+							The <b>LEADING</b> phrase causes counting/replacement of all Compare$il
+							characters from the first valid one encountered to the first invalid one.
+						</p>
+						<p>The <b>FIRST</b> phrase causes only the first valid character to be replaced.</p>
+						<p>
+							The <b>BEFORE</b> phrase designates as valid those characters to the left of the
+							delimiter associated with it.
+						</p>
+						<p>
+							The <b>AFTER</b> phrase designates as valid those characters to the right of the
+							delimiter associated with it.
+						</p>
+						<p>
+							If the delimiter is not present in the SourceStr$i then using the BEFORE phrase
+							implies the whole string and using the AFTER phrase implies no characters at
+							all.
+						</p>
+					</div>
+				</div>
+			</div>
+			<div class="page-top-link">
+				<hr />
+				<p align="center">
+					<a href="#top"
+						><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
+					/></a>
+				</p>
+			</div>
+			<div class="course-section">
+				<div class="course-section-header">
+					<h2 id="count">The counting INSPECT</h2>
+				</div>
+				<div class="course-section-full">
+					<h3>Syntax</h3>
+					<p><img src="Resources/pics/CntInspect.gif" /></p>
+					<p align="left">
+						This format of the Inspect is used to count characters in a string.
+					</p>
+					<hr />
+				</div>
+				<div class="course-section-row">
+					<div class="course-section-label">
+						<h3>Notes</h3>
+					</div>
+					<div class="course-section-content">
+						<p>If Compare$il or Delim$il is a figurative constant it is 1 character in size.</p>
+						<p>
+							An ALL, LEADING or CHARACTERS phrase can have not more than one BEFORE and one
+							AFTER phrase following it.
+						</p>
+					</div>
+				</div>
+				<div class="course-section-row">
+					<div class="course-section-label">
+						<h3>Examples</h3>
+					</div>
+					<div class="course-section-content">
+						<pre
+							class="language-cobol"
+						><code class="language-cobol">INSPECT FullName TALLYING UnstrPtr FOR LEADING SPACES.
 
 INSPECT SourceLine TALLYING ECount
         FOR ALL "e" AFTER  INITIAL "start"
                     BEFORE INITIAL "end".   </code></pre>
-								</td>
-							</tr>
-						</table>
-						<table border="0" width="710">
-							<tr>
-								<td>
-									<hr />
-									<p align="center">
-										<a href="#top"
-											><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-										/></a>
-									</p>
-								</td>
-							</tr>
-						</table>
-						<table border="0" cellpadding="4" cellspacing="0" width="710">
-							<tr>
-								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="replace">The replacing INSPECT</h2>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" colspan="2" valign="top" width="175">
-									<h3>Syntax</h3>
-									<p><img height="255" src="Resources/pics/RepInspect.gif" width="619" /></p>
-									<p align="left">
-										This format of the INSPECT is used to count characters in a string.
-									</p>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Rules</h3>
-								</td>
-								<td width="525">
-									<p>The sizes of Compare$il and Replace$il must be equal.</p>
-									<p>When Replace$il is a figurative constant its size equals that of Compare$il.</p>
-									<p>
-										When there is a CHARACTERS phrase, the size of ReplaceChar$il and the delimiter
-										which may follow it (Delim$il) must be one character.
-									</p>
-									<p>
-										If Compare$il, Delim$il or Replace$il is a figurative constant it is 1 character
-										in size.
-									</p>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>
-										Example 1<br />
-										with animation
-									</h3>
-								</td>
-								<td width="525">
-									<p>
-										The following examples work on the data in StringData to produce the results
-										shown in the storage schematic below.
-									</p>
-									<p>
-										Click on the storage schematic to see the result of each of these INSPECT
-										statements (use left click or PageDown for next item and right click or PageUp
-										for previsou item) .&nbsp;
-									</p>
-									<pre class="language-cobol"><code class="language-cobol">
+					</div>
+				</div>
+			</div>
+			<div class="page-top-link">
+				<hr />
+				<p align="center">
+					<a href="#top"
+						><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
+					/></a>
+				</p>
+			</div>
+			<div class="course-section">
+				<div class="course-section-header">
+					<h2 id="replace">The replacing INSPECT</h2>
+				</div>
+				<div class="course-section-full">
+					<h3>Syntax</h3>
+					<p><img height="255" src="Resources/pics/RepInspect.gif" width="619" /></p>
+					<p align="left">
+						This format of the INSPECT is used to count characters in a string.
+					</p>
+					<hr />
+				</div>
+				<div class="course-section-row">
+					<div class="course-section-label">
+						<h3>Rules</h3>
+					</div>
+					<div class="course-section-content">
+						<p>The sizes of Compare$il and Replace$il must be equal.</p>
+						<p>When Replace$il is a figurative constant its size equals that of Compare$il.</p>
+						<p>
+							When there is a CHARACTERS phrase, the size of ReplaceChar$il and the delimiter
+							which may follow it (Delim$il) must be one character.
+						</p>
+						<p>
+							If Compare$il, Delim$il or Replace$il is a figurative constant it is 1 character
+							in size.
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="course-section-row">
+					<div class="course-section-label">
+						<h3>
+							Example 1<br />
+							with animation
+						</h3>
+					</div>
+					<div class="course-section-content">
+						<p>
+							The following examples work on the data in StringData to produce the results
+							shown in the storage schematic below.
+						</p>
+						<p>
+							Click on the storage schematic to see the result of each of these INSPECT
+							statements (use left click or PageDown for next item and right click or PageUp
+							for previsou item) .&nbsp;
+						</p>
+						<pre class="language-cobol"><code class="language-cobol">
 1. INSPECT StringData REPLACING ALL "R" BY "G"
        AFTER INITIAL "A" BEFORE INITIAL "Q".
 
@@ -639,181 +567,164 @@ INSPECT SourceLine TALLYING ECount
        ALL "RRRR" BY "FROG"
        AFTER INITIAL "A" BEFORE INITIAL "Q".
 </code></pre>
-									<center>
-										<p>
-											<iframe
-												height="125"
-												src="Resources/pdf-viewer.html?src=ppz/Inspect1.pdf"
-												style="border: 1px solid #ccc; width: 100%; aspect-ratio: 500/125"
-												width="500"
-											></iframe>
-										</p>
-										<hr />
-									</center>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Example 2</h3>
-								</td>
-								<td width="525">
-									<p>
-										This example inspects the string TextLine and checks it for each of the 4 letter
-										swear words in the table. If one is found it is replaced by the text *#@!.
-									</p>
-									<pre
-										class="language-cobol"
-									><code class="language-cobol">PERFORM VARYING idx FROM 1 BY 1 UNTIL idx &gt; 10
+						<center>
+							<p>
+								<iframe
+									height="125"
+									src="Resources/pdf-viewer.html?src=ppz/Inspect1.pdf"
+									style="border: 1px solid #ccc; width: 100%; aspect-ratio: 500/125"
+									width="500"
+								></iframe>
+							</p>
+							<hr />
+						</center>
+					</div>
+				</div>
+				<div class="course-section-row">
+					<div class="course-section-label">
+						<h3>Example 2</h3>
+					</div>
+					<div class="course-section-content">
+						<p>
+							This example inspects the string TextLine and checks it for each of the 4 letter
+							swear words in the table. If one is found it is replaced by the text *#@!.
+						</p>
+						<pre
+							class="language-cobol"
+						><code class="language-cobol">PERFORM VARYING idx FROM 1 BY 1 UNTIL idx &gt; 10
   INSPECT TextLine REPLACING SwearWord(idx) BY "*#@!"
 END-PERFORM</code></pre>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>
-										Example 3<br />
-										with animation
-									</h3>
-								</td>
-								<td width="525">
-									<p>
-										In this example we want to create an edited item with a floating Rouble currency
-										symbol instead of a floating dollar sign.
-									</p>
-									<p>
-										To achieve we use a picture clause edited with a floating dollar sign and then
-										we use the INSPECT to replace the dollar sign with the Rouble symbol "R".
-									</p>
-									<p>
-										This works because when a value is moved into an edited item the editing is
-										immediately applied to the value.
-									</p>
-									<p>
-										Click on the diagram below to see how this use of the INSPECT works (use left
-										click or PageDown for next item and right click or PageUp for previsou item) .
-									</p>
-									<center>
-										<iframe
-											height="333"
-											src="Resources/pdf-viewer.html?src=ppz/Inspect3.pdf"
-											style="border: 1px solid #ccc; width: 100%; aspect-ratio: 520/333"
-											width="520"
-										></iframe>
-									</center>
-								</td>
-							</tr>
-						</table>
-						<table border="0" width="710">
-							<tr>
-								<td>
-									<hr />
-									<p align="center">
-										<a href="#top"
-											><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-										/></a>
-									</p>
-								</td>
-							</tr>
-						</table>
-						<table border="0" cellpadding="4" cellspacing="0" width="710">
-							<tr>
-								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="combine">The combined INSPECT</h2>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" colspan="2" valign="top" width="175">
-									<h3>Syntax</h3>
-									<p><img height="338" src="Resources/pics/CombInspect.gif" width="649" /></p>
-									<p>
-										This format of the INSPECT combines the syntactic elements of the previous two
-										formats allowing both counting and replacing to be done in one statement.&nbsp;
-									</p>
-								</td>
-							</tr>
-						</table>
-						<table border="0" width="710">
-							<tr>
-								<td>
-									<hr />
-									<p align="center">
-										<a href="#top"
-											><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-										/></a>
-									</p>
-								</td>
-							</tr>
-						</table>
 						<hr />
-						<table border="0" cellpadding="4" cellspacing="0" width="710">
-							<tr>
-								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="convert">The converting INSPECT</h2>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" colspan="2" valign="top" width="175">
-									<h3>Syntax</h3>
-									<p><img src="Resources/pics/ConvInspect.gif" /></p>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>How this format of the INSPECT works</h3>
-								</td>
-								<td width="525">
-									<p>
-										The INSPECT..CONVERTING works on individual characters. Compare$il is a list of
-										characters that will be replaced with the characters in Convert$il on a one for
-										one basis.
-									</p>
-									<p>For instance the statement -</p>
-									<pre
-										class="language-cobol"
-									><code class="language-cobol">INSPECT StringData CONVERTING "abc" TO "XYZ". </code></pre>
-									<p>replaces "a" with "X", "b" with "Y" and "c" with "Z".</p>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Rules</h3>
-								</td>
-								<td width="525">
-									<ol class="spaced">
-										<li>Compare$il and Convert$il must be equal in size.</li>
-										<li>
-											When Convert$il is a figurative constant its size equals that of Compare$il.
-										</li>
-										<li>
-											The same character cannot appear more than once in the Compare$il (because
-											each character in the Compare$il string is associated with a replacement).
-										</li>
-									</ol>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>
-										Example 1<br />
-										with animation
-									</h3>
-								</td>
-								<td width="525">
-									<div align="center">
-										<p align="left">
-											The following examples work on the data in StringData to produce the results
-											shown in the storage schematic below.
-										</p>
-										<p align="left">
-											Click on the storage schematic to see the result of each of these INSPECT
-											statements (use left click or PageDown for next item and right click or
-											PageUp for previsou item).&nbsp;
-										</p>
-										<pre class="language-cobol"><code class="language-cobol">
+					</div>
+				</div>
+				<div class="course-section-row">
+					<div class="course-section-label">
+						<h3>
+							Example 3<br />
+							with animation
+						</h3>
+					</div>
+					<div class="course-section-content">
+						<p>
+							In this example we want to create an edited item with a floating Rouble currency
+							symbol instead of a floating dollar sign.
+						</p>
+						<p>
+							To achieve we use a picture clause edited with a floating dollar sign and then
+							we use the INSPECT to replace the dollar sign with the Rouble symbol "R".
+						</p>
+						<p>
+							This works because when a value is moved into an edited item the editing is
+							immediately applied to the value.
+						</p>
+						<p>
+							Click on the diagram below to see how this use of the INSPECT works (use left
+							click or PageDown for next item and right click or PageUp for previsou item) .
+						</p>
+						<center>
+							<iframe
+								height="333"
+								src="Resources/pdf-viewer.html?src=ppz/Inspect3.pdf"
+								style="border: 1px solid #ccc; width: 100%; aspect-ratio: 520/333"
+								width="520"
+							></iframe>
+						</center>
+					</div>
+				</div>
+			</div>
+			<div class="page-top-link">
+				<hr />
+				<p align="center">
+					<a href="#top"
+						><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
+					/></a>
+				</p>
+			</div>
+			<div class="course-section">
+				<div class="course-section-header">
+					<h2 id="combine">The combined INSPECT</h2>
+				</div>
+				<div class="course-section-full">
+					<h3>Syntax</h3>
+					<p><img height="338" src="Resources/pics/CombInspect.gif" width="649" /></p>
+					<p>
+						This format of the INSPECT combines the syntactic elements of the previous two
+						formats allowing both counting and replacing to be done in one statement.&nbsp;
+					</p>
+				</div>
+			</div>
+			<div class="page-top-link">
+				<hr />
+				<p align="center">
+					<a href="#top"
+						><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
+					/></a>
+				</p>
+			</div>
+			<hr />
+			<div class="course-section">
+				<div class="course-section-header">
+					<h2 id="convert">The converting INSPECT</h2>
+				</div>
+				<div class="course-section-full">
+					<h3>Syntax</h3>
+					<p><img src="Resources/pics/ConvInspect.gif" /></p>
+					<hr />
+				</div>
+				<div class="course-section-row">
+					<div class="course-section-label">
+						<h3>How this format of the INSPECT works</h3>
+					</div>
+					<div class="course-section-content">
+						<p>
+							The INSPECT..CONVERTING works on individual characters. Compare$il is a list of
+							characters that will be replaced with the characters in Convert$il on a one for
+							one basis.
+						</p>
+						<p>For instance the statement -</p>
+						<pre
+							class="language-cobol"
+						><code class="language-cobol">INSPECT StringData CONVERTING "abc" TO "XYZ". </code></pre>
+						<p>replaces "a" with "X", "b" with "Y" and "c" with "Z".</p>
+						<hr />
+					</div>
+				</div>
+				<div class="course-section-row">
+					<div class="course-section-label">
+						<h3>Rules</h3>
+					</div>
+					<div class="course-section-content">
+						<ol class="spaced">
+							<li>Compare$il and Convert$il must be equal in size.</li>
+							<li>
+								When Convert$il is a figurative constant its size equals that of Compare$il.
+							</li>
+							<li>
+								The same character cannot appear more than once in the Compare$il (because
+								each character in the Compare$il string is associated with a replacement).
+							</li>
+						</ol>
+						<hr />
+					</div>
+				</div>
+				<div class="course-section-row">
+					<div class="course-section-label">
+						<h3>
+							Example 1<br />
+							with animation
+						</h3>
+					</div>
+					<div class="course-section-content">
+						<p align="left">
+							The following examples work on the data in StringData to produce the results
+							shown in the storage schematic below.
+						</p>
+						<p align="left">
+							Click on the storage schematic to see the result of each of these INSPECT
+							statements (use left click or PageDown for next item and right click or
+							PageUp for previsou item).&nbsp;
+						</p>
+						<pre class="language-cobol"><code class="language-cobol">
 1. INSPECT StringData CONVERTING "fxtd" TO "ZYAB".
 
 2. INSPECT StringData REPLACING "fxtd" BY "ZYAB".
@@ -823,57 +734,56 @@ END-PERFORM</code></pre>
                                     "f" BY "S".
 
 </code></pre>
-										<p>
-											<iframe
-												height="125"
-												src="Resources/pdf-viewer.html?src=ppz/Inspect1.pdf"
-												style="border: 1px solid #ccc; width: 100%; aspect-ratio: 500/125"
-												width="500"
-											></iframe>
-										</p>
-										<hr />
-									</div>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Example 2</h3>
-								</td>
-								<td width="525">
-									<p>
-										This example shows how the INSPECT..CONVERTING can be used to implement a simple
-										encoding mechanism.
-									</p>
-									<p>
-										It converts the character 0 to character 5, 1 to 2, 2 to 9, 3 to 8 etc.
-										Conversion starts when the word "codeon" is encountered in the string and stops
-										when "codeoff" is encountered.
-									</p>
-									<pre class="language-cobol"><code class="language-cobol">INSPECT TextLine 
+						<p>
+							<iframe
+								height="125"
+								src="Resources/pdf-viewer.html?src=ppz/Inspect1.pdf"
+								style="border: 1px solid #ccc; width: 100%; aspect-ratio: 500/125"
+								width="500"
+							></iframe>
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="course-section-row">
+					<div class="course-section-label">
+						<h3>Example 2</h3>
+					</div>
+					<div class="course-section-content">
+						<p>
+							This example shows how the INSPECT..CONVERTING can be used to implement a simple
+							encoding mechanism.
+						</p>
+						<p>
+							It converts the character 0 to character 5, 1 to 2, 2 to 9, 3 to 8 etc.
+							Conversion starts when the word "codeon" is encountered in the string and stops
+							when "codeoff" is encountered.
+						</p>
+						<pre class="language-cobol"><code class="language-cobol">INSPECT TextLine
     CONVERTING "0123456789" TO "5298317046"
     AFTER INITIAL "codeon" BEFORE INITIAL "codeoff". </code></pre>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Example 3</h3>
-								</td>
-								<td width="525">
-									<p>
-										In this example, the INSPECT..CONVERTING is used to convert upper case letters
-										to lower case and visa versa.
-									</p>
-									<p>
-										The first INSPECT shows how we can convert the characters using string literals
-										and the next two show how storing the strings in data items makes the conversion
-										operation more versatile.
-									</p>
-									<p>
-										Actually, these days we can do this with the UPPER-CASE and LOWER-CASE Intrinsic
-										Functions.
-									</p>
-									<pre class="language-cobol"><code class="language-cobol">*&gt; Data Division entries
+						<hr />
+					</div>
+				</div>
+				<div class="course-section-row">
+					<div class="course-section-label">
+						<h3>Example 3</h3>
+					</div>
+					<div class="course-section-content">
+						<p>
+							In this example, the INSPECT..CONVERTING is used to convert upper case letters
+							to lower case and visa versa.
+						</p>
+						<p>
+							The first INSPECT shows how we can convert the characters using string literals
+							and the next two show how storing the strings in data items makes the conversion
+							operation more versatile.
+						</p>
+						<p>
+							Actually, these days we can do this with the UPPER-CASE and LOWER-CASE Intrinsic
+							Functions.
+						</p>
+						<pre class="language-cobol"><code class="language-cobol">*&gt; Data Division entries
 01 AlphaChars.
    02 AlphaLower PIC X(26) VALUE "abcdefghijklmnopqrstuvwxyz".
    02 AlphaUpper PIC X(26) VALUE "ABCDEFGHIJKLMNOPQRSTUVWXYZ".
@@ -887,23 +797,16 @@ END-PERFORM</code></pre>
         CONVERTING AlphaLower TO AlphaUpper.
     INSPECT CustAddress
         CONVERTING AlphaUpper TO AlphaLower.    </code></pre>
-								</td>
-							</tr>
-						</table>
-					</td>
-				</tr>
-				<tr>
-					<td>
-						<hr />
-						<div align="center">
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</div>
-						<copyright-notice></copyright-notice>
-					</td>
-				</tr>
-			</tbody>
-		</table>
+					</div>
+				</div>
+			</div>
+			<hr />
+			<div style="text-align: center;">
+				<a href="#top"
+					><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
+				/></a>
+			</div>
+			<copyright-notice></copyright-notice>
+		</div>
 	</body>
 </html>


### PR DESCRIPTION
## Summary

- Replaces 14 layout tables in `course/Inspect.html` with semantic `div` elements and CSS Grid
- The actual data table (syntax legend mapping `$i`/`$il`/`#i`/`#il`/`$#i` to their meanings) is left untouched
- Section tables converted to a `.course-section` / `.course-section-row` CSS Grid pattern (175px label column + `1fr` content column)
- Full-width `colspan="2"` rows become `.course-section-full` divs
- Separator tables become `.page-top-link` divs
- Nested layout table inside the "Example program" row removed; `background-image` moved to a wrapping `div`
- `td[bgcolor]` attribute selectors in CSS replaced with `.course-section-header` / `.course-section-label` class selectors
- Mobile media query simplified: removed large block of `table[width]` targeting rules, replaced with a single `grid-template-columns: 1fr` override for `.course-section-row`

## Test plan

- [ ] Load `course/Inspect.html` in a desktop browser and verify all sections render correctly with brown headers and yellow label columns
- [ ] Resize to mobile (≤600px) and verify single-column layout with labels stacking above content
- [ ] Confirm the syntax legend table still renders as a bordered table with green background
- [ ] Verify all anchor links in the table of contents (`#intro`, `#inspect`, `#count`, `#replace`, `#combine`, `#convert`) still work
- [ ] Confirm code blocks with `code.gif` background texture still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)