### PR TITLE
Refactor SequentialFiles2.html layout tables to CSS grid/flexbox

### DIFF
--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -5,83 +5,186 @@
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>Processing Sequential Files</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
-		<style>table{max-width:100%}body>table,body>hr{margin-left:auto;margin-right:auto}img{max-width:100%;height:auto}pre{overflow-x:auto;max-width:100%}</style>
-		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
-		<script src="Resources/vendor/prism/prism.min.js" defer></script>
-		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
-		<style type="text/css">
+		<style>
+			.section-header h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			.section-sidebar h3,
+			.section-sidebar h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			.page-wrapper {
+				max-width: 715px;
+				margin: 0 auto;
+				border: 1px solid;
+				box-sizing: border-box;
+			}
+
+			.page-content {
+				padding: 2px;
+			}
+
+			.page-footer {
+				padding: 2px;
+			}
+
+			.section-grid {
+				display: grid;
+				grid-template-columns: 175px 1fr;
+				align-items: stretch;
+			}
+
+			.section-header {
+				grid-column: 1 / -1;
+				background-color: #993300;
+				padding: 4px;
+			}
+
+			.section-sidebar {
+				background-color: #FFFFCC;
+				padding: 4px;
+			}
+
+			.section-content {
+				padding: 4px;
+				min-width: 0;
+			}
+
+			.section-full {
+				grid-column: 1 / -1;
+				padding: 4px;
+			}
+
+			.qa-form {
+				border: 1px solid;
+				width: 96%;
+				margin: 0 auto;
+			}
+
+			.qa-row {
+				display: grid;
+				grid-template-columns: 8% 62% 30%;
+				border-bottom: 1px solid #ccc;
+			}
+
+			.qa-row:last-child {
+				border-bottom: none;
+			}
+
+			.qa-label {
+				background-color: #FFFFCC;
+				padding: 4px 8px;
+				border-right: 1px solid #ccc;
+			}
+
+			.qa-question {
+				background-color: #E1FFE1;
+				padding: 4px 8px;
+				border-right: 1px solid #ccc;
+			}
+
+			.qa-answer {
+				background-color: #E1FFE1;
+				padding: 4px 8px;
+				overflow: hidden;
+			}
+
+			.qa-answer select {
+				max-width: 100%;
+				width: 100%;
+				box-sizing: border-box;
+			}
+
 			@media (max-width: 600px) {
-				form table:has(select) select {
+				.section-grid {
+					display: block;
+				}
+
+				.section-sidebar h3,
+				.section-sidebar h4,
+				.section-sidebar p {
+					margin: 0.2em 0;
+				}
+
+				.qa-row {
+					display: block;
+					border-bottom: 2px solid #999;
+					margin-bottom: 0;
+				}
+
+				.qa-label {
+					display: block;
+					font-weight: bold;
+					padding-bottom: 2px;
+				}
+
+				.qa-question {
+					display: block;
+				}
+
+				.qa-answer {
+					display: block;
+				}
+
+				.qa-answer select {
 					max-width: 100%;
 					width: 100%;
 					box-sizing: border-box;
 				}
-
-				form table:has(select) > tbody > tr {
-					display: block;
-					border-bottom: 2px solid #999;
-				}
-
-				form table:has(select) > tbody > tr > td {
-					display: block;
-					width: auto !important;
-					padding: 6px 8px;
-				}
-
-				form table:has(select) > tbody > tr > td[bgcolor="#FFFFCC"] {
-					font-weight: bold;
-					padding-bottom: 2px;
-				}
 			}
 		</style>
+		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
+		<script src="Resources/vendor/prism/prism.min.js" defer></script>
+		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
 	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
-		<table id="layout-table" border="1" width="715" cellpadding="4" cellspacing="0">
-			<tr>
-				<td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
-					<center>
-						<p><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
-						<h1>Processing Sequential Files</h1>
-					</center>
-					<hr />
-					<ul class="toc">
-						<li>
-							<a href="#intro">Introduction</a><br />
-							Unit aims, objectives, prerequisites.
-						</li>
-						<li>
-							<a href="#part1">Organization and Access</a><br />
-							This section introduces the concepts of file organization and access. It describes how
-							Sequential files are organized and introduces the idea of ordered and unordered Sequential
-							files.
-						</li>
-						<li>
-							<a href="#part2">Processing unordered Sequential files</a><br />
-							This section explores the processing restrictions of unordered Sequential files. It
-							demonstrates that, while records can be easily added to unordered files, deleting and
-							updating records is not really feasible.
-						</li>
-						<li>
-							<a href="#part3">Processing ordered Sequential files</a><br />
-							This section demonstrates how to use a file of batched transactions to insert (add), delete
-							and update records in an ordered Sequential file..
-						</li>
-					</ul>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
+		<div class="page-wrapper">
+			<div class="page-content" id="top">
+				<center>
+					<p><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
+					<h1>Processing Sequential Files</h1>
+				</center>
+				<hr />
+				<ul class="toc">
+					<li>
+						<a href="#intro">Introduction</a><br />
+						Unit aims, objectives, prerequisites.
+					</li>
+					<li>
+						<a href="#part1">Organization and Access</a><br />
+						This section introduces the concepts of file organization and access. It describes how
+						Sequential files are organized and introduces the idea of ordered and unordered Sequential
+						files.
+					</li>
+					<li>
+						<a href="#part2">Processing unordered Sequential files</a><br />
+						This section explores the processing restrictions of unordered Sequential files. It
+						demonstrates that, while records can be easily added to unordered files, deleting and
+						updating records is not really feasible.
+					</li>
+					<li>
+						<a href="#part3">Processing ordered Sequential files</a><br />
+						This section demonstrates how to use a file of batched transactions to insert (add), delete
+						and update records in an ordered Sequential file..
+					</li>
+				</ul>
+				<hr />
+			</div>
+			<!-- Introduction -->
+			<div class="section-grid">
+				<div class="section-header">
 					<h2 align="center" id="intro">Introduction</h2>
-				</td>
-			</tr>
-			<tr>
-				<td bgcolor="#FFFFCC" height="172" valign="top" width="175">
+				</div>
+				<div class="section-sidebar">
 					<h4>Aims</h4>
-				</td>
-				<td height="172" valign="top" width="540">
+				</div>
+				<div class="section-content">
 					<div align="center">
 						<p align="left">
 							The records in a Sequential file are organized serially, one after another, but the records
@@ -97,13 +200,11 @@
 					<div align="center">
 						<hr width="50%" />
 					</div>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" height="135" valign="top" width="175">
+				</div>
+				<div class="section-sidebar">
 					<h4>Objectives</h4>
-				</td>
-				<td height="135" valign="top" width="540">
+				</div>
+				<div class="section-content">
 					<p>By the end of this unit you should -</p>
 					<ol>
 						<li>Understand how Sequential files are organized.</li>
@@ -111,13 +212,11 @@
 						<li>Be able to add, delete and update records in an ordered Sequential file.</li>
 					</ol>
 					<hr width="50%" />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" height="77" valign="top" width="175">
+				</div>
+				<div class="section-sidebar">
 					<h4>Prerequisites</h4>
-				</td>
-				<td height="77" valign="top" width="525">
+				</div>
+				<div class="section-content">
 					<ul>
 						<li>Introduction to COBOL</li>
 						<li>Declaring data in COBOL</li>
@@ -126,10 +225,8 @@
 						<li>Iteration Constructs</li>
 						<li>Introduction to Sequential files</li>
 					</ul>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
+				</div>
+				<div class="section-full">
 					<div align="center">
 						<hr />
 						<p>
@@ -138,18 +235,17 @@
 							/></a>
 						</p>
 					</div>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
+				</div>
+			</div>
+			<!-- Organization and Access -->
+			<div class="section-grid">
+				<div class="section-header">
 					<h2 align="center" id="part1">Organization and Access</h2>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
+				</div>
+				<div class="section-sidebar">
 					<h4>Introduction</h4>
-				</td>
-				<td valign="top" width="525">
+				</div>
+				<div class="section-content">
 					<div align="center">
 						<p align="left">
 							Two important characteristics of files are <i>Data Organization</i> and
@@ -182,13 +278,11 @@
 					<div align="center">
 						<hr width="50%" />
 					</div>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
+				</div>
+				<div class="section-sidebar">
 					<h4>Sequential Organization</h4>
-				</td>
-				<td valign="top" width="525">
+				</div>
+				<div class="section-content">
 					<div align="center">
 						<p align="left">Sequential organization is simplest file organization in COBOL.</p>
 						<p align="left">
@@ -206,13 +300,11 @@
 					<div align="left">
 						<hr width="50%" />
 					</div>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
+				</div>
+				<div class="section-sidebar">
 					<h4>Ordered and Unordered files</h4>
-				</td>
-				<td valign="top" width="525">
+				</div>
+				<div class="section-content">
 					<div align="center">
 						<div align="center">
 							<p align="left">
@@ -252,10 +344,8 @@
 							</tr>
 						</table>
 					</div>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
+				</div>
+				<div class="section-full">
 					<div align="center">
 						<hr />
 						<p>
@@ -264,18 +354,17 @@
 							/></a>
 						</p>
 					</div>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
+				</div>
+			</div>
+			<!-- Processing unordered Sequential Files -->
+			<div class="section-grid">
+				<div class="section-header">
 					<h2 align="center" id="part2">Processing unordered Sequential Files</h2>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" height="97" valign="top" width="175">
+				</div>
+				<div class="section-sidebar">
 					<h4 align="left">Introduction</h4>
-				</td>
-				<td height="97" valign="top" width="525">
+				</div>
+				<div class="section-content">
 					<p>
 						It is easy to add records to an unordered Sequential file because we can simply add them to the
 						end of the file by opening the file for
@@ -285,13 +374,11 @@
 						unordered Sequential file.
 					</p>
 					<hr width="50%" />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" height="157" valign="top" width="175">
+				</div>
+				<div class="section-sidebar">
 					<h4 align="left">Adding records to an unordered Sequential File</h4>
-				</td>
-				<td height="157" valign="top" width="525">
+				</div>
+				<div class="section-content">
 					<p>
 						To add records to an unordered Sequential File the file must be opened for
 						<code class="language-cobol">EXTEND</code>. Opening a file for
@@ -310,10 +397,8 @@
 						/></a>
 					</p>
 					<hr width="50%" />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" height="173" valign="top" width="175">
+				</div>
+				<div class="section-sidebar">
 					<h4 align="left">Problems with unordered Sequential files</h4>
 					<aside>
 						<p align="center">
@@ -322,8 +407,8 @@
 							"in situ", many vendors, including Microfocus, allow this for disk based files.
 						</p>
 					</aside>
-				</td>
-				<td height="173" valign="top" width="525">
+				</div>
+				<div class="section-content">
 					<p>
 						While it is easy to add records to an unordered Sequential file it is not really feasible to
 						delete or update records in an unordered Sequential file.
@@ -336,13 +421,11 @@
 						do not work for unordered Sequential files.
 					</p>
 					<hr width="50%" />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" height="433" valign="top" width="175">
+				</div>
+				<div class="section-sidebar">
 					<h4 align="left">Record matching</h4>
-				</td>
-				<td height="433" valign="top" width="525">
+				</div>
+				<div class="section-content">
 					<p>
 						Updates to Sequential files are normally done in batch mode. That is, all the updates are
 						gathered together into a transaction file, and then applied to the target file in one go. The
@@ -369,13 +452,11 @@
 						master file is unordered, record matching cannot work.
 					</p>
 					<hr width="50%" />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" height="177" valign="top" width="175">
+				</div>
+				<div class="section-sidebar">
 					<h4>Attempting to batch delete records in an unordered file.</h4>
-				</td>
-				<td height="177" valign="top" width="525">
+				</div>
+				<div class="section-content">
 					<div align="center">
 						<p align="left">
 							Suppose we have an unordered transaction file and an unordered master file. The transaction
@@ -396,10 +477,8 @@
 					<div align="center">
 						<hr width="50%" />
 					</div>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
+				</div>
+				<div class="section-full">
 					<div align="center">
 						<hr />
 						<p>
@@ -408,18 +487,17 @@
 							/></a>
 						</p>
 					</div>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
+				</div>
+			</div>
+			<!-- Processing Ordered Sequential Files -->
+			<div class="section-grid">
+				<div class="section-header">
 					<h2 align="center" id="part3">Processing Ordered Sequential Files</h2>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
+				</div>
+				<div class="section-sidebar">
 					<h4 align="left">Introduction</h4>
-				</td>
-				<td valign="top" width="525">
+				</div>
+				<div class="section-content">
 					<p>
 						An ordered Sequential file, is a file ordered upon some key field. The ordering of the records
 						in the file makes it possible to process an ordered file in ways that are not available to us
@@ -427,13 +505,11 @@
 						unordered file these are possible with ordered files.
 					</p>
 					<hr width="50%" />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" height="389" valign="top" width="175">
+				</div>
+				<div class="section-sidebar">
 					<h4 align="left">Inserting records into an ordered Sequential file.</h4>
-				</td>
-				<td height="389" valign="top" width="525">
+				</div>
+				<div class="section-content">
 					<p align="left">
 						To add records to an ordered file a major consideration is to preserve the ordering. This means
 						that the record must be inserted into the file in the correct position. It can't just be added
@@ -453,23 +529,18 @@
 						/></a>
 					</p>
 					<hr width="50%" />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" height="536" valign="top" width="175">
+				</div>
+				<div class="section-sidebar">
 					<h4 align="left">Self Assessment questions</h4>
 					<p align="center"><img height="44" src="Resources/pics/ProgFrag.gif" width="48" /></p>
 					<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" /></p>
-				</td>
-				<td height="536" valign="top" width="525">
+				</div>
+				<div class="section-content">
 					<p>
 						The main processing loop from the animation is shown below. Examine the code in this program
 						fragment and then attempt to answer the questions below.
 					</p>
-					<table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="392">
-						<tr valign="top">
-							<td height="188">
-								<pre class="language-cobol"><code class="language-cobol">PERFORM UNTIL EndTF AND EndMF
+					<pre class="language-cobol"><code class="language-cobol">PERFORM UNTIL EndTF AND EndMF
   IF TFKey &lt; MFKey
      MOVE TFRec TO NFRec
      WRITE NFRec
@@ -483,85 +554,78 @@
   END-IF
 END-PERFORM
 </code></pre>
-							</td>
-						</tr>
-					</table>
-					<form action="SequentialFiles2.html" method="post">
-						<table align="center" bgcolor="#FFFFCC" border="1" width="96%">
-							<tr>
-								<td bgcolor="#FFFFCC" width="8%">Q1</td>
-								<td bgcolor="#E1FFE1" valign="top" width="62%">
-									In the program, no allowance has been made for when the key fields are equal. What
-									would it mean if the keys were equal?
-								</td>
-								<td bgcolor="#E1FFE1" valign="top" width="30%">
-									<select name="select" size="1">
-										<option selected>Click the arrow for the answer</option>
-										<option>---------------------------------------------------------------</option>
-										<option>Since the key field is supposed to</option>
-										<option>be unique this would be a transaction</option>
-										<option>error. It would mean that we were trying</option>
-										<option>to insert a record when a record with</option>
-										<option>that key already exists.</option>
-										<option>Of course, transaction errors do occur</option>
-										<option>so you might want to include code</option>
-										<option>to handle these errors.</option>
-									</select>
-								</td>
-							</tr>
-							<tr>
-								<td bgcolor="#FFFFCC" width="8%">Q2</td>
-								<td bgcolor="#E1FFE1" valign="top" width="62%">
-									Why do you think the complex condition <i>EndTF <b>AND</b> EndMF</i> has been used
-									to terminate the loop?
-								</td>
-								<td bgcolor="#E1FFE1" valign="top" width="30%">
-									<select name="select" size="1">
-										<option selected>Click the arrow for the answer</option>
-										<option>---------------------------------------------------------------</option>
-										<option>Since we don't know which file is going</option>
-										<option>to be exhausted first we have to use</option>
-										<option>a condition which says - keep going</option>
-										<option>until the end of both files is reached.</option>
-									</select>
-								</td>
-							</tr>
-							<tr>
-								<td bgcolor="#FFFFCC" width="8%">Q3</td>
-								<td bgcolor="#E1FFE1" valign="top" width="62%">
-									There does not seem to be any special code to write out the remaining records when
-									one file ends before the other. Can the code above be correct?
-								</td>
-								<td bgcolor="#E1FFE1" valign="top" width="30%">
-									<select name="select" size="1">
-										<option selected>Click the arrow for the answer</option>
-										<option>---------------------------------------------------------------</option>
-										<option>Yes the code is correct!!!</option>
-										<option>It takes advantage of the fact that</option>
-										<option>when either condition name is set to</option>
-										<option>true, the corresponding record</option>
-										<option>(including its key field) is filled with</option>
-										<option>HIGH-VALUES. Since the key field of</option>
-										<option>the ended file contains the highest</option>
-										<option>possible value, all the keys in the</option>
-										<option>other file will be less than it and so</option>
-										<option>all the remaining records in that file will</option>
-										<option>automatically be written to the new file.</option>
-										<option>I told you using HIGH-VALUES would</option>
-										<option>come in handy.</option>
-									</select>
-								</td>
-							</tr>
-						</table>
+					<form action="SequentialFiles2.html" method="post" class="qa-form">
+						<div class="qa-row">
+							<div class="qa-label">Q1</div>
+							<div class="qa-question">
+								In the program, no allowance has been made for when the key fields are equal. What
+								would it mean if the keys were equal?
+							</div>
+							<div class="qa-answer">
+								<select name="select" size="1">
+									<option selected>Click the arrow for the answer</option>
+									<option>---------------------------------------------------------------</option>
+									<option>Since the key field is supposed to</option>
+									<option>be unique this would be a transaction</option>
+									<option>error. It would mean that we were trying</option>
+									<option>to insert a record when a record with</option>
+									<option>that key already exists.</option>
+									<option>Of course, transaction errors do occur</option>
+									<option>so you might want to include code</option>
+									<option>to handle these errors.</option>
+								</select>
+							</div>
+						</div>
+						<div class="qa-row">
+							<div class="qa-label">Q2</div>
+							<div class="qa-question">
+								Why do you think the complex condition <i>EndTF <b>AND</b> EndMF</i> has been used
+								to terminate the loop?
+							</div>
+							<div class="qa-answer">
+								<select name="select" size="1">
+									<option selected>Click the arrow for the answer</option>
+									<option>---------------------------------------------------------------</option>
+									<option>Since we don't know which file is going</option>
+									<option>to be exhausted first we have to use</option>
+									<option>a condition which says - keep going</option>
+									<option>until the end of both files is reached.</option>
+								</select>
+							</div>
+						</div>
+						<div class="qa-row">
+							<div class="qa-label">Q3</div>
+							<div class="qa-question">
+								There does not seem to be any special code to write out the remaining records when
+								one file ends before the other. Can the code above be correct?
+							</div>
+							<div class="qa-answer">
+								<select name="select" size="1">
+									<option selected>Click the arrow for the answer</option>
+									<option>---------------------------------------------------------------</option>
+									<option>Yes the code is correct!!!</option>
+									<option>It takes advantage of the fact that</option>
+									<option>when either condition name is set to</option>
+									<option>true, the corresponding record</option>
+									<option>(including its key field) is filled with</option>
+									<option>HIGH-VALUES. Since the key field of</option>
+									<option>the ended file contains the highest</option>
+									<option>possible value, all the keys in the</option>
+									<option>other file will be less than it and so</option>
+									<option>all the remaining records in that file will</option>
+									<option>automatically be written to the new file.</option>
+									<option>I told you using HIGH-VALUES would</option>
+									<option>come in handy.</option>
+								</select>
+							</div>
+						</div>
 					</form>
 					<hr width="50%" />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" height="147" valign="top" width="175">
+				</div>
+				<div class="section-sidebar">
 					<h4 align="left">Deleting records from an ordered Sequential file.</h4>
-				</td>
-				<td height="147" valign="top" width="525">
+				</div>
+				<div class="section-content">
 					<p>The animation below demonstrates how to delete records from an ordered Sequential file.</p>
 					<p align="center">
 						<a href="Resources/ppz/TC-SeqFile2d.html"
@@ -569,13 +633,11 @@ END-PERFORM
 						/></a>
 					</p>
 					<hr width="50%" />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" height="210" valign="top" width="175">
+				</div>
+				<div class="section-sidebar">
 					<h4 align="left">Updating records in an ordered Sequential file.</h4>
-				</td>
-				<td height="210" valign="top" width="525">
+				</div>
+				<div class="section-content">
 					<p>
 						Updating a record requires a change to one or more of the fields in the record. Updates to
 						Sequential files are usually collected together and applied to the file in one go - a batch. To
@@ -588,13 +650,11 @@ END-PERFORM
 							><img border="0" height="62" src="Resources/pics/i-Animation.gif" width="62"
 						/></a>
 					</p>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
+				</div>
+				<div class="section-sidebar">
 					<h4 align="left">Multiple record type transaction files</h4>
-				</td>
-				<td valign="top" width="525">
+				</div>
+				<div class="section-content">
 					<p>
 						In all the examples in this tutorial the transaction file has contained only records of one type
 						or another. For instance, the transaction file contained either a batch of deletions, or a batch
@@ -612,17 +672,15 @@ END-PERFORM
 						types.
 					</p>
 					<hr width="50%" />
-				</td>
-			</tr>
-			<tr>
-				<td colspan="2">
-					<hr />
-					<div align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</div>
-					<copyright-notice></copyright-notice>
-				</td>
-			</tr>
-		</table>
+				</div>
+			</div>
+			<div class="page-footer">
+				<hr />
+				<div align="center">
+					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
+				</div>
+				<copyright-notice></copyright-notice>
+			</div>
+		</div>
 	</body>
 </html>


### PR DESCRIPTION
## Summary

- Replaced the outer 2-column layout table (`#layout-table`, 175px sidebar + content) with `.page-wrapper` + `.section-grid` CSS grid divs, matching the established pattern from `SequentialFiles1.html`
- Replaced the code snippet table (which used a `background` attribute to show `code.gif`) with a free-flowing `<pre>` element — the background image wrapper was removed entirely per review feedback
- Replaced the 3-column form Q&A layout table with `.qa-form` + `.qa-row` CSS grid divs; updated the responsive CSS accordingly (was targeting `form table:has(select)`, now targets `.qa-row`/`.qa-label`/`.qa-answer`)
- Preserved the "Ordered File vs Unordered File" comparison table unchanged — it contains actual tabular data

## What a reviewer should know

- The Q&A form rows use `border-bottom`/`border-right` on cells rather than a grid gap to avoid column overflow with percentage-based widths
- CSS follows the same class names and structure as the already-merged `SequentialFiles1.html` refactor (#141)
- Mobile breakpoint at 600px collapses `.section-grid` to single column and stacks `.qa-row` cells with bold labels, preserving the original responsive behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)