### PR TITLE
Refactor layout tables to CSS grid/flexbox in Prj-NewtronicsFileMaint

### DIFF
--- a/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html
+++ b/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
 	<head>
+		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<link href="CSISEvalForm_files/editdata.mso" rel="Edit-Time-Data" />
 		<link href="CSISEvalForm_files/oledata.mso" rel="OLE-Object-Data" />
@@ -22,7 +23,6 @@
 			}
 			-->
 		</style>
-		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<style type="text/css">
 			img {
 				max-width: 100%;
@@ -40,6 +40,53 @@
 
 			body {
 				-webkit-text-size-adjust: 100%;
+			}
+
+			.page-layout {
+				display: grid;
+				grid-template-columns: 21fr 79fr;
+				max-width: 812px;
+				border: 1px solid black;
+				background-color: black;
+				gap: 1px;
+			}
+
+			.page-layout > * {
+				background-color: white;
+				padding: 5px;
+			}
+
+			.page-header {
+				grid-column: 1 / -1;
+				background-color: #990000;
+			}
+
+			.page-content {
+				grid-column: 1 / -1;
+			}
+
+			.meta-label {
+				display: flex;
+				align-items: center;
+			}
+
+			.calc-steps {
+				max-width: 613px;
+			}
+
+			.calc-step {
+				display: flex;
+				align-items: flex-start;
+				margin-bottom: 0.5em;
+			}
+
+			.calc-label {
+				flex: 0 0 99px;
+				white-space: nowrap;
+			}
+
+			.calc-desc {
+				flex: 1;
 			}
 
 			@media (max-width: 600px) {
@@ -60,11 +107,6 @@
 				th[height] {
 					width: auto !important;
 					height: auto !important;
-				}
-
-				td[bgcolor="#993300"] > h2,
-				td[bgcolor="#993300"] > h3 {
-					margin: 0.3em 0;
 				}
 
 				blockquote {
@@ -92,452 +134,138 @@
 					overflow-wrap: break-word;
 				}
 
-				table[width="715"],
-				table[width="725"],
-				table[width="715"] > tbody,
-				table[width="725"] > tbody,
-				table[width="715"] > tbody > tr,
-				table[width="725"] > tbody > tr,
-				table[width="715"] > tbody > tr > td,
-				table[width="725"] > tbody > tr > td,
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])),
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])) > tbody,
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])) > tbody > tr,
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])) > tbody > tr > td {
-					display: block;
-					width: auto !important;
+				.calc-step {
+					flex-direction: column;
 				}
 
-				table[width="710"]:has(> tbody > tr > td[width="93%"]),
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody {
-					display: block;
-					width: 100% !important;
-				}
-
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr {
-					display: flex;
-					align-items: baseline;
-					gap: 0.4em;
-					margin: 0.4em 0;
-				}
-
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr > td[width="3%"] {
-					display: none;
-				}
-
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr > td[width="4%"] {
-					display: block;
-					flex: 0 0 auto;
-					width: auto !important;
-					padding: 0;
-				}
-
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr > td[width="93%"] {
-					display: block;
-					flex: 1 1 auto;
-					width: auto !important;
-					padding: 0;
-				}
-
-				td[width="175"] > h4:not(:first-child):not(:has(img)),
-				td[width="160"] > h4:not(:first-child):not(:has(img)),
-				h4:has(> img[src*="PanelLine"]) {
-					display: none;
-				}
-
-				td[width="175"] > h3,
-				td[width="175"] > h4,
-				td[width="175"] > p,
-				td[width="160"] > h3,
-				td[width="160"] > h4,
-				td[width="160"] > p {
-					margin: 0.2em 0;
+				.calc-label {
+					flex: none;
 				}
 			}
 		</style>
 		<script src="../../components/copyright-notice.js" defer></script>
 	</head>
 	<body bgcolor="#FFFFFF" class="Normal" lang="EN-GB" link="blue" vlink="purple">
-		<table border="1" cellpadding="5" cellspacing="0" width="800">
-			<tr>
-				<td bgcolor="#990000" colspan="2" height="59" valign="middle">
-					<h2 align="center">
-						<b
-							>Newtronics Plc.<br />
-							File Maintenance Program</b
-						>
-					</h2>
-				</td>
-			</tr>
-			<tr>
-				<td height="2" valign="middle" width="21%"><b>Time to complete</b></td>
-				<td height="2" valign="middle" width="79%">Allow 25 hours continuous</td>
-			</tr>
-			<tr>
-				<td height="31" valign="top" width="21%"><b>Test Data Files</b></td>
-				<td height="31" valign="top" width="79%">
-					<p>None available. You will have to develop your own test data.</p>
-				</td>
-			</tr>
-			<tr>
-				<td colspan="2" valign="top">
-					<h3 align="left">
-						<span style="font-variant: normal; text-transform: uppercase">Introduction</span>
-					</h3>
-					<p>
-						Newtronics Plc. is a company which sells electronic parts (diodes, transistors, IC's, LED's
-						thermostats etc.) and goods.&nbsp; Currently, the company is being computerised and you have
-						been retained to write one of the programs required.
-					</p>
-					<p>
-						Information about the parts and goods held in stock by the company is contained in two files;
-						the Stock Master File and the Supplier Master File.&nbsp; Adjustments to stock, such as selling
-						an item or receiving new supplies into stock are made on-line by an update program written by
-						others.&nbsp; File maintenance&nbsp; (Insertion, Deletion and Adjusting of records)&nbsp; to
-						the&nbsp; master files will be achieved by applying a file of transaction records to them at the
-						end of each day.&nbsp;&nbsp; Your task is to write the program which will take the Transaction
-						file and apply it to the master files.
-					</p>
-					<h3><span style="font-variant: normal; text-transform: uppercase">The Transaction File</span></h3>
-					<p>
-						The Transaction File is a unsorted, unvalidated file containing a number of different types of
-						transaction record.&nbsp; Each transaction record type is identified by a transaction type code
-						in the first character position.&nbsp; The following transaction types have been identified :-
-					</p>
-					<div align="left">
-						<table border="0" cellpadding="0" cellspacing="0" height="64" width="366">
-							<tr>
-								<td width="62">&nbsp;</td>
-								<td width="304">
-									<table border="1" cellpadding="0" cellspacing="0" width="302">
-										<tr bgcolor="#FFFFCC">
-											<td class="Normal" valign="top" width="89">
-												<p align="center" style="text-align: center">
-													<b><span style="text-transform: uppercase">Trans Type</span></b>
-												</p>
-											</td>
-											<td class="Normal" valign="top" width="266">
-												<p align="center" style="text-align: center">
-													<b><span style="text-transform: uppercase">Description</span></b>
-												</p>
-											</td>
-										</tr>
-										<tr>
-											<td class="Normal" valign="top" width="89">
-												<p align="center" style="text-align: center">1</p>
-											</td>
-											<td class="Normal" valign="top" width="266">
-												<p align="center" style="text-align: center">Delete Stock Record</p>
-											</td>
-										</tr>
-										<tr>
-											<td class="Normal" valign="top" width="89">
-												<p align="center" style="text-align: center">2</p>
-											</td>
-											<td class="Normal" valign="top" width="266">
-												<p align="center" style="text-align: center">Insert Stock Record</p>
-											</td>
-										</tr>
-										<tr>
-											<td class="Normal" valign="top" width="89">
-												<p align="center" style="text-align: center">3</p>
-											</td>
-											<td class="Normal" valign="top" width="266">
-												<p align="center" style="text-align: center">Adjust Reorder Level</p>
-											</td>
-										</tr>
-										<tr>
-											<td class="Normal" valign="top" width="89">
-												<p align="center" style="text-align: center">4</p>
-											</td>
-											<td class="Normal" valign="top" width="266">
-												<p align="center" style="text-align: center">Adjust Reorder Qty</p>
-											</td>
-										</tr>
-										<tr>
-											<td class="Normal" valign="top" width="89">
-												<p align="center" style="text-align: center">5</p>
-											</td>
-											<td class="Normal" valign="top" width="266">
-												<p align="center" style="text-align: center">Adjust Price</p>
-											</td>
-										</tr>
-										<tr>
-											<td class="Normal" valign="top" width="89">
-												<p align="center" style="text-align: center">6</p>
-											</td>
-											<td class="Normal" valign="top" width="266">
-												<p align="center" style="text-align: center">Delete Supplier Record</p>
-											</td>
-										</tr>
-										<tr>
-											<td class="Normal" valign="top" width="89">
-												<p align="center" style="text-align: center">7</p>
-											</td>
-											<td class="Normal" valign="top" width="266">
-												<p align="center" style="text-align: center">Insert Supplier Record</p>
-											</td>
-										</tr>
-									</table>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<blockquote>
-						<blockquote></blockquote>
-					</blockquote>
-					<p>
-						<b>Transaction Record Descriptions<br /></b> Descriptions of the different types of transaction
-						record are shown below.
-					</p>
-					<p align="left"><b>Delete Stock Record</b></p>
-					<div align="left">
-						<table border="1" cellpadding="0" cellspacing="0">
-							<tr bgcolor="#FFFFCC">
-								<td class="Normal" valign="top" width="168">
-									<p align="center" style="text-align: center">
-										<b><span style="text-transform: uppercase">FieldName</span></b>
-									</p>
-								</td>
-								<td class="Normal" valign="top" width="87">
-									<p align="center" style="text-align: center">
-										<b><span style="text-transform: uppercase">Type</span></b>
-									</p>
-								</td>
-								<td class="Normal" valign="top" width="84">
-									<p align="center" style="text-align: center">
-										<b><span style="text-transform: uppercase">Length</span></b>
-									</p>
-								</td>
-								<td class="Normal" valign="top" width="148">
-									<p align="center" style="text-align: center">
-										<b><span style="text-transform: uppercase">Format</span></b>
-									</p>
-								</td>
-							</tr>
-							<tr>
-								<td class="Normal" valign="top" width="168">
-									<p>Transaction-Type</p>
-								</td>
-								<td class="Normal" valign="top" width="87">
-									<p align="center" style="text-align: center">Numeric</p>
-								</td>
-								<td class="Normal" valign="top" width="84">
-									<p align="center" style="text-align: center">1</p>
-								</td>
-								<td class="Normal" valign="top" width="148">
-									<p align="center" style="text-align: center">Value 1</p>
-								</td>
-							</tr>
-							<tr>
-								<td class="Normal" valign="top" width="168">
-									<p>Stock-Number</p>
-								</td>
-								<td class="Normal" valign="top" width="87">
-									<p align="center" style="text-align: center">Character</p>
-								</td>
-								<td class="Normal" valign="top" width="84">
-									<p align="center" style="text-align: center">7</p>
-								</td>
-								<td class="Normal" valign="top" width="148">
-									<p align="center" style="text-align: center">9999999</p>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<p><b>Insert Stock&nbsp; Record</b></p>
-					<div align="left">
-						<table border="1" cellpadding="0" cellspacing="0">
-							<tr bgcolor="#FFFFCC">
-								<td class="Normal" valign="top" width="168">
-									<p align="center" style="text-align: center">
-										<b><span style="text-transform: uppercase">FieldName</span></b>
-									</p>
-								</td>
-								<td class="Normal" valign="top" width="87">
-									<p align="center" style="text-align: center">
-										<b><span style="text-transform: uppercase">Type</span></b>
-									</p>
-								</td>
-								<td class="Normal" valign="top" width="84">
-									<p align="center" style="text-align: center">
-										<b><span style="text-transform: uppercase">Length</span></b>
-									</p>
-								</td>
-								<td class="Normal" valign="top" width="148">
-									<p align="center" style="text-align: center">
-										<b><span style="text-transform: uppercase">Format</span></b>
-									</p>
-								</td>
-							</tr>
-							<tr>
-								<td class="Normal" valign="top" width="168">
-									<p>Transaction-Type</p>
-								</td>
-								<td class="Normal" valign="top" width="87">
-									<p align="center" style="text-align: center">Numeric</p>
-								</td>
-								<td class="Normal" valign="top" width="84">
-									<p align="center" style="text-align: center">1</p>
-								</td>
-								<td class="Normal" valign="top" width="148">
-									<p align="center" style="text-align: center">Value 2</p>
-								</td>
-							</tr>
-							<tr>
-								<td class="Normal" valign="top" width="168">
-									<p>Stock-Number</p>
-								</td>
-								<td class="Normal" valign="top" width="87">
-									<p align="center" style="text-align: center">Numeric</p>
-								</td>
-								<td class="Normal" valign="top" width="84">
-									<p align="center" style="text-align: center">7</p>
-								</td>
-								<td class="Normal" valign="top" width="148">
-									<p align="center" style="text-align: center">9999999</p>
-								</td>
-							</tr>
-							<tr>
-								<td class="Normal" valign="top" width="168">
-									<p>Qty-In-Stock</p>
-								</td>
-								<td class="Normal" valign="top" width="87">
-									<p align="center" style="text-align: center">Numeric</p>
-								</td>
-								<td class="Normal" valign="top" width="84">
-									<p align="center" style="text-align: center">5</p>
-								</td>
-								<td class="Normal" valign="top" width="148">
-									<p align="center" style="text-align: center">99999</p>
-								</td>
-							</tr>
-							<tr>
-								<td class="Normal" valign="top" width="168">
-									<p>Price</p>
-								</td>
-								<td class="Normal" valign="top" width="87">
-									<p align="center" style="text-align: center">Numeric</p>
-								</td>
-								<td class="Normal" valign="top" width="84">
-									<p align="center" style="text-align: center">6</p>
-								</td>
-								<td class="Normal" valign="top" width="148">
-									<p align="center" style="text-align: center">9999.99</p>
-								</td>
-							</tr>
-							<tr>
-								<td class="Normal" valign="top" width="168">
-									<p>Reorder-Level</p>
-								</td>
-								<td class="Normal" valign="top" width="87">
-									<p align="center" style="text-align: center">Numeric</p>
-								</td>
-								<td class="Normal" valign="top" width="84">
-									<p align="center" style="text-align: center">3</p>
-								</td>
-								<td class="Normal" valign="top" width="148">
-									<p align="center" style="text-align: center">999</p>
-								</td>
-							</tr>
-							<tr>
-								<td class="Normal" valign="top" width="168">
-									<p>Reorder-Qty</p>
-								</td>
-								<td class="Normal" valign="top" width="87">
-									<p align="center" style="text-align: center">Numeric</p>
-								</td>
-								<td class="Normal" valign="top" width="84">
-									<p align="center" style="text-align: center">5</p>
-								</td>
-								<td class="Normal" valign="top" width="148">
-									<p align="center" style="text-align: center">99999</p>
-								</td>
-							</tr>
-							<tr>
-								<td class="Normal" valign="top" width="168">
-									<p>Supplier-Number</p>
-								</td>
-								<td class="Normal" valign="top" width="87">
-									<p align="center" style="text-align: center">Character</p>
-								</td>
-								<td class="Normal" valign="top" width="84">
-									<p align="center" style="text-align: center">4</p>
-								</td>
-								<td class="Normal" valign="top" width="148">
-									<p align="center" style="text-align: center">X999</p>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<p class="recorddesc"><b>Adjust Reorder Level</b></p>
-					<table border="1" cellpadding="0" cellspacing="0">
+		<div class="page-layout">
+			<div class="page-header">
+				<h2 align="center">
+					<b
+						>Newtronics Plc.<br />
+						File Maintenance Program</b
+					>
+				</h2>
+			</div>
+			<div class="meta-label"><b>Time to complete</b></div>
+			<div class="meta-value">Allow 25 hours continuous</div>
+			<div class="meta-label"><b>Test Data Files</b></div>
+			<div class="meta-value">
+				<p>None available. You will have to develop your own test data.</p>
+			</div>
+			<div class="page-content">
+				<h3 align="left">
+					<span style="font-variant: normal; text-transform: uppercase">Introduction</span>
+				</h3>
+				<p>
+					Newtronics Plc. is a company which sells electronic parts (diodes, transistors, IC's, LED's
+					thermostats etc.) and goods.&nbsp; Currently, the company is being computerised and you have
+					been retained to write one of the programs required.
+				</p>
+				<p>
+					Information about the parts and goods held in stock by the company is contained in two files;
+					the Stock Master File and the Supplier Master File.&nbsp; Adjustments to stock, such as selling
+					an item or receiving new supplies into stock are made on-line by an update program written by
+					others.&nbsp; File maintenance&nbsp; (Insertion, Deletion and Adjusting of records)&nbsp; to
+					the&nbsp; master files will be achieved by applying a file of transaction records to them at the
+					end of each day.&nbsp;&nbsp; Your task is to write the program which will take the Transaction
+					file and apply it to the master files.
+				</p>
+				<h3><span style="font-variant: normal; text-transform: uppercase">The Transaction File</span></h3>
+				<p>
+					The Transaction File is a unsorted, unvalidated file containing a number of different types of
+					transaction record.&nbsp; Each transaction record type is identified by a transaction type code
+					in the first character position.&nbsp; The following transaction types have been identified :-
+				</p>
+				<div align="left" style="margin-left: 62px;">
+					<table border="1" cellpadding="0" cellspacing="0" width="302">
 						<tr bgcolor="#FFFFCC">
-							<td class="Normal" valign="top" width="168">
+							<td class="Normal" valign="top" width="89">
 								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">FieldName</span></b>
+									<b><span style="text-transform: uppercase">Trans Type</span></b>
 								</p>
 							</td>
-							<td class="Normal" valign="top" width="87">
+							<td class="Normal" valign="top" width="266">
 								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">Type</span></b>
-								</p>
-							</td>
-							<td class="Normal" valign="top" width="84">
-								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">Length</span></b>
-								</p>
-							</td>
-							<td class="Normal" valign="top" width="148">
-								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">Format</span></b>
+									<b><span style="text-transform: uppercase">Description</span></b>
 								</p>
 							</td>
 						</tr>
 						<tr>
-							<td class="Normal" valign="top" width="168">
-								<p>Transaction-Type</p>
-							</td>
-							<td class="Normal" valign="top" width="87">
-								<p align="center" style="text-align: center">Numeric</p>
-							</td>
-							<td class="Normal" valign="top" width="84">
+							<td class="Normal" valign="top" width="89">
 								<p align="center" style="text-align: center">1</p>
 							</td>
-							<td class="Normal" valign="top" width="148">
-								<p align="center" style="text-align: center">Value 3</p>
+							<td class="Normal" valign="top" width="266">
+								<p align="center" style="text-align: center">Delete Stock Record</p>
 							</td>
 						</tr>
 						<tr>
-							<td class="Normal" valign="top" width="168">
-								<p>Stock-Number</p>
+							<td class="Normal" valign="top" width="89">
+								<p align="center" style="text-align: center">2</p>
 							</td>
-							<td class="Normal" valign="top" width="87">
-								<p align="center" style="text-align: center">Numeric</p>
-							</td>
-							<td class="Normal" valign="top" width="84">
-								<p align="center" style="text-align: center">7</p>
-							</td>
-							<td class="Normal" valign="top" width="148">
-								<p align="center" style="text-align: center">9999999</p>
+							<td class="Normal" valign="top" width="266">
+								<p align="center" style="text-align: center">Insert Stock Record</p>
 							</td>
 						</tr>
 						<tr>
-							<td class="Normal" valign="top" width="168">
-								<p>Reorder-Level</p>
-							</td>
-							<td class="Normal" valign="top" width="87">
-								<p align="center" style="text-align: center">Numeric</p>
-							</td>
-							<td class="Normal" valign="top" width="84">
+							<td class="Normal" valign="top" width="89">
 								<p align="center" style="text-align: center">3</p>
 							</td>
-							<td class="Normal" valign="top" width="148">
-								<p align="center" style="text-align: center">999</p>
+							<td class="Normal" valign="top" width="266">
+								<p align="center" style="text-align: center">Adjust Reorder Level</p>
+							</td>
+						</tr>
+						<tr>
+							<td class="Normal" valign="top" width="89">
+								<p align="center" style="text-align: center">4</p>
+							</td>
+							<td class="Normal" valign="top" width="266">
+								<p align="center" style="text-align: center">Adjust Reorder Qty</p>
+							</td>
+						</tr>
+						<tr>
+							<td class="Normal" valign="top" width="89">
+								<p align="center" style="text-align: center">5</p>
+							</td>
+							<td class="Normal" valign="top" width="266">
+								<p align="center" style="text-align: center">Adjust Price</p>
+							</td>
+						</tr>
+						<tr>
+							<td class="Normal" valign="top" width="89">
+								<p align="center" style="text-align: center">6</p>
+							</td>
+							<td class="Normal" valign="top" width="266">
+								<p align="center" style="text-align: center">Delete Supplier Record</p>
+							</td>
+						</tr>
+						<tr>
+							<td class="Normal" valign="top" width="89">
+								<p align="center" style="text-align: center">7</p>
+							</td>
+							<td class="Normal" valign="top" width="266">
+								<p align="center" style="text-align: center">Insert Supplier Record</p>
 							</td>
 						</tr>
 					</table>
-					<p class="recorddesc"><b>Adjust Reorder Qty</b></p>
+				</div>
+				<blockquote>
+					<blockquote></blockquote>
+				</blockquote>
+				<p>
+					<b>Transaction Record Descriptions<br /></b> Descriptions of the different types of transaction
+					record are shown below.
+				</p>
+				<p align="left"><b>Delete Stock Record</b></p>
+				<div align="left">
 					<table border="1" cellpadding="0" cellspacing="0">
 						<tr bgcolor="#FFFFCC">
 							<td class="Normal" valign="top" width="168">
@@ -572,7 +300,62 @@
 								<p align="center" style="text-align: center">1</p>
 							</td>
 							<td class="Normal" valign="top" width="148">
-								<p align="center" style="text-align: center">Value 4</p>
+								<p align="center" style="text-align: center">Value 1</p>
+							</td>
+						</tr>
+						<tr>
+							<td class="Normal" valign="top" width="168">
+								<p>Stock-Number</p>
+							</td>
+							<td class="Normal" valign="top" width="87">
+								<p align="center" style="text-align: center">Character</p>
+							</td>
+							<td class="Normal" valign="top" width="84">
+								<p align="center" style="text-align: center">7</p>
+							</td>
+							<td class="Normal" valign="top" width="148">
+								<p align="center" style="text-align: center">9999999</p>
+							</td>
+						</tr>
+					</table>
+				</div>
+				<p><b>Insert Stock&nbsp; Record</b></p>
+				<div align="left">
+					<table border="1" cellpadding="0" cellspacing="0">
+						<tr bgcolor="#FFFFCC">
+							<td class="Normal" valign="top" width="168">
+								<p align="center" style="text-align: center">
+									<b><span style="text-transform: uppercase">FieldName</span></b>
+								</p>
+							</td>
+							<td class="Normal" valign="top" width="87">
+								<p align="center" style="text-align: center">
+									<b><span style="text-transform: uppercase">Type</span></b>
+								</p>
+							</td>
+							<td class="Normal" valign="top" width="84">
+								<p align="center" style="text-align: center">
+									<b><span style="text-transform: uppercase">Length</span></b>
+								</p>
+							</td>
+							<td class="Normal" valign="top" width="148">
+								<p align="center" style="text-align: center">
+									<b><span style="text-transform: uppercase">Format</span></b>
+								</p>
+							</td>
+						</tr>
+						<tr>
+							<td class="Normal" valign="top" width="168">
+								<p>Transaction-Type</p>
+							</td>
+							<td class="Normal" valign="top" width="87">
+								<p align="center" style="text-align: center">Numeric</p>
+							</td>
+							<td class="Normal" valign="top" width="84">
+								<p align="center" style="text-align: center">1</p>
+							</td>
+							<td class="Normal" valign="top" width="148">
+								<p align="center" style="text-align: center">Value 2</p>
 							</td>
 						</tr>
 						<tr>
@@ -591,7 +374,7 @@
 						</tr>
 						<tr>
 							<td class="Normal" valign="top" width="168">
-								<p>Reorder-Qty</p>
+								<p>Qty-In-Stock</p>
 							</td>
 							<td class="Normal" valign="top" width="87">
 								<p align="center" style="text-align: center">Numeric</p>
@@ -601,59 +384,6 @@
 							</td>
 							<td class="Normal" valign="top" width="148">
 								<p align="center" style="text-align: center">99999</p>
-							</td>
-						</tr>
-					</table>
-					<p class="recorddesc"><b>Adjust Price</b></p>
-					<table border="1" cellpadding="0" cellspacing="0">
-						<tr bgcolor="#FFFFCC">
-							<td class="Normal" valign="top" width="168">
-								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">FieldName</span></b>
-								</p>
-							</td>
-							<td class="Normal" valign="top" width="87">
-								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">Type</span></b>
-								</p>
-							</td>
-							<td class="Normal" valign="top" width="84">
-								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">Length</span></b>
-								</p>
-							</td>
-							<td class="Normal" valign="top" width="148">
-								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">Format</span></b>
-								</p>
-							</td>
-						</tr>
-						<tr>
-							<td class="Normal" valign="top" width="168">
-								<p>Transaction-Type</p>
-							</td>
-							<td class="Normal" valign="top" width="87">
-								<p align="center" style="text-align: center">Numeric</p>
-							</td>
-							<td class="Normal" valign="top" width="84">
-								<p align="center" style="text-align: center">1</p>
-							</td>
-							<td class="Normal" valign="top" width="148">
-								<p align="center" style="text-align: center">Value 5</p>
-							</td>
-						</tr>
-						<tr>
-							<td class="Normal" valign="top" width="168">
-								<p>Stock-Number</p>
-							</td>
-							<td class="Normal" valign="top" width="87">
-								<p align="center" style="text-align: center">Numeric</p>
-							</td>
-							<td class="Normal" valign="top" width="84">
-								<p align="center" style="text-align: center">7</p>
-							</td>
-							<td class="Normal" valign="top" width="148">
-								<p align="center" style="text-align: center">9999999</p>
 							</td>
 						</tr>
 						<tr>
@@ -670,43 +400,32 @@
 								<p align="center" style="text-align: center">9999.99</p>
 							</td>
 						</tr>
-					</table>
-					<p class="recorddesc"><b>Delete Supplier Record</b></p>
-					<table border="1" cellpadding="0" cellspacing="0">
-						<tr bgcolor="#FFFFCC">
-							<td class="Normal" valign="top" width="168">
-								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">FieldName</span></b>
-								</p>
-							</td>
-							<td class="Normal" valign="top" width="87">
-								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">Type</span></b>
-								</p>
-							</td>
-							<td class="Normal" valign="top" width="84">
-								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">Length</span></b>
-								</p>
-							</td>
-							<td class="Normal" valign="top" width="148">
-								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">Format</span></b>
-								</p>
-							</td>
-						</tr>
 						<tr>
 							<td class="Normal" valign="top" width="168">
-								<p>Transaction-Type</p>
+								<p>Reorder-Level</p>
 							</td>
 							<td class="Normal" valign="top" width="87">
 								<p align="center" style="text-align: center">Numeric</p>
 							</td>
 							<td class="Normal" valign="top" width="84">
-								<p align="center" style="text-align: center">1</p>
+								<p align="center" style="text-align: center">3</p>
 							</td>
 							<td class="Normal" valign="top" width="148">
-								<p align="center" style="text-align: center">Value 6</p>
+								<p align="center" style="text-align: center">999</p>
+							</td>
+						</tr>
+						<tr>
+							<td class="Normal" valign="top" width="168">
+								<p>Reorder-Qty</p>
+							</td>
+							<td class="Normal" valign="top" width="87">
+								<p align="center" style="text-align: center">Numeric</p>
+							</td>
+							<td class="Normal" valign="top" width="84">
+								<p align="center" style="text-align: center">5</p>
+							</td>
+							<td class="Normal" valign="top" width="148">
+								<p align="center" style="text-align: center">99999</p>
 							</td>
 						</tr>
 						<tr>
@@ -724,531 +443,785 @@
 							</td>
 						</tr>
 					</table>
-					<p class="recorddesc"><b>Insert Supplier Record</b></p>
-					<table border="1" cellpadding="0" cellspacing="0">
-						<tr bgcolor="#FFFFCC">
-							<td class="Normal" valign="top" width="168">
-								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">FieldName</span></b>
-								</p>
-							</td>
-							<td class="Normal" valign="top" width="66">
-								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">Type</span></b>
-								</p>
-							</td>
-							<td class="Normal" valign="top" width="80">
-								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">Length</span></b>
-								</p>
-							</td>
-							<td class="Normal" valign="top" width="128">
-								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">Format</span></b>
-								</p>
-							</td>
-						</tr>
-						<tr>
-							<td class="Normal" valign="top" width="168">
-								<p>Transaction-Type</p>
-							</td>
-							<td class="Normal" valign="top" width="66">
-								<p align="center" style="text-align: center">9</p>
-							</td>
-							<td class="Normal" valign="top" width="80">
-								<p align="center" style="text-align: center">1</p>
-							</td>
-							<td class="Normal" valign="top" width="128">
-								<p align="center" style="text-align: center">Value 7</p>
-							</td>
-						</tr>
-						<tr>
-							<td class="Normal" valign="top" width="168">
-								<p>Supplier-Number</p>
-							</td>
-							<td class="Normal" valign="top" width="66">
-								<p align="center" style="text-align: center">X</p>
-							</td>
-							<td class="Normal" valign="top" width="80">
-								<p align="center" style="text-align: center">4</p>
-							</td>
-							<td class="Normal" valign="top" width="128">
-								<p align="center" style="text-align: center">X999</p>
-							</td>
-						</tr>
-						<tr>
-							<td class="Normal" valign="top" width="168">
-								<p>Supplier-Name</p>
-							</td>
-							<td class="Normal" valign="top" width="66">
-								<p align="center" style="text-align: center">X</p>
-							</td>
-							<td class="Normal" valign="top" width="80">
-								<p align="center" style="text-align: center">20</p>
-							</td>
-							<td class="Normal" valign="top" width="128">
-								<p align="center" style="text-align: center">-</p>
-							</td>
-						</tr>
-						<tr>
-							<td class="Normal" valign="top" width="168">
-								<p>Supplier-Address</p>
-							</td>
-							<td class="Normal" valign="top" width="66">
-								<p align="center" style="text-align: center">X</p>
-							</td>
-							<td class="Normal" valign="top" width="80">
-								<p align="center" style="text-align: center">35</p>
-							</td>
-							<td class="Normal" valign="top" width="128">
-								<p align="center" style="text-align: center">-</p>
-							</td>
-						</tr>
-					</table>
-					<h3>The Master Files</h3>
-					<h4>The Stock Master File</h4>
-					<p>The Stock Master File is an Indexed file with the following record description.</p>
-					<table border="1" cellpadding="0" cellspacing="0" width="617">
-						<tr bgcolor="#FFFFCC">
-							<td class="Normal" valign="top" width="175">
-								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">FieldName</span></b>
-								</p>
-							</td>
-							<td class="Normal" valign="top" width="153">
-								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">Key type</span></b>
-								</p>
-							</td>
-							<td class="Normal" valign="top" width="69">
-								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">Type</span></b>
-								</p>
-							</td>
-							<td class="Normal" valign="top" width="82">
-								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">Length</span></b>
-								</p>
-							</td>
-							<td class="Normal" valign="top" width="126">
-								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">Format</span></b>
-								</p>
-							</td>
-						</tr>
-						<tr>
-							<td class="Normal" valign="top" width="175">
-								<p>StockNumber</p>
-							</td>
-							<td class="Normal" valign="top" width="153">
-								<p align="center" style="text-align: center">Primary</p>
-							</td>
-							<td class="Normal" valign="top" width="69">
-								<p align="center" style="text-align: center">9</p>
-							</td>
-							<td class="Normal" valign="top" width="82">
-								<p align="center" style="text-align: center">7</p>
-							</td>
-							<td class="Normal" valign="top" width="126">
-								<p align="center" style="text-align: center">9999999</p>
-							</td>
-						</tr>
-						<tr>
-							<td class="Normal" valign="top" width="175">
-								<p>QtyInStock</p>
-							</td>
-							<td class="Normal" valign="top" width="153">&nbsp;</td>
-							<td class="Normal" valign="top" width="69">
-								<p align="center" style="text-align: center">9</p>
-							</td>
-							<td class="Normal" valign="top" width="82">
-								<p align="center" style="text-align: center">5</p>
-							</td>
-							<td class="Normal" valign="top" width="126">
-								<p align="center" style="text-align: center">99999</p>
-							</td>
-						</tr>
-						<tr>
-							<td class="Normal" valign="top" width="175">
-								<p>Price</p>
-							</td>
-							<td class="Normal" valign="top" width="153">&nbsp;</td>
-							<td class="Normal" valign="top" width="69">
-								<p align="center" style="text-align: center">9</p>
-							</td>
-							<td class="Normal" valign="top" width="82">
-								<p align="center" style="text-align: center">6</p>
-							</td>
-							<td class="Normal" valign="top" width="126">
-								<p align="center" style="text-align: center">9999.99</p>
-							</td>
-						</tr>
-						<tr>
-							<td class="Normal" valign="top" width="175">
-								<p>ReorderLevel</p>
-							</td>
-							<td class="Normal" valign="top" width="153">&nbsp;</td>
-							<td class="Normal" valign="top" width="69">
-								<p align="center" style="text-align: center">9</p>
-							</td>
-							<td class="Normal" valign="top" width="82">
-								<p align="center" style="text-align: center">3</p>
-							</td>
-							<td class="Normal" valign="top" width="126">
-								<p align="center" style="text-align: center">999</p>
-							</td>
-						</tr>
-						<tr>
-							<td class="Normal" valign="top" width="175">
-								<p>ReorderQty</p>
-							</td>
-							<td class="Normal" valign="top" width="153">&nbsp;</td>
-							<td class="Normal" valign="top" width="69">
-								<p align="center" style="text-align: center">9</p>
-							</td>
-							<td class="Normal" valign="top" width="82">
-								<p align="center" style="text-align: center">5</p>
-							</td>
-							<td class="Normal" valign="top" width="126">
-								<p align="center" style="text-align: center">99999</p>
-							</td>
-						</tr>
-						<tr>
-							<td class="Normal" valign="top" width="175">
-								<p>SupplierNumber</p>
-							</td>
-							<td class="Normal" valign="top" width="153">
-								<p align="center" style="text-align: center">ALT with Duplicates</p>
-							</td>
-							<td class="Normal" valign="top" width="69">
-								<p align="center" style="text-align: center">X</p>
-							</td>
-							<td class="Normal" valign="top" width="82">
-								<p align="center" style="text-align: center">4</p>
-							</td>
-							<td class="Normal" valign="top" width="126">
-								<p align="center" style="text-align: center">X999</p>
-							</td>
-						</tr>
-					</table>
-					<h4>The Supplier Master File</h4>
-					<p>The Supplier Master File is an Indexed file with the following record description.<br /></p>
-					<table border="1" cellpadding="0" cellspacing="0">
-						<tr bgcolor="#FFFFCC">
-							<td class="Normal" valign="top" width="168">
-								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">FieldName</span></b>
-								</p>
-							</td>
-							<td class="Normal" valign="top" width="132">
-								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">Key type</span></b>
-								</p>
-							</td>
-							<td class="Normal" valign="top" width="77">
-								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">Type</span></b>
-								</p>
-							</td>
-							<td class="Normal" valign="top" width="84">
-								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">Length</span></b>
-								</p>
-							</td>
-							<td class="Normal" valign="top" width="114">
-								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">Format</span></b>
-								</p>
-							</td>
-						</tr>
-						<tr>
-							<td class="Normal" valign="top" width="168">
-								<p>SupplierNumber</p>
-							</td>
-							<td class="Normal" valign="top" width="132">
-								<p align="center" style="text-align: center">Primary</p>
-							</td>
-							<td class="Normal" valign="top" width="77">
-								<p align="center" style="text-align: center">X</p>
-							</td>
-							<td class="Normal" valign="top" width="84">
-								<p align="center" style="text-align: center">4</p>
-							</td>
-							<td class="Normal" valign="top" width="114">
-								<p align="center" style="text-align: center">X999</p>
-							</td>
-						</tr>
-						<tr>
-							<td class="Normal" valign="top" width="168">
-								<p>SupplierName</p>
-							</td>
-							<td class="Normal" valign="top" width="132">
-								<p align="center" style="text-align: center">ALT with Duplicates</p>
-							</td>
-							<td class="Normal" valign="top" width="77">
-								<p align="center" style="text-align: center">X</p>
-							</td>
-							<td class="Normal" valign="top" width="84">
-								<p align="center" style="text-align: center">20</p>
-							</td>
-							<td class="Normal" valign="top" width="114">
-								<p align="center" style="text-align: center">-</p>
-							</td>
-						</tr>
-						<tr>
-							<td class="Normal" valign="top" width="168">
-								<p>SupplierAddress</p>
-							</td>
-							<td class="Normal" valign="top" width="132">&nbsp;</td>
-							<td class="Normal" valign="top" width="77">
-								<p align="center" style="text-align: center">X</p>
-							</td>
-							<td class="Normal" valign="top" width="84">
-								<p align="center" style="text-align: center">40</p>
-							</td>
-							<td class="Normal" valign="top" width="114">
-								<p align="center" style="text-align: center">-</p>
-							</td>
-						</tr>
-					</table>
-					<h3>The Stock Archive File</h3>
-					<p>The Stock Archive File is a sequential file with the following record description.</p>
-					<table border="1" cellpadding="0" cellspacing="0">
-						<tr bgcolor="#FFFFCC">
-							<td class="Normal" valign="top" width="168">
-								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">FieldName</span></b>
-								</p>
-							</td>
-							<td class="Normal" valign="top" width="87">
-								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">Type</span></b>
-								</p>
-							</td>
-							<td class="Normal" valign="top" width="84">
-								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">Length</span></b>
-								</p>
-							</td>
-							<td class="Normal" valign="top" width="118">
-								<p align="center" style="text-align: center">
-									<b><span style="text-transform: uppercase">Format</span></b>
-								</p>
-							</td>
-						</tr>
-						<tr>
-							<td class="Normal" valign="top" width="168">
-								<p>StockNumber</p>
-							</td>
-							<td class="Normal" valign="top" width="87">
-								<p align="center" style="text-align: center">9</p>
-							</td>
-							<td class="Normal" valign="top" width="84">
-								<p align="center" style="text-align: center">7</p>
-							</td>
-							<td class="Normal" valign="top" width="118">
-								<p align="center" style="text-align: center">9999999</p>
-							</td>
-						</tr>
-						<tr>
-							<td class="Normal" valign="top" width="168">
-								<p>QtyInStock</p>
-							</td>
-							<td class="Normal" valign="top" width="87">
-								<p align="center" style="text-align: center">9</p>
-							</td>
-							<td class="Normal" valign="top" width="84">
-								<p align="center" style="text-align: center">5</p>
-							</td>
-							<td class="Normal" valign="top" width="118">
-								<p align="center" style="text-align: center">99999</p>
-							</td>
-						</tr>
-						<tr>
-							<td class="Normal" valign="top" width="168">
-								<p>Price</p>
-							</td>
-							<td class="Normal" valign="top" width="87">
-								<p align="center" style="text-align: center">9</p>
-							</td>
-							<td class="Normal" valign="top" width="84">
-								<p align="center" style="text-align: center">6</p>
-							</td>
-							<td class="Normal" valign="top" width="118">
-								<p align="center" style="text-align: center">9999.99</p>
-							</td>
-						</tr>
-						<tr>
-							<td class="Normal" valign="top" width="168">
-								<p>ReorderLevel</p>
-							</td>
-							<td class="Normal" valign="top" width="87">
-								<p align="center" style="text-align: center">9</p>
-							</td>
-							<td class="Normal" valign="top" width="84">
-								<p align="center" style="text-align: center">3</p>
-							</td>
-							<td class="Normal" valign="top" width="118">
-								<p align="center" style="text-align: center">999</p>
-							</td>
-						</tr>
-						<tr>
-							<td class="Normal" valign="top" width="168">
-								<p>ReorderQty</p>
-							</td>
-							<td class="Normal" valign="top" width="87">
-								<p align="center" style="text-align: center">9</p>
-							</td>
-							<td class="Normal" valign="top" width="84">
-								<p align="center" style="text-align: center">5</p>
-							</td>
-							<td class="Normal" valign="top" width="118">
-								<p align="center" style="text-align: center">99999</p>
-							</td>
-						</tr>
-						<tr>
-							<td class="Normal" valign="top" width="168">
-								<p>SupplierNumber</p>
-							</td>
-							<td class="Normal" valign="top" width="87">
-								<p align="center" style="text-align: center">X</p>
-							</td>
-							<td class="Normal" valign="top" width="84">
-								<p align="center" style="text-align: center">4</p>
-							</td>
-							<td class="Normal" valign="top" width="118">
-								<p align="center" style="text-align: center">X999</p>
-							</td>
-						</tr>
-					</table>
-					<h3><span style="font-variant: normal; text-transform: uppercase">The Error File</span></h3>
+				</div>
+				<p class="recorddesc"><b>Adjust Reorder Level</b></p>
+				<table border="1" cellpadding="0" cellspacing="0">
+					<tr bgcolor="#FFFFCC">
+						<td class="Normal" valign="top" width="168">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">FieldName</span></b>
+							</p>
+						</td>
+						<td class="Normal" valign="top" width="87">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">Type</span></b>
+							</p>
+						</td>
+						<td class="Normal" valign="top" width="84">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">Length</span></b>
+							</p>
+						</td>
+						<td class="Normal" valign="top" width="148">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">Format</span></b>
+							</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="168">
+							<p>Transaction-Type</p>
+						</td>
+						<td class="Normal" valign="top" width="87">
+							<p align="center" style="text-align: center">Numeric</p>
+						</td>
+						<td class="Normal" valign="top" width="84">
+							<p align="center" style="text-align: center">1</p>
+						</td>
+						<td class="Normal" valign="top" width="148">
+							<p align="center" style="text-align: center">Value 3</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="168">
+							<p>Stock-Number</p>
+						</td>
+						<td class="Normal" valign="top" width="87">
+							<p align="center" style="text-align: center">Numeric</p>
+						</td>
+						<td class="Normal" valign="top" width="84">
+							<p align="center" style="text-align: center">7</p>
+						</td>
+						<td class="Normal" valign="top" width="148">
+							<p align="center" style="text-align: center">9999999</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="168">
+							<p>Reorder-Level</p>
+						</td>
+						<td class="Normal" valign="top" width="87">
+							<p align="center" style="text-align: center">Numeric</p>
+						</td>
+						<td class="Normal" valign="top" width="84">
+							<p align="center" style="text-align: center">3</p>
+						</td>
+						<td class="Normal" valign="top" width="148">
+							<p align="center" style="text-align: center">999</p>
+						</td>
+					</tr>
+				</table>
+				<p class="recorddesc"><b>Adjust Reorder Qty</b></p>
+				<table border="1" cellpadding="0" cellspacing="0">
+					<tr bgcolor="#FFFFCC">
+						<td class="Normal" valign="top" width="168">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">FieldName</span></b>
+							</p>
+						</td>
+						<td class="Normal" valign="top" width="87">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">Type</span></b>
+							</p>
+						</td>
+						<td class="Normal" valign="top" width="84">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">Length</span></b>
+							</p>
+						</td>
+						<td class="Normal" valign="top" width="148">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">Format</span></b>
+							</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="168">
+							<p>Transaction-Type</p>
+						</td>
+						<td class="Normal" valign="top" width="87">
+							<p align="center" style="text-align: center">Numeric</p>
+						</td>
+						<td class="Normal" valign="top" width="84">
+							<p align="center" style="text-align: center">1</p>
+						</td>
+						<td class="Normal" valign="top" width="148">
+							<p align="center" style="text-align: center">Value 4</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="168">
+							<p>Stock-Number</p>
+						</td>
+						<td class="Normal" valign="top" width="87">
+							<p align="center" style="text-align: center">Numeric</p>
+						</td>
+						<td class="Normal" valign="top" width="84">
+							<p align="center" style="text-align: center">7</p>
+						</td>
+						<td class="Normal" valign="top" width="148">
+							<p align="center" style="text-align: center">9999999</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="168">
+							<p>Reorder-Qty</p>
+						</td>
+						<td class="Normal" valign="top" width="87">
+							<p align="center" style="text-align: center">Numeric</p>
+						</td>
+						<td class="Normal" valign="top" width="84">
+							<p align="center" style="text-align: center">5</p>
+						</td>
+						<td class="Normal" valign="top" width="148">
+							<p align="center" style="text-align: center">99999</p>
+						</td>
+					</tr>
+				</table>
+				<p class="recorddesc"><b>Adjust Price</b></p>
+				<table border="1" cellpadding="0" cellspacing="0">
+					<tr bgcolor="#FFFFCC">
+						<td class="Normal" valign="top" width="168">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">FieldName</span></b>
+							</p>
+						</td>
+						<td class="Normal" valign="top" width="87">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">Type</span></b>
+							</p>
+						</td>
+						<td class="Normal" valign="top" width="84">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">Length</span></b>
+							</p>
+						</td>
+						<td class="Normal" valign="top" width="148">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">Format</span></b>
+							</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="168">
+							<p>Transaction-Type</p>
+						</td>
+						<td class="Normal" valign="top" width="87">
+							<p align="center" style="text-align: center">Numeric</p>
+						</td>
+						<td class="Normal" valign="top" width="84">
+							<p align="center" style="text-align: center">1</p>
+						</td>
+						<td class="Normal" valign="top" width="148">
+							<p align="center" style="text-align: center">Value 5</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="168">
+							<p>Stock-Number</p>
+						</td>
+						<td class="Normal" valign="top" width="87">
+							<p align="center" style="text-align: center">Numeric</p>
+						</td>
+						<td class="Normal" valign="top" width="84">
+							<p align="center" style="text-align: center">7</p>
+						</td>
+						<td class="Normal" valign="top" width="148">
+							<p align="center" style="text-align: center">9999999</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="168">
+							<p>Price</p>
+						</td>
+						<td class="Normal" valign="top" width="87">
+							<p align="center" style="text-align: center">Numeric</p>
+						</td>
+						<td class="Normal" valign="top" width="84">
+							<p align="center" style="text-align: center">6</p>
+						</td>
+						<td class="Normal" valign="top" width="148">
+							<p align="center" style="text-align: center">9999.99</p>
+						</td>
+					</tr>
+				</table>
+				<p class="recorddesc"><b>Delete Supplier Record</b></p>
+				<table border="1" cellpadding="0" cellspacing="0">
+					<tr bgcolor="#FFFFCC">
+						<td class="Normal" valign="top" width="168">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">FieldName</span></b>
+							</p>
+						</td>
+						<td class="Normal" valign="top" width="87">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">Type</span></b>
+							</p>
+						</td>
+						<td class="Normal" valign="top" width="84">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">Length</span></b>
+							</p>
+						</td>
+						<td class="Normal" valign="top" width="148">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">Format</span></b>
+							</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="168">
+							<p>Transaction-Type</p>
+						</td>
+						<td class="Normal" valign="top" width="87">
+							<p align="center" style="text-align: center">Numeric</p>
+						</td>
+						<td class="Normal" valign="top" width="84">
+							<p align="center" style="text-align: center">1</p>
+						</td>
+						<td class="Normal" valign="top" width="148">
+							<p align="center" style="text-align: center">Value 6</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="168">
+							<p>Supplier-Number</p>
+						</td>
+						<td class="Normal" valign="top" width="87">
+							<p align="center" style="text-align: center">Character</p>
+						</td>
+						<td class="Normal" valign="top" width="84">
+							<p align="center" style="text-align: center">4</p>
+						</td>
+						<td class="Normal" valign="top" width="148">
+							<p align="center" style="text-align: center">X999</p>
+						</td>
+					</tr>
+				</table>
+				<p class="recorddesc"><b>Insert Supplier Record</b></p>
+				<table border="1" cellpadding="0" cellspacing="0">
+					<tr bgcolor="#FFFFCC">
+						<td class="Normal" valign="top" width="168">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">FieldName</span></b>
+							</p>
+						</td>
+						<td class="Normal" valign="top" width="66">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">Type</span></b>
+							</p>
+						</td>
+						<td class="Normal" valign="top" width="80">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">Length</span></b>
+							</p>
+						</td>
+						<td class="Normal" valign="top" width="128">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">Format</span></b>
+							</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="168">
+							<p>Transaction-Type</p>
+						</td>
+						<td class="Normal" valign="top" width="66">
+							<p align="center" style="text-align: center">9</p>
+						</td>
+						<td class="Normal" valign="top" width="80">
+							<p align="center" style="text-align: center">1</p>
+						</td>
+						<td class="Normal" valign="top" width="128">
+							<p align="center" style="text-align: center">Value 7</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="168">
+							<p>Supplier-Number</p>
+						</td>
+						<td class="Normal" valign="top" width="66">
+							<p align="center" style="text-align: center">X</p>
+						</td>
+						<td class="Normal" valign="top" width="80">
+							<p align="center" style="text-align: center">4</p>
+						</td>
+						<td class="Normal" valign="top" width="128">
+							<p align="center" style="text-align: center">X999</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="168">
+							<p>Supplier-Name</p>
+						</td>
+						<td class="Normal" valign="top" width="66">
+							<p align="center" style="text-align: center">X</p>
+						</td>
+						<td class="Normal" valign="top" width="80">
+							<p align="center" style="text-align: center">20</p>
+						</td>
+						<td class="Normal" valign="top" width="128">
+							<p align="center" style="text-align: center">-</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="168">
+							<p>Supplier-Address</p>
+						</td>
+						<td class="Normal" valign="top" width="66">
+							<p align="center" style="text-align: center">X</p>
+						</td>
+						<td class="Normal" valign="top" width="80">
+							<p align="center" style="text-align: center">35</p>
+						</td>
+						<td class="Normal" valign="top" width="128">
+							<p align="center" style="text-align: center">-</p>
+						</td>
+					</tr>
+				</table>
+				<h3>The Master Files</h3>
+				<h4>The Stock Master File</h4>
+				<p>The Stock Master File is an Indexed file with the following record description.</p>
+				<table border="1" cellpadding="0" cellspacing="0" width="617">
+					<tr bgcolor="#FFFFCC">
+						<td class="Normal" valign="top" width="175">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">FieldName</span></b>
+							</p>
+						</td>
+						<td class="Normal" valign="top" width="153">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">Key type</span></b>
+							</p>
+						</td>
+						<td class="Normal" valign="top" width="69">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">Type</span></b>
+							</p>
+						</td>
+						<td class="Normal" valign="top" width="82">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">Length</span></b>
+							</p>
+						</td>
+						<td class="Normal" valign="top" width="126">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">Format</span></b>
+							</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="175">
+							<p>StockNumber</p>
+						</td>
+						<td class="Normal" valign="top" width="153">
+							<p align="center" style="text-align: center">Primary</p>
+						</td>
+						<td class="Normal" valign="top" width="69">
+							<p align="center" style="text-align: center">9</p>
+						</td>
+						<td class="Normal" valign="top" width="82">
+							<p align="center" style="text-align: center">7</p>
+						</td>
+						<td class="Normal" valign="top" width="126">
+							<p align="center" style="text-align: center">9999999</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="175">
+							<p>QtyInStock</p>
+						</td>
+						<td class="Normal" valign="top" width="153">&nbsp;</td>
+						<td class="Normal" valign="top" width="69">
+							<p align="center" style="text-align: center">9</p>
+						</td>
+						<td class="Normal" valign="top" width="82">
+							<p align="center" style="text-align: center">5</p>
+						</td>
+						<td class="Normal" valign="top" width="126">
+							<p align="center" style="text-align: center">99999</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="175">
+							<p>Price</p>
+						</td>
+						<td class="Normal" valign="top" width="153">&nbsp;</td>
+						<td class="Normal" valign="top" width="69">
+							<p align="center" style="text-align: center">9</p>
+						</td>
+						<td class="Normal" valign="top" width="82">
+							<p align="center" style="text-align: center">6</p>
+						</td>
+						<td class="Normal" valign="top" width="126">
+							<p align="center" style="text-align: center">9999.99</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="175">
+							<p>ReorderLevel</p>
+						</td>
+						<td class="Normal" valign="top" width="153">&nbsp;</td>
+						<td class="Normal" valign="top" width="69">
+							<p align="center" style="text-align: center">9</p>
+						</td>
+						<td class="Normal" valign="top" width="82">
+							<p align="center" style="text-align: center">3</p>
+						</td>
+						<td class="Normal" valign="top" width="126">
+							<p align="center" style="text-align: center">999</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="175">
+							<p>ReorderQty</p>
+						</td>
+						<td class="Normal" valign="top" width="153">&nbsp;</td>
+						<td class="Normal" valign="top" width="69">
+							<p align="center" style="text-align: center">9</p>
+						</td>
+						<td class="Normal" valign="top" width="82">
+							<p align="center" style="text-align: center">5</p>
+						</td>
+						<td class="Normal" valign="top" width="126">
+							<p align="center" style="text-align: center">99999</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="175">
+							<p>SupplierNumber</p>
+						</td>
+						<td class="Normal" valign="top" width="153">
+							<p align="center" style="text-align: center">ALT with Duplicates</p>
+						</td>
+						<td class="Normal" valign="top" width="69">
+							<p align="center" style="text-align: center">X</p>
+						</td>
+						<td class="Normal" valign="top" width="82">
+							<p align="center" style="text-align: center">4</p>
+						</td>
+						<td class="Normal" valign="top" width="126">
+							<p align="center" style="text-align: center">X999</p>
+						</td>
+					</tr>
+				</table>
+				<h4>The Supplier Master File</h4>
+				<p>The Supplier Master File is an Indexed file with the following record description.<br /></p>
+				<table border="1" cellpadding="0" cellspacing="0">
+					<tr bgcolor="#FFFFCC">
+						<td class="Normal" valign="top" width="168">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">FieldName</span></b>
+							</p>
+						</td>
+						<td class="Normal" valign="top" width="132">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">Key type</span></b>
+							</p>
+						</td>
+						<td class="Normal" valign="top" width="77">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">Type</span></b>
+							</p>
+						</td>
+						<td class="Normal" valign="top" width="84">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">Length</span></b>
+							</p>
+						</td>
+						<td class="Normal" valign="top" width="114">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">Format</span></b>
+							</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="168">
+							<p>SupplierNumber</p>
+						</td>
+						<td class="Normal" valign="top" width="132">
+							<p align="center" style="text-align: center">Primary</p>
+						</td>
+						<td class="Normal" valign="top" width="77">
+							<p align="center" style="text-align: center">X</p>
+						</td>
+						<td class="Normal" valign="top" width="84">
+							<p align="center" style="text-align: center">4</p>
+						</td>
+						<td class="Normal" valign="top" width="114">
+							<p align="center" style="text-align: center">X999</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="168">
+							<p>SupplierName</p>
+						</td>
+						<td class="Normal" valign="top" width="132">
+							<p align="center" style="text-align: center">ALT with Duplicates</p>
+						</td>
+						<td class="Normal" valign="top" width="77">
+							<p align="center" style="text-align: center">X</p>
+						</td>
+						<td class="Normal" valign="top" width="84">
+							<p align="center" style="text-align: center">20</p>
+						</td>
+						<td class="Normal" valign="top" width="114">
+							<p align="center" style="text-align: center">-</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="168">
+							<p>SupplierAddress</p>
+						</td>
+						<td class="Normal" valign="top" width="132">&nbsp;</td>
+						<td class="Normal" valign="top" width="77">
+							<p align="center" style="text-align: center">X</p>
+						</td>
+						<td class="Normal" valign="top" width="84">
+							<p align="center" style="text-align: center">40</p>
+						</td>
+						<td class="Normal" valign="top" width="114">
+							<p align="center" style="text-align: center">-</p>
+						</td>
+					</tr>
+				</table>
+				<h3>The Stock Archive File</h3>
+				<p>The Stock Archive File is a sequential file with the following record description.</p>
+				<table border="1" cellpadding="0" cellspacing="0">
+					<tr bgcolor="#FFFFCC">
+						<td class="Normal" valign="top" width="168">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">FieldName</span></b>
+							</p>
+						</td>
+						<td class="Normal" valign="top" width="87">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">Type</span></b>
+							</p>
+						</td>
+						<td class="Normal" valign="top" width="84">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">Length</span></b>
+							</p>
+						</td>
+						<td class="Normal" valign="top" width="118">
+							<p align="center" style="text-align: center">
+								<b><span style="text-transform: uppercase">Format</span></b>
+							</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="168">
+							<p>StockNumber</p>
+						</td>
+						<td class="Normal" valign="top" width="87">
+							<p align="center" style="text-align: center">9</p>
+						</td>
+						<td class="Normal" valign="top" width="84">
+							<p align="center" style="text-align: center">7</p>
+						</td>
+						<td class="Normal" valign="top" width="118">
+							<p align="center" style="text-align: center">9999999</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="168">
+							<p>QtyInStock</p>
+						</td>
+						<td class="Normal" valign="top" width="87">
+							<p align="center" style="text-align: center">9</p>
+						</td>
+						<td class="Normal" valign="top" width="84">
+							<p align="center" style="text-align: center">5</p>
+						</td>
+						<td class="Normal" valign="top" width="118">
+							<p align="center" style="text-align: center">99999</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="168">
+							<p>Price</p>
+						</td>
+						<td class="Normal" valign="top" width="87">
+							<p align="center" style="text-align: center">9</p>
+						</td>
+						<td class="Normal" valign="top" width="84">
+							<p align="center" style="text-align: center">6</p>
+						</td>
+						<td class="Normal" valign="top" width="118">
+							<p align="center" style="text-align: center">9999.99</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="168">
+							<p>ReorderLevel</p>
+						</td>
+						<td class="Normal" valign="top" width="87">
+							<p align="center" style="text-align: center">9</p>
+						</td>
+						<td class="Normal" valign="top" width="84">
+							<p align="center" style="text-align: center">3</p>
+						</td>
+						<td class="Normal" valign="top" width="118">
+							<p align="center" style="text-align: center">999</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="168">
+							<p>ReorderQty</p>
+						</td>
+						<td class="Normal" valign="top" width="87">
+							<p align="center" style="text-align: center">9</p>
+						</td>
+						<td class="Normal" valign="top" width="84">
+							<p align="center" style="text-align: center">5</p>
+						</td>
+						<td class="Normal" valign="top" width="118">
+							<p align="center" style="text-align: center">99999</p>
+						</td>
+					</tr>
+					<tr>
+						<td class="Normal" valign="top" width="168">
+							<p>SupplierNumber</p>
+						</td>
+						<td class="Normal" valign="top" width="87">
+							<p align="center" style="text-align: center">X</p>
+						</td>
+						<td class="Normal" valign="top" width="84">
+							<p align="center" style="text-align: center">4</p>
+						</td>
+						<td class="Normal" valign="top" width="118">
+							<p align="center" style="text-align: center">X999</p>
+						</td>
+					</tr>
+				</table>
+				<h3><span style="font-variant: normal; text-transform: uppercase">The Error File</span></h3>
+				<p>
+					The Error File is an unordered Sequential File.&nbsp; Records in the Error File have the same
+					format as those in the Transaction File.
+				</p>
+				<h3>
+					<br clear="all" style="page-break-before: always" />
+					Validation Requirements
+				</h3>
+				<p>
+					For the sake of efficiency, the Transaction File should be sorted on ascending TransactionType
+					within ascending StockNumber before the records are applied to the Master Files.&nbsp; Some of
+					the validation can be done before the Sort executes and should be done in an Input
+					Procedure.&nbsp; The rest of the processing should be done in an Output Procedure.
+				</p>
+				<p>
+					When an error occurs the transaction record should be written to an Error File.&nbsp; Records in
+					the Error File have the same format as those in the Transaction File.&nbsp;&nbsp; As soon as an
+					error is found in a transaction record, the record should be written to the Error File and no
+					further checking should be done.
+				</p>
+				<blockquote>
 					<p>
-						The Error File is an unordered Sequential File.&nbsp; Records in the Error File have the same
-						format as those in the Transaction File.
-					</p>
-					<h3>
-						<br clear="all" style="page-break-before: always" />
-						Validation Requirements
-					</h3>
-					<p>
-						For the sake of efficiency, the Transaction File should be sorted on ascending TransactionType
-						within ascending StockNumber before the records are applied to the Master Files.&nbsp; Some of
-						the validation can be done before the Sort executes and should be done in an Input
-						Procedure.&nbsp; The rest of the processing should be done in an Output Procedure.
+						<b>General Validation<br /></b> Ensure that the Transaction-Type is numeric and within range
+						1 to 7.
 					</p>
 					<p>
-						When an error occurs the transaction record should be written to an Error File.&nbsp; Records in
-						the Error File have the same format as those in the Transaction File.&nbsp;&nbsp; As soon as an
-						error is found in a transaction record, the record should be written to the Error File and no
-						further checking should be done.
+						<b>General Transaction Record Validation<br /></b> Ensure that the Stock-Number is numeric
+						and that the check digit is correct (implement check digit validation as a contained
+						sub-program with no Global data).&nbsp;
 					</p>
-					<blockquote>
-						<p>
-							<b>General Validation<br /></b> Ensure that the Transaction-Type is numeric and within range
-							1 to 7.
-						</p>
-						<p>
-							<b>General Transaction Record Validation<br /></b> Ensure that the Stock-Number is numeric
-							and that the check digit is correct (implement check digit validation as a contained
-							sub-program with no Global data).&nbsp;
-						</p>
-						<p>
-							<b>Delete Stock Record Special Validation<br /></b> Ensure that the record does exist in the
-							master file and that&nbsp; the Qty-In-Stock in the master file record is zero.&nbsp; If all
-							is OK&nbsp; write the Stock Master File record to the Stock Archive File and then delete the
-							master file record.
-						</p>
-						<p>
-							<b>Insert Stock Record Special Validation<br /></b> Ensure that the record does not already
-							exist and that there is a corresponding record in the Supplier Master File.&nbsp; Ensure
-							that the Qty-In-Stock, Price, Reorder-Level and Reorder-Qty fields are numeric and
-							initialized to zero.&nbsp; If all is OK&nbsp; insert the record.
-						</p>
-						<p>
-							<b>Adjust Special Validation<br /></b> Ensure that the record does exist in the master
-							file.&nbsp; If all is OK update the master record.<b
-								>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b
-							>
-						</p>
-						<p>
-							<b>Insert Supplier Record Special Validation<br /></b> Ensure that the record does not
-							already exist.&nbsp; If all is OK then insert the record.
-						</p>
-						<p>
-							<b>Delete Supplier Record Special Validation<br /></b> Ensure that the record does exist and
-							that there are no records with this SupplierNumber left in the Stock Master File. If all is
-							OK delete the master file record.
-						</p>
-					</blockquote>
-					<h3>
-						<span style="font-variant: normal; text-transform: uppercase"
-							>Validating The StockNumber Check Digit</span
+					<p>
+						<b>Delete Stock Record Special Validation<br /></b> Ensure that the record does exist in the
+						master file and that&nbsp; the Qty-In-Stock in the master file record is zero.&nbsp; If all
+						is OK&nbsp; write the Stock Master File record to the Stock Archive File and then delete the
+						master file record.
+					</p>
+					<p>
+						<b>Insert Stock Record Special Validation<br /></b> Ensure that the record does not already
+						exist and that there is a corresponding record in the Supplier Master File.&nbsp; Ensure
+						that the Qty-In-Stock, Price, Reorder-Level and Reorder-Qty fields are numeric and
+						initialized to zero.&nbsp; If all is OK&nbsp; insert the record.
+					</p>
+					<p>
+						<b>Adjust Special Validation<br /></b> Ensure that the record does exist in the master
+						file.&nbsp; If all is OK update the master record.<b
+							>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b
 						>
-					</h3>
-					<p>
-						The StockNumber is a seven digit number with the seventh (rightmost) digit being the calculated
-						check digit.&nbsp; Each of the real digits ( the first six) has a weight associated with it.
-						Starting from the leftmost digit the weights are as follows:-
 					</p>
 					<p>
-						&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-						D1 = 7, D2 = 6, D3 = 5, D4 = 4, D5 = 3, D6 = 2.
+						<b>Insert Supplier Record Special Validation<br /></b> Ensure that the record does not
+						already exist.&nbsp; If all is OK then insert the record.
 					</p>
 					<p>
-						In the StockNumber the check digit modulus is 11.&nbsp; The check digit can be calculated as
-						follows:-
+						<b>Delete Supplier Record Special Validation<br /></b> Ensure that the record does exist and
+						that there are no records with this SupplierNumber left in the Stock Master File. If all is
+						OK delete the master file record.
 					</p>
-					<p class="in5">
-						Multiply each digit by its weight and add the results together.&nbsp; Divide the sum of the
-						results by the modulus 11 and subtract the remainder from the modulus.&nbsp; The result is the
-						check digit.&nbsp;&nbsp; The check digit in your student number is calculated in exactly the
-						same way so any valid student number will be a valid StockNumber.
-					</p>
-					<p class="in5">Here is an example:-</p>
-					<pre>
+				</blockquote>
+				<h3>
+					<span style="font-variant: normal; text-transform: uppercase"
+						>Validating The StockNumber Check Digit</span
+					>
+				</h3>
+				<p>
+					The StockNumber is a seven digit number with the seventh (rightmost) digit being the calculated
+					check digit.&nbsp; Each of the real digits ( the first six) has a weight associated with it.
+					Starting from the leftmost digit the weights are as follows:-
+				</p>
+				<p>
+					&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+					D1 = 7, D2 = 6, D3 = 5, D4 = 4, D5 = 3, D6 = 2.
+				</p>
+				<p>
+					In the StockNumber the check digit modulus is 11.&nbsp; The check digit can be calculated as
+					follows:-
+				</p>
+				<p class="in5">
+					Multiply each digit by its weight and add the results together.&nbsp; Divide the sum of the
+					results by the modulus 11 and subtract the remainder from the modulus.&nbsp; The result is the
+					check digit.&nbsp;&nbsp; The check digit in your student number is calculated in exactly the
+					same way so any valid student number will be a valid StockNumber.
+				</p>
+				<p class="in5">Here is an example:-</p>
+				<pre>
 StockNumber    = 7944454
 Real  Number    = 794445
 Check Digit       =            4</pre
-					>
-					<pre
-						class="in1"
-					><span style="text-transform:uppercase">Digit</span>                      D1       D2       D3       D4       D5       D6 
+				>
+				<pre
+					class="in1"
+				><span style="text-transform:uppercase">Digit</span>                      D1       D2       D3       D4       D5       D6
                               *          *          *         *          *          *<br><span style="text-transform:uppercase">Weight</span>                   7          6          5        4          3         2<br>                            ----        ----        ----      ----       ----       ----<br><span style="text-transform:uppercase">Result</span>                  R1  +   R2  +   R3   +  R4  +   R5   +  R6      =   <span style="text-transform:uppercase">Sum Of  Results</span></pre>
-					<pre></pre>
-					<pre
-						class="in1"
-					><span style="text-transform:uppercase">Digit</span>                      7          9          4          4          4          5<br>    <span>         </span>                *          *           *          *           *          *<br><span style="text-transform:uppercase">Weight</span>                  7          6          5          4          3          2<br>                           ----        ----        ----       ----        ----        ----<br><span style="text-transform:uppercase">Result</span>                  49  +    54  +     20   +   16  +    12   +   10    =  161
+				<pre></pre>
+				<pre
+					class="in1"
+				><span style="text-transform:uppercase">Digit</span>                      7          9          4          4          4          5<br>    <span>         </span>                *          *           *          *           *          *<br><span style="text-transform:uppercase">Weight</span>                  7          6          5          4          3          2<br>                           ----        ----        ----       ----        ----        ----<br><span style="text-transform:uppercase">Result</span>                  49  +    54  +     20   +   16  +    12   +   10    =  161
 
 </pre>
-					<table border="0" cellpadding="0" cellspacing="0" width="613">
-						<tr valign="top">
-							<td width="99">161/11 = 7 &nbsp;&nbsp;</td>
-							<td width="514">
-								Divide the <span style="text-transform: uppercase">Sum Of Results</span> by
-								<span style="text-transform: uppercase">Modulus</span> 11 giving
-								<span style="text-transform: uppercase">Remainder</span>.<br />
-								&nbsp;
-							</td>
-						</tr>
-						<tr valign="top">
-							<td width="99">11-7&nbsp;&nbsp;&nbsp;&nbsp; = 4</td>
-							<td width="514">
-								Subtract&nbsp; the <span style="text-transform: uppercase">Remainder</span> from the
-								<span style="text-transform: uppercase">Modulus</span> giving
-								<span style="text-transform: uppercase">CheckDigit</span>.&nbsp;<br />
-								StockNumbers that yield check digits of 10 and 11 are invalid StockNumbers.
-							</td>
-						</tr>
-					</table>
-					<p class="h1">So the check digit is 4.</p>
-					<p>
-						If you only want to discover whether a check digit is correct or not then get the
-						<span style="text-transform: uppercase">Sum Of Results</span> as above,&nbsp; add the check
-						digit to it and divide by 11.&nbsp; If there is no remainder then the check digit is correct.
-					</p>
-					<copyright-notice type="project"></copyright-notice>
-				</td>
-			</tr>
-		</table>
+				<div class="calc-steps">
+					<div class="calc-step">
+						<span class="calc-label">161/11 = 7 &nbsp;&nbsp;</span>
+						<span class="calc-desc"
+							>Divide the <span style="text-transform: uppercase">Sum Of Results</span> by
+							<span style="text-transform: uppercase">Modulus</span> 11 giving
+							<span style="text-transform: uppercase">Remainder</span>.<br />
+							&nbsp;
+						</span>
+					</div>
+					<div class="calc-step">
+						<span class="calc-label">11-7&nbsp;&nbsp;&nbsp;&nbsp; = 4</span>
+						<span class="calc-desc"
+							>Subtract&nbsp; the <span style="text-transform: uppercase">Remainder</span> from the
+							<span style="text-transform: uppercase">Modulus</span> giving
+							<span style="text-transform: uppercase">CheckDigit</span>.&nbsp;<br />
+							StockNumbers that yield check digits of 10 and 11 are invalid StockNumbers.
+						</span>
+					</div>
+				</div>
+				<p class="h1">So the check digit is 4.</p>
+				<p>
+					If you only want to discover whether a check digit is correct or not then get the
+					<span style="text-transform: uppercase">Sum Of Results</span> as above,&nbsp; add the check
+					digit to it and divide by 11.&nbsp; If there is no remainder then the check digit is correct.
+				</p>
+				<copyright-notice type="project"></copyright-notice>
+			</div>
+		</div>
 	</body>
 </html>


### PR DESCRIPTION
## Summary

- Converts 3 layout tables to modern CSS (grid/flexbox), leaving all 11 data tables unchanged
- Moves `<meta viewport>` to first position in `<head>` per project convention

## What changed

**Outer wrapper table → CSS grid**
The page-level table (header, metadata rows, main content) is replaced with a `.page-layout` CSS grid using `21fr 79fr` columns. The `background-color: black; gap: 1px` trick replicates the table border appearance. `max-width` is set to 812px to match the original table's effective rendered width (the legacy border model adds ~12px beyond `width="800"`), preventing `<pre>` block content from overflowing.

**Indentation spacer table → margin-left**
A `<table border="0">` used solely to add 62px of left indent around the transaction types data table is replaced with `style="margin-left: 62px"` on the wrapper div.

**Check digit calculation table → flexbox**
A borderless 2-column table showing `161/11 = 7` / `11-7 = 4` with explanations is replaced with `.calc-steps`/`.calc-step` flexbox divs. On mobile the steps stack vertically.

## Reviewer notes

- All 11 data tables (record descriptions, master file schemas, transaction type list) are preserved as `<table>` elements — they contain actual tabular data
- Verified visually against https://bushidocodes.github.io/limerick-cobol/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html at desktop width; layout, borders, and pre block alignment match the original

🤖 Generated with [Claude Code](https://claude.com/claude-code)