### PR TITLE
Refactor Unstring.html layout tables to CSS grid/flexbox

### DIFF
--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -24,15 +24,59 @@
 				font-size: larger;
 			}
 
-			td[bgcolor="#993300"] h2 {
+			.section-header h2 {
 				color: #ffff00;
 				font-family: Arial, Helvetica, sans-serif;
 			}
 
-			td[bgcolor="#FFFFCC"] h3,
-			td[bgcolor="#FFFFCC"] h4 {
+			.section-sidebar h3,
+			.section-sidebar h4 {
 				color: #800000;
 				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			.page-wrapper {
+				max-width: 715px;
+				margin: 0 auto;
+				border: 1px solid;
+				box-sizing: border-box;
+			}
+
+			.page-content {
+				padding: 2px;
+			}
+
+			.page-footer {
+				padding: 2px;
+			}
+
+			.section-grid {
+				display: grid;
+				grid-template-columns: 175px 1fr;
+			}
+
+			.section-header {
+				grid-column: 1 / -1;
+				background-color: #993300;
+				padding: 4px;
+			}
+
+			.section-sidebar {
+				background-color: #ffffcc;
+				padding: 4px;
+				align-self: stretch;
+			}
+
+			.section-content {
+				padding: 4px;
+				align-self: start;
+			}
+
+			.code-bg-box {
+				background-image: url(Resources/pics/code.gif);
+				border: 1px solid #c0c0c0;
+				padding: 10px;
+				box-sizing: border-box;
 			}
 		</style>
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
@@ -44,12 +88,6 @@
 
 			table {
 				max-width: 100%;
-			}
-
-			body > table,
-			body > hr {
-				margin-left: auto;
-				margin-right: auto;
 			}
 
 			pre {
@@ -81,8 +119,8 @@
 					height: auto !important;
 				}
 
-				td[bgcolor="#993300"] > h2,
-				td[bgcolor="#993300"] > h3 {
+				.section-header h2,
+				.section-header h3 {
 					margin: 0.3em 0;
 				}
 
@@ -124,65 +162,13 @@
 					overflow-x: auto;
 				}
 
-				table[width="715"],
-				table[width="725"],
-				table[width="715"] > tbody,
-				table[width="725"] > tbody,
-				table[width="715"] > tbody > tr,
-				table[width="725"] > tbody > tr,
-				table[width="715"] > tbody > tr > td,
-				table[width="725"] > tbody > tr > td,
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])),
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])) > tbody,
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])) > tbody > tr,
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])) > tbody > tr > td {
+				.section-grid {
 					display: block;
-					width: auto !important;
 				}
 
-				table[width="710"]:has(> tbody > tr > td[width="93%"]),
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody {
-					display: block;
-					width: 100% !important;
-				}
-
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr {
-					display: flex;
-					align-items: baseline;
-					gap: 0.4em;
-					margin: 0.4em 0;
-				}
-
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr > td[width="3%"] {
-					display: none;
-				}
-
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr > td[width="4%"] {
-					display: block;
-					flex: 0 0 auto;
-					width: auto !important;
-					padding: 0;
-				}
-
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr > td[width="93%"] {
-					display: block;
-					flex: 1 1 auto;
-					width: auto !important;
-					padding: 0;
-				}
-
-				td[width="175"] > h4:not(:first-child):not(:has(img)),
-				td[width="160"] > h4:not(:first-child):not(:has(img)),
-				h4:has(> img[src*="PanelLine"]) {
-					display: none;
-				}
-
-				td[width="175"] > h3,
-				td[width="175"] > h4,
-				td[width="175"] > p,
-				td[width="160"] > h3,
-				td[width="160"] > h4,
-				td[width="160"] > p {
+				.section-sidebar h3,
+				.section-sidebar h4,
+				.section-sidebar p {
 					margin: 0.2em 0;
 				}
 			}
@@ -190,522 +176,453 @@
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
-		<table border="1" width="715">
-			<tbody>
-				<tr>
-					<td>
-						<center>
-							<div align="left">
-								<table border="0" width="710">
-									<tr>
-										<td>
-											<center>
-												<p id="top">
-													<img
-														alt=""
-														height="59"
-														src="Resources/pics/t-CobolTut.gif"
-														width="173"
-													/>
-												</p>
-											</center>
-											<center>
-												<h1>The UNSTRING verb</h1>
-												<hr align="left" />
-											</center>
-										</td>
-									</tr>
-								</table>
-							</div>
-						</center>
-						<ul class="toc">
-							<li>
-								<a href="#intro">Introduction</a><br />
-								Unit aims, objectives and prerequisites.
-							</li>
-							<li>
-								<a href="#verb">The UNSTRING verb</a><br />
-								This section examines the syntax, functioning and rules of the
-								<code class="language-cobol">UNSTRING</code>.
-							</li>
-							<li>
-								<a href="#examples">UNSTRING examples</a><br />
-								This section starts with some abstract examples, goes on to a more practical example and
-								ends with a example program
-							</li>
-							<li>
-								<a href="#combined">A combined example</a><br />
-								The unit ends with a practical example that uses the
-								<code class="language-cobol">STRING</code> and
-								<code class="language-cobol">UNSTRING</code> verbs in combination.
-							</li>
+		<div class="page-wrapper">
+			<div class="page-content">
+				<div style="text-align: center;">
+					<p id="top">
+						<img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173" />
+					</p>
+					<h1>The UNSTRING verb</h1>
+					<hr align="left" />
+				</div>
+				<ul class="toc">
+					<li>
+						<a href="#intro">Introduction</a><br />
+						Unit aims, objectives and prerequisites.
+					</li>
+					<li>
+						<a href="#verb">The UNSTRING verb</a><br />
+						This section examines the syntax, functioning and rules of the
+						<code class="language-cobol">UNSTRING</code>.
+					</li>
+					<li>
+						<a href="#examples">UNSTRING examples</a><br />
+						This section starts with some abstract examples, goes on to a more practical example and
+						ends with a example program
+					</li>
+					<li>
+						<a href="#combined">A combined example</a><br />
+						The unit ends with a practical example that uses the
+						<code class="language-cobol">STRING</code> and
+						<code class="language-cobol">UNSTRING</code> verbs in combination.
+					</li>
+				</ul>
+				<div class="section-grid">
+					<div class="section-header">
+						<h2 align="center" id="intro">Introduction</h2>
+					</div>
+					<div class="section-sidebar">
+						<h3>Aims</h3>
+					</div>
+					<div class="section-content">
+						<p>
+							The aim of this unit is to provide to provide you with a solid understanding of
+							the UNSTRING verb.
+						</p>
+						<hr />
+					</div>
+					<div class="section-sidebar">
+						<h3>Objectives</h3>
+					</div>
+					<div class="section-content">
+						<p>By the end of this unit you should:By the end of this unit you should:</p>
+						<ol>
+							<li>Understand how the UNSTRING works</li>
+							<li>Be able to use the UNSTRING to divide a string into sub-strings</li>
+						</ol>
+						<hr />
+					</div>
+					<div class="section-sidebar">
+						<h3>Prerequisites</h3>
+					</div>
+					<div class="section-content">
+						<p>You should be familiar with the material covered in the unit;</p>
+						<ul>
+							<li>Data Declaration</li>
+							<li>Iteration</li>
+							<li>Selection</li>
+							<li>Tables</li>
+							<li>Edited Pictures</li>
+							<li>The INSPECT verb</li>
+							<li>The STRING verb</li>
 						</ul>
-						<table border="0" cellpadding="4" cellspacing="0" width="710">
-							<tr>
-								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="intro">Introduction</h2>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Aims</h3>
-								</td>
-								<td width="525">
-									<p>
-										The aim of this unit is to provide to provide you with a solid understanding of
-										the UNSTRING verb.
-									</p>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Objectives</h3>
-								</td>
-								<td width="525">
-									<p>By the end of this unit you should:By the end of this unit you should:</p>
-									<ol>
-										<li>Understand how the UNSTRING works</li>
-										<li>Be able to use the UNSTRING to divide a string into sub-strings</li>
-									</ol>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Prerequisites</h3>
-								</td>
-								<td width="525">
-									<p>You should be familiar with the material covered in the unit;</p>
-									<ul>
-										<li>Data Declaration</li>
-										<li>Iteration</li>
-										<li>Selection</li>
-										<li>Tables</li>
-										<li>Edited Pictures</li>
-										<li>The INSPECT verb</li>
-										<li>The STRING verb</li>
-									</ul>
-								</td>
-							</tr>
-						</table>
-						<table border="0" width="710">
-							<tr>
-								<td>
-									<hr />
-									<p align="center">
-										<a href="#top"
-											><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-										/></a>
-									</p>
-								</td>
-							</tr>
-						</table>
-						<table border="0" cellpadding="4" cellspacing="0" width="710">
-							<tr>
-								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="verb">The UNSTRING verb</h2>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="left">Introduction</h3>
-								</td>
-								<td width="525">
-									<p>The UNSTRING is used to divide a string into sub-strings.</p>
-									<p>The examples below show how the UNSTRING is used.</p>
-									<p>
-										The first example breaks a name string into its three constituent part - the
-										first name , second name and surname. For instance the string "John Joseph Ryan"
-										is broken into the three strings "John", "Joseph" and "Ryan".
-									</p>
-									<p>
-										The second example breaks an address string (where the parts of the address are
-										separated from one another by commas) into separate address lines. The address
-										lines are stored in a six element table.
-									</p>
-									<p>
-										Since not all addresses will have six parts exactly, we use the TALLYING clause
-										to discover how many parts there are.
-									</p>
-									<pre
-										class="language-cobol"
-									><code class="language-cobol">UNSTRING FullName DELIMITED BY ALL SPACES
+					</div>
+				</div>
+				<div>
+					<hr />
+					<p align="center">
+						<a href="#top"
+							><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
+						/></a>
+					</p>
+				</div>
+				<div class="section-grid">
+					<div class="section-header">
+						<h2 align="center" id="verb">The UNSTRING verb</h2>
+					</div>
+					<div class="section-sidebar">
+						<h3 align="left">Introduction</h3>
+					</div>
+					<div class="section-content">
+						<p>The UNSTRING is used to divide a string into sub-strings.</p>
+						<p>The examples below show how the UNSTRING is used.</p>
+						<p>
+							The first example breaks a name string into its three constituent part - the
+							first name , second name and surname. For instance the string "John Joseph Ryan"
+							is broken into the three strings "John", "Joseph" and "Ryan".
+						</p>
+						<p>
+							The second example breaks an address string (where the parts of the address are
+							separated from one another by commas) into separate address lines. The address
+							lines are stored in a six element table.
+						</p>
+						<p>
+							Since not all addresses will have six parts exactly, we use the TALLYING clause
+							to discover how many parts there are.
+						</p>
+						<pre
+							class="language-cobol"
+						><code class="language-cobol">UNSTRING FullName DELIMITED BY ALL SPACES
     INTO FirstName, SecondName, Surname
 END-UNSTRING.
 
 UNSTRING CustAddress DELIMITED BY ","
-   INTO AdrLine(1), AdrLine(2), AdrLine(3), 
-        AdrLine(4), AdrLine(5), AdrLine(6) 
+   INTO AdrLine(1), AdrLine(2), AdrLine(3),
+        AdrLine(4), AdrLine(5), AdrLine(6)
    TALLYING IN AdrLinesUsed
 END-UNSTRING.</code></pre>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>UNSTRING syntax</h3>
-								</td>
-								<td width="525">
-									<p><img src="Resources/pics/I-UnString.gif" /></p>
-									<div align="center">
-										<table bgcolor="#DDFFDD" border="1" cellpadding="5" width="77%">
-											<tr>
-												<td width="21%">Delim$il</td>
-												<td width="79%">
-													Character or set of characters in the source string that terminate
-													data transfer to a particular destination String
-												</td>
-											</tr>
-											<tr>
-												<td width="21%">HoldDelim$i</td>
-												<td width="79%">
-													Holds the delimiter that caused data transfer to a particular
-													destination string to terminate.
-												</td>
-											</tr>
-											<tr>
-												<td width="21%">CharCounter#i</td>
-												<td width="79%">
-													Is associated with a particular destination string and holds a count
-													of the characters copied into it.
-												</td>
-											</tr>
-											<tr>
-												<td width="21%">Pointer#i</td>
-												<td width="79%">
-													Points to the position in the source string from which the next
-													character will be taken.
-												</td>
-											</tr>
-											<tr>
-												<td width="21%">DestCounter#i</td>
-												<td width="79%">
-													Holds the count of the number of destination strings affected by the
-													UNSTRING operation.
-												</td>
-											</tr>
-										</table>
-									</div>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>How the UNSTRING works</h3>
-								</td>
-								<td width="525">
-									<p>
-										The UNSTRING copies characters from the source string, to the destination
-										string, until a condition is encountered that terminates data movement.
-									</p>
-									<p>
-										When data movement ends for a particular destination string, the next
-										destination string becomes the receiving area and characters are copied into it
-										until once again a terminating condition is encountered.
-									</p>
-									<p>
-										Characters are copied from the source string to the destination strings
-										according to the rules for alphanumeric moves. There is space filling.
-									</p>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Data movement termination</h3>
-								</td>
-								<td width="525">
-									<p>
-										When the DELIMITED BY clause is used data movement from the source string to the
-										current destination string ends when either ;
-									</p>
-									<ul>
-										<li>a delimiter is encountered in the source string</li>
-										<li>the end of the source string is reached.</li>
-									</ul>
-									<p>
-										When the DELIMITED BY clause is not used, data movement from the source string
-										to the current destination string ends when either;
-									</p>
-									<ul>
-										<li>the destination string is full</li>
-										<li>the end of the source string is reached</li>
-									</ul>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>UNSTRING termination</h3>
-								</td>
-								<td width="525">
-									<p>The UNSTRING statement terminates when either;</p>
-									<ul>
-										<li>All the characters in the source string have been examined</li>
-										<li>All the destination strings have been processed</li>
-										<li>
-											Some error condition is encountered (such as the pointer pointing outside
-											the source string).
-										</li>
-									</ul>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>UNSTRING rules</h3>
-								</td>
-								<td width="525">
-									<ol>
-										<li>
-											Where a literal can be used any figurative constant can be used except the
-											ALL (literal).<br />
-											<br />
-										</li>
-										<li>
-											When a figurative constant is used then its length is one character.<br />
-											<br />
-										</li>
-										<li>
-											Characters are moved from the source string to the destination strings
-											according to the rules for the MOVE, with space filling if required.<br />
-											<br />
-										</li>
-										<li>
-											The delimiter is moved into HoldDelim$i according to the rules for the
-											MOVE.<br />
-											<br />
-										</li>
-										<li>
-											The DELIMITER IN and COUNT IN phrases may be specified only if the DELIMITED
-											BY phrase is used.
-										</li>
-									</ol>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>UNSTRING clauses</h3>
-								</td>
-								<td width="525">
-									<p>
-										<b>ON OVERFLOW</b><br />
-										The ON OVERFLOW is activated if :-
-									</p>
-									<ul>
-										<li>
-											The unstring pointer (Pointer#i) is not pointing to a character position
-											within the source string when the UNSTRING executes.
-										</li>
-										<li>
-											All the destination strings have been processed but there are still valid
-											unexamined characters in the source string.
-										</li>
-									</ul>
-									<p>
-										The statements following the NOT ON OVERFLOW are executed if the UNSTRING is
-										about to terminate successfully.
-									</p>
-									<p>
-										<b>COUNT IN</b><br />
-										The COUNT IN clause is associated with a particular destination string and holds
-										a count of the number of characters passed to the destination string.
-									</p>
-									<p>
-										<b>TALLYING IN</b><br />
-										Only one TALLYING clause can be used with each UNSTRING . It holds a count of
-										the number of destination strings affected by the UNSTRING operation.
-									</p>
-									<p>
-										<b>WITH POINTER</b><br />
-										When the WITH POINTER clause is used the Pointer#i holds the position of the
-										next non-delimiter character to be examined in the source string.
-									</p>
-									<p>
-										Pointer#i must be large enough to hold a value one greater than the size of the
-										source string.
-									</p>
-									<p>
-										<b>ALL<br /></b>
-										When the ALL phrase is used, contiguous delimiters are treated as if only one
-										delimiter had been encountered. <b></b>
-										<b><br /></b>
-									</p>
-									<p>
-										If the ALL is not used, contiguous delimiters will result in spaces being sent
-										to some of the destination strings
-									</p>
-									<p>
-										<b>DELIMITER IN</b><br />
-										A DELIMITER IN clause is associated with a particular destination string.
-										HoldDelim$i holds the delimiter that was encountered in the source string.
-									</p>
-									<p>
-										If the DELIMITER IN phrase is used with the ALL phrase then only one occurrence
-										of the delimiter will be moved to HoldDelim$i.
-									</p>
-									<p>
-										<b>DELIMITED BY<br /></b>
-										When the DELIMITED BY phrase is used, characters are examined in the source
-										string and transferred to the current destination string until one of the
-										specified delimiters is encountered or the end the source string is reached.
-									</p>
-									<p>
-										If there is not enough room in the destination string to take all the characters
-										that are sent to it from the source string then the remaining characters will be
-										truncated/lost.
-									</p>
-									<p>
-										When the delimiter is encountered in the source string, the next destination
-										string becomes current and characters are transferred into it, from the source
-										string.
-									</p>
-									<p>Delimiters are not transferred or counted in CharCounter#i.</p>
-								</td>
-							</tr>
-						</table>
-						<table border="0" width="710">
-							<tr>
-								<td>
-									<hr />
-									<p align="center">
-										<a href="#top"
-											><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-										/></a>
-									</p>
-								</td>
-							</tr>
-						</table>
-						<table border="0" cellpadding="4" cellspacing="0" width="710">
-							<tr>
-								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="examples">UNSTRING examples</h2>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Introduction</h3>
-								</td>
-								<td width="525">
-									<p>
-										This section starts with 6 short examples exploring various aspects the
-										UNSTRING.
-									</p>
-									<p>Example 7 is a longer and more practical example</p>
-									<p>Finally the section ends with an example program that uses the UNSTRING.</p>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>
-										Examples 1 - 6<br />
-										(animation)
-									</h3>
-								</td>
-								<td width="525">
-									<p>
-										When you view these examples start by carefully examining the UNSTRING
-										statement. See if you can figure out what it's going to do (you may need to
-										review the material above for this).
-									</p>
-									<p>
-										When you are happy with your prediction step through the example and see if you
-										were correct.
-									</p>
-									<p>
-										If your prediction is not correct try to discover what misunderstanding has led
-										to your error.
-									</p>
-									<center>
-										<iframe
-											height="416"
-											src="Resources/pdf-viewer.html?src=ppz/Unstring2.pdf"
-											style="border: 1px solid #ccc; width: 100%; aspect-ratio: 520/416"
-											width="520"
-										></iframe>
-										Left click or PageDown to go to the next frame and right click or press PageUp
-										to go to the previous frame.
-									</center>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>
-										Example 7<br />
-										(animation)
-									</h3>
-								</td>
-								<td width="525">
-									<p>
-										The WITH POINTER phrase is often very useful because it means that we don't have
-										to unpack the whole source string in one go..
-									</p>
-									<p>
-										In this example, we unpack a full name, any number of Christian names followed
-										by a surname, and display the names one after another.
-									</p>
-									<center>
-										<iframe
-											height="416"
-											src="Resources/pdf-viewer.html?src=ppz/Unstring1.pdf"
-											style="border: 1px solid #ccc; width: 100%; aspect-ratio: 520/416"
-											width="520"
-										></iframe>
-										Click on the diagram below to step through the animation. Left click or PageDown
-										to go to the next step and right click or press PageUp to go to the previous
-										step.
-									</center>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Example program</h3>
-								</td>
-								<td width="525">
-									<p>
-										Comma delimited or comma separated values (CSV) is a file format widely used in
-										the computing industry.
-									</p>
-									<p>
-										It allows data to be transferred between applications with incompatible file
-										formats (Excel, for example, can save its spreadsheets in this form).
-									</p>
-									<p>
-										But before the records in a CSV format file can be processed they must be
-										unpacked into individual fields.
-									</p>
-									<p>
-										In this example, a file of customer records is held in file with a CSV-like
-										format. Each record contains a customer name, a customer address and the
-										customer balance. The fields are separated from one another by commas. The
-										individual parts of the customer address are separated by the slash "/"
-										character.
-									</p>
-									<p>An example record is -</p>
-									<p>Michael Ryan,3 Winchester Drive/Castletroy/Limerick/Ireland,0022456</p>
-									<p>
-										The program below reads the file, unpacks each the record into separate fields
-										and writes the unpacked record to a new file.
-									</p>
-									<div align="center">
-										<table
-											background="Resources/pics/code.gif"
-											border="1"
-											bordercolor="#C0C0C0"
-											cellpadding="10"
-											cellspacing="0"
-											width="75%"
-										>
-											<tr>
-												<td>
-													<pre
-														class="language-cobol"
-													><code class="language-cobol">IDENTIFICATION DIVISION.
+						<hr />
+					</div>
+					<div class="section-sidebar">
+						<h3>UNSTRING syntax</h3>
+					</div>
+					<div class="section-content">
+						<p><img src="Resources/pics/I-UnString.gif" /></p>
+						<div align="center">
+							<table bgcolor="#DDFFDD" border="1" cellpadding="5" width="77%">
+								<tr>
+									<td width="21%">Delim$il</td>
+									<td width="79%">
+										Character or set of characters in the source string that terminate
+										data transfer to a particular destination String
+									</td>
+								</tr>
+								<tr>
+									<td width="21%">HoldDelim$i</td>
+									<td width="79%">
+										Holds the delimiter that caused data transfer to a particular
+										destination string to terminate.
+									</td>
+								</tr>
+								<tr>
+									<td width="21%">CharCounter#i</td>
+									<td width="79%">
+										Is associated with a particular destination string and holds a count
+										of the characters copied into it.
+									</td>
+								</tr>
+								<tr>
+									<td width="21%">Pointer#i</td>
+									<td width="79%">
+										Points to the position in the source string from which the next
+										character will be taken.
+									</td>
+								</tr>
+								<tr>
+									<td width="21%">DestCounter#i</td>
+									<td width="79%">
+										Holds the count of the number of destination strings affected by the
+										UNSTRING operation.
+									</td>
+								</tr>
+							</table>
+						</div>
+						<hr />
+					</div>
+					<div class="section-sidebar">
+						<h3>How the UNSTRING works</h3>
+					</div>
+					<div class="section-content">
+						<p>
+							The UNSTRING copies characters from the source string, to the destination
+							string, until a condition is encountered that terminates data movement.
+						</p>
+						<p>
+							When data movement ends for a particular destination string, the next
+							destination string becomes the receiving area and characters are copied into it
+							until once again a terminating condition is encountered.
+						</p>
+						<p>
+							Characters are copied from the source string to the destination strings
+							according to the rules for alphanumeric moves. There is space filling.
+						</p>
+						<hr />
+					</div>
+					<div class="section-sidebar">
+						<h3>Data movement termination</h3>
+					</div>
+					<div class="section-content">
+						<p>
+							When the DELIMITED BY clause is used data movement from the source string to the
+							current destination string ends when either ;
+						</p>
+						<ul>
+							<li>a delimiter is encountered in the source string</li>
+							<li>the end of the source string is reached.</li>
+						</ul>
+						<p>
+							When the DELIMITED BY clause is not used, data movement from the source string
+							to the current destination string ends when either;
+						</p>
+						<ul>
+							<li>the destination string is full</li>
+							<li>the end of the source string is reached</li>
+						</ul>
+						<hr />
+					</div>
+					<div class="section-sidebar">
+						<h3>UNSTRING termination</h3>
+					</div>
+					<div class="section-content">
+						<p>The UNSTRING statement terminates when either;</p>
+						<ul>
+							<li>All the characters in the source string have been examined</li>
+							<li>All the destination strings have been processed</li>
+							<li>
+								Some error condition is encountered (such as the pointer pointing outside
+								the source string).
+							</li>
+						</ul>
+						<hr />
+					</div>
+					<div class="section-sidebar">
+						<h3>UNSTRING rules</h3>
+					</div>
+					<div class="section-content">
+						<ol>
+							<li>
+								Where a literal can be used any figurative constant can be used except the
+								ALL (literal).<br />
+								<br />
+							</li>
+							<li>
+								When a figurative constant is used then its length is one character.<br />
+								<br />
+							</li>
+							<li>
+								Characters are moved from the source string to the destination strings
+								according to the rules for the MOVE, with space filling if required.<br />
+								<br />
+							</li>
+							<li>
+								The delimiter is moved into HoldDelim$i according to the rules for the
+								MOVE.<br />
+								<br />
+							</li>
+							<li>
+								The DELIMITER IN and COUNT IN phrases may be specified only if the DELIMITED
+								BY phrase is used.
+							</li>
+						</ol>
+						<hr />
+					</div>
+					<div class="section-sidebar">
+						<h3>UNSTRING clauses</h3>
+					</div>
+					<div class="section-content">
+						<p>
+							<b>ON OVERFLOW</b><br />
+							The ON OVERFLOW is activated if :-
+						</p>
+						<ul>
+							<li>
+								The unstring pointer (Pointer#i) is not pointing to a character position
+								within the source string when the UNSTRING executes.
+							</li>
+							<li>
+								All the destination strings have been processed but there are still valid
+								unexamined characters in the source string.
+							</li>
+						</ul>
+						<p>
+							The statements following the NOT ON OVERFLOW are executed if the UNSTRING is
+							about to terminate successfully.
+						</p>
+						<p>
+							<b>COUNT IN</b><br />
+							The COUNT IN clause is associated with a particular destination string and holds
+							a count of the number of characters passed to the destination string.
+						</p>
+						<p>
+							<b>TALLYING IN</b><br />
+							Only one TALLYING clause can be used with each UNSTRING . It holds a count of
+							the number of destination strings affected by the UNSTRING operation.
+						</p>
+						<p>
+							<b>WITH POINTER</b><br />
+							When the WITH POINTER clause is used the Pointer#i holds the position of the
+							next non-delimiter character to be examined in the source string.
+						</p>
+						<p>
+							Pointer#i must be large enough to hold a value one greater than the size of the
+							source string.
+						</p>
+						<p>
+							<b>ALL<br /></b>
+							When the ALL phrase is used, contiguous delimiters are treated as if only one
+							delimiter had been encountered. <b></b>
+							<b><br /></b>
+						</p>
+						<p>
+							If the ALL is not used, contiguous delimiters will result in spaces being sent
+							to some of the destination strings
+						</p>
+						<p>
+							<b>DELIMITER IN</b><br />
+							A DELIMITER IN clause is associated with a particular destination string.
+							HoldDelim$i holds the delimiter that was encountered in the source string.
+						</p>
+						<p>
+							If the DELIMITER IN phrase is used with the ALL phrase then only one occurrence
+							of the delimiter will be moved to HoldDelim$i.
+						</p>
+						<p>
+							<b>DELIMITED BY<br /></b>
+							When the DELIMITED BY phrase is used, characters are examined in the source
+							string and transferred to the current destination string until one of the
+							specified delimiters is encountered or the end the source string is reached.
+						</p>
+						<p>
+							If there is not enough room in the destination string to take all the characters
+							that are sent to it from the source string then the remaining characters will be
+							truncated/lost.
+						</p>
+						<p>
+							When the delimiter is encountered in the source string, the next destination
+							string becomes current and characters are transferred into it, from the source
+							string.
+						</p>
+						<p>Delimiters are not transferred or counted in CharCounter#i.</p>
+					</div>
+				</div>
+				<div>
+					<hr />
+					<p align="center">
+						<a href="#top"
+							><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
+						/></a>
+					</p>
+				</div>
+				<div class="section-grid">
+					<div class="section-header">
+						<h2 align="center" id="examples">UNSTRING examples</h2>
+					</div>
+					<div class="section-sidebar">
+						<h3>Introduction</h3>
+					</div>
+					<div class="section-content">
+						<p>
+							This section starts with 6 short examples exploring various aspects the
+							UNSTRING.
+						</p>
+						<p>Example 7 is a longer and more practical example</p>
+						<p>Finally the section ends with an example program that uses the UNSTRING.</p>
+						<hr />
+					</div>
+					<div class="section-sidebar">
+						<h3>
+							Examples 1 - 6<br />
+							(animation)
+						</h3>
+					</div>
+					<div class="section-content">
+						<p>
+							When you view these examples start by carefully examining the UNSTRING
+							statement. See if you can figure out what it's going to do (you may need to
+							review the material above for this).
+						</p>
+						<p>
+							When you are happy with your prediction step through the example and see if you
+							were correct.
+						</p>
+						<p>
+							If your prediction is not correct try to discover what misunderstanding has led
+							to your error.
+						</p>
+						<center>
+							<iframe
+								height="416"
+								src="Resources/pdf-viewer.html?src=ppz/Unstring2.pdf"
+								style="border: 1px solid #ccc; width: 100%; aspect-ratio: 520/416"
+								width="520"
+							></iframe>
+							Left click or PageDown to go to the next frame and right click or press PageUp
+							to go to the previous frame.
+						</center>
+						<hr />
+					</div>
+					<div class="section-sidebar">
+						<h3>
+							Example 7<br />
+							(animation)
+						</h3>
+					</div>
+					<div class="section-content">
+						<p>
+							The WITH POINTER phrase is often very useful because it means that we don't have
+							to unpack the whole source string in one go..
+						</p>
+						<p>
+							In this example, we unpack a full name, any number of Christian names followed
+							by a surname, and display the names one after another.
+						</p>
+						<center>
+							<iframe
+								height="416"
+								src="Resources/pdf-viewer.html?src=ppz/Unstring1.pdf"
+								style="border: 1px solid #ccc; width: 100%; aspect-ratio: 520/416"
+								width="520"
+							></iframe>
+							Click on the diagram below to step through the animation. Left click or PageDown
+							to go to the next step and right click or press PageUp to go to the previous
+							step.
+						</center>
+						<hr />
+					</div>
+					<div class="section-sidebar">
+						<h3>Example program</h3>
+					</div>
+					<div class="section-content">
+						<p>
+							Comma delimited or comma separated values (CSV) is a file format widely used in
+							the computing industry.
+						</p>
+						<p>
+							It allows data to be transferred between applications with incompatible file
+							formats (Excel, for example, can save its spreadsheets in this form).
+						</p>
+						<p>
+							But before the records in a CSV format file can be processed they must be
+							unpacked into individual fields.
+						</p>
+						<p>
+							In this example, a file of customer records is held in file with a CSV-like
+							format. Each record contains a customer name, a customer address and the
+							customer balance. The fields are separated from one another by commas. The
+							individual parts of the customer address are separated by the slash "/"
+							character.
+						</p>
+						<p>An example record is -</p>
+						<p>Michael Ryan,3 Winchester Drive/Castletroy/Limerick/Ireland,0022456</p>
+						<p>
+							The program below reads the file, unpacks each the record into separate fields
+							and writes the unpacked record to a new file.
+						</p>
+						<div align="center">
+							<div class="code-bg-box">
+								<pre
+									class="language-cobol"
+								><code class="language-cobol">IDENTIFICATION DIVISION.
 PROGRAM-ID. CDFILE.
 AUTHOR. Michael Coughlan.
 
@@ -759,51 +676,39 @@ Begin.
     END-PERFORM
     CLOSE CommaDelimitedFile, CustomerFile
     STOP RUN.</code></pre>
-												</td>
-											</tr>
-										</table>
-									</div>
-								</td>
-							</tr>
-						</table>
-						<table border="0" width="710">
-							<tr>
-								<td>
-									<hr />
-									<p align="center">
-										<a href="#top"
-											><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-										/></a>
-									</p>
-								</td>
-							</tr>
-						</table>
-						<table border="0" cellpadding="4" cellspacing="0" width="710">
-							<tr>
-								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="combined">Combined example</h2>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Introduction</h3>
-								</td>
-								<td width="525">
-									<p>
-										This example takes a string, containing a name consisting of any number of
-										Christian names followed by a surname, and converts it by reducing the Christian
-										names to their first letters followed by a period.
-									</p>
-									<p>For example "Michael John Tim James Ryan" becomes "M.J.T.J. Ryan".</p>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Data items used in the example</h3>
-								</td>
-								<td width="525">
-									<pre class="language-cobol"><code class="language-cobol">01 OldName  PIC X(80).
-  
+							</div>
+						</div>
+					</div>
+				</div>
+				<div>
+					<hr />
+					<p align="center">
+						<a href="#top"
+							><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
+						/></a>
+					</p>
+				</div>
+				<div class="section-grid">
+					<div class="section-header">
+						<h2 align="center" id="combined">Combined example</h2>
+					</div>
+					<div class="section-sidebar">
+						<h3>Introduction</h3>
+					</div>
+					<div class="section-content">
+						<p>
+							This example takes a string, containing a name consisting of any number of
+							Christian names followed by a surname, and converts it by reducing the Christian
+							names to their first letters followed by a period.
+						</p>
+						<p>For example "Michael John Tim James Ryan" becomes "M.J.T.J. Ryan".</p>
+					</div>
+					<div class="section-sidebar">
+						<h3>Data items used in the example</h3>
+					</div>
+					<div class="section-content">
+						<pre class="language-cobol"><code class="language-cobol">01 OldName  PIC X(80).
+
 01 TempName.
    02 NameInitial  PIC X.
    02 FILLER       PIC X(15).
@@ -814,44 +719,37 @@ Begin.
    02 StrPtr       PIC 99 VALUE 1.
    02 UnstrPtr     PIC 99 VALUE 1.
       88 NameProcessed VALUE 81.</code></pre>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Animation</h3>
-								</td>
-								<td width="525">
-									<center>
-										<iframe
-											height="416"
-											src="Resources/pdf-viewer.html?src=ppz/Unstring3.pdf"
-											style="border: 1px solid #ccc; width: 100%; aspect-ratio: 520/416"
-											width="520"
-										></iframe>
-									</center>
-									<div align="center">
-										Click on the diagram below to step through the animation. Left click or PageDown
-										to go to the next step and right click or press PageUp to go to the previous
-										step.
-									</div>
-								</td>
-							</tr>
-						</table>
-					</td>
-				</tr>
-				<tr>
-					<td>
 						<hr />
+					</div>
+					<div class="section-sidebar">
+						<h3>Animation</h3>
+					</div>
+					<div class="section-content">
+						<center>
+							<iframe
+								height="416"
+								src="Resources/pdf-viewer.html?src=ppz/Unstring3.pdf"
+								style="border: 1px solid #ccc; width: 100%; aspect-ratio: 520/416"
+								width="520"
+							></iframe>
+						</center>
 						<div align="center">
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
+							Click on the diagram below to step through the animation. Left click or PageDown
+							to go to the next step and right click or press PageUp to go to the previous
+							step.
 						</div>
-						<copyright-notice></copyright-notice>
-					</td>
-				</tr>
-			</tbody>
-		</table>
+					</div>
+				</div>
+			</div>
+			<div class="page-footer">
+				<hr />
+				<div align="center">
+					<a href="#top"
+						><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
+					/></a>
+				</div>
+				<copyright-notice></copyright-notice>
+			</div>
+		</div>
 	</body>
 </html>


### PR DESCRIPTION
## Summary

- Converted 10 layout tables in `course/Unstring.html` to semantic divs using CSS grid, following the same pattern established in the IndexedFiles.html refactor
- Preserved the 1 genuine data table (UNSTRING syntax terms, `bgcolor="#DDFFDD"`)
- Added mobile-responsive styles via `@media (max-width: 600px)`

## What changed

**CSS classes added** (matching project pattern from IndexedFiles.html):
- `.page-wrapper` — max-width container with border
- `.section-grid` — `display: grid; grid-template-columns: 175px 1fr`
- `.section-header` — full-width maroon header bar (`grid-column: 1 / -1`)
- `.section-sidebar` — yellow sidebar (`background-color: #ffffcc`) with `align-self: stretch` so the background fills the full row height
- `.section-content` — right column content area
- `.code-bg-box` — replaces background-image table with a div; width left as block default (100%) so long COBOL code lines don't overflow

**Regressions caught and fixed** (verified against production at bushidocodes.github.io):
1. Sidebar yellow background not stretching to full row height → fixed with `align-self: stretch`
2. Code background box too narrow (75% width) → fixed by removing the `width: 75%` rule; block div defaults to 100%

## Reviewer notes

- Net reduction of ~100 lines despite equivalent functionality
- The single remaining `<table>` is the UNSTRING syntax reference table; intentionally left as-is
- Mobile breakpoint matches the project's existing pattern (`max-width: 600px`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)