### PR TITLE
Refactor layout tables to CSS grid in String.html

### DIFF
--- a/course/String.html
+++ b/course/String.html
@@ -24,15 +24,57 @@
 				font-size: larger;
 			}
 
-			td[bgcolor="#993300"] h2 {
+			.section-header h2 {
 				color: #ffff00;
 				font-family: Arial, Helvetica, sans-serif;
 			}
 
-			td[bgcolor="#FFFFCC"] h3,
-			td[bgcolor="#FFFFCC"] h4 {
+			.section-sidebar h3,
+			.section-sidebar h4 {
 				color: #800000;
 				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			.page-wrapper {
+				border: 1px solid;
+				max-width: 715px;
+				margin-left: auto;
+				margin-right: auto;
+			}
+
+			.page-header {
+				max-width: 710px;
+				margin: 0 auto;
+			}
+
+			.section-grid {
+				display: grid;
+				grid-template-columns: 175px 1fr;
+				max-width: 710px;
+				margin: 0 auto;
+			}
+
+			.section-header {
+				grid-column: 1 / -1;
+				background-color: #993300;
+				padding: 4px;
+				text-align: left;
+			}
+
+			.section-sidebar {
+				background-color: #FFFFCC;
+				padding: 4px;
+				text-align: left;
+			}
+
+			.section-content {
+				padding: 4px;
+				min-width: 0;
+			}
+
+			.page-nav {
+				max-width: 710px;
+				margin: 0 auto;
 			}
 		</style>
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
@@ -44,12 +86,6 @@
 
 			table {
 				max-width: 100%;
-			}
-
-			body > table,
-			body > hr {
-				margin-left: auto;
-				margin-right: auto;
 			}
 
 			pre {
@@ -68,8 +104,11 @@
 					word-wrap: break-word;
 				}
 
-				table[width] {
-					width: 100% !important;
+				table[width],
+				table[width] > tbody,
+				table[width] > tbody > tr,
+				table[width] > tbody > tr > td {
+					width: auto !important;
 					height: auto !important;
 				}
 
@@ -81,8 +120,8 @@
 					height: auto !important;
 				}
 
-				td[bgcolor="#993300"] > h2,
-				td[bgcolor="#993300"] > h3 {
+				.section-header h2,
+				.section-header h3 {
 					margin: 0.3em 0;
 				}
 
@@ -124,65 +163,22 @@
 					overflow-x: auto;
 				}
 
-				table[width="715"],
-				table[width="725"],
-				table[width="715"] > tbody,
-				table[width="725"] > tbody,
-				table[width="715"] > tbody > tr,
-				table[width="725"] > tbody > tr,
-				table[width="715"] > tbody > tr > td,
-				table[width="725"] > tbody > tr > td,
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])),
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])) > tbody,
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])) > tbody > tr,
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])) > tbody > tr > td {
-					display: block;
-					width: auto !important;
+				.section-grid {
+					grid-template-columns: 1fr;
 				}
 
-				table[width="710"]:has(> tbody > tr > td[width="93%"]),
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody {
-					display: block;
-					width: 100% !important;
+				.section-header {
+					grid-column: 1;
 				}
 
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr {
-					display: flex;
-					align-items: baseline;
-					gap: 0.4em;
-					margin: 0.4em 0;
-				}
-
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr > td[width="3%"] {
-					display: none;
-				}
-
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr > td[width="4%"] {
-					display: block;
-					flex: 0 0 auto;
-					width: auto !important;
-					padding: 0;
-				}
-
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr > td[width="93%"] {
-					display: block;
-					flex: 1 1 auto;
-					width: auto !important;
-					padding: 0;
-				}
-
-				td[width="175"] > h4:not(:first-child):not(:has(img)),
-				td[width="160"] > h4:not(:first-child):not(:has(img)),
+				.section-sidebar > h4:not(:first-child):not(:has(img)),
 				h4:has(> img[src*="PanelLine"]) {
 					display: none;
 				}
 
-				td[width="175"] > h3,
-				td[width="175"] > h4,
-				td[width="175"] > p,
-				td[width="160"] > h3,
-				td[width="160"] > h4,
-				td[width="160"] > p {
+				.section-sidebar > h3,
+				.section-sidebar > h4,
+				.section-sidebar > p {
 					margin: 0.2em 0;
 				}
 			}
@@ -190,138 +186,112 @@
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
-		<table border="1" width="715">
-			<tbody>
-				<tr>
-					<td>
-						<center>
-							<div align="left">
-								<table border="0" width="710">
-									<tr>
-										<td>
-											<center>
-												<p id="top">
-													<img
-														alt="Cobol Tutorial"
-														height="59"
-														src="Resources/pics/t-CobolTut.gif"
-														width="173"
-													/>
-												</p>
-											</center>
-											<center>
-												<h1>The STRING verb</h1>
-												<hr align="left" />
-											</center>
-										</td>
-									</tr>
-								</table>
-							</div>
-						</center>
-						<ul class="toc">
-							<li>
-								<a href="#intro">Introduction</a><br />
-								Unit aims, objectives and prerequisites.
-							</li>
-							<li>
-								<a href="#verb">The STRING verb</a><br />
-								This section examines the syntax, functioning and rules of the STRING verb
-							</li>
-							<li>
-								<a href="#examples">STRING examples</a><br />
-								This section starts with some animated examples and ends with some examples that take
-								the form of Self Assessment Questions (SAQ).
-							</li>
-						</ul>
-						<table border="0" cellpadding="4" cellspacing="0" width="710">
-							<tr>
-								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="intro">Introduction</h2>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Aims</h3>
-								</td>
-								<td width="525">
-									<p>
-										The aim of this unit is to provide to provide you with a solid understanding of
-										the STRING verb.
-									</p>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Objectives</h3>
-								</td>
-								<td width="525">
-									<p>By the end of this unit you should:By the end of this unit you should:</p>
-									<ol>
-										<li>Understand how the STRING verb works.</li>
-										<li>Be able to use the STRING to concatenate text strings in your programs</li>
-									</ol>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Prerequisites</h3>
-								</td>
-								<td width="525">
-									<p>You should be familiar with the material covered in the unit;</p>
-									<ul>
-										<li>Data Declaration</li>
-										<li>Iteration</li>
-										<li>Selection</li>
-										<li>Tables</li>
-										<li>Edited Pictures</li>
-										<li>The INSPECT verb</li>
-									</ul>
-								</td>
-							</tr>
-						</table>
-						<table border="0" width="710">
-							<tr>
-								<td>
-									<hr />
-									<p align="center">
-										<a href="#top"
-											><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-										/></a>
-									</p>
-								</td>
-							</tr>
-						</table>
-						<table border="0" cellpadding="4" cellspacing="0" width="710">
-							<tr>
-								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="verb">The STRING verb</h2>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="left">Introduction</h3>
-								</td>
-								<td width="525">
-									<p>
-										The STRING verb is used for string concatenation. That is, it is used to join
-										together the contents of two or more source strings or partial source string to
-										create a single destination string.
-									</p>
-									<p>The examples below show how the STRING is used.</p>
-									<p>
-										The first example concatenates the entire contents of the identifiers Indent1
-										and Ident2 with the literal "10" and puts the resulting sting into DestString.
-									</p>
-									<p>
-										The second example concatenates the entire contents of Ident1, with the partial
-										contents of Ident2 (all the characters up to the first space) and Ident3 (all
-										the characters up to the word "frogs").
-									</p>
-									<pre
-										class="language-cobol"
-									><code class="language-cobol">STRING Ident1, Ident2, "10" DELIMITED BY SIZE
+		<div class="page-wrapper">
+			<div class="page-header">
+				<center>
+					<p id="top">
+						<img
+							alt="Cobol Tutorial"
+							height="59"
+							src="Resources/pics/t-CobolTut.gif"
+							width="173"
+						/>
+					</p>
+				</center>
+				<center>
+					<h1>The STRING verb</h1>
+					<hr align="left" />
+				</center>
+			</div>
+			<ul class="toc">
+				<li>
+					<a href="#intro">Introduction</a><br />
+					Unit aims, objectives and prerequisites.
+				</li>
+				<li>
+					<a href="#verb">The STRING verb</a><br />
+					This section examines the syntax, functioning and rules of the STRING verb
+				</li>
+				<li>
+					<a href="#examples">STRING examples</a><br />
+					This section starts with some animated examples and ends with some examples that take
+					the form of Self Assessment Questions (SAQ).
+				</li>
+			</ul>
+			<div class="section-grid">
+				<div class="section-header">
+					<h2 align="center" id="intro">Introduction</h2>
+				</div>
+				<div class="section-sidebar">
+					<h3>Aims</h3>
+				</div>
+				<div class="section-content">
+					<p>
+						The aim of this unit is to provide to provide you with a solid understanding of
+						the STRING verb.
+					</p>
+					<hr />
+				</div>
+				<div class="section-sidebar">
+					<h3>Objectives</h3>
+				</div>
+				<div class="section-content">
+					<p>By the end of this unit you should:By the end of this unit you should:</p>
+					<ol>
+						<li>Understand how the STRING verb works.</li>
+						<li>Be able to use the STRING to concatenate text strings in your programs</li>
+					</ol>
+					<hr />
+				</div>
+				<div class="section-sidebar">
+					<h3>Prerequisites</h3>
+				</div>
+				<div class="section-content">
+					<p>You should be familiar with the material covered in the unit;</p>
+					<ul>
+						<li>Data Declaration</li>
+						<li>Iteration</li>
+						<li>Selection</li>
+						<li>Tables</li>
+						<li>Edited Pictures</li>
+						<li>The INSPECT verb</li>
+					</ul>
+				</div>
+			</div>
+			<div class="page-nav">
+				<hr />
+				<p align="center">
+					<a href="#top"
+						><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
+					/></a>
+				</p>
+			</div>
+			<div class="section-grid">
+				<div class="section-header">
+					<h2 align="center" id="verb">The STRING verb</h2>
+				</div>
+				<div class="section-sidebar">
+					<h3 align="left">Introduction</h3>
+				</div>
+				<div class="section-content">
+					<p>
+						The STRING verb is used for string concatenation. That is, it is used to join
+						together the contents of two or more source strings or partial source string to
+						create a single destination string.
+					</p>
+					<p>The examples below show how the STRING is used.</p>
+					<p>
+						The first example concatenates the entire contents of the identifiers Indent1
+						and Ident2 with the literal "10" and puts the resulting sting into DestString.
+					</p>
+					<p>
+						The second example concatenates the entire contents of Ident1, with the partial
+						contents of Ident2 (all the characters up to the first space) and Ident3 (all
+						the characters up to the word "frogs").
+					</p>
+					<pre
+						class="language-cobol"
+					><code class="language-cobol">STRING Ident1, Ident2, "10" DELIMITED BY SIZE
     INTO DestString
 END-STRING
 
@@ -331,283 +301,257 @@ STRING
    Ident3 DELIMITED BY "Frogs"
 INTO Ident4 WITH POINTER StrPtr
 END-STRING.</code></pre>
-									<hr />
+					<hr />
+				</div>
+				<div class="section-sidebar">
+					<h3>STRING syntax</h3>
+				</div>
+				<div class="section-content">
+					<p><img src="Resources/pics/I-String.gif" /></p>
+					<div align="center">
+						<table bgcolor="#DDFFDD" border="1" cellpadding="5" width="77%">
+							<tr>
+								<td width="21%">Delim$il</td>
+								<td width="79%">
+									Character or set of characters in a source string that terminates
+									data transfer to the destination string.
 								</td>
 							</tr>
 							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>STRING syntax</h3>
-								</td>
-								<td width="525">
-									<p><img src="Resources/pics/I-String.gif" /></p>
-									<div align="center">
-										<table bgcolor="#DDFFDD" border="1" cellpadding="5" width="77%">
-											<tr>
-												<td width="21%">Delim$il</td>
-												<td width="79%">
-													Character or set of characters in a source string that terminates
-													data transfer to the destination string.
-												</td>
-											</tr>
-											<tr>
-												<td width="21%">Pointer#i</td>
-												<td width="79%">
-													Points to the position in the destination string where the next
-													character will go.
-												</td>
-											</tr>
-										</table>
-									</div>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>How the STRING works</h3>
-								</td>
-								<td width="525">
-									<p>
-										The STRING statement moves characters from the source string to the destination
-										string according to the rules for alphanumeric to alphanumeric moves.
-									</p>
-									<p>
-										However, no space filling occurs and unless characters in the destination string
-										are explicitly overwritten they remain undisturbed.
-									</p>
-									<p>
-										As usual with alphanumeric to alphanumeric MOVEs, data movement is from left to
-										right.
-									</p>
-									<p>
-										The leftmost character of the source is moved to the leftmost position of the
-										destination then the next leftmost of the source to the next leftmost of the
-										destination and so on.
-									</p>
-									<p>
-										When a number of source strings are concatenated, characters are moved from the
-										leftmost source string first.
-									</p>
-									<p>
-										When a WITH POINTER phrase is used, its value determines the starting character
-										position for insertion into the destination string.
-									</p>
-									<p>
-										The ON OVERFLOW clause executes if there are still valid characters left in the
-										source strings but the destination string is full.
-									</p>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Data movement termination</h3>
-								</td>
-								<td width="525">
-									<p>Data movement from a particular source string ends when either;</p>
-									<ul>
-										<li>the end of the source string is reached</li>
-										<li>the end of the destination string is reached</li>
-										<li>the delimiter is detected.</li>
-									</ul>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>STRING termination</h3>
-								</td>
-								<td width="525">
-									<p>The STRING statement ends when either;</p>
-									<ul>
-										<li>all the source strings have been processed</li>
-										<li>the destination string is full</li>
-										<li>the pointer points outside the string.</li>
-									</ul>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>STRING rules</h3>
-								</td>
-								<td width="525">
-									<ol>
-										<li>
-											Where a literal can be use, a Figurative Constant can be used except the ALL
-											(literal).<br />
-											<br />
-										</li>
-										<li>
-											When a Figurative Constant is used its size is one character.<br />
-											<br />
-										</li>
-										<li>
-											The destination item Dest$i must be an elementary data item without editing
-											symbols or the JUSTIFIED clause.<br />
-											<br />
-										</li>
-										<li>
-											Pointer#i must be an integer item and its description must allow it to
-											contain a value one greater than the size of the destination string. For
-											instance, a pointer declared as PIC 9 is too small if the destination string
-											is 10 characters long.
-										</li>
-									</ol>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>STRING clauses</h3>
-								</td>
-								<td width="525">
-									<p>
-										<b>ON OVERFLOW</b> <b></b><br />
-										If the ON OVERFLOW clause is used then the statement following it will be
-										executed if there are still characters left to pass across in the source
-										field(s) but the destination field has been filled.
-									</p>
-									<p>
-										<b>WITH POINTER</b> <b></b><br />
-										The WITH POINTER phrase allows an identifier/dataname to be kept which holds the
-										position in the Destination String where the next character will go.
-									</p>
-									<p>
-										When the WITH POINTER phrase is used, the program must set the pointer to an
-										initial value greater than 0 and less than the length of the destination string
-										before the STRING statement executes.
-									</p>
-									<p>
-										If the WITH POINTER phrase is <b>not</b> used, operation on the destination
-										field starts from the leftmost position.
-									</p>
-									<p>
-										<b>DELIMITED BY SIZE</b> <b></b><br />
-										The DELIMITED BY SIZE clause means that the whole of the sending field will be
-										added to the destination string.
-									</p>
+								<td width="21%">Pointer#i</td>
+								<td width="79%">
+									Points to the position in the destination string where the next
+									character will go.
 								</td>
 							</tr>
 						</table>
-						<table border="0" width="710">
-							<tr>
-								<td>
-									<hr />
-									<p align="center">
-										<a href="#top"
-											><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-										/></a>
-									</p>
-								</td>
-							</tr>
-						</table>
-						<table border="0" cellpadding="4" cellspacing="0" width="710">
-							<tr>
-								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="examples">STRING examples</h2>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Introduction</h3>
-								</td>
-								<td width="525">
-									<p>
-										This section starts with some examples to reinforce the material you have just
-										read and it ends with a few test/examples to let you see if you have understood
-										everything so far.
-									</p>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>
-										Example 1<br />
-										(animation)
-									</h3>
-								</td>
-								<td width="525">
-									<p>
-										The animation in this example shows how the STRING works by stepping though each
-										clause in the STRING statement.
-									</p>
-									<p>
-										<iframe
-											height="333"
-											src="Resources/pdf-viewer.html?src=ppz/String1.pdf"
-											style="border: 1px solid #ccc; width: 100%; aspect-ratio: 520/333"
-											width="520"
-										></iframe>
-									</p>
-									<p align="center">
-										Click on the diagram below to step through the animation. Left click or PageDown
-										to go to the next step and right click or press PageUp to go to the previous
-										step.
-									</p>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>
-										Example 2<br />
-										(animation)
-									</h3>
-								</td>
-								<td width="525">
-									<p>
-										The WITH POINTER phrase is often very useful because it means that we don't have
-										to STRING all the source strings together in one go.
-									</p>
-									<p>
-										Using the WITH POINTER we can build the destination string by executing a number
-										of separate STRING statements or by executing a STRING statement a number of
-										times.
-									</p>
-									<p>
-										In this example we show how a destination string may be built a piece at a time
-										by executing several separate STRING statements. At the end of this unit in the
-										combined example you will see how a STRING statement may be used within a loop
-										to build a destination string.
-									</p>
-									<p>
-										<iframe
-											height="416"
-											src="Resources/pdf-viewer.html?src=ppz/String2.pdf"
-											style="border: 1px solid #ccc; width: 100%; aspect-ratio: 520/416"
-											width="520"
-										></iframe>
-									</p>
-									<p align="center">
-										Click on the diagram below to step through the animation. Left click or PageDown
-										to go to the next step and right click or press PageUp to go to the previous
-										step.
-									</p>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="left">Self assessment questions/examples</h3>
-								</td>
-								<td width="525">
-									<p>
-										The examples below consist of data delarations and a number of STRING
-										statements.
-									</p>
-									<p>
-										For each STRING example, write out the text that would be displayed by the
-										DISPLAY statement. Assume that the data starts off fresh for each STRING
-										statement.
-									</p>
-									<p>
-										Treat the examples as an opportunity to test your understanding of the STRING
-										verb. Before you click on the answers in the frame below write down your own
-										answer.
-									</p>
-									<p><b>Data Declarations.</b></p>
-									<pre class="language-cobol"><code class="language-cobol">01 StringFields.
+					</div>
+					<hr />
+				</div>
+				<div class="section-sidebar">
+					<h3>How the STRING works</h3>
+				</div>
+				<div class="section-content">
+					<p>
+						The STRING statement moves characters from the source string to the destination
+						string according to the rules for alphanumeric to alphanumeric moves.
+					</p>
+					<p>
+						However, no space filling occurs and unless characters in the destination string
+						are explicitly overwritten they remain undisturbed.
+					</p>
+					<p>
+						As usual with alphanumeric to alphanumeric MOVEs, data movement is from left to
+						right.
+					</p>
+					<p>
+						The leftmost character of the source is moved to the leftmost position of the
+						destination then the next leftmost of the source to the next leftmost of the
+						destination and so on.
+					</p>
+					<p>
+						When a number of source strings are concatenated, characters are moved from the
+						leftmost source string first.
+					</p>
+					<p>
+						When a WITH POINTER phrase is used, its value determines the starting character
+						position for insertion into the destination string.
+					</p>
+					<p>
+						The ON OVERFLOW clause executes if there are still valid characters left in the
+						source strings but the destination string is full.
+					</p>
+					<hr />
+				</div>
+				<div class="section-sidebar">
+					<h3>Data movement termination</h3>
+				</div>
+				<div class="section-content">
+					<p>Data movement from a particular source string ends when either;</p>
+					<ul>
+						<li>the end of the source string is reached</li>
+						<li>the end of the destination string is reached</li>
+						<li>the delimiter is detected.</li>
+					</ul>
+					<hr />
+				</div>
+				<div class="section-sidebar">
+					<h3>STRING termination</h3>
+				</div>
+				<div class="section-content">
+					<p>The STRING statement ends when either;</p>
+					<ul>
+						<li>all the source strings have been processed</li>
+						<li>the destination string is full</li>
+						<li>the pointer points outside the string.</li>
+					</ul>
+					<hr />
+				</div>
+				<div class="section-sidebar">
+					<h3>STRING rules</h3>
+				</div>
+				<div class="section-content">
+					<ol>
+						<li>
+							Where a literal can be use, a Figurative Constant can be used except the ALL
+							(literal).<br />
+							<br />
+						</li>
+						<li>
+							When a Figurative Constant is used its size is one character.<br />
+							<br />
+						</li>
+						<li>
+							The destination item Dest$i must be an elementary data item without editing
+							symbols or the JUSTIFIED clause.<br />
+							<br />
+						</li>
+						<li>
+							Pointer#i must be an integer item and its description must allow it to
+							contain a value one greater than the size of the destination string. For
+							instance, a pointer declared as PIC 9 is too small if the destination string
+							is 10 characters long.
+						</li>
+					</ol>
+					<hr />
+				</div>
+				<div class="section-sidebar">
+					<h3>STRING clauses</h3>
+				</div>
+				<div class="section-content">
+					<p>
+						<b>ON OVERFLOW</b> <b></b><br />
+						If the ON OVERFLOW clause is used then the statement following it will be
+						executed if there are still characters left to pass across in the source
+						field(s) but the destination field has been filled.
+					</p>
+					<p>
+						<b>WITH POINTER</b> <b></b><br />
+						The WITH POINTER phrase allows an identifier/dataname to be kept which holds the
+						position in the Destination String where the next character will go.
+					</p>
+					<p>
+						When the WITH POINTER phrase is used, the program must set the pointer to an
+						initial value greater than 0 and less than the length of the destination string
+						before the STRING statement executes.
+					</p>
+					<p>
+						If the WITH POINTER phrase is <b>not</b> used, operation on the destination
+						field starts from the leftmost position.
+					</p>
+					<p>
+						<b>DELIMITED BY SIZE</b> <b></b><br />
+						The DELIMITED BY SIZE clause means that the whole of the sending field will be
+						added to the destination string.
+					</p>
+				</div>
+			</div>
+			<div class="page-nav">
+				<hr />
+				<p align="center">
+					<a href="#top"
+						><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
+					/></a>
+				</p>
+			</div>
+			<div class="section-grid">
+				<div class="section-header">
+					<h2 align="center" id="examples">STRING examples</h2>
+				</div>
+				<div class="section-sidebar">
+					<h3>Introduction</h3>
+				</div>
+				<div class="section-content">
+					<p>
+						This section starts with some examples to reinforce the material you have just
+						read and it ends with a few test/examples to let you see if you have understood
+						everything so far.
+					</p>
+					<hr />
+				</div>
+				<div class="section-sidebar">
+					<h3>
+						Example 1<br />
+						(animation)
+					</h3>
+				</div>
+				<div class="section-content">
+					<p>
+						The animation in this example shows how the STRING works by stepping though each
+						clause in the STRING statement.
+					</p>
+					<p>
+						<iframe
+							height="333"
+							src="Resources/pdf-viewer.html?src=ppz/String1.pdf"
+							style="border: 1px solid #ccc; width: 100%; aspect-ratio: 520/333"
+							width="520"
+						></iframe>
+					</p>
+					<p align="center">
+						Click on the diagram below to step through the animation. Left click or PageDown
+						to go to the next step and right click or press PageUp to go to the previous
+						step.
+					</p>
+					<hr />
+				</div>
+				<div class="section-sidebar">
+					<h3>
+						Example 2<br />
+						(animation)
+					</h3>
+				</div>
+				<div class="section-content">
+					<p>
+						The WITH POINTER phrase is often very useful because it means that we don't have
+						to STRING all the source strings together in one go.
+					</p>
+					<p>
+						Using the WITH POINTER we can build the destination string by executing a number
+						of separate STRING statements or by executing a STRING statement a number of
+						times.
+					</p>
+					<p>
+						In this example we show how a destination string may be built a piece at a time
+						by executing several separate STRING statements. At the end of this unit in the
+						combined example you will see how a STRING statement may be used within a loop
+						to build a destination string.
+					</p>
+					<p>
+						<iframe
+							height="416"
+							src="Resources/pdf-viewer.html?src=ppz/String2.pdf"
+							style="border: 1px solid #ccc; width: 100%; aspect-ratio: 520/416"
+							width="520"
+						></iframe>
+					</p>
+					<p align="center">
+						Click on the diagram below to step through the animation. Left click or PageDown
+						to go to the next step and right click or press PageUp to go to the previous
+						step.
+					</p>
+					<hr />
+				</div>
+				<div class="section-sidebar">
+					<h3 align="left">Self assessment questions/examples</h3>
+				</div>
+				<div class="section-content">
+					<p>
+						The examples below consist of data delarations and a number of STRING
+						statements.
+					</p>
+					<p>
+						For each STRING example, write out the text that would be displayed by the
+						DISPLAY statement. Assume that the data starts off fresh for each STRING
+						statement.
+					</p>
+					<p>
+						Treat the examples as an opportunity to test your understanding of the STRING
+						verb. Before you click on the answers in the frame below write down your own
+						answer.
+					</p>
+					<p><b>Data Declarations.</b></p>
+					<pre class="language-cobol"><code class="language-cobol">01 StringFields.
    02 Field1   PIC X(18) VALUE "Where does this go".
    02 Field2   PIC X(30) VALUE "This is the destination string".
    02 Field3   PIC X(15) VALUE "Here is another".
@@ -616,24 +560,24 @@ END-STRING.</code></pre>
 01 StrPointers.
    02 StrPtr  PIC 99.
    02 NewPtr  PIC 9.</code></pre>
-									<p><b>STRING examples.</b></p>
-									<pre
-										class="language-cobol"
-									><code class="language-cobol">1. STRING Field1 DELIMITED BY SPACES INTO Field2.
+					<p><b>STRING examples.</b></p>
+					<pre
+						class="language-cobol"
+					><code class="language-cobol">1. STRING Field1 DELIMITED BY SPACES INTO Field2.
    DISPLAY Field2.
 
 2. STRING Field1 DELIMITED BY SIZE INTO Field2.
    DISPLAY Field2.
 
 3. MOVE 6 TO StrPtr.
-   STRING Field1, Field3 DELIMITED BY SPACE 
+   STRING Field1, Field3 DELIMITED BY SPACE
        INTO Field2 WITH POINTER StrPtr
        ON OVERFLOW DISPLAY "String Error"
        NOT ON OVERFLOW DISPLAY "No Error"
    END-STRING.
    DISPLAY Field2.
 
-4. STRING Field1, Field2, Field3 
+4. STRING Field1, Field2, Field3
        DELIMITED BY SPACES INTO Field4
    END-STRING.
    DISPLAY Field4
@@ -655,40 +599,30 @@ END-STRING.</code></pre>
        NOT ON OVERFLOW DISPLAY "No Error"
    END-STRING.
    DISPLAY Field2. </code></pre>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Answers to SAQs</h3>
-								</td>
-								<td width="525">
-									<p align="center">
-										<iframe
-											height="208"
-											src="Resources/pdf-viewer.html?src=ppz/String3.pdf"
-											style="border: 1px solid #ccc; width: 100%; aspect-ratio: 520/208"
-											width="520"
-										></iframe>
-										Left click or PageDown to go to the next answer and right click or press PageUp
-										to go to the previous answer.&nbsp;
-									</p>
-								</td>
-							</tr>
-						</table>
-					</td>
-				</tr>
-				<tr>
-					<td>
-						<hr />
-						<div align="center">
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</div>
-						<copyright-notice></copyright-notice>
-					</td>
-				</tr>
-			</tbody>
-		</table>
+				</div>
+				<div class="section-sidebar">
+					<h3>Answers to SAQs</h3>
+				</div>
+				<div class="section-content">
+					<p align="center">
+						<iframe
+							height="208"
+							src="Resources/pdf-viewer.html?src=ppz/String3.pdf"
+							style="border: 1px solid #ccc; width: 100%; aspect-ratio: 520/208"
+							width="520"
+						></iframe>
+						Left click or PageDown to go to the next answer and right click or press PageUp
+						to go to the previous answer.&nbsp;
+					</p>
+				</div>
+			</div>
+			<hr />
+			<div align="center">
+				<a href="#top"
+					><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
+				/></a>
+			</div>
+			<copyright-notice></copyright-notice>
+		</div>
 	</body>
 </html>


### PR DESCRIPTION
## Summary

- Replaces 7 layout tables in `course/String.html` with CSS grid (`display: grid`) and plain `div` elements
- Preserves the one genuine data table (the `Delim$il` / `Pointer#i` definition table in the STRING syntax section)
- Visual output matches the reference page at [bushidocodes.github.io/limerick-cobol/course/String.html](https://bushidocodes.github.io/limerick-cobol/course/String.html) — verified by side-by-side screenshot comparison

## What changed

| Before | After |
|--------|-------|
| `<table border="1" width="715">` outer wrapper | `.page-wrapper` div with `border: 1px solid; max-width: 715px` |
| `<table border="0" width="710">` page header | `.page-header` div |
| 3× two-column sidebar section tables | `.section-grid` CSS grid (`175px 1fr` columns) |
| 2× hr/nav-link tables | `.page-nav` div |

CSS selector updates:
- `td[bgcolor="#993300"] h2` → `.section-header h2`
- `td[bgcolor="#FFFFCC"] h3, h4` → `.section-sidebar h3, h4`
- Mobile `@media` block updated to use class names; removed now-irrelevant `table[width="715/710"]` hacks

Notable fix: added `min-width: 0` on `.section-content` to prevent the CSS Grid `min-width: auto` default from allowing wide iframes to blow out the content column.

## Reviewer notes

- The `align-self: start` property was intentionally omitted from `.section-sidebar` so the yellow background stretches the full row height, matching the original table-cell behaviour.
- Only `course/String.html` is modified — no shared CSS or other pages touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)