### PR TITLE
Refactor Usage.html layout tables to CSS grid/flexbox

### DIFF
--- a/course/Usage.html
+++ b/course/Usage.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
 	<head>
+		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>The USAGE clause</title>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
-		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<style type="text/css">
 			img {
 				max-width: 100%;
@@ -15,12 +15,6 @@
 
 			table {
 				max-width: 100%;
-			}
-
-			body > table,
-			body > hr {
-				margin-left: auto;
-				margin-right: auto;
 			}
 
 			pre {
@@ -32,29 +26,88 @@
 				-webkit-text-size-adjust: 100%;
 			}
 
+			ul.toc {
+				list-style-image: url(Resources/pics/BallGreenG.gif);
+				padding-left: 2.5em;
+				margin: 1em 0;
+			}
+
+			ul.toc > li {
+				padding-left: 0.4em;
+				margin-bottom: 0.6em;
+				font-size: smaller;
+			}
+
+			ul.toc a {
+				font-weight: bold;
+				font-size: larger;
+			}
+
+			.section-header h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			.section-sidebar h3,
+			.section-sidebar h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			.page-wrapper {
+				max-width: 715px;
+				margin: 0 auto;
+				border: 1px solid;
+				box-sizing: border-box;
+			}
+
+			.page-footer {
+				padding: 4px;
+			}
+
+			.section-grid {
+				display: grid;
+				grid-template-columns: 175px 1fr;
+				padding: 4px;
+			}
+
+			.section-header {
+				grid-column: 1 / -1;
+				background-color: #993300;
+				padding: 4px;
+			}
+
+			.section-sidebar {
+				background-color: #FFFFCC;
+				padding: 4px;
+			}
+
+			.section-content {
+				padding: 4px;
+				align-self: start;
+			}
+
+			.section-full {
+				grid-column: 1 / -1;
+				padding: 4px;
+			}
+
+			.code-fragment {
+				background-image: url(Resources/pics/code.gif);
+				border: 1px solid;
+				padding: 5px;
+				margin: 0 auto;
+				overflow-x: auto;
+				display: block;
+				width: fit-content;
+				max-width: 100%;
+			}
+
 			@media (max-width: 600px) {
 				body {
 					margin: 4px;
 					overflow-wrap: break-word;
 					word-wrap: break-word;
-				}
-
-				table[width] {
-					width: 100% !important;
-					height: auto !important;
-				}
-
-				td[width],
-				th[width],
-				td[height],
-				th[height] {
-					width: auto !important;
-					height: auto !important;
-				}
-
-				td[bgcolor="#993300"] > h2,
-				td[bgcolor="#993300"] > h3 {
-					margin: 0.3em 0;
 				}
 
 				blockquote {
@@ -95,2347 +148,2238 @@
 					overflow-x: auto;
 				}
 
-				table[width="715"],
-				table[width="725"],
-				table[width="715"] > tbody,
-				table[width="725"] > tbody,
-				table[width="715"] > tbody > tr,
-				table[width="725"] > tbody > tr,
-				table[width="715"] > tbody > tr > td,
-				table[width="725"] > tbody > tr > td,
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])),
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])) > tbody,
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])) > tbody > tr,
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])) > tbody > tr > td {
+				.section-grid {
 					display: block;
-					width: auto !important;
 				}
 
-				table[width="710"]:has(> tbody > tr > td[width="93%"]),
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody {
-					display: block;
-					width: 100% !important;
+				.section-header h2,
+				.section-header h3 {
+					margin: 0.3em 0;
 				}
 
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr {
-					display: flex;
-					align-items: baseline;
-					gap: 0.4em;
-					margin: 0.4em 0;
-				}
-
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr > td[width="3%"] {
-					display: none;
-				}
-
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr > td[width="4%"] {
-					display: block;
-					flex: 0 0 auto;
-					width: auto !important;
-					padding: 0;
-				}
-
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr > td[width="93%"] {
-					display: block;
-					flex: 1 1 auto;
-					width: auto !important;
-					padding: 0;
-				}
-
-				td[width="175"] > h4:not(:first-child):not(:has(img)),
-				td[width="160"] > h4:not(:first-child):not(:has(img)),
+				.section-sidebar h4:not(:first-child):not(:has(img)),
 				h4:has(> img[src*="PanelLine"]) {
 					display: none;
 				}
 
-				td[width="175"] > h3,
-				td[width="175"] > h4,
-				td[width="175"] > p,
-				td[width="160"] > h3,
-				td[width="160"] > h4,
-				td[width="160"] > p {
+				.section-sidebar h3,
+				.section-sidebar h4,
+				.section-sidebar p {
 					margin: 0.2em 0;
 				}
-			}
-
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
-
-			td[bgcolor="#993300"] h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			td[bgcolor="#FFFFCC"] h3,
-			td[bgcolor="#FFFFCC"] h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
 			}
 		</style>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
 	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
-		<table border="1" height="100%" width="715">
-			<tr>
-				<td>
-					<table border="0" cellpadding="4" cellspacing="0" width="710">
-						<tr>
-							<td align="left" bgcolor="#FFFFFF" colspan="2" valign="top">
-								<center>
-									<p><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
-								</center>
-								<center>
-									<h1>The USAGE clause</h1>
-									<hr />
-								</center>
-								<ul class="toc">
-									<li>
-										<a href="#intro">Introduction</a><br />
-										Unit aims, objectives, prerequisites.
-									</li>
-									<li>
-										<a href="#part1">The USAGE clause</a><br />
-										Subprograms, the syntax and semantics of the
-										<code class="language-cobol">CALL</code> verb and parameter passing mechanisms.
-										State memory, the <code class="language-cobol">IS INITIAL</code> clause and the
-										<code class="language-cobol">CANCEL</code> command.
-									</li>
-								</ul>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#993300" colspan="2" valign="top">
-								<h2 align="center" id="intro">Introduction</h2>
-							</td>
-						</tr>
-						<tr>
-							<td bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>Aims</h4>
-								<h4><img height="1" src="Resources/pics/PanelLine.gif" width="175" /></h4>
-							</td>
-							<td valign="top" width="525">
-								<div align="center">
-									<p align="left">
-										The internal representation of data can be an important consideration for
-										program efficiency. Unfortunately the default representation used by COBOL for
-										numeric data items can negatively impact the speed of computations. A more
-										efficient format for numeric data can be specified by using the USAGE clause.
-									</p>
-									<p align="left">
-										This unit introduces the concept of internal data representations, it discusses
-										the default representation used in COBOL and outlines how that representation,
-										used for numeric data, might cause inefficiencies.
-									</p>
-									<p align="left">
-										The syntax of the <code class="language-cobol">USAGE</code> clause is given and
-										the various options explained.
-									</p>
-									<p align="left">
-										The <code class="language-cobol">SYNCHRONIZED</code> clause is introduced and a
-										generalized example given.
-									</p>
-									<hr align="center" size="1" width="100%" />
-								</div>
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>Objectives</h4>
-							</td>
-							<td valign="top" width="525">
-								<p>By the end of this unit you should -</p>
-								<ol>
-									<li>
-										Know that text is stored in a computer using some encoding sequence.<br />
-										<br />
-									</li>
-									<li>
-										Understand the problems caused by storing numeric data as ASCII digits.<br />
-										<br />
-									</li>
-									<li>
-										Be able to use use the <code class="language-cobol">USAGE</code> clause to
-										change the way numeric data is stored in the computer.<br />
-										<br />
-									</li>
-									<li>
-										Know when and how to use the
-										<code class="language-cobol">SYNCHRONIZED</code> clause.
-									</li>
-								</ol>
-								<hr align="center" size="1" width="100%" />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>Prerequisites</h4>
-							</td>
-							<td valign="top" width="525">
-								<ul>
-									<li>Introduction to COBOL</li>
-									<li>Declaring data in COBOL</li>
-									<li>Basic Procedure Division commands</li>
-									<li>Selection in COBOL</li>
-									<li>Iteration in COBOL</li>
-									<li>Introduction to Sequential files</li>
-									<li>Processing Sequential files</li>
-									<li>Reading Sequential Files</li>
-									<li>Edited Pictures</li>
-								</ul>
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFFF" colspan="2" valign="top">
-								<div align="center">
-									<hr />
-									<p>
-										<a href="#top"
-											><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-										/></a>
-									</p>
-								</div>
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#993300" colspan="2" valign="top">
-								<h2 align="center" id="part1">The USAGE clause</h2>
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4><b>Introduction</b></h4>
-								<div align="center">
-									<img height="37" src="Resources/pics/i-Detail.gif" width="30" />
-								</div>
-								<div align="center">
-									<p>
-										<br />
-										<b>ASCII</b><br />
-										<b>A</b>merican <b>S</b>tandard <b>C</b>ode for <b>I</b>nformation
-										<b>I</b>nterchange
-									</p>
-									<p>
-										<b>EBCDIC<br /></b>
-										<b>E</b>xtended <b>B</b>inary <b>C</b>oded <b>D</b>ecimal <b>I</b>nterchange
-										<b>C</b>ode
-									</p>
-									<p>
-										<b>BCD</b><br />
-										<b>B</b>inary <b>C</b>oded <b>D</b>ecimal
-									</p>
-								</div>
-							</td>
-							<td valign="top" width="525">
-								<p>
-									Computers store their data in the form of binary digits. Apart from cardinal numbers
-									(positive integers) all other data stored in the computer's memory uses some sort of
-									formatting convention.
-								</p>
-								<p>
-									Text data, for example, is stored using an encoding sequence like ASCII or EBCDIC.
-									An encoding system is simply a convention which specifies that a particular set of
-									bits is to be used to represent a particular character. For instance, the diagram
-									below shows the bit configuration used to represent an upper case "A" in the ASCII
-									and the EBCDIC encoding sequences.
-								</p>
-								<p align="center"><img height="102" src="Resources/pics/Usage1.gif" width="396" /></p>
-								<p>
-									Numeric data can be held as text digits (ASCII digits) or as pure binary numbers (in
-									the case of cardinal values), or as twos complement binary numbers (in the case of
-									integers), or as decimal numbers (using BCD), or as real numbers (using a real
-									number format such as the IEEE specification for floating point numbers).
-								</p>
-								<p>
-									The <code class="language-cobol">USAGE</code> clause is used to specify how a data
-									item is to be stored in the computer's memory. Every variable declared in a COBOL
-									program has a <code class="language-cobol">USAGE</code> clause - even when no
-									explicit clause is specified. When there is no explicit
-									<code class="language-cobol">USAGE</code> clause, the default -
-									<code class="language-cobol">USAGE IS DISPLAY</code> - is applied.
-								</p>
-								<hr align="center" size="1" width="100%" />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4><b>Problems with USAGE IS DISPLAY</b></h4>
-								<p align="center">
-									<img height="44" src="Resources/pics/aa-ProgFrag.gif" width="48" />
-								</p>
-								<aside>
-									<p align="center">
-										<img height="44" src="Resources/pics/aai-LightBulbTip.gif" width="42" />
-									</p>
-									<p>
-										The speed of modern computers means that it is hardly worth the effort of using
-										the USAGE clause unless the data item is going to be used in thousands of
-										computations.
-									</p>
-									<p>
-										For reasons of portability the
-										<code class="language-cobol">USAGE</code> clause should never be used in record
-										descriptions.<br />
-										If the file is read on a different make of computer we have no guarantee that
-										the data will be interpreted correctly.
-									</p>
-									<p>
-										Even on the same make of computer, using the
-										<code class="language-cobol">USAGE</code> clause in record descriptions means
-										that the data in the file will probably not be understood by other programming
-										languages or by utility programs or by text editors.
-									</p>
-								</aside>
-							</td>
-							<td valign="top" width="525">
-								<p>
-									For text items, or for numeric items that are not going to be used in a computation
-									(Account Numbers, Phone Numbers etc.), the default of
-									<code class="language-cobol">USAGE IS DISPLAY</code> presents no problems; but for
-									numeric items upon which some calculation is to be performed the default usage is
-									not the most efficient way to store the data.
-								</p>
-								<p>
-									When numeric items (PIC 9 items) have a usage of
-									<code class="language-cobol">DISPLAY</code>, they are stored as ASCII digits (see
-									the ASCII digits 0-9 in the ASCII table below).
-								</p>
-								<p>
-									Consider the following program fragment. What would happen if computations were done
-									directly on numbers stored in this format?
-								</p>
-								<table
-									align="center"
-									background="Resources/pics/code.gif"
-									border="1"
-									cellpadding="5"
-									width="289"
-								>
-									<tr>
-										<td>
-											<pre
-												class="language-cobol"
-											><code class="language-cobol">   ? ? ? ? ? ? ? ? ? ? ? ? 
+		<div class="page-wrapper">
+			<div class="section-grid">
+				<div class="section-full">
+					<center>
+						<p><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
+					</center>
+					<center>
+						<h1>The USAGE clause</h1>
+						<hr />
+					</center>
+					<ul class="toc">
+						<li>
+							<a href="#intro">Introduction</a><br />
+							Unit aims, objectives, prerequisites.
+						</li>
+						<li>
+							<a href="#part1">The USAGE clause</a><br />
+							Subprograms, the syntax and semantics of the
+							<code class="language-cobol">CALL</code> verb and parameter passing mechanisms.
+							State memory, the <code class="language-cobol">IS INITIAL</code> clause and the
+							<code class="language-cobol">CANCEL</code> command.
+						</li>
+					</ul>
+					<hr />
+				</div>
+				<div class="section-header">
+					<h2 align="center" id="intro">Introduction</h2>
+				</div>
+				<div class="section-sidebar">
+					<h4>Aims</h4>
+					<h4><img height="1" src="Resources/pics/PanelLine.gif" width="175" /></h4>
+				</div>
+				<div class="section-content">
+					<div align="center">
+						<p align="left">
+							The internal representation of data can be an important consideration for
+							program efficiency. Unfortunately the default representation used by COBOL for
+							numeric data items can negatively impact the speed of computations. A more
+							efficient format for numeric data can be specified by using the USAGE clause.
+						</p>
+						<p align="left">
+							This unit introduces the concept of internal data representations, it discusses
+							the default representation used in COBOL and outlines how that representation,
+							used for numeric data, might cause inefficiencies.
+						</p>
+						<p align="left">
+							The syntax of the <code class="language-cobol">USAGE</code> clause is given and
+							the various options explained.
+						</p>
+						<p align="left">
+							The <code class="language-cobol">SYNCHRONIZED</code> clause is introduced and a
+							generalized example given.
+						</p>
+						<hr align="center" size="1" width="100%" />
+					</div>
+				</div>
+				<div class="section-sidebar">
+					<h4>Objectives</h4>
+				</div>
+				<div class="section-content">
+					<p>By the end of this unit you should -</p>
+					<ol>
+						<li>
+							Know that text is stored in a computer using some encoding sequence.<br />
+							<br />
+						</li>
+						<li>
+							Understand the problems caused by storing numeric data as ASCII digits.<br />
+							<br />
+						</li>
+						<li>
+							Be able to use use the <code class="language-cobol">USAGE</code> clause to
+							change the way numeric data is stored in the computer.<br />
+							<br />
+						</li>
+						<li>
+							Know when and how to use the
+							<code class="language-cobol">SYNCHRONIZED</code> clause.
+						</li>
+					</ol>
+					<hr align="center" size="1" width="100%" />
+				</div>
+				<div class="section-sidebar">
+					<h4>Prerequisites</h4>
+				</div>
+				<div class="section-content">
+					<ul>
+						<li>Introduction to COBOL</li>
+						<li>Declaring data in COBOL</li>
+						<li>Basic Procedure Division commands</li>
+						<li>Selection in COBOL</li>
+						<li>Iteration in COBOL</li>
+						<li>Introduction to Sequential files</li>
+						<li>Processing Sequential files</li>
+						<li>Reading Sequential Files</li>
+						<li>Edited Pictures</li>
+					</ul>
+				</div>
+				<div class="section-full">
+					<div align="center">
+						<hr />
+						<p>
+							<a href="#top"
+								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
+							/></a>
+						</p>
+					</div>
+				</div>
+				<div class="section-header">
+					<h2 align="center" id="part1">The USAGE clause</h2>
+				</div>
+				<div class="section-sidebar">
+					<h4><b>Introduction</b></h4>
+					<div align="center">
+						<img height="37" src="Resources/pics/i-Detail.gif" width="30" />
+					</div>
+					<div align="center">
+						<p>
+							<br />
+							<b>ASCII</b><br />
+							<b>A</b>merican <b>S</b>tandard <b>C</b>ode for <b>I</b>nformation
+							<b>I</b>nterchange
+						</p>
+						<p>
+							<b>EBCDIC<br /></b>
+							<b>E</b>xtended <b>B</b>inary <b>C</b>oded <b>D</b>ecimal <b>I</b>nterchange
+							<b>C</b>ode
+						</p>
+						<p>
+							<b>BCD</b><br />
+							<b>B</b>inary <b>C</b>oded <b>D</b>ecimal
+						</p>
+					</div>
+				</div>
+				<div class="section-content">
+					<p>
+						Computers store their data in the form of binary digits. Apart from cardinal numbers
+						(positive integers) all other data stored in the computer's memory uses some sort of
+						formatting convention.
+					</p>
+					<p>
+						Text data, for example, is stored using an encoding sequence like ASCII or EBCDIC.
+						An encoding system is simply a convention which specifies that a particular set of
+						bits is to be used to represent a particular character. For instance, the diagram
+						below shows the bit configuration used to represent an upper case "A" in the ASCII
+						and the EBCDIC encoding sequences.
+					</p>
+					<p align="center"><img height="102" src="Resources/pics/Usage1.gif" width="396" /></p>
+					<p>
+						Numeric data can be held as text digits (ASCII digits) or as pure binary numbers (in
+						the case of cardinal values), or as twos complement binary numbers (in the case of
+						integers), or as decimal numbers (using BCD), or as real numbers (using a real
+						number format such as the IEEE specification for floating point numbers).
+					</p>
+					<p>
+						The <code class="language-cobol">USAGE</code> clause is used to specify how a data
+						item is to be stored in the computer's memory. Every variable declared in a COBOL
+						program has a <code class="language-cobol">USAGE</code> clause - even when no
+						explicit clause is specified. When there is no explicit
+						<code class="language-cobol">USAGE</code> clause, the default -
+						<code class="language-cobol">USAGE IS DISPLAY</code> - is applied.
+					</p>
+					<hr align="center" size="1" width="100%" />
+				</div>
+				<div class="section-sidebar">
+					<h4><b>Problems with USAGE IS DISPLAY</b></h4>
+					<p align="center">
+						<img height="44" src="Resources/pics/aa-ProgFrag.gif" width="48" />
+					</p>
+					<aside>
+						<p align="center">
+							<img height="44" src="Resources/pics/aai-LightBulbTip.gif" width="42" />
+						</p>
+						<p>
+							The speed of modern computers means that it is hardly worth the effort of using
+							the USAGE clause unless the data item is going to be used in thousands of
+							computations.
+						</p>
+						<p>
+							For reasons of portability the
+							<code class="language-cobol">USAGE</code> clause should never be used in record
+							descriptions.<br />
+							If the file is read on a different make of computer we have no guarantee that
+							the data will be interpreted correctly.
+						</p>
+						<p>
+							Even on the same make of computer, using the
+							<code class="language-cobol">USAGE</code> clause in record descriptions means
+							that the data in the file will probably not be understood by other programming
+							languages or by utility programs or by text editors.
+						</p>
+					</aside>
+				</div>
+				<div class="section-content">
+					<p>
+						For text items, or for numeric items that are not going to be used in a computation
+						(Account Numbers, Phone Numbers etc.), the default of
+						<code class="language-cobol">USAGE IS DISPLAY</code> presents no problems; but for
+						numeric items upon which some calculation is to be performed the default usage is
+						not the most efficient way to store the data.
+					</p>
+					<p>
+						When numeric items (PIC 9 items) have a usage of
+						<code class="language-cobol">DISPLAY</code>, they are stored as ASCII digits (see
+						the ASCII digits 0-9 in the ASCII table below).
+					</p>
+					<p>
+						Consider the following program fragment. What would happen if computations were done
+						directly on numbers stored in this format?
+					</p>
+					<div class="code-fragment">
+						<pre
+							class="language-cobol"
+						><code class="language-cobol">   ? ? ? ? ? ? ? ? ? ? ? ?
 WORKING-STORAGE SECTION.
 01 Num1    PIC 9 VALUE 4.
 01 NUM2    PIC 9 VALUE 1.
 01 Num3    PIC 9 VALUE ZERO.
-   ? ? ? ? ? ? ? ? ? ? ? ? 
+   ? ? ? ? ? ? ? ? ? ? ? ?
 
 PROCEDURE DIVISION.
-Begin. 
-   ? ? ? ? ? ? ? ? ? ? ? ? 
+Begin.
+   ? ? ? ? ? ? ? ? ? ? ? ?
    ADD Num1, Num2 GIVING Num3
    ? ? ? ? ? ? ? ? ? ? ? ?</code></pre>
-										</td>
-									</tr>
-								</table>
-								<p>
-									Since none of the data items have an explicit
-									<code class="language-cobol">USAGE</code> clause they default to -
-									<code class="language-cobol">USAGE IS DISPLAY</code>. This means that the values in
-									the variables Num1, Num2 and Num3 are stored as ASCII digits. How does this effect
-									calculations?
-								</p>
-								<p>
-									If you examine the ASCII table below you will see that the digit 4 (the value in
-									Num1) is encoded as
-									<b>
-										<span style="color: #ff0000">00110100</span>
-									</b>
-									and the digit 1 is encoded as <span style="color: #ff0000"><b>00110001</b></span
-									>.
-								</p>
-								<p>
-									When these these binary numbers are added together the result is
-									<b>
-										<span style="color: #ff0000">01100101</span>
-									</b>
-									which is the ASCII code for the lower case letter "e".
-								</p>
-								<p>The sum <b>4 + 1 = e</b> does not compute.</p>
-								<p align="center"><img height="202" src="Resources/pics/Usage2.gif" width="439" /></p>
-								<p>
-									When calculations are done with numeric data items whose
-									<code class="language-cobol">USAGE IS DISPLAY</code>, the computer has to convert
-									the numeric values to their binary equivalents before the calculation can be done.
-									When the result has been computed the computer has to reconvert it to ASCII digits.
-									Conversion to and from ASCII digits slows down computations.
-								</p>
-								<p>
-									For this reason, data that is heavily involved in computation is often declared
-									using one of the usages optimized for computation such as
-									<code class="language-cobol">USAGE IS COMPUTATIONAL</code>.
-								</p>
-								<div align="center">
-									<p><b>ASCII Table</b></p>
-									<table align="center" border="1" cellpadding="0" cellspacing="0">
-										<tr bgcolor="#FFFFCC">
-											<th scope="col" width="114">Char</th>
-											<th scope="col" width="66">Dec</th>
-											<th scope="col" width="60">Hex</th>
-											<th scope="col" width="108">Binary</th>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^@ (NUL)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">0</p>
-											</td>
-											<td width="60">
-												<p align="center">00</p>
-											</td>
-											<td width="108">
-												<p align="center">00000000</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^A (SOX)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">1</p>
-											</td>
-											<td width="60">
-												<p align="center">01</p>
-											</td>
-											<td width="108">
-												<p align="center">00000001</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^B (STX)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">2</p>
-											</td>
-											<td width="60">
-												<p align="center">02</p>
-											</td>
-											<td width="108">
-												<p align="center">00000010</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^C (ETX)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">3</p>
-											</td>
-											<td width="60">
-												<p align="center">03</p>
-											</td>
-											<td width="108">
-												<p align="center">00000011</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^D (EOT)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">4</p>
-											</td>
-											<td width="60">
-												<p align="center">04</p>
-											</td>
-											<td width="108">
-												<p align="center">00000100</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^E (ENQ)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">5</p>
-											</td>
-											<td width="60">
-												<p align="center">05</p>
-											</td>
-											<td width="108">
-												<p align="center">00000101</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^F (ACK)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">6</p>
-											</td>
-											<td width="60">
-												<p align="center">06</p>
-											</td>
-											<td width="108">
-												<p align="center">00000110</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^G (BEL)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">7</p>
-											</td>
-											<td width="60">
-												<p align="center">07</p>
-											</td>
-											<td width="108">
-												<p align="center">00000111</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^H (BS)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">8</p>
-											</td>
-											<td width="60">
-												<p align="center">08</p>
-											</td>
-											<td width="108">
-												<p align="center">00001000</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^I (HT)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">9</p>
-											</td>
-											<td width="60">
-												<p align="center">09</p>
-											</td>
-											<td width="108">
-												<p align="center">00001001</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^J (NL)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">10</p>
-											</td>
-											<td width="60">
-												<p align="center">0A</p>
-											</td>
-											<td width="108">
-												<p align="center">00001010</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^K (VT)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">11</p>
-											</td>
-											<td width="60">
-												<p align="center">0B</p>
-											</td>
-											<td width="108">
-												<p align="center">00001011</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^L (NP)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">12</p>
-											</td>
-											<td width="60">
-												<p align="center">0C</p>
-											</td>
-											<td width="108">
-												<p align="center">00001100</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^M (CR)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">13</p>
-											</td>
-											<td width="60">
-												<p align="center">0D</p>
-											</td>
-											<td width="108">
-												<p align="center">00001101</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^N (SO)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">14</p>
-											</td>
-											<td width="60">
-												<p align="center">0E</p>
-											</td>
-											<td width="108">
-												<p align="center">00001110</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^O (SI)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">15</p>
-											</td>
-											<td width="60">
-												<p align="center">0F</p>
-											</td>
-											<td width="108">
-												<p align="center">00001111</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^P (DLE)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">16</p>
-											</td>
-											<td width="60">
-												<p align="center">10</p>
-											</td>
-											<td width="108">
-												<p align="center">00010000</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^Q (DS1)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">17</p>
-											</td>
-											<td width="60">
-												<p align="center">11</p>
-											</td>
-											<td width="108">
-												<p align="center">00010001</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^R (DS2)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">18</p>
-											</td>
-											<td width="60">
-												<p align="center">12</p>
-											</td>
-											<td width="108">
-												<p align="center">00010010</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^S (DS3)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">19</p>
-											</td>
-											<td width="60">
-												<p align="center">13</p>
-											</td>
-											<td width="108">
-												<p align="center">00010011</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^T (DC4)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">20</p>
-											</td>
-											<td width="60">
-												<p align="center">14</p>
-											</td>
-											<td width="108">
-												<p align="center">00010100</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^U (NAK)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">21</p>
-											</td>
-											<td width="60">
-												<p align="center">15</p>
-											</td>
-											<td width="108">
-												<p align="center">00010101</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^V (SYN)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">22</p>
-											</td>
-											<td width="60">
-												<p align="center">16</p>
-											</td>
-											<td width="108">
-												<p align="center">00010110</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^W (ETB)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">23</p>
-											</td>
-											<td width="60">
-												<p align="center">17</p>
-											</td>
-											<td width="108">
-												<p align="center">00010111</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^X (CAN)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">24</p>
-											</td>
-											<td width="60">
-												<p align="center">18</p>
-											</td>
-											<td width="108">
-												<p align="center">00011000</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^Y (EM)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">25</p>
-											</td>
-											<td width="60">
-												<p align="center">19</p>
-											</td>
-											<td width="108">
-												<p align="center">00011001</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^Z (SUB)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">26</p>
-											</td>
-											<td width="60">
-												<p align="center">1A</p>
-											</td>
-											<td width="108">
-												<p align="center">00011010</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^[ (ESC)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">27</p>
-											</td>
-											<td width="60">
-												<p align="center">1B</p>
-											</td>
-											<td width="108">
-												<p align="center">00011011</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^\ (FS)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">28</p>
-											</td>
-											<td width="60">
-												<p align="center">1C</p>
-											</td>
-											<td width="108">
-												<p align="center">00011100</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^] (GS)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">29</p>
-											</td>
-											<td width="60">
-												<p align="center">1D</p>
-											</td>
-											<td width="108">
-												<p align="center">00011101</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^^ (RS)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">30</p>
-											</td>
-											<td width="60">
-												<p align="center">1E</p>
-											</td>
-											<td width="108">
-												<p align="center">00011110</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^_ (US)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">31</p>
-											</td>
-											<td width="60">
-												<p align="center">1F</p>
-											</td>
-											<td width="108">
-												<p align="center">00011111</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>(SP)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">32</p>
-											</td>
-											<td width="60">
-												<p align="center">20</p>
-											</td>
-											<td width="108">
-												<p align="center">00100000</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>!</b></p>
-											</td>
-											<td width="66">
-												<p align="center">33</p>
-											</td>
-											<td width="60">
-												<p align="center">21</p>
-											</td>
-											<td width="108">
-												<p align="center">00100001</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>"</b></p>
-											</td>
-											<td width="66">
-												<p align="center">34</p>
-											</td>
-											<td width="60">
-												<p align="center">22</p>
-											</td>
-											<td width="108">
-												<p align="center">00100010</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>#</b></p>
-											</td>
-											<td width="66">
-												<p align="center">35</p>
-											</td>
-											<td width="60">
-												<p align="center">23</p>
-											</td>
-											<td width="108">
-												<p align="center">00100011</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>$</b></p>
-											</td>
-											<td width="66">
-												<p align="center">36</p>
-											</td>
-											<td width="60">
-												<p align="center">24</p>
-											</td>
-											<td width="108">
-												<p align="center">00100100</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>%</b></p>
-											</td>
-											<td width="66">
-												<p align="center">37</p>
-											</td>
-											<td width="60">
-												<p align="center">25</p>
-											</td>
-											<td width="108">
-												<p align="center">00100101</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>&</b></p>
-											</td>
-											<td width="66">
-												<p align="center">38</p>
-											</td>
-											<td width="60">
-												<p align="center">26</p>
-											</td>
-											<td width="108">
-												<p align="center">00100110</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>'</b></p>
-											</td>
-											<td width="66">
-												<p align="center">39</p>
-											</td>
-											<td width="60">
-												<p align="center">27</p>
-											</td>
-											<td width="108">
-												<p align="center">00100111</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>(</b></p>
-											</td>
-											<td width="66">
-												<p align="center">40</p>
-											</td>
-											<td width="60">
-												<p align="center">28</p>
-											</td>
-											<td width="108">
-												<p align="center">00101000</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">41</p>
-											</td>
-											<td width="60">
-												<p align="center">29</p>
-											</td>
-											<td width="108">
-												<p align="center">00101001</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>*</b></p>
-											</td>
-											<td width="66">
-												<p align="center">42</p>
-											</td>
-											<td width="60">
-												<p align="center">2A</p>
-											</td>
-											<td width="108">
-												<p align="center">00101010</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>+</b></p>
-											</td>
-											<td width="66">
-												<p align="center">43</p>
-											</td>
-											<td width="60">
-												<p align="center">2B</p>
-											</td>
-											<td width="108">
-												<p align="center">00101011</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>,</b></p>
-											</td>
-											<td width="66">
-												<p align="center">44</p>
-											</td>
-											<td width="60">
-												<p align="center">2C</p>
-											</td>
-											<td width="108">
-												<p align="center">00101100</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>-</b></p>
-											</td>
-											<td width="66">
-												<p align="center">45</p>
-											</td>
-											<td width="60">
-												<p align="center">2D</p>
-											</td>
-											<td width="108">
-												<p align="center">00101101</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>.</b></p>
-											</td>
-											<td width="66">
-												<p align="center">46</p>
-											</td>
-											<td width="60">
-												<p align="center">2E</p>
-											</td>
-											<td width="108">
-												<p align="center">00101110</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>/</b></p>
-											</td>
-											<td width="66">
-												<p align="center">47</p>
-											</td>
-											<td width="60">
-												<p align="center">2F</p>
-											</td>
-											<td width="108">
-												<p align="center">00101111</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>0</b></p>
-											</td>
-											<td width="66">
-												<p align="center">48</p>
-											</td>
-											<td width="60">
-												<p align="center">30</p>
-											</td>
-											<td width="108">
-												<p align="center">00110000</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center">
-													<b>
-														<span style="color: #ff0000">1</span>
-													</b>
-												</p>
-											</td>
-											<td width="66">
-												<p align="center">
-													<b>
-														<span style="color: #ff0000">49</span>
-													</b>
-												</p>
-											</td>
-											<td width="60">
-												<p align="center">
-													<b>
-														<span style="color: #ff0000">31</span>
-													</b>
-												</p>
-											</td>
-											<td width="108">
-												<p align="center">
-													<b>
-														<span style="color: #ff0000">00110001</span>
-													</b>
-												</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>2</b></p>
-											</td>
-											<td width="66">
-												<p align="center">50</p>
-											</td>
-											<td width="60">
-												<p align="center">32</p>
-											</td>
-											<td width="108">
-												<p align="center">00110010</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>3</b></p>
-											</td>
-											<td width="66">
-												<p align="center">51</p>
-											</td>
-											<td width="60">
-												<p align="center">33</p>
-											</td>
-											<td width="108">
-												<p align="center">00110011</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center">
-													<b>
-														<span style="color: #ff0000">4</span>
-													</b>
-												</p>
-											</td>
-											<td width="66">
-												<p align="center">
-													<b>
-														<span style="color: #ff0000">52</span>
-													</b>
-												</p>
-											</td>
-											<td width="60">
-												<p align="center">
-													<b>
-														<span style="color: #ff0000">34</span>
-													</b>
-												</p>
-											</td>
-											<td width="108">
-												<p align="center">
-													<b>
-														<span style="color: #ff0000">00110100</span>
-													</b>
-												</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>5</b></p>
-											</td>
-											<td width="66">
-												<p align="center">53</p>
-											</td>
-											<td width="60">
-												<p align="center">35</p>
-											</td>
-											<td width="108">
-												<p align="center">00110101</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>6</b></p>
-											</td>
-											<td width="66">
-												<p align="center">54</p>
-											</td>
-											<td width="60">
-												<p align="center">36</p>
-											</td>
-											<td width="108">
-												<p align="center">00110110</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>7</b></p>
-											</td>
-											<td width="66">
-												<p align="center">55</p>
-											</td>
-											<td width="60">
-												<p align="center">37</p>
-											</td>
-											<td width="108">
-												<p align="center">00110111</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>8</b></p>
-											</td>
-											<td width="66">
-												<p align="center">56</p>
-											</td>
-											<td width="60">
-												<p align="center">38</p>
-											</td>
-											<td width="108">
-												<p align="center">00111000</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>9</b></p>
-											</td>
-											<td width="66">
-												<p align="center">57</p>
-											</td>
-											<td width="60">
-												<p align="center">39</p>
-											</td>
-											<td width="108">
-												<p align="center">00111001</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>:</b></p>
-											</td>
-											<td width="66">
-												<p align="center">58</p>
-											</td>
-											<td width="60">
-												<p align="center">3A</p>
-											</td>
-											<td width="108">
-												<p align="center">00111010</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>;</b></p>
-											</td>
-											<td width="66">
-												<p align="center">59</p>
-											</td>
-											<td width="60">
-												<p align="center">3B</p>
-											</td>
-											<td width="108">
-												<p align="center">00111011</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>&lt;</b></p>
-											</td>
-											<td width="66">
-												<p align="center">60</p>
-											</td>
-											<td width="60">
-												<p align="center">3C</p>
-											</td>
-											<td width="108">
-												<p align="center">00111100</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>=</b></p>
-											</td>
-											<td width="66">
-												<p align="center">61</p>
-											</td>
-											<td width="60">
-												<p align="center">3D</p>
-											</td>
-											<td width="108">
-												<p align="center">00111101</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>&gt;</b></p>
-											</td>
-											<td width="66">
-												<p align="center">62</p>
-											</td>
-											<td width="60">
-												<p align="center">3E</p>
-											</td>
-											<td width="108">
-												<p align="center">00111110</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>?</b></p>
-											</td>
-											<td width="66">
-												<p align="center">63</p>
-											</td>
-											<td width="60">
-												<p align="center">3F</p>
-											</td>
-											<td width="108">
-												<p align="center">00111111</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>@</b></p>
-											</td>
-											<td width="66">
-												<p align="center">64</p>
-											</td>
-											<td width="60">
-												<p align="center">40</p>
-											</td>
-											<td width="108">
-												<p align="center">01000000</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>A</b></p>
-											</td>
-											<td width="66">
-												<p align="center">65</p>
-											</td>
-											<td width="60">
-												<p align="center">41</p>
-											</td>
-											<td width="108">
-												<p align="center">01000001</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>B</b></p>
-											</td>
-											<td width="66">
-												<p align="center">66</p>
-											</td>
-											<td width="60">
-												<p align="center">42</p>
-											</td>
-											<td width="108">
-												<p align="center">01000010</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>C</b></p>
-											</td>
-											<td width="66">
-												<p align="center">67</p>
-											</td>
-											<td width="60">
-												<p align="center">43</p>
-											</td>
-											<td width="108">
-												<p align="center">01000011</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>D</b></p>
-											</td>
-											<td width="66">
-												<p align="center">68</p>
-											</td>
-											<td width="60">
-												<p align="center">44</p>
-											</td>
-											<td width="108">
-												<p align="center">01000100</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>E</b></p>
-											</td>
-											<td width="66">
-												<p align="center">69</p>
-											</td>
-											<td width="60">
-												<p align="center">45</p>
-											</td>
-											<td width="108">
-												<p align="center">01000101</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>F</b></p>
-											</td>
-											<td width="66">
-												<p align="center">70</p>
-											</td>
-											<td width="60">
-												<p align="center">46</p>
-											</td>
-											<td width="108">
-												<p align="center">01000110</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>G</b></p>
-											</td>
-											<td width="66">
-												<p align="center">71</p>
-											</td>
-											<td width="60">
-												<p align="center">47</p>
-											</td>
-											<td width="108">
-												<p align="center">01000111</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>H</b></p>
-											</td>
-											<td width="66">
-												<p align="center">72</p>
-											</td>
-											<td width="60">
-												<p align="center">48</p>
-											</td>
-											<td width="108">
-												<p align="center">01001000</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>I</b></p>
-											</td>
-											<td width="66">
-												<p align="center">73</p>
-											</td>
-											<td width="60">
-												<p align="center">49</p>
-											</td>
-											<td width="108">
-												<p align="center">01001001</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>J</b></p>
-											</td>
-											<td width="66">
-												<p align="center">74</p>
-											</td>
-											<td width="60">
-												<p align="center">4A</p>
-											</td>
-											<td width="108">
-												<p align="center">01001010</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>K</b></p>
-											</td>
-											<td width="66">
-												<p align="center">75</p>
-											</td>
-											<td width="60">
-												<p align="center">4B</p>
-											</td>
-											<td width="108">
-												<p align="center">01001011</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>L</b></p>
-											</td>
-											<td width="66">
-												<p align="center">76</p>
-											</td>
-											<td width="60">
-												<p align="center">4C</p>
-											</td>
-											<td width="108">
-												<p align="center">01001100</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>M</b></p>
-											</td>
-											<td width="66">
-												<p align="center">77</p>
-											</td>
-											<td width="60">
-												<p align="center">4D</p>
-											</td>
-											<td width="108">
-												<p align="center">01001101</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>N</b></p>
-											</td>
-											<td width="66">
-												<p align="center">78</p>
-											</td>
-											<td width="60">
-												<p align="center">4E</p>
-											</td>
-											<td width="108">
-												<p align="center">01001110</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>O</b></p>
-											</td>
-											<td width="66">
-												<p align="center">79</p>
-											</td>
-											<td width="60">
-												<p align="center">4F</p>
-											</td>
-											<td width="108">
-												<p align="center">01001111</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>P</b></p>
-											</td>
-											<td width="66">
-												<p align="center">80</p>
-											</td>
-											<td width="60">
-												<p align="center">50</p>
-											</td>
-											<td width="108">
-												<p align="center">01010000</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>Q</b></p>
-											</td>
-											<td width="66">
-												<p align="center">81</p>
-											</td>
-											<td width="60">
-												<p align="center">51</p>
-											</td>
-											<td width="108">
-												<p align="center">01010001</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>R</b></p>
-											</td>
-											<td width="66">
-												<p align="center">82</p>
-											</td>
-											<td width="60">
-												<p align="center">52</p>
-											</td>
-											<td width="108">
-												<p align="center">01010010</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>S</b></p>
-											</td>
-											<td width="66">
-												<p align="center">83</p>
-											</td>
-											<td width="60">
-												<p align="center">53</p>
-											</td>
-											<td width="108">
-												<p align="center">01010011</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>T</b></p>
-											</td>
-											<td width="66">
-												<p align="center">84</p>
-											</td>
-											<td width="60">
-												<p align="center">54</p>
-											</td>
-											<td width="108">
-												<p align="center">01010100</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>U</b></p>
-											</td>
-											<td width="66">
-												<p align="center">85</p>
-											</td>
-											<td width="60">
-												<p align="center">55</p>
-											</td>
-											<td width="108">
-												<p align="center">01010101</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>V</b></p>
-											</td>
-											<td width="66">
-												<p align="center">86</p>
-											</td>
-											<td width="60">
-												<p align="center">56</p>
-											</td>
-											<td width="108">
-												<p align="center">01010110</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>W</b></p>
-											</td>
-											<td width="66">
-												<p align="center">87</p>
-											</td>
-											<td width="60">
-												<p align="center">57</p>
-											</td>
-											<td width="108">
-												<p align="center">01010111</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>X</b></p>
-											</td>
-											<td width="66">
-												<p align="center">88</p>
-											</td>
-											<td width="60">
-												<p align="center">58</p>
-											</td>
-											<td width="108">
-												<p align="center">01011000</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>Y</b></p>
-											</td>
-											<td width="66">
-												<p align="center">89</p>
-											</td>
-											<td width="60">
-												<p align="center">59</p>
-											</td>
-											<td width="108">
-												<p align="center">01011001</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>Z</b></p>
-											</td>
-											<td width="66">
-												<p align="center">90</p>
-											</td>
-											<td width="60">
-												<p align="center">5A</p>
-											</td>
-											<td width="108">
-												<p align="center">01011010</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>[</b></p>
-											</td>
-											<td width="66">
-												<p align="center">91</p>
-											</td>
-											<td width="60">
-												<p align="center">5B</p>
-											</td>
-											<td width="108">
-												<p align="center">01011011</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>\</b></p>
-											</td>
-											<td width="66">
-												<p align="center">92</p>
-											</td>
-											<td width="60">
-												<p align="center">5C</p>
-											</td>
-											<td width="108">
-												<p align="center">01011100</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>]</b></p>
-											</td>
-											<td width="66">
-												<p align="center">93</p>
-											</td>
-											<td width="60">
-												<p align="center">5D</p>
-											</td>
-											<td width="108">
-												<p align="center">01011101</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^</b></p>
-											</td>
-											<td width="66">
-												<p align="center">94</p>
-											</td>
-											<td width="60">
-												<p align="center">5E</p>
-											</td>
-											<td width="108">
-												<p align="center">01011110</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>_</b></p>
-											</td>
-											<td width="66">
-												<p align="center">95</p>
-											</td>
-											<td width="60">
-												<p align="center">5F</p>
-											</td>
-											<td width="108">
-												<p align="center">01011111</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>`</b></p>
-											</td>
-											<td width="66">
-												<p align="center">96</p>
-											</td>
-											<td width="60">
-												<p align="center">60</p>
-											</td>
-											<td width="108">
-												<p align="center">01100000</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>a</b></p>
-											</td>
-											<td width="66">
-												<p align="center">97</p>
-											</td>
-											<td width="60">
-												<p align="center">61</p>
-											</td>
-											<td width="108">
-												<p align="center">01100001</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>b</b></p>
-											</td>
-											<td width="66">
-												<p align="center">98</p>
-											</td>
-											<td width="60">
-												<p align="center">62</p>
-											</td>
-											<td width="108">
-												<p align="center">01100010</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>c</b></p>
-											</td>
-											<td width="66">
-												<p align="center">99</p>
-											</td>
-											<td width="60">
-												<p align="center">63</p>
-											</td>
-											<td width="108">
-												<p align="center">01100011</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>d</b></p>
-											</td>
-											<td width="66">
-												<p align="center">100</p>
-											</td>
-											<td width="60">
-												<p align="center">64</p>
-											</td>
-											<td width="108">
-												<p align="center">01100100</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center">
-													<b>
-														<span style="color: #ff0000">e</span>
-													</b>
-												</p>
-											</td>
-											<td width="66">
-												<p align="center">
-													<b>
-														<span style="color: #ff0000">101</span>
-													</b>
-												</p>
-											</td>
-											<td width="60">
-												<p align="center">
-													<b>
-														<span style="color: #ff0000">65</span>
-													</b>
-												</p>
-											</td>
-											<td width="108">
-												<p align="center">
-													<b>
-														<span style="color: #ff0000">01100101</span>
-													</b>
-												</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>f</b></p>
-											</td>
-											<td width="66">
-												<p align="center">102</p>
-											</td>
-											<td width="60">
-												<p align="center">66</p>
-											</td>
-											<td width="108">
-												<p align="center">01100110</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>g</b></p>
-											</td>
-											<td width="66">
-												<p align="center">103</p>
-											</td>
-											<td width="60">
-												<p align="center">67</p>
-											</td>
-											<td width="108">
-												<p align="center">01100111</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>h</b></p>
-											</td>
-											<td width="66">
-												<p align="center">104</p>
-											</td>
-											<td width="60">
-												<p align="center">68</p>
-											</td>
-											<td width="108">
-												<p align="center">01101000</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>i</b></p>
-											</td>
-											<td width="66">
-												<p align="center">105</p>
-											</td>
-											<td width="60">
-												<p align="center">69</p>
-											</td>
-											<td width="108">
-												<p align="center">01101001</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>j</b></p>
-											</td>
-											<td width="66">
-												<p align="center">106</p>
-											</td>
-											<td width="60">
-												<p align="center">6A</p>
-											</td>
-											<td width="108">
-												<p align="center">01101010</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>k</b></p>
-											</td>
-											<td width="66">
-												<p align="center">107</p>
-											</td>
-											<td width="60">
-												<p align="center">6B</p>
-											</td>
-											<td width="108">
-												<p align="center">01101011</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>l</b></p>
-											</td>
-											<td width="66">
-												<p align="center">108</p>
-											</td>
-											<td width="60">
-												<p align="center">6C</p>
-											</td>
-											<td width="108">
-												<p align="center">01101100</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>m</b></p>
-											</td>
-											<td width="66">
-												<p align="center">109</p>
-											</td>
-											<td width="60">
-												<p align="center">6D</p>
-											</td>
-											<td width="108">
-												<p align="center">01101101</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>n</b></p>
-											</td>
-											<td width="66">
-												<p align="center">110</p>
-											</td>
-											<td width="60">
-												<p align="center">6E</p>
-											</td>
-											<td width="108">
-												<p align="center">01101110</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>o</b></p>
-											</td>
-											<td width="66">
-												<p align="center">111</p>
-											</td>
-											<td width="60">
-												<p align="center">6F</p>
-											</td>
-											<td width="108">
-												<p align="center">01101111</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>p</b></p>
-											</td>
-											<td width="66">
-												<p align="center">112</p>
-											</td>
-											<td width="60">
-												<p align="center">70</p>
-											</td>
-											<td width="108">
-												<p align="center">01110000</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>q</b></p>
-											</td>
-											<td width="66">
-												<p align="center">113</p>
-											</td>
-											<td width="60">
-												<p align="center">71</p>
-											</td>
-											<td width="108">
-												<p align="center">01110001</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>r</b></p>
-											</td>
-											<td width="66">
-												<p align="center">114</p>
-											</td>
-											<td width="60">
-												<p align="center">72</p>
-											</td>
-											<td width="108">
-												<p align="center">01110010</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>s</b></p>
-											</td>
-											<td width="66">
-												<p align="center">115</p>
-											</td>
-											<td width="60">
-												<p align="center">73</p>
-											</td>
-											<td width="108">
-												<p align="center">01110011</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>t</b></p>
-											</td>
-											<td width="66">
-												<p align="center">116</p>
-											</td>
-											<td width="60">
-												<p align="center">74</p>
-											</td>
-											<td width="108">
-												<p align="center">01110100</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>u</b></p>
-											</td>
-											<td width="66">
-												<p align="center">117</p>
-											</td>
-											<td width="60">
-												<p align="center">75</p>
-											</td>
-											<td width="108">
-												<p align="center">01110101</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>v</b></p>
-											</td>
-											<td width="66">
-												<p align="center">118</p>
-											</td>
-											<td width="60">
-												<p align="center">76</p>
-											</td>
-											<td width="108">
-												<p align="center">01110110</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>w</b></p>
-											</td>
-											<td width="66">
-												<p align="center">119</p>
-											</td>
-											<td width="60">
-												<p align="center">77</p>
-											</td>
-											<td width="108">
-												<p align="center">01110111</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>x</b></p>
-											</td>
-											<td width="66">
-												<p align="center">120</p>
-											</td>
-											<td width="60">
-												<p align="center">78</p>
-											</td>
-											<td width="108">
-												<p align="center">01111000</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>y</b></p>
-											</td>
-											<td width="66">
-												<p align="center">121</p>
-											</td>
-											<td width="60">
-												<p align="center">79</p>
-											</td>
-											<td width="108">
-												<p align="center">01111001</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>z</b></p>
-											</td>
-											<td width="66">
-												<p align="center">122</p>
-											</td>
-											<td width="60">
-												<p align="center">7A</p>
-											</td>
-											<td width="108">
-												<p align="center">01111010</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>{</b></p>
-											</td>
-											<td width="66">
-												<p align="center">123</p>
-											</td>
-											<td width="60">
-												<p align="center">7B</p>
-											</td>
-											<td width="108">
-												<p align="center">01111011</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>|</b></p>
-											</td>
-											<td width="66">
-												<p align="center">124</p>
-											</td>
-											<td width="60">
-												<p align="center">7C</p>
-											</td>
-											<td width="108">
-												<p align="center">01111100</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>}</b></p>
-											</td>
-											<td width="66">
-												<p align="center">125</p>
-											</td>
-											<td width="60">
-												<p align="center">7D</p>
-											</td>
-											<td width="108">
-												<p align="center">01111101</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>~</b></p>
-											</td>
-											<td width="66">
-												<p align="center">126</p>
-											</td>
-											<td width="60">
-												<p align="center">7E</p>
-											</td>
-											<td width="108">
-												<p align="center">01111110</p>
-											</td>
-										</tr>
-										<tr>
-											<td width="114">
-												<p align="center"><b>^? (DEL)</b></p>
-											</td>
-											<td width="66">
-												<p align="center">127</p>
-											</td>
-											<td width="60">
-												<p align="center">7F</p>
-											</td>
-											<td width="108">
-												<p align="center">01111111</p>
-											</td>
-										</tr>
-									</table>
-								</div>
-								<hr align="center" size="1" width="100%" />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<p>
-									<b>USAGE syntax and notes</b>
-								</p>
-								<p align="center">
-									<img height="44" src="Resources/pics/aa-ProgFrag.gif" width="48" />
-								</p>
-								<aside>
+					</div>
+					<p>
+						Since none of the data items have an explicit
+						<code class="language-cobol">USAGE</code> clause they default to -
+						<code class="language-cobol">USAGE IS DISPLAY</code>. This means that the values in
+						the variables Num1, Num2 and Num3 are stored as ASCII digits. How does this effect
+						calculations?
+					</p>
+					<p>
+						If you examine the ASCII table below you will see that the digit 4 (the value in
+						Num1) is encoded as
+						<b>
+							<span style="color: #ff0000">00110100</span>
+						</b>
+						and the digit 1 is encoded as <span style="color: #ff0000"><b>00110001</b></span
+						>.
+					</p>
+					<p>
+						When these these binary numbers are added together the result is
+						<b>
+							<span style="color: #ff0000">01100101</span>
+						</b>
+						which is the ASCII code for the lower case letter "e".
+					</p>
+					<p>The sum <b>4 + 1 = e</b> does not compute.</p>
+					<p align="center"><img height="202" src="Resources/pics/Usage2.gif" width="439" /></p>
+					<p>
+						When calculations are done with numeric data items whose
+						<code class="language-cobol">USAGE IS DISPLAY</code>, the computer has to convert
+						the numeric values to their binary equivalents before the calculation can be done.
+						When the result has been computed the computer has to reconvert it to ASCII digits.
+						Conversion to and from ASCII digits slows down computations.
+					</p>
+					<p>
+						For this reason, data that is heavily involved in computation is often declared
+						using one of the usages optimized for computation such as
+						<code class="language-cobol">USAGE IS COMPUTATIONAL</code>.
+					</p>
+					<div align="center">
+						<p><b>ASCII Table</b></p>
+						<table align="center" border="1" cellpadding="0" cellspacing="0">
+							<tr bgcolor="#FFFFCC">
+								<th scope="col" width="114">Char</th>
+								<th scope="col" width="66">Dec</th>
+								<th scope="col" width="60">Hex</th>
+								<th scope="col" width="108">Binary</th>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^@ (NUL)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">0</p>
+								</td>
+								<td width="60">
+									<p align="center">00</p>
+								</td>
+								<td width="108">
+									<p align="center">00000000</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^A (SOX)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">1</p>
+								</td>
+								<td width="60">
+									<p align="center">01</p>
+								</td>
+								<td width="108">
+									<p align="center">00000001</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^B (STX)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">2</p>
+								</td>
+								<td width="60">
+									<p align="center">02</p>
+								</td>
+								<td width="108">
+									<p align="center">00000010</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^C (ETX)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">3</p>
+								</td>
+								<td width="60">
+									<p align="center">03</p>
+								</td>
+								<td width="108">
+									<p align="center">00000011</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^D (EOT)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">4</p>
+								</td>
+								<td width="60">
+									<p align="center">04</p>
+								</td>
+								<td width="108">
+									<p align="center">00000100</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^E (ENQ)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">5</p>
+								</td>
+								<td width="60">
+									<p align="center">05</p>
+								</td>
+								<td width="108">
+									<p align="center">00000101</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^F (ACK)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">6</p>
+								</td>
+								<td width="60">
+									<p align="center">06</p>
+								</td>
+								<td width="108">
+									<p align="center">00000110</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^G (BEL)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">7</p>
+								</td>
+								<td width="60">
+									<p align="center">07</p>
+								</td>
+								<td width="108">
+									<p align="center">00000111</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^H (BS)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">8</p>
+								</td>
+								<td width="60">
+									<p align="center">08</p>
+								</td>
+								<td width="108">
+									<p align="center">00001000</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^I (HT)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">9</p>
+								</td>
+								<td width="60">
+									<p align="center">09</p>
+								</td>
+								<td width="108">
+									<p align="center">00001001</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^J (NL)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">10</p>
+								</td>
+								<td width="60">
+									<p align="center">0A</p>
+								</td>
+								<td width="108">
+									<p align="center">00001010</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^K (VT)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">11</p>
+								</td>
+								<td width="60">
+									<p align="center">0B</p>
+								</td>
+								<td width="108">
+									<p align="center">00001011</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^L (NP)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">12</p>
+								</td>
+								<td width="60">
+									<p align="center">0C</p>
+								</td>
+								<td width="108">
+									<p align="center">00001100</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^M (CR)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">13</p>
+								</td>
+								<td width="60">
+									<p align="center">0D</p>
+								</td>
+								<td width="108">
+									<p align="center">00001101</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^N (SO)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">14</p>
+								</td>
+								<td width="60">
+									<p align="center">0E</p>
+								</td>
+								<td width="108">
+									<p align="center">00001110</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^O (SI)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">15</p>
+								</td>
+								<td width="60">
+									<p align="center">0F</p>
+								</td>
+								<td width="108">
+									<p align="center">00001111</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^P (DLE)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">16</p>
+								</td>
+								<td width="60">
+									<p align="center">10</p>
+								</td>
+								<td width="108">
+									<p align="center">00010000</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^Q (DS1)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">17</p>
+								</td>
+								<td width="60">
+									<p align="center">11</p>
+								</td>
+								<td width="108">
+									<p align="center">00010001</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^R (DS2)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">18</p>
+								</td>
+								<td width="60">
+									<p align="center">12</p>
+								</td>
+								<td width="108">
+									<p align="center">00010010</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^S (DS3)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">19</p>
+								</td>
+								<td width="60">
+									<p align="center">13</p>
+								</td>
+								<td width="108">
+									<p align="center">00010011</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^T (DC4)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">20</p>
+								</td>
+								<td width="60">
+									<p align="center">14</p>
+								</td>
+								<td width="108">
+									<p align="center">00010100</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^U (NAK)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">21</p>
+								</td>
+								<td width="60">
+									<p align="center">15</p>
+								</td>
+								<td width="108">
+									<p align="center">00010101</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^V (SYN)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">22</p>
+								</td>
+								<td width="60">
+									<p align="center">16</p>
+								</td>
+								<td width="108">
+									<p align="center">00010110</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^W (ETB)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">23</p>
+								</td>
+								<td width="60">
+									<p align="center">17</p>
+								</td>
+								<td width="108">
+									<p align="center">00010111</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^X (CAN)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">24</p>
+								</td>
+								<td width="60">
+									<p align="center">18</p>
+								</td>
+								<td width="108">
+									<p align="center">00011000</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^Y (EM)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">25</p>
+								</td>
+								<td width="60">
+									<p align="center">19</p>
+								</td>
+								<td width="108">
+									<p align="center">00011001</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^Z (SUB)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">26</p>
+								</td>
+								<td width="60">
+									<p align="center">1A</p>
+								</td>
+								<td width="108">
+									<p align="center">00011010</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^[ (ESC)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">27</p>
+								</td>
+								<td width="60">
+									<p align="center">1B</p>
+								</td>
+								<td width="108">
+									<p align="center">00011011</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^\ (FS)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">28</p>
+								</td>
+								<td width="60">
+									<p align="center">1C</p>
+								</td>
+								<td width="108">
+									<p align="center">00011100</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^] (GS)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">29</p>
+								</td>
+								<td width="60">
+									<p align="center">1D</p>
+								</td>
+								<td width="108">
+									<p align="center">00011101</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^^ (RS)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">30</p>
+								</td>
+								<td width="60">
+									<p align="center">1E</p>
+								</td>
+								<td width="108">
+									<p align="center">00011110</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^_ (US)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">31</p>
+								</td>
+								<td width="60">
+									<p align="center">1F</p>
+								</td>
+								<td width="108">
+									<p align="center">00011111</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>(SP)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">32</p>
+								</td>
+								<td width="60">
+									<p align="center">20</p>
+								</td>
+								<td width="108">
+									<p align="center">00100000</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>!</b></p>
+								</td>
+								<td width="66">
+									<p align="center">33</p>
+								</td>
+								<td width="60">
+									<p align="center">21</p>
+								</td>
+								<td width="108">
+									<p align="center">00100001</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>"</b></p>
+								</td>
+								<td width="66">
+									<p align="center">34</p>
+								</td>
+								<td width="60">
+									<p align="center">22</p>
+								</td>
+								<td width="108">
+									<p align="center">00100010</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>#</b></p>
+								</td>
+								<td width="66">
+									<p align="center">35</p>
+								</td>
+								<td width="60">
+									<p align="center">23</p>
+								</td>
+								<td width="108">
+									<p align="center">00100011</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>$</b></p>
+								</td>
+								<td width="66">
+									<p align="center">36</p>
+								</td>
+								<td width="60">
+									<p align="center">24</p>
+								</td>
+								<td width="108">
+									<p align="center">00100100</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>%</b></p>
+								</td>
+								<td width="66">
+									<p align="center">37</p>
+								</td>
+								<td width="60">
+									<p align="center">25</p>
+								</td>
+								<td width="108">
+									<p align="center">00100101</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>&</b></p>
+								</td>
+								<td width="66">
+									<p align="center">38</p>
+								</td>
+								<td width="60">
+									<p align="center">26</p>
+								</td>
+								<td width="108">
+									<p align="center">00100110</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>'</b></p>
+								</td>
+								<td width="66">
+									<p align="center">39</p>
+								</td>
+								<td width="60">
+									<p align="center">27</p>
+								</td>
+								<td width="108">
+									<p align="center">00100111</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>(</b></p>
+								</td>
+								<td width="66">
+									<p align="center">40</p>
+								</td>
+								<td width="60">
+									<p align="center">28</p>
+								</td>
+								<td width="108">
+									<p align="center">00101000</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">41</p>
+								</td>
+								<td width="60">
+									<p align="center">29</p>
+								</td>
+								<td width="108">
+									<p align="center">00101001</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>*</b></p>
+								</td>
+								<td width="66">
+									<p align="center">42</p>
+								</td>
+								<td width="60">
+									<p align="center">2A</p>
+								</td>
+								<td width="108">
+									<p align="center">00101010</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>+</b></p>
+								</td>
+								<td width="66">
+									<p align="center">43</p>
+								</td>
+								<td width="60">
+									<p align="center">2B</p>
+								</td>
+								<td width="108">
+									<p align="center">00101011</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>,</b></p>
+								</td>
+								<td width="66">
+									<p align="center">44</p>
+								</td>
+								<td width="60">
+									<p align="center">2C</p>
+								</td>
+								<td width="108">
+									<p align="center">00101100</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>-</b></p>
+								</td>
+								<td width="66">
+									<p align="center">45</p>
+								</td>
+								<td width="60">
+									<p align="center">2D</p>
+								</td>
+								<td width="108">
+									<p align="center">00101101</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>.</b></p>
+								</td>
+								<td width="66">
+									<p align="center">46</p>
+								</td>
+								<td width="60">
+									<p align="center">2E</p>
+								</td>
+								<td width="108">
+									<p align="center">00101110</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>/</b></p>
+								</td>
+								<td width="66">
+									<p align="center">47</p>
+								</td>
+								<td width="60">
+									<p align="center">2F</p>
+								</td>
+								<td width="108">
+									<p align="center">00101111</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>0</b></p>
+								</td>
+								<td width="66">
+									<p align="center">48</p>
+								</td>
+								<td width="60">
+									<p align="center">30</p>
+								</td>
+								<td width="108">
+									<p align="center">00110000</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
 									<p align="center">
-										<img height="62" src="Resources/pics/aai-BugAlert.gif" width="56" />
+										<b>
+											<span style="color: #ff0000">1</span>
+										</b>
 									</p>
+								</td>
+								<td width="66">
 									<p align="center">
-										Group items are always treated as alphanumeric and this can cause problems when
-										there are subordinate COMP items.
+										<b>
+											<span style="color: #ff0000">49</span>
+										</b>
 									</p>
+								</td>
+								<td width="60">
 									<p align="center">
-										For instance, suppose we had a statement like -<br />
-										<code class="language-cobol">MOVE ZEROS TO GROUP2</code>.<br />
-										in the program opposite.<br />
-										<br />
-										On the surface it looks as if this statement is moving the numeric value 0 to
-										NumItem1 and NumItem2 but what is actually moved into these items is the ASCII
-										digit "0".<br />
-										<br />
-										When an attempt is made to use NumItem1 or NumItem2 in a calculation the program
-										will crash because these data-items contain non-numeric data.
+										<b>
+											<span style="color: #ff0000">31</span>
+										</b>
 									</p>
-								</aside>
-							</td>
-							<td valign="top" width="525">
-								<p align="center">
-									<img height="118" src="Resources/pics/UsageSyn1.gif" width="214" />
-								</p>
-								<p><b>USAGE notes</b></p>
-								<ul>
-									<li>
-										The <code class="language-cobol">USAGE</code> clause may be used with any data
-										description entry except those with level numbers of 66 or 88.<br />
-										<br />
-									</li>
-									<li>
-										When the <code class="language-cobol">USAGE</code> clause is declared for a
-										group item, the usage specified is applied to every item in the group. The group
-										item itself is still treated as an alphanumeric data-item (see example program
-										below).<br />
-										<br />
-									</li>
-									<li>
-										<code class="language-cobol">USAGE IS COMPUTATIONAL</code> or
-										<code class="language-cobol">COMP</code> or
-										<code class="language-cobol">BINARY</code> are synonyms of one another.<br />
-										<br />
-									</li>
-									<li>
-										The <code class="language-cobol">USAGE IS INDEX</code> clause is used to provide
-										an optimized table subscript. When a table is the target of a
-										<code class="language-cobol">SEARCH</code> statement it must have an associated
-										index item (see the Search Tutorial).
-									</li>
-								</ul>
-								<p>
-									<br />
-									<b>USAGE rules</b><br />
-								</p>
-								<ol>
-									<li>
-										Any item declared with <code class="language-cobol">USAGE IS INDEX</code> can
-										only appear in:<br />
-										- A <code class="language-cobol">SEARCH</code> or
-										<code class="language-cobol">SET</code> statement<br />
-										- A relation condition<br />
-										- The <code class="language-cobol">USING</code> phrase of the
-										<code class="language-cobol">PROCEDURE DIVISION</code><br />
-										- The <code class="language-cobol">USING</code> phrase of the
-										<code class="language-cobol">CALL</code> statement<br />
-										<br />
-									</li>
-									<li>
-										The picture string of a <code class="language-cobol">COMP</code> or
-										<code class="language-cobol">PACKED-DECIMAL</code> item can contain only the
-										symbols 9, S, V and/or P.<br />
-										<br />
-									</li>
-									<li>
-										The picture clause used for <code class="language-cobol">COMP</code> or
-										<code class="language-cobol">PACKED-DECIMAL</code> items must be numeric.<br />
-									</li>
-								</ol>
-								<p><b>USAGE examples</b></p>
-								<table
-									align="center"
-									background="Resources/pics/code.gif"
-									border="1"
-									cellpadding="5"
-									width="374"
-								>
-									<tr>
-										<td>
-											<pre class="language-cobol"><code class="language-cobol">
+								</td>
+								<td width="108">
+									<p align="center">
+										<b>
+											<span style="color: #ff0000">00110001</span>
+										</b>
+									</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>2</b></p>
+								</td>
+								<td width="66">
+									<p align="center">50</p>
+								</td>
+								<td width="60">
+									<p align="center">32</p>
+								</td>
+								<td width="108">
+									<p align="center">00110010</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>3</b></p>
+								</td>
+								<td width="66">
+									<p align="center">51</p>
+								</td>
+								<td width="60">
+									<p align="center">33</p>
+								</td>
+								<td width="108">
+									<p align="center">00110011</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center">
+										<b>
+											<span style="color: #ff0000">4</span>
+										</b>
+									</p>
+								</td>
+								<td width="66">
+									<p align="center">
+										<b>
+											<span style="color: #ff0000">52</span>
+										</b>
+									</p>
+								</td>
+								<td width="60">
+									<p align="center">
+										<b>
+											<span style="color: #ff0000">34</span>
+										</b>
+									</p>
+								</td>
+								<td width="108">
+									<p align="center">
+										<b>
+											<span style="color: #ff0000">00110100</span>
+										</b>
+									</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>5</b></p>
+								</td>
+								<td width="66">
+									<p align="center">53</p>
+								</td>
+								<td width="60">
+									<p align="center">35</p>
+								</td>
+								<td width="108">
+									<p align="center">00110101</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>6</b></p>
+								</td>
+								<td width="66">
+									<p align="center">54</p>
+								</td>
+								<td width="60">
+									<p align="center">36</p>
+								</td>
+								<td width="108">
+									<p align="center">00110110</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>7</b></p>
+								</td>
+								<td width="66">
+									<p align="center">55</p>
+								</td>
+								<td width="60">
+									<p align="center">37</p>
+								</td>
+								<td width="108">
+									<p align="center">00110111</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>8</b></p>
+								</td>
+								<td width="66">
+									<p align="center">56</p>
+								</td>
+								<td width="60">
+									<p align="center">38</p>
+								</td>
+								<td width="108">
+									<p align="center">00111000</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>9</b></p>
+								</td>
+								<td width="66">
+									<p align="center">57</p>
+								</td>
+								<td width="60">
+									<p align="center">39</p>
+								</td>
+								<td width="108">
+									<p align="center">00111001</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>:</b></p>
+								</td>
+								<td width="66">
+									<p align="center">58</p>
+								</td>
+								<td width="60">
+									<p align="center">3A</p>
+								</td>
+								<td width="108">
+									<p align="center">00111010</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>;</b></p>
+								</td>
+								<td width="66">
+									<p align="center">59</p>
+								</td>
+								<td width="60">
+									<p align="center">3B</p>
+								</td>
+								<td width="108">
+									<p align="center">00111011</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>&lt;</b></p>
+								</td>
+								<td width="66">
+									<p align="center">60</p>
+								</td>
+								<td width="60">
+									<p align="center">3C</p>
+								</td>
+								<td width="108">
+									<p align="center">00111100</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>=</b></p>
+								</td>
+								<td width="66">
+									<p align="center">61</p>
+								</td>
+								<td width="60">
+									<p align="center">3D</p>
+								</td>
+								<td width="108">
+									<p align="center">00111101</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>&gt;</b></p>
+								</td>
+								<td width="66">
+									<p align="center">62</p>
+								</td>
+								<td width="60">
+									<p align="center">3E</p>
+								</td>
+								<td width="108">
+									<p align="center">00111110</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>?</b></p>
+								</td>
+								<td width="66">
+									<p align="center">63</p>
+								</td>
+								<td width="60">
+									<p align="center">3F</p>
+								</td>
+								<td width="108">
+									<p align="center">00111111</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>@</b></p>
+								</td>
+								<td width="66">
+									<p align="center">64</p>
+								</td>
+								<td width="60">
+									<p align="center">40</p>
+								</td>
+								<td width="108">
+									<p align="center">01000000</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>A</b></p>
+								</td>
+								<td width="66">
+									<p align="center">65</p>
+								</td>
+								<td width="60">
+									<p align="center">41</p>
+								</td>
+								<td width="108">
+									<p align="center">01000001</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>B</b></p>
+								</td>
+								<td width="66">
+									<p align="center">66</p>
+								</td>
+								<td width="60">
+									<p align="center">42</p>
+								</td>
+								<td width="108">
+									<p align="center">01000010</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>C</b></p>
+								</td>
+								<td width="66">
+									<p align="center">67</p>
+								</td>
+								<td width="60">
+									<p align="center">43</p>
+								</td>
+								<td width="108">
+									<p align="center">01000011</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>D</b></p>
+								</td>
+								<td width="66">
+									<p align="center">68</p>
+								</td>
+								<td width="60">
+									<p align="center">44</p>
+								</td>
+								<td width="108">
+									<p align="center">01000100</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>E</b></p>
+								</td>
+								<td width="66">
+									<p align="center">69</p>
+								</td>
+								<td width="60">
+									<p align="center">45</p>
+								</td>
+								<td width="108">
+									<p align="center">01000101</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>F</b></p>
+								</td>
+								<td width="66">
+									<p align="center">70</p>
+								</td>
+								<td width="60">
+									<p align="center">46</p>
+								</td>
+								<td width="108">
+									<p align="center">01000110</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>G</b></p>
+								</td>
+								<td width="66">
+									<p align="center">71</p>
+								</td>
+								<td width="60">
+									<p align="center">47</p>
+								</td>
+								<td width="108">
+									<p align="center">01000111</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>H</b></p>
+								</td>
+								<td width="66">
+									<p align="center">72</p>
+								</td>
+								<td width="60">
+									<p align="center">48</p>
+								</td>
+								<td width="108">
+									<p align="center">01001000</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>I</b></p>
+								</td>
+								<td width="66">
+									<p align="center">73</p>
+								</td>
+								<td width="60">
+									<p align="center">49</p>
+								</td>
+								<td width="108">
+									<p align="center">01001001</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>J</b></p>
+								</td>
+								<td width="66">
+									<p align="center">74</p>
+								</td>
+								<td width="60">
+									<p align="center">4A</p>
+								</td>
+								<td width="108">
+									<p align="center">01001010</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>K</b></p>
+								</td>
+								<td width="66">
+									<p align="center">75</p>
+								</td>
+								<td width="60">
+									<p align="center">4B</p>
+								</td>
+								<td width="108">
+									<p align="center">01001011</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>L</b></p>
+								</td>
+								<td width="66">
+									<p align="center">76</p>
+								</td>
+								<td width="60">
+									<p align="center">4C</p>
+								</td>
+								<td width="108">
+									<p align="center">01001100</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>M</b></p>
+								</td>
+								<td width="66">
+									<p align="center">77</p>
+								</td>
+								<td width="60">
+									<p align="center">4D</p>
+								</td>
+								<td width="108">
+									<p align="center">01001101</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>N</b></p>
+								</td>
+								<td width="66">
+									<p align="center">78</p>
+								</td>
+								<td width="60">
+									<p align="center">4E</p>
+								</td>
+								<td width="108">
+									<p align="center">01001110</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>O</b></p>
+								</td>
+								<td width="66">
+									<p align="center">79</p>
+								</td>
+								<td width="60">
+									<p align="center">4F</p>
+								</td>
+								<td width="108">
+									<p align="center">01001111</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>P</b></p>
+								</td>
+								<td width="66">
+									<p align="center">80</p>
+								</td>
+								<td width="60">
+									<p align="center">50</p>
+								</td>
+								<td width="108">
+									<p align="center">01010000</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>Q</b></p>
+								</td>
+								<td width="66">
+									<p align="center">81</p>
+								</td>
+								<td width="60">
+									<p align="center">51</p>
+								</td>
+								<td width="108">
+									<p align="center">01010001</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>R</b></p>
+								</td>
+								<td width="66">
+									<p align="center">82</p>
+								</td>
+								<td width="60">
+									<p align="center">52</p>
+								</td>
+								<td width="108">
+									<p align="center">01010010</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>S</b></p>
+								</td>
+								<td width="66">
+									<p align="center">83</p>
+								</td>
+								<td width="60">
+									<p align="center">53</p>
+								</td>
+								<td width="108">
+									<p align="center">01010011</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>T</b></p>
+								</td>
+								<td width="66">
+									<p align="center">84</p>
+								</td>
+								<td width="60">
+									<p align="center">54</p>
+								</td>
+								<td width="108">
+									<p align="center">01010100</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>U</b></p>
+								</td>
+								<td width="66">
+									<p align="center">85</p>
+								</td>
+								<td width="60">
+									<p align="center">55</p>
+								</td>
+								<td width="108">
+									<p align="center">01010101</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>V</b></p>
+								</td>
+								<td width="66">
+									<p align="center">86</p>
+								</td>
+								<td width="60">
+									<p align="center">56</p>
+								</td>
+								<td width="108">
+									<p align="center">01010110</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>W</b></p>
+								</td>
+								<td width="66">
+									<p align="center">87</p>
+								</td>
+								<td width="60">
+									<p align="center">57</p>
+								</td>
+								<td width="108">
+									<p align="center">01010111</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>X</b></p>
+								</td>
+								<td width="66">
+									<p align="center">88</p>
+								</td>
+								<td width="60">
+									<p align="center">58</p>
+								</td>
+								<td width="108">
+									<p align="center">01011000</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>Y</b></p>
+								</td>
+								<td width="66">
+									<p align="center">89</p>
+								</td>
+								<td width="60">
+									<p align="center">59</p>
+								</td>
+								<td width="108">
+									<p align="center">01011001</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>Z</b></p>
+								</td>
+								<td width="66">
+									<p align="center">90</p>
+								</td>
+								<td width="60">
+									<p align="center">5A</p>
+								</td>
+								<td width="108">
+									<p align="center">01011010</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>[</b></p>
+								</td>
+								<td width="66">
+									<p align="center">91</p>
+								</td>
+								<td width="60">
+									<p align="center">5B</p>
+								</td>
+								<td width="108">
+									<p align="center">01011011</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>\</b></p>
+								</td>
+								<td width="66">
+									<p align="center">92</p>
+								</td>
+								<td width="60">
+									<p align="center">5C</p>
+								</td>
+								<td width="108">
+									<p align="center">01011100</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>]</b></p>
+								</td>
+								<td width="66">
+									<p align="center">93</p>
+								</td>
+								<td width="60">
+									<p align="center">5D</p>
+								</td>
+								<td width="108">
+									<p align="center">01011101</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^</b></p>
+								</td>
+								<td width="66">
+									<p align="center">94</p>
+								</td>
+								<td width="60">
+									<p align="center">5E</p>
+								</td>
+								<td width="108">
+									<p align="center">01011110</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>_</b></p>
+								</td>
+								<td width="66">
+									<p align="center">95</p>
+								</td>
+								<td width="60">
+									<p align="center">5F</p>
+								</td>
+								<td width="108">
+									<p align="center">01011111</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>`</b></p>
+								</td>
+								<td width="66">
+									<p align="center">96</p>
+								</td>
+								<td width="60">
+									<p align="center">60</p>
+								</td>
+								<td width="108">
+									<p align="center">01100000</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>a</b></p>
+								</td>
+								<td width="66">
+									<p align="center">97</p>
+								</td>
+								<td width="60">
+									<p align="center">61</p>
+								</td>
+								<td width="108">
+									<p align="center">01100001</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>b</b></p>
+								</td>
+								<td width="66">
+									<p align="center">98</p>
+								</td>
+								<td width="60">
+									<p align="center">62</p>
+								</td>
+								<td width="108">
+									<p align="center">01100010</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>c</b></p>
+								</td>
+								<td width="66">
+									<p align="center">99</p>
+								</td>
+								<td width="60">
+									<p align="center">63</p>
+								</td>
+								<td width="108">
+									<p align="center">01100011</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>d</b></p>
+								</td>
+								<td width="66">
+									<p align="center">100</p>
+								</td>
+								<td width="60">
+									<p align="center">64</p>
+								</td>
+								<td width="108">
+									<p align="center">01100100</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center">
+										<b>
+											<span style="color: #ff0000">e</span>
+										</b>
+									</p>
+								</td>
+								<td width="66">
+									<p align="center">
+										<b>
+											<span style="color: #ff0000">101</span>
+										</b>
+									</p>
+								</td>
+								<td width="60">
+									<p align="center">
+										<b>
+											<span style="color: #ff0000">65</span>
+										</b>
+									</p>
+								</td>
+								<td width="108">
+									<p align="center">
+										<b>
+											<span style="color: #ff0000">01100101</span>
+										</b>
+									</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>f</b></p>
+								</td>
+								<td width="66">
+									<p align="center">102</p>
+								</td>
+								<td width="60">
+									<p align="center">66</p>
+								</td>
+								<td width="108">
+									<p align="center">01100110</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>g</b></p>
+								</td>
+								<td width="66">
+									<p align="center">103</p>
+								</td>
+								<td width="60">
+									<p align="center">67</p>
+								</td>
+								<td width="108">
+									<p align="center">01100111</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>h</b></p>
+								</td>
+								<td width="66">
+									<p align="center">104</p>
+								</td>
+								<td width="60">
+									<p align="center">68</p>
+								</td>
+								<td width="108">
+									<p align="center">01101000</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>i</b></p>
+								</td>
+								<td width="66">
+									<p align="center">105</p>
+								</td>
+								<td width="60">
+									<p align="center">69</p>
+								</td>
+								<td width="108">
+									<p align="center">01101001</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>j</b></p>
+								</td>
+								<td width="66">
+									<p align="center">106</p>
+								</td>
+								<td width="60">
+									<p align="center">6A</p>
+								</td>
+								<td width="108">
+									<p align="center">01101010</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>k</b></p>
+								</td>
+								<td width="66">
+									<p align="center">107</p>
+								</td>
+								<td width="60">
+									<p align="center">6B</p>
+								</td>
+								<td width="108">
+									<p align="center">01101011</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>l</b></p>
+								</td>
+								<td width="66">
+									<p align="center">108</p>
+								</td>
+								<td width="60">
+									<p align="center">6C</p>
+								</td>
+								<td width="108">
+									<p align="center">01101100</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>m</b></p>
+								</td>
+								<td width="66">
+									<p align="center">109</p>
+								</td>
+								<td width="60">
+									<p align="center">6D</p>
+								</td>
+								<td width="108">
+									<p align="center">01101101</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>n</b></p>
+								</td>
+								<td width="66">
+									<p align="center">110</p>
+								</td>
+								<td width="60">
+									<p align="center">6E</p>
+								</td>
+								<td width="108">
+									<p align="center">01101110</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>o</b></p>
+								</td>
+								<td width="66">
+									<p align="center">111</p>
+								</td>
+								<td width="60">
+									<p align="center">6F</p>
+								</td>
+								<td width="108">
+									<p align="center">01101111</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>p</b></p>
+								</td>
+								<td width="66">
+									<p align="center">112</p>
+								</td>
+								<td width="60">
+									<p align="center">70</p>
+								</td>
+								<td width="108">
+									<p align="center">01110000</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>q</b></p>
+								</td>
+								<td width="66">
+									<p align="center">113</p>
+								</td>
+								<td width="60">
+									<p align="center">71</p>
+								</td>
+								<td width="108">
+									<p align="center">01110001</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>r</b></p>
+								</td>
+								<td width="66">
+									<p align="center">114</p>
+								</td>
+								<td width="60">
+									<p align="center">72</p>
+								</td>
+								<td width="108">
+									<p align="center">01110010</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>s</b></p>
+								</td>
+								<td width="66">
+									<p align="center">115</p>
+								</td>
+								<td width="60">
+									<p align="center">73</p>
+								</td>
+								<td width="108">
+									<p align="center">01110011</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>t</b></p>
+								</td>
+								<td width="66">
+									<p align="center">116</p>
+								</td>
+								<td width="60">
+									<p align="center">74</p>
+								</td>
+								<td width="108">
+									<p align="center">01110100</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>u</b></p>
+								</td>
+								<td width="66">
+									<p align="center">117</p>
+								</td>
+								<td width="60">
+									<p align="center">75</p>
+								</td>
+								<td width="108">
+									<p align="center">01110101</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>v</b></p>
+								</td>
+								<td width="66">
+									<p align="center">118</p>
+								</td>
+								<td width="60">
+									<p align="center">76</p>
+								</td>
+								<td width="108">
+									<p align="center">01110110</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>w</b></p>
+								</td>
+								<td width="66">
+									<p align="center">119</p>
+								</td>
+								<td width="60">
+									<p align="center">77</p>
+								</td>
+								<td width="108">
+									<p align="center">01110111</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>x</b></p>
+								</td>
+								<td width="66">
+									<p align="center">120</p>
+								</td>
+								<td width="60">
+									<p align="center">78</p>
+								</td>
+								<td width="108">
+									<p align="center">01111000</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>y</b></p>
+								</td>
+								<td width="66">
+									<p align="center">121</p>
+								</td>
+								<td width="60">
+									<p align="center">79</p>
+								</td>
+								<td width="108">
+									<p align="center">01111001</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>z</b></p>
+								</td>
+								<td width="66">
+									<p align="center">122</p>
+								</td>
+								<td width="60">
+									<p align="center">7A</p>
+								</td>
+								<td width="108">
+									<p align="center">01111010</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>{</b></p>
+								</td>
+								<td width="66">
+									<p align="center">123</p>
+								</td>
+								<td width="60">
+									<p align="center">7B</p>
+								</td>
+								<td width="108">
+									<p align="center">01111011</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>|</b></p>
+								</td>
+								<td width="66">
+									<p align="center">124</p>
+								</td>
+								<td width="60">
+									<p align="center">7C</p>
+								</td>
+								<td width="108">
+									<p align="center">01111100</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>}</b></p>
+								</td>
+								<td width="66">
+									<p align="center">125</p>
+								</td>
+								<td width="60">
+									<p align="center">7D</p>
+								</td>
+								<td width="108">
+									<p align="center">01111101</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>~</b></p>
+								</td>
+								<td width="66">
+									<p align="center">126</p>
+								</td>
+								<td width="60">
+									<p align="center">7E</p>
+								</td>
+								<td width="108">
+									<p align="center">01111110</p>
+								</td>
+							</tr>
+							<tr>
+								<td width="114">
+									<p align="center"><b>^? (DEL)</b></p>
+								</td>
+								<td width="66">
+									<p align="center">127</p>
+								</td>
+								<td width="60">
+									<p align="center">7F</p>
+								</td>
+								<td width="108">
+									<p align="center">01111111</p>
+								</td>
+							</tr>
+						</table>
+					</div>
+					<hr align="center" size="1" width="100%" />
+				</div>
+				<div class="section-sidebar">
+					<p>
+						<b>USAGE syntax and notes</b>
+					</p>
+					<p align="center">
+						<img height="44" src="Resources/pics/aa-ProgFrag.gif" width="48" />
+					</p>
+					<aside>
+						<p align="center">
+							<img height="62" src="Resources/pics/aai-BugAlert.gif" width="56" />
+						</p>
+						<p align="center">
+							Group items are always treated as alphanumeric and this can cause problems when
+							there are subordinate COMP items.
+						</p>
+						<p align="center">
+							For instance, suppose we had a statement like -<br />
+							<code class="language-cobol">MOVE ZEROS TO GROUP2</code>.<br />
+							in the program opposite.<br />
+							<br />
+							On the surface it looks as if this statement is moving the numeric value 0 to
+							NumItem1 and NumItem2 but what is actually moved into these items is the ASCII
+							digit "0".<br />
+							<br />
+							When an attempt is made to use NumItem1 or NumItem2 in a calculation the program
+							will crash because these data-items contain non-numeric data.
+						</p>
+					</aside>
+				</div>
+				<div class="section-content">
+					<p align="center">
+						<img height="118" src="Resources/pics/UsageSyn1.gif" width="214" />
+					</p>
+					<p><b>USAGE notes</b></p>
+					<ul>
+						<li>
+							The <code class="language-cobol">USAGE</code> clause may be used with any data
+							description entry except those with level numbers of 66 or 88.<br />
+							<br />
+						</li>
+						<li>
+							When the <code class="language-cobol">USAGE</code> clause is declared for a
+							group item, the usage specified is applied to every item in the group. The group
+							item itself is still treated as an alphanumeric data-item (see example program
+							below).<br />
+							<br />
+						</li>
+						<li>
+							<code class="language-cobol">USAGE IS COMPUTATIONAL</code> or
+							<code class="language-cobol">COMP</code> or
+							<code class="language-cobol">BINARY</code> are synonyms of one another.<br />
+							<br />
+						</li>
+						<li>
+							The <code class="language-cobol">USAGE IS INDEX</code> clause is used to provide
+							an optimized table subscript. When a table is the target of a
+							<code class="language-cobol">SEARCH</code> statement it must have an associated
+							index item (see the Search Tutorial).
+						</li>
+					</ul>
+					<p>
+						<br />
+						<b>USAGE rules</b><br />
+					</p>
+					<ol>
+						<li>
+							Any item declared with <code class="language-cobol">USAGE IS INDEX</code> can
+							only appear in:<br />
+							- A <code class="language-cobol">SEARCH</code> or
+							<code class="language-cobol">SET</code> statement<br />
+							- A relation condition<br />
+							- The <code class="language-cobol">USING</code> phrase of the
+							<code class="language-cobol">PROCEDURE DIVISION</code><br />
+							- The <code class="language-cobol">USING</code> phrase of the
+							<code class="language-cobol">CALL</code> statement<br />
+							<br />
+						</li>
+						<li>
+							The picture string of a <code class="language-cobol">COMP</code> or
+							<code class="language-cobol">PACKED-DECIMAL</code> item can contain only the
+							symbols 9, S, V and/or P.<br />
+							<br />
+						</li>
+						<li>
+							The picture clause used for <code class="language-cobol">COMP</code> or
+							<code class="language-cobol">PACKED-DECIMAL</code> items must be numeric.<br />
+						</li>
+					</ol>
+					<p><b>USAGE examples</b></p>
+					<div class="code-fragment">
+						<pre class="language-cobol"><code class="language-cobol">
 01 Num1 PIC 9(5)V99 USAGE IS COMP.
 01 Num2 PIC 99 USAGE IS PACKED-DECIMAL.
 01 IdxItem USAGE IS INDEX.
@@ -2449,144 +2393,135 @@ Begin.
    02 NumItem1 PIC 9(3)V99 USAGE IS COMP.
    02 NumItem2 PIC 99V99   USAGE IS COMP.
 </code></pre>
-										</td>
-									</tr>
-								</table>
-								<p>
-									<b>COMP/COMPUTATIONAL/BINARY</b><br />
-									<code class="language-cobol">COMP</code> items are held in memory as pure binary
-									two's complement numbers. The storage requirements for fields described as
-									<code class="language-cobol">COMP</code> are as follows:
-								</p>
-								<table align="center" border="1" cellpadding="1" cellspacing="1" width="293">
-									<tr bgcolor="#FFFFCC">
-										<th scope="col" width="133">Number of Digits</th>
-										<th scope="col" width="166">Storage Required.</th>
-									</tr>
-									<tr>
-										<td width="133">PIC 9(1 to 4)</td>
-										<td width="166">1 Word (2 Bytes)</td>
-									</tr>
-									<tr>
-										<td width="133">PIC 9(5 to 9)</td>
-										<td width="166">1 LongWord (4 Bytes)</td>
-									</tr>
-									<tr>
-										<td width="133">PIC 9(10 to 18)</td>
-										<td width="166">1QuadWord (8 Bytes)</td>
-									</tr>
-								</table>
-								<p>
-									<br />
-									<br />
-									<b>PACKED-DECIMAL</b><br />
-									Data-items declared as <code class="language-cobol">PACKED-DECIMAL</code> are held
-									in binary-coded-decimal (BCD) form.<br />
-									Instead of representing the value as a single binary number, the binary value of
-									each digit is held in a nibble (half a byte). The sign is held in a separate nibble
-									in the least significant position of the item (see diagram below).
-								</p>
-								<p align="center"><img height="155" src="Resources/pics/Usage3.gif" width="406" /></p>
-								<p>
-									<br />
-									<b>General USAGE notes</b><br />
-									The <code class="language-cobol">USAGE</code> clause is one of the areas where many
-									vendors have introduced extensions to the COBOL standard. It is not uncommon to see
-									<code class="language-cobol">COMP-1</code>,
-									<code class="language-cobol">COMP-2</code>,
-									<code class="language-cobol">COMP-3</code>,
-									<code class="language-cobol">COMP-4</code>,
-									<code class="language-cobol">COMP-5</code> and
-									<code class="language-cobol">POINTER</code> usage items in programs written using
-									these extensions.
-								</p>
-								<p>
-									Even though <code class="language-cobol">COMP-1</code> and
-									<code class="language-cobol">COMP-2</code> are extensions to the COBOL standard,
-									vendors seem to use identical representations for these usages.
-									<code class="language-cobol">COMP-1</code> is usually defined as a single precision,
-									floating point number, adhering to the IEEE specification for such numbers (Real or
-									Float in typed languages) and <code class="language-cobol">COMP-2</code> is usually
-									defined as a double precision, floating point number (LongReal or Double in typed
-									languages).
-								</p>
-								<hr align="center" size="1" width="100%" />
-							</td>
+					</div>
+					<p>
+						<b>COMP/COMPUTATIONAL/BINARY</b><br />
+						<code class="language-cobol">COMP</code> items are held in memory as pure binary
+						two's complement numbers. The storage requirements for fields described as
+						<code class="language-cobol">COMP</code> are as follows:
+					</p>
+					<table align="center" border="1" cellpadding="1" cellspacing="1" width="293">
+						<tr bgcolor="#FFFFCC">
+							<th scope="col" width="133">Number of Digits</th>
+							<th scope="col" width="166">Storage Required.</th>
 						</tr>
 						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<b>The SYNCHRONIZED clause</b>
-							</td>
-							<td valign="top" width="525">
-								<p>
-									The <code class="language-cobol">SYNCHRONIZED</code> clause is sometimes used with
-									<code class="language-cobol">USAGE IS COMP</code> or
-									<code class="language-cobol">USAGE IS INDEX</code> items. It is used to optimize
-									speed of processing but it does so at the expense of increased storage requirements.
-								</p>
-								<p>
-									Many computer memories are organized in such a way that there are natural addressing
-									boundaries - such as word boundaries. If no special action is taken some data items
-									in memory may straddle theses boundaries. This may cause a processing overhead as
-									the CPU may need two fetch cycles to retrieve the data from memory.
-								</p>
-								<p>
-									The <code class="language-cobol">SYNCHRONIZED</code> clause is used to explicitly
-									align <code class="language-cobol">COMP</code> and
-									<code class="language-cobol">INDEX</code> items along their natural word boundaries.
-									Without the <code class="language-cobol">SYNCHRONIZED</code> clause, data-items are
-									aligned on byte boundaries.
-								</p>
-								<p>
-									The word <code class="language-cobol">SYNC</code> can be used instead of
-									<code class="language-cobol">SYNCHRONIZED</code>.
-								</p>
-								<p>
-									The effect of the synchronized clause is implementation dependant. You will need to
-									read your vendor manual to see how it works on your computer (in some cases it may
-									have no effect).
-								</p>
-								<p>
-									For the purpose of illustrating how the
-									<code class="language-cobol">SYNCHRONIZED</code> clause works let us assume that a
-									COBOL program is running on a word-oriented computer where the CPU fetches data from
-									memory a word at a time.
-								</p>
-								<p>
-									In this program we want to perform a calculation on the number stored in the
-									variable <i>TwoBytes</i> (as declared in the diagram below). Because of the way the
-									data items have been declared, the number stored in <i>TwoBytes</i> straddles a word
-									boundary.
-								</p>
-								<p>
-									In order to use the number, the CPU has to execute two fetch cycles - one to get the
-									first part of the number in Word2 and the second to get the second part of the
-									number in Word3. This double fetch slows down calculations.
-								</p>
-								<p align="center"><img height="164" src="Resources/pics/Usage4.gif" width="492" /></p>
-								<p>
-									Now consider the impact of using the
-									<code class="language-cobol">SYNCHRONIZED</code> clause. The number in
-									<i>TwoBytes</i> is now aligned along the word boundary, so the CPU only has to do
-									one fetch cycle to retrieve the number from memory. This speeds up processing but at
-									the expense of wasting some storage (the second byte of Word2 is no longer used).
-								</p>
-								<p align="center"><img height="164" src="Resources/pics/Usage5.gif" width="492" /></p>
-								<hr align="center" size="1" width="100%" />
-							</td>
+							<td width="133">PIC 9(1 to 4)</td>
+							<td width="166">1 Word (2 Bytes)</td>
+						</tr>
+						<tr>
+							<td width="133">PIC 9(5 to 9)</td>
+							<td width="166">1 LongWord (4 Bytes)</td>
+						</tr>
+						<tr>
+							<td width="133">PIC 9(10 to 18)</td>
+							<td width="166">1QuadWord (8 Bytes)</td>
 						</tr>
 					</table>
-				</td>
-			</tr>
-			<tr>
-				<td>
-					<hr />
-					<div align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</div>
-					<copyright-notice></copyright-notice>
-				</td>
-			</tr>
-		</table>
+					<p>
+						<br />
+						<br />
+						<b>PACKED-DECIMAL</b><br />
+						Data-items declared as <code class="language-cobol">PACKED-DECIMAL</code> are held
+						in binary-coded-decimal (BCD) form.<br />
+						Instead of representing the value as a single binary number, the binary value of
+						each digit is held in a nibble (half a byte). The sign is held in a separate nibble
+						in the least significant position of the item (see diagram below).
+					</p>
+					<p align="center"><img height="155" src="Resources/pics/Usage3.gif" width="406" /></p>
+					<p>
+						<br />
+						<b>General USAGE notes</b><br />
+						The <code class="language-cobol">USAGE</code> clause is one of the areas where many
+						vendors have introduced extensions to the COBOL standard. It is not uncommon to see
+						<code class="language-cobol">COMP-1</code>,
+						<code class="language-cobol">COMP-2</code>,
+						<code class="language-cobol">COMP-3</code>,
+						<code class="language-cobol">COMP-4</code>,
+						<code class="language-cobol">COMP-5</code> and
+						<code class="language-cobol">POINTER</code> usage items in programs written using
+						these extensions.
+					</p>
+					<p>
+						Even though <code class="language-cobol">COMP-1</code> and
+						<code class="language-cobol">COMP-2</code> are extensions to the COBOL standard,
+						vendors seem to use identical representations for these usages.
+						<code class="language-cobol">COMP-1</code> is usually defined as a single precision,
+						floating point number, adhering to the IEEE specification for such numbers (Real or
+						Float in typed languages) and <code class="language-cobol">COMP-2</code> is usually
+						defined as a double precision, floating point number (LongReal or Double in typed
+						languages).
+					</p>
+					<hr align="center" size="1" width="100%" />
+				</div>
+				<div class="section-sidebar">
+					<b>The SYNCHRONIZED clause</b>
+				</div>
+				<div class="section-content">
+					<p>
+						The <code class="language-cobol">SYNCHRONIZED</code> clause is sometimes used with
+						<code class="language-cobol">USAGE IS COMP</code> or
+						<code class="language-cobol">USAGE IS INDEX</code> items. It is used to optimize
+						speed of processing but it does so at the expense of increased storage requirements.
+					</p>
+					<p>
+						Many computer memories are organized in such a way that there are natural addressing
+						boundaries - such as word boundaries. If no special action is taken some data items
+						in memory may straddle theses boundaries. This may cause a processing overhead as
+						the CPU may need two fetch cycles to retrieve the data from memory.
+					</p>
+					<p>
+						The <code class="language-cobol">SYNCHRONIZED</code> clause is used to explicitly
+						align <code class="language-cobol">COMP</code> and
+						<code class="language-cobol">INDEX</code> items along their natural word boundaries.
+						Without the <code class="language-cobol">SYNCHRONIZED</code> clause, data-items are
+						aligned on byte boundaries.
+					</p>
+					<p>
+						The word <code class="language-cobol">SYNC</code> can be used instead of
+						<code class="language-cobol">SYNCHRONIZED</code>.
+					</p>
+					<p>
+						The effect of the synchronized clause is implementation dependant. You will need to
+						read your vendor manual to see how it works on your computer (in some cases it may
+						have no effect).
+					</p>
+					<p>
+						For the purpose of illustrating how the
+						<code class="language-cobol">SYNCHRONIZED</code> clause works let us assume that a
+						COBOL program is running on a word-oriented computer where the CPU fetches data from
+						memory a word at a time.
+					</p>
+					<p>
+						In this program we want to perform a calculation on the number stored in the
+						variable <i>TwoBytes</i> (as declared in the diagram below). Because of the way the
+						data items have been declared, the number stored in <i>TwoBytes</i> straddles a word
+						boundary.
+					</p>
+					<p>
+						In order to use the number, the CPU has to execute two fetch cycles - one to get the
+						first part of the number in Word2 and the second to get the second part of the
+						number in Word3. This double fetch slows down calculations.
+					</p>
+					<p align="center"><img height="164" src="Resources/pics/Usage4.gif" width="492" /></p>
+					<p>
+						Now consider the impact of using the
+						<code class="language-cobol">SYNCHRONIZED</code> clause. The number in
+						<i>TwoBytes</i> is now aligned along the word boundary, so the CPU only has to do
+						one fetch cycle to retrieve the number from memory. This speeds up processing but at
+						the expense of wasting some storage (the second byte of Word2 is no longer used).
+					</p>
+					<p align="center"><img height="164" src="Resources/pics/Usage5.gif" width="492" /></p>
+					<hr align="center" size="1" width="100%" />
+				</div>
+			</div>
+			<div class="page-footer">
+				<hr />
+				<div align="center">
+					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
+				</div>
+				<copyright-notice></copyright-notice>
+			</div>
+		</div>
 	</body>
 </html>


### PR DESCRIPTION
## Summary

- Replaces 4 layout-only `<table>` elements in `course/Usage.html` with semantic `<div>` elements using CSS grid and flexbox
- Preserves the 2 actual data tables unchanged: the ASCII character table (Char/Dec/Hex/Binary) and the COMP storage requirements table (Number of Digits/Storage Required)
- Moves viewport `<meta>` to first position in `<head>` to prevent FOUC from layout reflow

## What changed

**Layout tables converted:**
1. Outer page wrapper `<table border="1" width="715">` → `.page-wrapper` div (max-width: 715px, centered, bordered)
2. Inner two-column section `<table width="710">` → `.section-grid` div (CSS grid, `grid-template-columns: 175px 1fr`)
3. First code fragment table (COBOL program snippet with `code.gif` background) → `.code-fragment` div
4. Second code fragment table (USAGE examples snippet) → `.code-fragment` div

**CSS updates:**
- `td[bgcolor="#993300"]` selectors → `.section-header` class
- `td[bgcolor="#FFFFCC"]` selectors → `.section-sidebar` class
- Complex `table[width]` mobile overrides → `.section-grid { display: block }` at ≤600px
- Media query placed after base class definitions to ensure correct cascade order
- Sidebar `align-self` removed so the yellow background stretches to match content row height

## Test plan

- [ ] Desktop: two-column layout renders with 175px yellow sidebar and full-height background
- [ ] Mobile (≤600px): grid collapses to single column, sidebar stacks above content
- [ ] ASCII table (128 rows, Char/Dec/Hex/Binary) displays correctly as a data table
- [ ] COMP storage requirements table displays correctly as a data table
- [ ] Both code fragment blocks show the `code.gif` tiled background
- [ ] Section headers render with maroon background and yellow text

🤖 Generated with [Claude Code](https://claude.com/claude-code)