### PR TITLE
Refactor DataDeclaration.html layout tables to CSS grid/flexbox

### DIFF
--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
 	<head>
+		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>Declaring Data in COBOL</title>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
-		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<style type="text/css">
 			img {
 				max-width: 100%;
@@ -15,12 +15,6 @@
 
 			table {
 				max-width: 100%;
-			}
-
-			body > table,
-			body > hr {
-				margin-left: auto;
-				margin-right: auto;
 			}
 
 			pre {
@@ -32,6 +26,99 @@
 				-webkit-text-size-adjust: 100%;
 			}
 
+			.page-layout {
+				display: grid;
+				grid-template-columns: 175px 1fr;
+				max-width: 715px;
+				margin: 0 auto;
+				border: 1px solid black;
+				border-right: none;
+				border-bottom: none;
+			}
+
+			.page-layout > div {
+				padding: 4px;
+				border-right: 1px solid black;
+				border-bottom: 1px solid black;
+				min-width: 0;
+				box-sizing: border-box;
+			}
+
+			.full-width {
+				grid-column: 1 / -1;
+			}
+
+			.section-header {
+				background-color: #993300;
+			}
+
+			.section-header h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			.sidebar {
+				background-color: #FFFFCC;
+				align-self: start;
+			}
+
+			.sidebar h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			.code-record {
+				background-color: #E1FFE1;
+				border: 1px solid black;
+				width: fit-content;
+				max-width: 90%;
+				margin: 0.5em auto;
+				overflow-x: auto;
+			}
+
+			.code-record .record-title {
+				font-weight: bold;
+				text-align: center;
+				padding: 4px;
+				border-bottom: 1px solid black;
+			}
+
+			.code-record pre {
+				margin: 0;
+			}
+
+			.qa-grid {
+				display: grid;
+				grid-template-columns: 8% 1fr;
+				column-gap: 5px;
+				row-gap: 0.3em;
+				width: 84%;
+				margin: 0 auto;
+			}
+
+			.qa-grid .qa-label {
+				font-weight: bold;
+				align-self: start;
+				padding-top: 0.15em;
+			}
+
+			ul.toc {
+				list-style-image: url(Resources/pics/BallGreenG.gif);
+				padding-left: 2.5em;
+				margin: 1em 0;
+			}
+
+			ul.toc > li {
+				padding-left: 0.4em;
+				margin-bottom: 0.6em;
+				font-size: smaller;
+			}
+
+			ul.toc a {
+				font-weight: bold;
+				font-size: larger;
+			}
+
 			@media (max-width: 600px) {
 				body {
 					margin: 4px;
@@ -39,22 +126,19 @@
 					word-wrap: break-word;
 				}
 
-				table[width] {
-					width: 100% !important;
-					height: auto !important;
+				.page-layout {
+					grid-template-columns: 1fr;
+					border-right: 1px solid black;
 				}
 
-				td[width],
-				th[width],
-				td[height],
-				th[height] {
-					width: auto !important;
-					height: auto !important;
+				.sidebar h4:not(:first-child):not(:has(img)) {
+					display: none;
 				}
 
-				td[bgcolor="#993300"] > h2,
-				td[bgcolor="#993300"] > h3 {
-					margin: 0.3em 0;
+				.sidebar h3,
+				.sidebar h4,
+				.sidebar p {
+					margin: 0.2em 0;
 				}
 
 				blockquote {
@@ -95,393 +179,714 @@
 					overflow-x: auto;
 				}
 
-				#layout-table,
-				#layout-table > tbody,
-				#layout-table > tbody > tr,
-				#layout-table > tbody > tr > td {
-					display: block;
-					width: auto !important;
+				.code-record {
+					width: 100%;
+					max-width: 100%;
 				}
 
-				td[width="175"] > h4:not(:first-child):not(:has(img)),
-				td[width="160"] > h4:not(:first-child):not(:has(img)),
-				h4:has(> img[src*="PanelLine"]) {
-					display: none;
+				.qa-grid {
+					width: 100%;
 				}
-
-				td[width="175"] > h3,
-				td[width="175"] > h4,
-				td[width="175"] > p,
-				td[width="160"] > h3,
-				td[width="160"] > h4,
-				td[width="160"] > p {
-					margin: 0.2em 0;
-				}
-			}
-
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
-
-			td[bgcolor="#993300"] h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			td[bgcolor="#FFFFCC"] h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
 			}
 		</style>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
-		<table id="layout-table" border="1" width="715" cellpadding="4" cellspacing="0">
-			<tr>
-				<td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
-					<center>
-						<p><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
-						<h1>Declaring Data in COBOL</h1>
-					</center>
+		<div class="page-layout">
+			<div class="full-width">
+				<center>
+					<p><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
+					<h1>Declaring Data in COBOL</h1>
+				</center>
+				<hr />
+				<ul class="toc">
+					<li>
+						<a href="#intro">Introduction</a><br />
+						Unit aims, objectives, prerequisites and further reading.
+					</li>
+					<li>
+						<a href="#part1">Categories of COBOL data</a><br />
+						This section introduces the three categories of COBOL data - Literals, Variables and
+						Figurative Constants.
+					</li>
+					<li>
+						<a href="#part2">Declaring Data-Items in COBOL</a><br />
+						In this section we show how variables are declared in COBOL using the
+						<code class="language-cobol">PICTURE</code> clause.
+					</li>
+					<li>
+						<a href="#part3">Group and Elementary Data-Items</a><br />
+						This section demonstrates how record structures can be specified using an appropriate
+						arrangement of level numbers.
+					</li>
+				</ul>
+			</div>
+			<div class="full-width section-header">
+				<h2 align="center" id="intro">Introduction</h2>
+			</div>
+			<div class="sidebar">
+				<h4>Aims</h4>
+			</div>
+			<div>
+				<p>
+					The aim of this unit is to give you an understanding of the different categories of data used in
+					a COBOL program and to demonstrate how items of each category may be created and used.
+				</p>
+				<hr width="50%" />
+			</div>
+			<div class="sidebar">
+				<h4>Objectives</h4>
+			</div>
+			<div>
+				<p>By the end of this unit you should -</p>
+				<ol>
+					<li>Know how to use and create literals, variables and Figurative Constants.</li>
+					<li>Understand how to declare numeric, alphabetic and alphanumeric data-items.</li>
+					<li>
+						Be able to create a record structure by assigning the appropriate level numbers to its
+						data-items.
+					</li>
+					<li>Understand the difference between group and an elementary data-items.</li>
+					<li>Be able to assign an initial value to a variable.</li>
+				</ol>
+				<hr width="50%" />
+			</div>
+			<div class="sidebar">
+				<h4>Prerequisites</h4>
+			</div>
+			<div>
+				<p>Introduction to COBOL.</p>
+				<p>but more information on declaring data items in COBOL can be found in the units covering</p>
+				<ul>
+					<li>Edited Pictures</li>
+					<li>Sequential Files</li>
+					<li>The USAGE clause</li>
+				</ul>
+			</div>
+			<div class="sidebar">
+				<h4>Further reading</h4>
+			</div>
+			<div>
+				<p>More information on declaring data items in COBOL can be found in the units covering -</p>
+				<ul>
+					<li>Edited Pictures</li>
+					<li>Sequential Files</li>
+					<li>The USAGE clause</li>
+				</ul>
+			</div>
+			<div class="full-width">
+				<div align="center">
 					<hr />
-					<ul class="toc">
-						<li>
-							<a href="#intro">Introduction</a><br />
-							Unit aims, objectives, prerequisites and further reading.
-						</li>
-						<li>
-							<a href="#part1">Categories of COBOL data</a><br />
-							This section introduces the three categories of COBOL data - Literals, Variables and
-							Figurative Constants.
-						</li>
-						<li>
-							<a href="#part2">Declaring Data-Items in COBOL</a><br />
-							In this section we show how variables are declared in COBOL using the
-							<code class="language-cobol">PICTURE</code> clause.
-						</li>
-						<li>
-							<a href="#part3">Group and Elementary Data-Items</a><br />
-							This section demonstrates how record structures can be specified using an appropriate
-							arrangement of level numbers.
-						</li>
-					</ul>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="intro">Introduction</h2>
-				</td>
-			</tr>
-			<tr>
-				<td bgcolor="#FFFFCC" valign="top" width="160">
-					<h4>Aims</h4>
-				</td>
-				<td width="540">
 					<p>
-						The aim of this unit is to give you an understanding of the different categories of data used in
-						a COBOL program and to demonstrate how items of each category may be created and used.
+						<a href="#top"
+							><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
+						/></a>
 					</p>
-					<hr width="50%" />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-					<h4>Objectives</h4>
-				</td>
-				<td width="540">
-					<p>By the end of this unit you should -</p>
-					<ol>
-						<li>Know how to use and create literals, variables and Figurative Constants.</li>
-						<li>Understand how to declare numeric, alphabetic and alphanumeric data-items.</li>
-						<li>
-							Be able to create a record structure by assigning the appropriate level numbers to its
-							data-items.
-						</li>
-						<li>Understand the difference between group and an elementary data-items.</li>
-						<li>Be able to assign an initial value to a variable.</li>
-					</ol>
-					<hr width="50%" />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-					<h4>Prerequisites</h4>
-				</td>
-				<td width="525">
-					<p>Introduction to COBOL.</p>
-					<p>but more information on declaring data items in COBOL can be found in the units covering</p>
-					<ul>
-						<li>Edited Pictures</li>
-						<li>Sequential Files</li>
-						<li>The USAGE clause</li>
-					</ul>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-					<h4>Further reading</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>More information on declaring data items in COBOL can be found in the units covering -</p>
-					<ul>
-						<li>Edited Pictures</li>
-						<li>Sequential Files</li>
-						<li>The USAGE clause</li>
-					</ul>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
-					<div align="center">
-						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
-					</div>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part1">Categories of COBOL data</h2>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-					<h4 align="left">Introduction</h4>
-				</td>
-				<td valign="top" width="540">
-					<p>There are three categories of data item used in COBOL programs:</p>
-					<ul>
-						<li>Variables.</li>
-						<li>Literals.</li>
-						<li>Figurative Constants.</li>
-					</ul>
-					<hr width="50%" />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">Variables</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						A data-name or identifier is the name used to identify the area of memory reserved for a
-						variable. A variable is a named location in memory into which a program can put data, and from
-						which it can retrieve data.
+				</div>
+			</div>
+			<div class="full-width section-header">
+				<h2 align="center" id="part1">Categories of COBOL data</h2>
+			</div>
+			<div class="sidebar">
+				<h4 align="left">Introduction</h4>
+			</div>
+			<div>
+				<p>There are three categories of data item used in COBOL programs:</p>
+				<ul>
+					<li>Variables.</li>
+					<li>Literals.</li>
+					<li>Figurative Constants.</li>
+				</ul>
+				<hr width="50%" />
+			</div>
+			<div class="sidebar">
+				<h4 align="left">Variables</h4>
+			</div>
+			<div>
+				<p>
+					A data-name or identifier is the name used to identify the area of memory reserved for a
+					variable. A variable is a named location in memory into which a program can put data, and from
+					which it can retrieve data.
+				</p>
+				<p>
+					Every variable used in a COBOL program must be described in the
+					<code class="language-cobol">DATA DIVISION</code>.
+				</p>
+				<p>
+					In addition to the data-name, a variable declaration also defines the type of data to be stored
+					in the variable. This is known as the variable's data type.
+				</p>
+			</div>
+			<div class="sidebar">
+				<h4 align="left">Variable Data types</h4>
+				<aside>
+					<p align="center">
+						<img height="62" src="Resources/pics/i-BugAlert.gif" width="56" /><br />
+						Attempting to perform computations on numeric data items that contain non-numeric data is a
+						frequent cause of program crashes for beginning COBOL programmers.
 					</p>
-					<p>
-						Every variable used in a COBOL program must be described in the
-						<code class="language-cobol">DATA DIVISION</code>.
-					</p>
-					<p>
-						In addition to the data-name, a variable declaration also defines the type of data to be stored
-						in the variable. This is known as the variable's data type.
-					</p>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">Variable Data types</h4>
-					<aside>
-						<p align="center">
-							<img height="62" src="Resources/pics/i-BugAlert.gif" width="56" /><br />
-							Attempting to perform computations on numeric data items that contain non-numeric data is a
-							frequent cause of program crashes for beginning COBOL programmers.
-						</p>
-					</aside>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						Some languages like Modula-2,Pascal or Ada are described as being
-						<i>strongly typed</i>. In these languages there are a large number of different data types and
-						the distinction between them is rigorously enforced by the compiler. For instance, the compiler
-						will reject a statement that attempts to assign character value to an integer data item.
-					</p>
-					<p>In COBOL, there are really only three data types -</p>
-					<ul>
-						<li>numeric</li>
-						<li>alphanumeric (text/string)</li>
-						<li>alphabetic</li>
-					</ul>
-					<p>
-						The distinction between these data types is a little blurred and only weakly enforced by the
-						compiler. For instance, it is perfectly possible to assign a non-numeric value to a data item
-						that has been declared to be numeric.
-					</p>
-					<p>
-						The problem with this lax approach to data typing is that, since COBOL programs crash (halt
-						unexpectedly) if they attempt to do computations on items that contain non-numeric data, it is
-						up to the programmer to make sure this never happens.
-					</p>
-					<p>
-						COBOL programmers must make sure that non-numeric data is never assigned to numeric items
-						intended for use in calculations. Programmers who use strongly typed languages don't need this
-						level of discipline because the compiler ensures that a variable of a particular type can only
-						be assigned appropriate values.
-					</p>
-					<hr width="50%" />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">Literals</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						A literal is a data-item that consists only of the data-item value itself. It cannot be referred
-						to by a name. By definition, literals are constant data-items.
-					</p>
-					<p>There are two types of literal -</p>
-					<ul>
-						<li>String/Alphanumeric Literals</li>
-						<li>Numeric Literals</li>
-					</ul>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">String Literals</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>String/Alphanumeric literals are enclosed in quotes and consist of alphanumeric characters.</p>
-					<p>For example: "Michael Ryan", "-123", "123.45"</p>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">Numeric Literals</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						Numeric literals may consist of numerals, the decimal point, and the plus or minus sign. Numeric
-						literals are not enclosed in quotes.
-					</p>
-					<p>For example: 123, 123.45, -256, +2987</p>
-					<hr width="50%" />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">Figurative Constants</h4>
-					<aside>
-						<p align="center">
-							<img height="37" src="Resources/pics/i-Detail.gif" width="30" />
-						</p>
-						<p align="center">
-							Actually COBOL does allow you to set up single character user-defined Figurative Constants.
-							These can be useful if you need to use the non-printable ASCII characters such as ESC or
-							FormFeed.
-						</p>
-						<p align="center">
-							User-defined Figurative Constants are declared in the
-							<code class="language-cobol">SYMBOLIC CHARACTERS</code> clause of the
-							<code class="language-cobol">ENVIRONMENT DIVISION</code>.
-						</p>
-						<p align="center">
-							In an extension that previews the new COBOL specification, NetExpress does allow
-							user-defined constants. It uses the level 78 for this purpose.
-						</p>
-					</aside>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						Unlike most other programming languages COBOL does not provide a mechanism for creating
-						user-defined constants but it does provide a set of special constants called Figurative
-						Constants.
-					</p>
-					<p>
-						A Figurative Constant may be used wherever it is legal to use a literal but unlike literals,
-						when a Figurative Constant is assigned to a data-item it fills the whole item overwriting
-						everything in it.
-					</p>
-					<p>The Figurative Constants are:</p>
-					<table align="center" bgcolor="#E1FFE1" border="1" cellpadding="5" cellspacing="0" width="439">
-						<tr>
-							<td valign="top" width="47%">
-								<code class="language-cobol">SPACE</code> or <code class="language-cobol">SPACES</code>
-							</td>
-							<td valign="top" width="53%">Acts like one or more spaces</td>
-						</tr>
-						<tr>
-							<td valign="top" width="47%">
-								<code class="language-cobol">ZERO</code> or <code class="language-cobol">ZEROS</code> or
-								<code class="language-cobol">ZEROES</code>
-							</td>
-							<td valign="top" width="53%">Acts like one or more zeros</td>
-						</tr>
-						<tr>
-							<td valign="top" width="47%">
-								<code class="language-cobol">QUOTE</code> or <code class="language-cobol">QUOTES</code>
-							</td>
-							<td valign="top" width="53%">Used instead of a quotation mark</td>
-						</tr>
-						<tr>
-							<td valign="top" width="47%">
-								<code class="language-cobol">HIGH-VALUE</code> or
-								<code class="language-cobol">HIGH-VALUES</code>
-							</td>
-							<td valign="top" width="53%">Uses the maximum value possible</td>
-						</tr>
-						<tr>
-							<td valign="top" width="47%">
-								<code class="language-cobol">LOW-VALUE</code> or
-								<code class="language-cobol">LOW-VALUES</code>
-							</td>
-							<td valign="top" width="53%">Uses the minimum value possible</td>
-						</tr>
-						<tr>
-							<td valign="top" width="47%"><code class="language-cobol">ALL</code> literal</td>
-							<td valign="top" width="53%">Allows an ordinary literal to act as Figurative Constant</td>
-						</tr>
-					</table>
-					<p><b>Figurative Constant Notes</b></p>
-					<ul>
-						<li>
-							When the <code class="language-cobol">ALL</code> Figurative Constant is used, it must be
-							followed by a one character literal. The designated literal then acts like the standard
-							Figurative Constants.
-						</li>
-						<li>
-							<code class="language-cobol">ZERO</code>, <code class="language-cobol">ZEROS</code> and
-							<code class="language-cobol">ZEROES</code> are synonyms, not separate Figurative Constants.
-							The same applies to <code class="language-cobol">SPACE</code> and
-							<code class="language-cobol">SPACES</code>, <code class="language-cobol">QUOTE</code> and
-							<code class="language-cobol">QUOTES</code>,
-							<code class="language-cobol">HIGH-VALUE</code> and
-							<code class="language-cobol">HIGH-VALUES</code>,
-							<code class="language-cobol">LOW-VALUE</code> and
-							<code class="language-cobol">LOW-VALUES</code>.
-						</li>
-					</ul>
-					<hr width="50%" />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">Using COBOL data — examples</h4>
-				</td>
-				<td valign="top" width="525">
-					<p id="data1">
-						The animated program fragments below demonstrate how variables, literals and Figurative
-						Constants may be created and used.
+				</aside>
+			</div>
+			<div>
+				<p>
+					Some languages like Modula-2,Pascal or Ada are described as being
+					<i>strongly typed</i>. In these languages there are a large number of different data types and
+					the distinction between them is rigorously enforced by the compiler. For instance, the compiler
+					will reject a statement that attempts to assign character value to an integer data item.
+				</p>
+				<p>In COBOL, there are really only three data types -</p>
+				<ul>
+					<li>numeric</li>
+					<li>alphanumeric (text/string)</li>
+					<li>alphabetic</li>
+				</ul>
+				<p>
+					The distinction between these data types is a little blurred and only weakly enforced by the
+					compiler. For instance, it is perfectly possible to assign a non-numeric value to a data item
+					that has been declared to be numeric.
+				</p>
+				<p>
+					The problem with this lax approach to data typing is that, since COBOL programs crash (halt
+					unexpectedly) if they attempt to do computations on items that contain non-numeric data, it is
+					up to the programmer to make sure this never happens.
+				</p>
+				<p>
+					COBOL programmers must make sure that non-numeric data is never assigned to numeric items
+					intended for use in calculations. Programmers who use strongly typed languages don't need this
+					level of discipline because the compiler ensures that a variable of a particular type can only
+					be assigned appropriate values.
+				</p>
+				<hr width="50%" />
+			</div>
+			<div class="sidebar">
+				<h4 align="left">Literals</h4>
+			</div>
+			<div>
+				<p>
+					A literal is a data-item that consists only of the data-item value itself. It cannot be referred
+					to by a name. By definition, literals are constant data-items.
+				</p>
+				<p>There are two types of literal -</p>
+				<ul>
+					<li>String/Alphanumeric Literals</li>
+					<li>Numeric Literals</li>
+				</ul>
+			</div>
+			<div class="sidebar">
+				<h4 align="left">String Literals</h4>
+			</div>
+			<div>
+				<p>String/Alphanumeric literals are enclosed in quotes and consist of alphanumeric characters.</p>
+				<p>For example: "Michael Ryan", "-123", "123.45"</p>
+			</div>
+			<div class="sidebar">
+				<h4 align="left">Numeric Literals</h4>
+			</div>
+			<div>
+				<p>
+					Numeric literals may consist of numerals, the decimal point, and the plus or minus sign. Numeric
+					literals are not enclosed in quotes.
+				</p>
+				<p>For example: 123, 123.45, -256, +2987</p>
+				<hr width="50%" />
+			</div>
+			<div class="sidebar">
+				<h4 align="left">Figurative Constants</h4>
+				<aside>
+					<p align="center">
+						<img height="37" src="Resources/pics/i-Detail.gif" width="30" />
 					</p>
 					<p align="center">
-						<a href="Resources/ppz/TC-Data1.html"
+						Actually COBOL does allow you to set up single character user-defined Figurative Constants.
+						These can be useful if you need to use the non-printable ASCII characters such as ESC or
+						FormFeed.
+					</p>
+					<p align="center">
+						User-defined Figurative Constants are declared in the
+						<code class="language-cobol">SYMBOLIC CHARACTERS</code> clause of the
+						<code class="language-cobol">ENVIRONMENT DIVISION</code>.
+					</p>
+					<p align="center">
+						In an extension that previews the new COBOL specification, NetExpress does allow
+						user-defined constants. It uses the level 78 for this purpose.
+					</p>
+				</aside>
+			</div>
+			<div>
+				<p>
+					Unlike most other programming languages COBOL does not provide a mechanism for creating
+					user-defined constants but it does provide a set of special constants called Figurative
+					Constants.
+				</p>
+				<p>
+					A Figurative Constant may be used wherever it is legal to use a literal but unlike literals,
+					when a Figurative Constant is assigned to a data-item it fills the whole item overwriting
+					everything in it.
+				</p>
+				<p>The Figurative Constants are:</p>
+				<table align="center" bgcolor="#E1FFE1" border="1" cellpadding="5" cellspacing="0" width="439">
+					<tr>
+						<td valign="top" width="47%">
+							<code class="language-cobol">SPACE</code> or <code class="language-cobol">SPACES</code>
+						</td>
+						<td valign="top" width="53%">Acts like one or more spaces</td>
+					</tr>
+					<tr>
+						<td valign="top" width="47%">
+							<code class="language-cobol">ZERO</code> or <code class="language-cobol">ZEROS</code> or
+							<code class="language-cobol">ZEROES</code>
+						</td>
+						<td valign="top" width="53%">Acts like one or more zeros</td>
+					</tr>
+					<tr>
+						<td valign="top" width="47%">
+							<code class="language-cobol">QUOTE</code> or <code class="language-cobol">QUOTES</code>
+						</td>
+						<td valign="top" width="53%">Used instead of a quotation mark</td>
+					</tr>
+					<tr>
+						<td valign="top" width="47%">
+							<code class="language-cobol">HIGH-VALUE</code> or
+							<code class="language-cobol">HIGH-VALUES</code>
+						</td>
+						<td valign="top" width="53%">Uses the maximum value possible</td>
+					</tr>
+					<tr>
+						<td valign="top" width="47%">
+							<code class="language-cobol">LOW-VALUE</code> or
+							<code class="language-cobol">LOW-VALUES</code>
+						</td>
+						<td valign="top" width="53%">Uses the minimum value possible</td>
+					</tr>
+					<tr>
+						<td valign="top" width="47%"><code class="language-cobol">ALL</code> literal</td>
+						<td valign="top" width="53%">Allows an ordinary literal to act as Figurative Constant</td>
+					</tr>
+				</table>
+				<p><b>Figurative Constant Notes</b></p>
+				<ul>
+					<li>
+						When the <code class="language-cobol">ALL</code> Figurative Constant is used, it must be
+						followed by a one character literal. The designated literal then acts like the standard
+						Figurative Constants.
+					</li>
+					<li>
+						<code class="language-cobol">ZERO</code>, <code class="language-cobol">ZEROS</code> and
+						<code class="language-cobol">ZEROES</code> are synonyms, not separate Figurative Constants.
+						The same applies to <code class="language-cobol">SPACE</code> and
+						<code class="language-cobol">SPACES</code>, <code class="language-cobol">QUOTE</code> and
+						<code class="language-cobol">QUOTES</code>,
+						<code class="language-cobol">HIGH-VALUE</code> and
+						<code class="language-cobol">HIGH-VALUES</code>,
+						<code class="language-cobol">LOW-VALUE</code> and
+						<code class="language-cobol">LOW-VALUES</code>.
+					</li>
+				</ul>
+				<hr width="50%" />
+			</div>
+			<div class="sidebar">
+				<h4 align="left">Using COBOL data — examples</h4>
+			</div>
+			<div>
+				<p id="data1">
+					The animated program fragments below demonstrate how variables, literals and Figurative
+					Constants may be created and used.
+				</p>
+				<p align="center">
+					<a href="Resources/ppz/TC-Data1.html"
+						><img
+							alt="Click to view the animation"
+							border="0"
+							height="62"
+							src="Resources/pics/i-Animation.gif"
+							width="62"
+					/></a>
+				</p>
+			</div>
+			<div class="full-width">
+				<div align="center">
+					<hr />
+					<p>
+						<a href="#top"
+							><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
+						/></a>
+					</p>
+				</div>
+			</div>
+			<div class="full-width section-header">
+				<h2 align="center" id="part2">Declaring Data-Items in COBOL</h2>
+			</div>
+			<div class="sidebar">
+				<h4>Introduction</h4>
+			</div>
+			<div>
+				<p>
+					Because COBOL is not a typed language like Modula-2 or C it employs a different mechanism for
+					describing the characteristics of the data-items in a program.
+				</p>
+				<p>
+					Rather than using types, as these languages do, COBOL uses a kind of "declaration by example"
+					strategy. The programmer provides the system with an example, or template, or PICture of the
+					storage required for the data-item.
+				</p>
+				<p>
+					In COBOL, a variable declaration consists of a line in the
+					<code class="language-cobol">DATA DIVISION</code> that contains the following items:
+				</p>
+				<ul>
+					<li>A level number.</li>
+					<li>A data-name or identifier.</li>
+					<li>A Picture clause.</li>
+				</ul>
+				<hr width="50%" />
+			</div>
+			<div class="sidebar">
+				<h4 align="left">COBOL picture clauses</h4>
+				<aside>
+					<p align="center">
+						<img height="37" src="Resources/pics/i-Detail.gif" width="30" /><br />
+						There are actually many more picture symbols than these. Most of these will be introduced
+						when we cover Edited Pictures.
+					</p>
+				</aside>
+			</div>
+			<div>
+				<p>
+					To create the required 'picture' the programmer uses a set of symbols. The most common symbols
+					used in standard picture clauses are:
+				</p>
+				<table align="center" bgcolor="#E1FFE1" border="1" cellpadding="7" cellspacing="0" width="445">
+					<tr>
+						<td valign="top" width="14%">
+							<p align="center">
+								<b>9</b>
+							</p>
+						</td>
+						<td valign="top" width="86%">
+							<p>
+								The digit nine is used to indicate the occurrence of a digit at the corresponding
+								position in the picture.
+							</p>
+						</td>
+					</tr>
+					<tr>
+						<td valign="top" width="14%">
+							<p align="center">
+								<b>X</b>
+							</p>
+						</td>
+						<td valign="top" width="86%">
+							<p>
+								The character X is used to indicate the occurrence of any character from the
+								character set at the corresponding position in the picture.
+							</p>
+						</td>
+					</tr>
+					<tr>
+						<td valign="top" width="14%">
+							<p align="center">
+								<b>A</b>
+							</p>
+						</td>
+						<td valign="top" width="86%">
+							<p>
+								The character A is used to indicate the occurrence of any alphabetic character (A to
+								Z plus blank) at the corresponding position in the picture.
+							</p>
+						</td>
+					</tr>
+					<tr>
+						<td valign="top" width="14%">
+							<p align="center">
+								<b>V</b>
+							</p>
+						</td>
+						<td valign="top" width="86%">
+							<p>
+								The character V is used to indicate the position of the decimal point in a numeric
+								value. It is often referred to as the "assumed decimal point". It is called that
+								because, although the actual decimal point is not stored, values are treated as if
+								they had a decimal point in that position.
+							</p>
+						</td>
+					</tr>
+					<tr>
+						<td valign="top" width="14%">
+							<p align="center">
+								<b>S</b>
+							</p>
+						</td>
+						<td valign="top" width="86%">
+							<p>
+								The character S indicates the presence of a sign and can only appear at the
+								beginning of a picture.
+							</p>
+						</td>
+					</tr>
+				</table>
+				<hr width="50%" />
+			</div>
+			<div class="sidebar">
+				<h4 align="left">Picture clause notes</h4>
+			</div>
+			<div>
+				<p>
+					Although the word <code class="language-cobol">PICTURE</code> can be used when defining a
+					picture clause it is normal to use the abbreviation <code class="language-cobol">PIC</code>.
+				</p>
+				<p>Recurring symbols may be specified by using a 'repeat' factor inside brackets. For instance:</p>
+				<pre
+					class="language-cobol"
+				><code class="language-cobol">PIC 9(6)       is equivalent to PICTURE 999999
+PIC 9(6)V99    is equivalent to PIC 999999V99
+PICTURE X(10)  is equivalent to PIC XXXXXXXXXX
+PIC S9(4)V9(4) is equivalent to PIC S9999V9999
+PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
+				<p>Numeric values can have a maximum of 18 (eighteen) digits.</p>
+				<p>The limit on string values is usually system dependent.</p>
+			</div>
+			<div class="full-width">
+				<div align="center">
+					<hr />
+					<p>
+						<a href="#top"
+							><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
+						/></a>
+					</p>
+				</div>
+			</div>
+			<div class="full-width section-header">
+				<h2 align="center" id="part3">Group and Elementary data-items</h2>
+			</div>
+			<div class="sidebar">
+				<h4>Introduction</h4>
+			</div>
+			<div>
+				<div align="center">
+					<p align="left">
+						Although we stated above that each variable declaration consists of a level number, an
+						identifying name and a picture clause, that definition only applies to elementary
+						data-items. Group items are defined using only a level-number and an identifying name; no
+						picture clause is required or allowed.
+					</p>
+					<p align="left">
+						Which begs the question - what is a group item and what is an elementary item?
+					</p>
+				</div>
+			</div>
+			<div class="sidebar">
+				<h4 align="left">Elementary items</h4>
+				<aside>
+					<p align="center">
+						<img height="37" src="Resources/pics/i-Detail.gif" width="30" /><br />
+						A variable declaration may also have a number of other clauses such as
+						<code class="language-cobol">USAGE</code> or
+						<code class="language-cobol">BLANK WHEN ZERO</code>
+					</p>
+				</aside>
+			</div>
+			<div>
+				<p>
+					An "elementary item" is the name we use in COBOL to describe a data-item that has not been
+					further subdivided. Other languages might describe these as ordinary variables.
+				</p>
+				<p align="left">
+					Elementary items <b>must</b> have a picture clause because they actually reserve the storage
+					required for the item. The amount of storage reserved is specified by the item's picture clause.
+				</p>
+				<p>An elementary item declaration consists of;</p>
+				<ul>
+					<li>a level number</li>
+					<li>a data name</li>
+					<li>a picture clause</li>
+				</ul>
+				<p align="left">
+					A starting value may be assigned to a variable by means of an extension to the
+					<code class="language-cobol">PICTURE</code> clause called the
+					<code class="language-cobol">VALUE</code> clause.
+				</p>
+				<p align="left"><b>Some examples:</b></p>
+				<pre class="language-cobol"><code class="language-cobol">01 GrossPay       PIC 9(5)V99 VALUE ZEROS.
+
+01 NetPay         PIC 9(5)V99 VALUE ZEROS.
+
+01 CustomerName   PIC X(20) VALUE SPACES.
+
+01 CustDiscount   PIC V99 VALUE .25.</code></pre>
+				<hr width="50%" />
+			</div>
+			<div class="sidebar">
+				<h4>Group items</h4>
+			</div>
+			<div>
+				<p align="left">
+					Sometimes when we are manipulating data it is convenient to treat a collection of elementary
+					items as a single group. For instance, we may want to group the data-items YearofBirth,
+					MonthofBirth, DayOfBirth under the group name - DateOfBirth. If we are recording information
+					about students we may want to subdivide StudentName into FirstName, MiddleInitial and Surname.
+					And we may want to use both these group items and the elementary items StudentId and CourseCode
+					in a student record description.
+				</p>
+				<p align="left">
+					We can create groups like these in COBOL using group items. A "group item" is the term used in
+					COBOL to describe a data-item - like DateOfBirth or StudentName - that has been further
+					subdivided. In other languages group items might be described as "structures".
+				</p>
+				<p align="left">
+					A group item consists of subordinate items. The items subordinate to a group item may be
+					elementary items or other group items. But ultimately every group item must be defined in terms
+					of its subordinate elementary items.
+				</p>
+				<p align="left">
+					In a group item, the hierarchical relationship between the various subordinate items of the
+					group is expressed using level numbers. The higher the level number, the lower the item is in
+					the hierarchy. Where a group item is the highest item in a data hierarchy it is referred to as a
+					"record" and uses the level number 01.
+				</p>
+				<p align="left">
+					Group items are declared using a level number and a data name only. A group item cannot have a
+					picture clause because it does not actually reserve any storage. It is merely a name given to a
+					collection of (ultimately) elementary items which do reserve the storage.
+				</p>
+				<p align="left">
+					Therefore, the size of a group item is the sum of the sizes of its subordinate elementary items.
+				</p>
+				<p align="left">
+					The type of a group item is always assumed to be
+					<code class="language-cobol">PIC X</code> because a group item may have several different data
+					items and types subordinate to it and an X picture is the only one which could support such
+					collections.
+				</p>
+				<hr width="50%" />
+			</div>
+			<div class="sidebar">
+				<h4>Level Numbers</h4>
+				<aside>
+					<p align="center">
+						<img height="44" src="Resources/pics/i-LightBulbTip.gif" width="42" /><br />
+						Although level numbers specify the actual data hierarchy you should use indentation to
+						provide a graphic representation of it. This will make your programs easier to read. For
+						instance, indentation makes it obvious that DayOfBirth, MonthOfBirth and YearOfBirth are
+						subordinate items of DateOfBirth, while CourseCode is not.
+					</p>
+				</aside>
+			</div>
+			<div>
+				<div align="center">
+					<p align="left">
+						Level numbers are used to express data hierarchy. The higher the level number, the lower the
+						item is in the hierarchy. At the lowest level the data is completely atomic.
+					</p>
+				</div>
+				<p align="left">
+					What is important in a structure defined with level numbers is the
+					<i>relationship</i> of the level numbers to one another, not the actual level numbers used. For
+					instance, the record descriptions shown below are equivalent.
+				</p>
+				<div class="code-record">
+					<div class="record-title">Record-A</div>
+					<pre class="language-cobol"><code class="language-cobol">01 StudentDetails.
+   02 StudentId        PIC 9(7).
+   02 StudentName.
+      03 FirstName     PIC X(10).
+      03 MiddleInitial PIC X.
+      03 Surname       PIC X(15).
+   02 DateOfBirth.
+      03 DayOfBirth    PIC 99.
+      03 MonthOfBirth  PIC 99.
+      03 YearOfBirth   PIC 9(4).
+   02 CourseCode       PIC X(4).
+</code></pre>
+				</div>
+				<div class="code-record">
+					<div class="record-title">Record-B</div>
+					<pre class="language-cobol"><code class="language-cobol">01 StudentDetails.
+   05 StudentId        PIC 9(7).
+   05 StudentName.
+      07 FirstName     PIC X(10).
+      07 MiddleInitial PIC X.
+      07 Surname       PIC X(15).
+   05 DateOfBirth.
+      07 DayOfBirth    PIC 99.
+      07 MonthOfBirth  PIC 99.
+      07 YearOfBirth   PIC 9(4).
+   05 CourseCode       PIC X(4).
+</code></pre>
+				</div>
+			</div>
+			<div class="sidebar">
+				<h4 align="left">Some observations on Record-A</h4>
+			</div>
+			<div>
+				<p>It is useful to examine Record-A above and to answer the following questions:</p>
+				<div class="qa-grid">
+					<div class="qa-label">Q1.</div>
+					<div>What is the size (in characters) of Record-A?</div>
+					<div class="qa-label">Q2.</div>
+					<div>What is the size of the data-item StudentName?</div>
+					<div class="qa-label">Q3.</div>
+					<div>What is the size of DateOfBirth?</div>
+					<div class="qa-label">Q4.</div>
+					<div>
+						What is the data type of DateOfBirth? Is it numeric, alphabetic or alphanumeric?
+					</div>
+					<div class="qa-label">A1.</div>
+					<div>
+						The size of Record-A is the sum of the sizes of all the elementary items subordinate to
+						it (7+10+1+15+2+2+4+4 = 45 characters).
+					</div>
+					<div class="qa-label">A2.</div>
+					<div>
+						The size of StudentName is the sum of the sizes of FirstName, MiddleInitial and Surname.
+						So StudentName is 26 characters in size (10+1+15).
+					</div>
+					<div class="qa-label">A3.</div>
+					<div>DateOfBirth is 8 characters in size (2+2+4).</div>
+					<div class="qa-label">A4.</div>
+					<div>
+						The data type of DateOfBirth is alphanumeric (i.e. PIC X) even though all its
+						subordinate items are numeric because the type of a group item is always alphanumeric.
+					</div>
+				</div>
+			</div>
+			<div class="sidebar">
+				<h4 align="left">Level number notes</h4>
+			</div>
+			<div>
+				<div align="center">
+					<p align="left">
+						The level numbers 01 through 49 are general level numbers but there are also special level
+						numbers such as 66, 77 and 88.
+					</p>
+				</div>
+				<div align="left">
+					<ul>
+						<li>
+							Level 77's can only be used to define individual elementary items. The use of 77's is
+							banned in some shops who take the view that instead of declaring large numbers of
+							indistinguishable 77's it is better to collect the individual items into groups.
+						</li>
+						<li>Level 88's are used to define Condition Names.</li>
+						<li>
+							Level 66's (<code class="language-cobol">RENAMES</code> clause) are used to apply a new
+							name to an identifier or group of identifiers. It is not generally used in modern COBOL
+							programs.
+						</li>
+					</ul>
+				</div>
+				<hr width="50%" />
+			</div>
+			<div class="sidebar">
+				<h4>Building a record structure</h4>
+			</div>
+			<div>
+				<p>
+					In the animation below we show how level numbers can be used to define a record structure as a
+					hierarchy of data-items.
+				</p>
+				<div align="center">
+					<p>
+						<a href="Resources/ppz/TC-Data2.html"
 							><img
 								alt="Click to view the animation"
 								border="0"
@@ -490,471 +895,15 @@
 								width="62"
 						/></a>
 					</p>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
-					<div align="center">
-						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
-					</div>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#993300" colspan="2" valign="top">
-					<h2 align="center" id="part2">Declaring Data-Items in COBOL</h2>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>Introduction</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						Because COBOL is not a typed language like Modula-2 or C it employs a different mechanism for
-						describing the characteristics of the data-items in a program.
-					</p>
-					<p>
-						Rather than using types, as these languages do, COBOL uses a kind of "declaration by example"
-						strategy. The programmer provides the system with an example, or template, or PICture of the
-						storage required for the data-item.
-					</p>
-					<p>
-						In COBOL, a variable declaration consists of a line in the
-						<code class="language-cobol">DATA DIVISION</code> that contains the following items:
-					</p>
-					<ul>
-						<li>A level number.</li>
-						<li>A data-name or identifier.</li>
-						<li>A Picture clause.</li>
-					</ul>
-					<hr width="50%" />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">COBOL picture clauses</h4>
-					<aside>
-						<p align="center">
-							<img height="37" src="Resources/pics/i-Detail.gif" width="30" /><br />
-							There are actually many more picture symbols than these. Most of these will be introduced
-							when we cover Edited Pictures.
-						</p>
-					</aside>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						To create the required 'picture' the programmer uses a set of symbols. The most common symbols
-						used in standard picture clauses are:
-					</p>
-					<table align="center" bgcolor="#E1FFE1" border="1" cellpadding="7" cellspacing="0" width="445">
-						<tr>
-							<td valign="top" width="14%">
-								<p align="center">
-									<b>9</b>
-								</p>
-							</td>
-							<td valign="top" width="86%">
-								<p>
-									The digit nine is used to indicate the occurrence of a digit at the corresponding
-									position in the picture.
-								</p>
-							</td>
-						</tr>
-						<tr>
-							<td valign="top" width="14%">
-								<p align="center">
-									<b>X</b>
-								</p>
-							</td>
-							<td valign="top" width="86%">
-								<p>
-									The character X is used to indicate the occurrence of any character from the
-									character set at the corresponding position in the picture.
-								</p>
-							</td>
-						</tr>
-						<tr>
-							<td valign="top" width="14%">
-								<p align="center">
-									<b>A</b>
-								</p>
-							</td>
-							<td valign="top" width="86%">
-								<p>
-									The character A is used to indicate the occurrence of any alphabetic character (A to
-									Z plus blank) at the corresponding position in the picture.
-								</p>
-							</td>
-						</tr>
-						<tr>
-							<td valign="top" width="14%">
-								<p align="center">
-									<b>V</b>
-								</p>
-							</td>
-							<td valign="top" width="86%">
-								<p>
-									The character V is used to indicate the position of the decimal point in a numeric
-									value. It is often referred to as the "assumed decimal point". It is called that
-									because, although the actual decimal point is not stored, values are treated as if
-									they had a decimal point in that position.
-								</p>
-							</td>
-						</tr>
-						<tr>
-							<td valign="top" width="14%">
-								<p align="center">
-									<b>S</b>
-								</p>
-							</td>
-							<td valign="top" width="86%">
-								<p>
-									The character S indicates the presence of a sign and can only appear at the
-									beginning of a picture.
-								</p>
-							</td>
-						</tr>
-					</table>
-					<hr width="50%" />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">Picture clause notes</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						Although the word <code class="language-cobol">PICTURE</code> can be used when defining a
-						picture clause it is normal to use the abbreviation <code class="language-cobol">PIC</code>.
-					</p>
-					<p>Recurring symbols may be specified by using a 'repeat' factor inside brackets. For instance:</p>
-					<pre
-						class="language-cobol"
-					><code class="language-cobol">PIC 9(6)       is equivalent to PICTURE 999999
-PIC 9(6)V99    is equivalent to PIC 999999V99
-PICTURE X(10)  is equivalent to PIC XXXXXXXXXX
-PIC S9(4)V9(4) is equivalent to PIC S9999V9999
-PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
-					<p>Numeric values can have a maximum of 18 (eighteen) digits.</p>
-					<p>The limit on string values is usually system dependent.</p>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
-					<div align="center">
-						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
-					</div>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-					<h2 align="center" id="part3">Group and Elementary data-items</h2>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>Introduction</h4>
-				</td>
-				<td valign="top" width="525">
-					<div align="center">
-						<p align="left">
-							Although we stated above that each variable declaration consists of a level number, an
-							identifying name and a picture clause, that definition only applies to elementary
-							data-items. Group items are defined using only a level-number and an identifying name; no
-							picture clause is required or allowed.
-						</p>
-						<p align="left">
-							Which begs the question - what is a group item and what is an elementary item?
-						</p>
-					</div>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">Elementary items</h4>
-					<aside>
-						<p align="center">
-							<img height="37" src="Resources/pics/i-Detail.gif" width="30" /><br />
-							A variable declaration may also have a number of other clauses such as
-							<code class="language-cobol">USAGE</code> or
-							<code class="language-cobol">BLANK WHEN ZERO</code>
-						</p>
-					</aside>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						An "elementary item" is the name we use in COBOL to describe a data-item that has not been
-						further subdivided. Other languages might describe these as ordinary variables.
-					</p>
-					<p align="left">
-						Elementary items <b>must</b> have a picture clause because they actually reserve the storage
-						required for the item. The amount of storage reserved is specified by the item's picture clause.
-					</p>
-					<p>An elementary item declaration consists of;</p>
-					<ul>
-						<li>a level number</li>
-						<li>a data name</li>
-						<li>a picture clause</li>
-					</ul>
-					<p align="left">
-						A starting value may be assigned to a variable by means of an extension to the
-						<code class="language-cobol">PICTURE</code> clause called the
-						<code class="language-cobol">VALUE</code> clause.
-					</p>
-					<p align="left"><b>Some examples:</b></p>
-					<pre class="language-cobol"><code class="language-cobol">01 GrossPay       PIC 9(5)V99 VALUE ZEROS.
-
-01 NetPay         PIC 9(5)V99 VALUE ZEROS.
-
-01 CustomerName   PIC X(20) VALUE SPACES.
-
-01 CustDiscount   PIC V99 VALUE .25.</code></pre>
-					<hr width="50%" />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>Group items</h4>
-				</td>
-				<td valign="top" width="525">
-					<p align="left">
-						Sometimes when we are manipulating data it is convenient to treat a collection of elementary
-						items as a single group. For instance, we may want to group the data-items YearofBirth,
-						MonthofBirth, DayOfBirth under the group name - DateOfBirth. If we are recording information
-						about students we may want to subdivide StudentName into FirstName, MiddleInitial and Surname.
-						And we may want to use both these group items and the elementary items StudentId and CourseCode
-						in a student record description.
-					</p>
-					<p align="left">
-						We can create groups like these in COBOL using group items. A "group item" is the term used in
-						COBOL to describe a data-item - like DateOfBirth or StudentName - that has been further
-						subdivided. In other languages group items might be described as "structures".
-					</p>
-					<p align="left">
-						A group item consists of subordinate items. The items subordinate to a group item may be
-						elementary items or other group items. But ultimately every group item must be defined in terms
-						of its subordinate elementary items.
-					</p>
-					<p align="left">
-						In a group item, the hierarchical relationship between the various subordinate items of the
-						group is expressed using level numbers. The higher the level number, the lower the item is in
-						the hierarchy. Where a group item is the highest item in a data hierarchy it is referred to as a
-						"record" and uses the level number 01.
-					</p>
-					<p align="left">
-						Group items are declared using a level number and a data name only. A group item cannot have a
-						picture clause because it does not actually reserve any storage. It is merely a name given to a
-						collection of (ultimately) elementary items which do reserve the storage.
-					</p>
-					<p align="left">
-						Therefore, the size of a group item is the sum of the sizes of its subordinate elementary items.
-					</p>
-					<p align="left">
-						The type of a group item is always assumed to be
-						<code class="language-cobol">PIC X</code> because a group item may have several different data
-						items and types subordinate to it and an X picture is the only one which could support such
-						collections.
-					</p>
-					<hr width="50%" />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>Level Numbers</h4>
-					<aside>
-						<p align="center">
-							<img height="44" src="Resources/pics/i-LightBulbTip.gif" width="42" /><br />
-							Although level numbers specify the actual data hierarchy you should use indentation to
-							provide a graphic representation of it. This will make your programs easier to read. For
-							instance, indentation makes it obvious that DayOfBirth, MonthOfBirth and YearOfBirth are
-							subordinate items of DateOfBirth, while CourseCode is not.
-						</p>
-					</aside>
-				</td>
-				<td valign="top" width="525">
-					<div align="center">
-						<p align="left">
-							Level numbers are used to express data hierarchy. The higher the level number, the lower the
-							item is in the hierarchy. At the lowest level the data is completely atomic.
-						</p>
-					</div>
-					<p align="left">
-						What is important in a structure defined with level numbers is the
-						<i>relationship</i> of the level numbers to one another, not the actual level numbers used. For
-						instance, the record descriptions shown below are equivalent.
-					</p>
-					<table align="center" bgcolor="#E1FFE1" border="1" width="60%">
-						<tr>
-							<td width="51%">
-								<div align="center"><b>Record-A</b></div>
-							</td>
-						</tr>
-						<tr>
-							<td width="51%">
-								<pre class="language-cobol"><code class="language-cobol">01 StudentDetails.
-   02 StudentId        PIC 9(7). 
-   02 StudentName. 
-      03 FirstName     PIC X(10).
-      03 MiddleInitial PIC X. 
-      03 Surname       PIC X(15).
-   02 DateOfBirth.
-      03 DayOfBirth    PIC 99.
-      03 MonthOfBirth  PIC 99.
-      03 YearOfBirth   PIC 9(4).
-   02 CourseCode       PIC X(4).
-</code></pre>
-							</td>
-						</tr>
-					</table>
-					<table align="center" bgcolor="#E1FFE1" border="1" width="60%">
-						<tr>
-							<td width="49%">
-								<div align="center"><b>Record-B</b></div>
-							</td>
-						</tr>
-						<tr>
-							<td width="49%">
-								<pre class="language-cobol"><code class="language-cobol">01 StudentDetails.
-   05 StudentId        PIC 9(7). 
-   05 StudentName. 
-      07 FirstName     PIC X(10).
-      07 MiddleInitial PIC X. 
-      07 Surname       PIC X(15).
-   05 DateOfBirth.
-      07 DayOfBirth    PIC 99.
-      07 MonthOfBirth  PIC 99.
-      07 YearOfBirth   PIC 9(4).
-   05 CourseCode       PIC X(4).
-</code></pre>
-							</td>
-						</tr>
-					</table>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">Some observations on Record-A</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>It is useful to examine Record-A above and to answer the following questions:</p>
-					<table align="center" border="0" cellspacing="5" width="84%">
-						<tr>
-							<td valign="top" width="8%"><b>Q1.</b></td>
-							<td width="92%">What is the size (in characters) of Record-A?</td>
-						</tr>
-						<tr>
-							<td valign="top" width="8%"><b>Q2.</b></td>
-							<td width="92%">What is the size of the data-item StudentName?</td>
-						</tr>
-						<tr>
-							<td valign="top" width="8%"><b>Q3.</b></td>
-							<td width="92%">What is the size of DateOfBirth?</td>
-						</tr>
-						<tr>
-							<td valign="top" width="8%"><b>Q4.</b></td>
-							<td width="92%">
-								What is the data type of DateOfBirth? Is it numeric, alphabetic or alphanumeric?
-							</td>
-						</tr>
-						<tr>
-							<td valign="top" width="8%"><b>A1.</b></td>
-							<td width="92%">
-								The size of Record-A is the sum of the sizes of all the elementary items subordinate to
-								it (7+10+1+15+2+2+4+4 = 45 characters).
-							</td>
-						</tr>
-						<tr>
-							<td valign="top" width="8%"><b>A2.</b></td>
-							<td width="92%">
-								The size of StudentName is the sum of the sizes of FirstName, MiddleInitial and Surname.
-								So StudentName is 26 characters in size (10+1+15).
-							</td>
-						</tr>
-						<tr>
-							<td valign="top" width="8%"><b>A3.</b></td>
-							<td width="92%">DateOfBirth is 8 characters in size (2+2+4).</td>
-						</tr>
-						<tr>
-							<td valign="top" width="8%"><b>A4.</b></td>
-							<td width="92%">
-								The data type of DateOfBirth is alphanumeric (i.e. PIC X) even though all its
-								subordinate items are numeric because the type of a group item is always alphanumeric.
-							</td>
-						</tr>
-					</table>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">Level number notes</h4>
-				</td>
-				<td valign="top" width="525">
-					<div align="center">
-						<p align="left">
-							The level numbers 01 through 49 are general level numbers but there are also special level
-							numbers such as 66, 77 and 88.
-						</p>
-					</div>
-					<div align="left">
-						<ul>
-							<li>
-								Level 77's can only be used to define individual elementary items. The use of 77's is
-								banned in some shops who take the view that instead of declaring large numbers of
-								indistinguishable 77's it is better to collect the individual items into groups.
-							</li>
-							<li>Level 88's are used to define Condition Names.</li>
-							<li>
-								Level 66's (<code class="language-cobol">RENAMES</code> clause) are used to apply a new
-								name to an identifier or group of identifiers. It is not generally used in modern COBOL
-								programs.
-							</li>
-						</ul>
-					</div>
-					<hr width="50%" />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>Building a record structure</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						In the animation below we show how level numbers can be used to define a record structure as a
-						hierarchy of data-items.
-					</p>
-					<div align="center">
-						<p>
-							<a href="Resources/ppz/TC-Data2.html"
-								><img
-									alt="Click to view the animation"
-									border="0"
-									height="62"
-									src="Resources/pics/i-Animation.gif"
-									width="62"
-							/></a>
-						</p>
-					</div>
-				</td>
-			</tr>
-			<tr>
-				<td colspan="2">
-					<hr />
-					<div align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</div>
-					<copyright-notice></copyright-notice>
-				</td>
-			</tr>
-		</table>
+				</div>
+			</div>
+			<div class="full-width">
+				<hr />
+				<div align="center">
+					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
+				</div>
+				<copyright-notice></copyright-notice>
+			</div>
+		</div>
 	</body>
 </html>


### PR DESCRIPTION
## Summary

- Replaces the main `#layout-table` wrapper with a `.page-layout` CSS grid (175px sidebar + 1fr content column)
- Replaces Record-A and Record-B display tables with `.code-record` divs (`width: fit-content; max-width: 90%`) preserving the green background, title bar, and syntax-highlighted code — without introducing a horizontal scrollbar
- Replaces the Q&A observations table (`border="0"`) with a `.qa-grid` two-column CSS grid (`8% 1fr`) matching the original label column width
- Leaves actual data tables unchanged: Figurative Constants table and Picture Clauses table
- Moves the viewport meta tag to first position in `<head>` to prevent FOUC

## Reviewer notes

- Verified against the live reference at `https://bushidocodes.github.io/limerick-cobol/course/DataDeclaration.html`
- Two regressions were found and fixed during review: (1) code-record boxes had a 3px overflow scrollbar due to CSS `width: 60%` being exact while HTML table `width="60%"` is a hint — fixed with `width: fit-content; max-width: 90%`; (2) Q&A label column was too narrow with `grid-template-columns: auto 1fr` — fixed with `8% 1fr` to match the original ~35px width
- Desktop and mobile layouts both verified visually and via DOM measurements

🤖 Generated with [Claude Code](https://claude.com/claude-code)