### PR TITLE
Refactor ReportWriterSS.html and Search.html layout tables to CSS grid/flexbox

### DIFF
--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -5,18 +5,173 @@
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>COBOL Report Writer - Syntax and Semantics</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
-		<style>table{max-width:100%}body>table,body>hr{margin-left:auto;margin-right:auto}img{max-width:100%;height:auto}pre{overflow-x:auto;max-width:100%}</style>
+		<style type="text/css">
+			ul.toc {
+				list-style-image: url(Resources/pics/BallGreenG.gif);
+				padding-left: 2.5em;
+				margin: 1em 0;
+			}
+
+			ul.toc > li {
+				padding-left: 0.4em;
+				margin-bottom: 0.6em;
+				font-size: smaller;
+			}
+
+			ul.toc a {
+				font-weight: bold;
+				font-size: larger;
+			}
+
+			.section-header h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			.section-sidebar h3,
+			.section-sidebar h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			.page-wrapper {
+				max-width: 715px;
+				margin: 0 auto;
+				border: 1px solid;
+				box-sizing: border-box;
+			}
+
+			.page-content {
+				padding: 2px;
+			}
+
+			.page-footer {
+				padding: 2px;
+			}
+
+			.section-grid {
+				display: grid;
+				grid-template-columns: 175px 1fr;
+			}
+
+			.section-header {
+				grid-column: 1 / -1;
+				background-color: #993300;
+				padding: 4px;
+				min-width: 0;
+				border-bottom: 1px solid;
+			}
+
+			.section-sidebar {
+				background-color: #FFFFCC;
+				padding: 4px;
+				align-self: stretch;
+				min-width: 0;
+				border-right: 1px solid;
+				border-bottom: 1px solid;
+			}
+
+			.section-content {
+				padding: 4px;
+				align-self: start;
+				min-width: 0;
+				overflow: hidden;
+				border-bottom: 1px solid;
+			}
+
+			.section-full {
+				grid-column: 1 / -1;
+				padding: 4px;
+				min-width: 0;
+				border-bottom: 1px solid;
+			}
+
+			.section-full:last-child {
+				border-bottom: none;
+			}
+
+			img {
+				max-width: 100%;
+				height: auto;
+			}
+
+			pre {
+				overflow-x: auto;
+				max-width: 100%;
+				white-space: pre-wrap;
+				word-wrap: break-word;
+				overflow-wrap: break-word;
+			}
+
+			pre[class*="language-"],
+			code[class*="language-"] {
+				white-space: pre-wrap !important;
+				overflow-wrap: break-word;
+			}
+
+			body {
+				-webkit-text-size-adjust: 100%;
+			}
+
+			@media (max-width: 600px) {
+				body {
+					margin: 4px;
+					overflow-wrap: break-word;
+					word-wrap: break-word;
+				}
+
+				.section-header h2,
+				.section-header h3 {
+					margin: 0.3em 0;
+				}
+
+				blockquote {
+					margin-left: 12px;
+					margin-right: 12px;
+				}
+
+				img,
+				iframe,
+				video,
+				embed,
+				object {
+					max-width: min(100%, calc(100vw - 16px)) !important;
+					height: auto;
+				}
+
+				pre {
+					max-width: min(100%, calc(100vw - 16px)) !important;
+				}
+
+				pre[class*="language-"] {
+					font-size: 0.8em;
+					line-height: 1.35;
+					padding: 0.6em;
+					overflow-x: auto;
+				}
+
+				.section-grid {
+					display: block;
+				}
+
+				.section-sidebar h3,
+				.section-sidebar h4,
+				.section-sidebar p {
+					margin: 0.2em 0;
+				}
+			}
+		</style>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
-		<table id="layout-table" border="1" width="715" cellpadding="4" cellspacing="0">
-			<tr>
-				<td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
+		<div class="page-wrapper">
+			<div class="page-content">
+				<div>
 					<center>
-						<p><img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
+						<p id="top"><img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
 						<h1>The COBOL Report Writer - Syntax and Semantics</h1>
 					</center>
 					<hr />
@@ -70,63 +225,59 @@
 							control break registers, are examined.
 						</li>
 					</ul>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
+				</div>
+				<div class="section-header">
 					<h2 align="center" id="intro">Introduction</h2>
-				</td>
-			</tr>
-			<tr>
-				<td bgcolor="#FFFFCC" valign="top" width="160">
-					<h4>Aims</h4>
-				</td>
-				<td width="540">
-					<p>
-						The unit provides a Report Writer reference. The syntax elements of the Report Writer are
-						presented and the semantics of their operation discussed.
-					</p>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-					<h4>Objectives</h4>
-				</td>
-				<td width="540">
-					<p>By the end of this unit you should -</p>
-					<ol>
-						<li>
-							Know how to set up a report file in the
-							<code class="language-cobol">ENVIRONMENT DIVISION</code> and the File Section.
-						</li>
-						<li>Be able to define a report and the appropriate report groups in the Report Section.</li>
-						<li>
-							Understand how Declaratives may be used to extend the functionality of the Report Writer.
-						</li>
-						<li>
-							Be able to write the Procedure Division code (using the INITIATE, GENERATE and TERMINATE
-							verbs) to create a report.
-						</li>
-					</ol>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-					<h4>Prerequisites</h4>
-				</td>
-				<td width="525">
-					<p>You should be familiar with the material covered in the units;</p>
-					<ul>
-						<li>Sequential files</li>
-						<li>Data Declaration</li>
-						<li>The Report Writer</li>
-					</ul>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Aims</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The unit provides a Report Writer reference. The syntax elements of the Report Writer are
+							presented and the semantics of their operation discussed.
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Objectives</h4>
+					</div>
+					<div class="section-content">
+						<p>By the end of this unit you should -</p>
+						<ol>
+							<li>
+								Know how to set up a report file in the
+								<code class="language-cobol">ENVIRONMENT DIVISION</code> and the File Section.
+							</li>
+							<li>Be able to define a report and the appropriate report groups in the Report Section.</li>
+							<li>
+								Understand how Declaratives may be used to extend the functionality of the Report Writer.
+							</li>
+							<li>
+								Be able to write the Procedure Division code (using the INITIATE, GENERATE and TERMINATE
+								verbs) to create a report.
+							</li>
+						</ol>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Prerequisites</h4>
+					</div>
+					<div class="section-content">
+						<p>You should be familiar with the material covered in the units;</p>
+						<ul>
+							<li>Sequential files</li>
+							<li>Data Declaration</li>
+							<li>The Report Writer</li>
+						</ul>
+					</div>
+				</div>
+				<div class="section-full">
 					<div align="center">
 						<hr />
 						<p>
@@ -135,35 +286,29 @@
 							/></a>
 						</p>
 					</div>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
+				</div>
+				<div class="section-header">
 					<h2 align="center" id="part1">Defining the Report - Report File entries</h2>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-					<h4><code class="language-cobol">ENVIRONMENT DIVISION</code> entries</h4>
-				</td>
-				<td valign="top" width="540">
-					<p>
-						Just like ordinary reports, the reports generated by the Report Writer are written to an
-						external device - usually a report file.
-					</p>
-					<p>
-						The <code class="language-cobol">ENVIRONMENT DIVISION</code> entries for a report file are the
-						same as those for an ordinary file. The same Select and Assign clauses apply.
-					</p>
-					<p>
-						For instance, in the program fragment below, the Select and Assign for the final example program
-						(given in the previous Report Writer unit) is shown.
-					</p>
-					<p>When the Report Writer generates this report it will be stored in the file SALESREPORT.LPT.</p>
-					<table background="Resources/pics/code.gif" border="1" width="100%">
-						<tr>
-							<td>
-								<pre class="language-cobol"><code class="language-cobol">ENVIRONMENT DIVISION.
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4><code class="language-cobol">ENVIRONMENT DIVISION</code> entries</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							Just like ordinary reports, the reports generated by the Report Writer are written to an
+							external device - usually a report file.
+						</p>
+						<p>
+							The <code class="language-cobol">ENVIRONMENT DIVISION</code> entries for a report file are the
+							same as those for an ordinary file. The same Select and Assign clauses apply.
+						</p>
+						<p>
+							For instance, in the program fragment below, the Select and Assign for the final example program
+							(given in the previous Report Writer unit) is shown.
+						</p>
+						<p>When the Report Writer generates this report it will be stored in the file SALESREPORT.LPT.</p>
+						<pre class="language-cobol"><code class="language-cobol">ENVIRONMENT DIVISION.
 INPUT-OUTPUT SECTION.
 FILE-CONTROL.
     SELECT SalesFile ASSIGN TO "GBPAY.DAT"
@@ -189,510 +334,492 @@ REPORT SECTION.
 RD  SalesReport
     CONTROLS ARE FINAL
                  CityCode
-                 SalesPersonNum 
+                 SalesPersonNum
     PAGE LIMIT IS 66
     HEADING 1
     FIRST DETAIL 6
     LAST DETAIL 42
     FOOTING 52.
 </code></pre>
-							</td>
-						</tr>
-					</table>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">File Section entries</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						Although the entries in the <code class="language-cobol">ENVIRONMENT DIVISION</code> are the
-						same as those for ordinary print files, in the File Section the normal file description is
-						replaced by phrase which points to the Report Description (RD) in the Report Section. The syntax
-						of the phrase is -
-					</p>
-					<p align="center">
-						<img height="48" src="Resources/pics/rwReportIS.gif" width="222" />
-					</p>
-					<p>
-						The <i>ReportName</i> must be the same as the <i>ReportName</i> used in the Report Description
-						(RD) entry.
-					</p>
-					<p>
-						You can see this in the program fragment above where the <b>REPORT IS</b>
-						<b>SalesReport</b> phrase links the PrintFile with the Report Description(RD) in the Report
-						Section.
-					</p>
-					<p><b>Notes:</b></p>
-					<p>
-						Before the report can be used it must be opened for output. For instance in the example above
-						the PrintFile must be opened for output before the SalesReport can be generated.
-					</p>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#993300" colspan="2" valign="top">
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4 align="left">File Section entries</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							Although the entries in the <code class="language-cobol">ENVIRONMENT DIVISION</code> are the
+							same as those for ordinary print files, in the File Section the normal file description is
+							replaced by phrase which points to the Report Description (RD) in the Report Section. The syntax
+							of the phrase is -
+						</p>
+						<p align="center">
+							<img height="48" src="Resources/pics/rwReportIS.gif" width="222" />
+						</p>
+						<p>
+							The <i>ReportName</i> must be the same as the <i>ReportName</i> used in the Report Description
+							(RD) entry.
+						</p>
+						<p>
+							You can see this in the program fragment above where the <b>REPORT IS</b>
+							<b>SalesReport</b> phrase links the PrintFile with the Report Description(RD) in the Report
+							Section.
+						</p>
+						<p><b>Notes:</b></p>
+						<p>
+							Before the report can be used it must be opened for output. For instance in the example above
+							the PrintFile must be opened for output before the SalesReport can be generated.
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-header">
 					<h2 align="center" id="part2">Defining the Report - Report Description (RD) Entries</h2>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>Introduction</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						Every report generated by the Report Writer must have a Report Description (RD) entry in the
-						Report Section.
-					</p>
-					<p>
-						The RD entry names the report and specifies the format of the printed page and identifies the
-						control break items.
-					</p>
-					<p>
-						Each RD entry is followed by one or more 01 level-number entries. Each 01 level-number entry
-						identifies a report group and consists of a hierarchical structure similar to a COBOL record.
-					</p>
-					<p>
-						Each report group is a unit consisting of one or more print lines and cannot be split across
-						pages.
-					</p>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">The Report Description (RD) entries - Syntax</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>The syntax for the Report Description (RD) entries is shown below -</p>
-					<p align="center"><img height="277" src="Resources/pics/rwRD.gif" width="360" /></p>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">The Report Description (RD) entries - Semantics</h4>
-				</td>
-				<td valign="top" width="525">
-					<p align="center"><b>RD Rules</b></p>
-					<ol>
-						<li>The <i>ReportName</i> can only appear in one RD entry.</li>
-						<li>
-							When more than one report is declared in the Report Section the
-							<i>ReportName</i> can be used to qualify the LINE-COUNTER and PAGE-COUNTER report registers.
-						</li>
-					</ol>
-					<hr width="50%" />
-					<p align="center"><b>CONTROL Rules</b></p>
-					<ol>
-						<li>The <i>ControlName$#i</i> must not be defined in the Report Section.</li>
-						<li>Each occurrence of <i>ControlName$#i</i> must identify a different data item.</li>
-						<li>The <i>ControlName$#i</i> must not have a variable length table subordinate to it.</li>
-						<li>
-							<i>ControlName$#i</i> and FINAL specify the levels of the control break hierarchy where
-							FINAL (if specified) is the highest and the first <i>ControlName$#i</i> the next highest and
-							so on.
-						</li>
-						<li>
-							When the value in any <i>ControlName$#i</i> changes a control break occurs. The level of the
-							control break depends on the position of the <i>ControlName$#i</i> in the control break
-							hierarchy.
-						</li>
-					</ol>
-					<hr width="50%" />
-					<p align="center"><b>PAGE Rules</b></p>
-					<ol>
-						<li><i>HeadingLine#l</i> must be greater than or equal to 1.</li>
-						<li>
-							<i>HeadingLine#l</i> &lt;= <i>FirstDetailLine#l</i> &lt;= <i>LastDetailLine#l</i> &lt;=
-							<i>FootingLine#l</i> &lt;= <i>PageSize#l</i>
-						</li>
-						<li>
-							Line numbers used in a Report Heading or Page Heading group must be greater than or equal to
-							<i>HeadingLine#l</i> and less than <i>FirstDetailLine#l</i> but when a Report Heading
-							appears on a page by itself any line number between <i>HeadingLine#l</i> and
-							<i>PageSize#l</i> may be used.
-						</li>
-						<li>
-							Line numbers used in Detail or Control Heading groups must be in the range
-							<i>FirstDetailLine#l</i> to <i>LastDetailLine#l</i> inclusive.
-						</li>
-						<li>
-							Line numbers used in Control Footing groups must be in the range
-							<i>FirstDetailLine#l FootingLine#l</i> inclusive
-						</li>
-						<li>
-							Line numbers used in the Report Footing or Page Footing groups must be greater than
-							<i>FootingLine#l</i> and less than or equal to <i>PageSize#l</i> but when a Report Footing
-							appears on a page by itself any line number between <i>HeadingLine#l</i> and
-							<i>PageSize#l</i> may be used.
-						</li>
-						<li>
-							All report groups must be defined so that they can be presented on one page. The Report
-							Writer never splits a multi-line group across page boundaries.
-						</li>
-					</ol>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#993300" colspan="2" valign="top">
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Introduction</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							Every report generated by the Report Writer must have a Report Description (RD) entry in the
+							Report Section.
+						</p>
+						<p>
+							The RD entry names the report and specifies the format of the printed page and identifies the
+							control break items.
+						</p>
+						<p>
+							Each RD entry is followed by one or more 01 level-number entries. Each 01 level-number entry
+							identifies a report group and consists of a hierarchical structure similar to a COBOL record.
+						</p>
+						<p>
+							Each report group is a unit consisting of one or more print lines and cannot be split across
+							pages.
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4 align="left">The Report Description (RD) entries - Syntax</h4>
+					</div>
+					<div class="section-content">
+						<p>The syntax for the Report Description (RD) entries is shown below -</p>
+						<p align="center"><img height="277" src="Resources/pics/rwRD.gif" width="360" /></p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4 align="left">The Report Description (RD) entries - Semantics</h4>
+					</div>
+					<div class="section-content">
+						<p align="center"><b>RD Rules</b></p>
+						<ol>
+							<li>The <i>ReportName</i> can only appear in one RD entry.</li>
+							<li>
+								When more than one report is declared in the Report Section the
+								<i>ReportName</i> can be used to qualify the LINE-COUNTER and PAGE-COUNTER report registers.
+							</li>
+						</ol>
+						<hr width="50%" />
+						<p align="center"><b>CONTROL Rules</b></p>
+						<ol>
+							<li>The <i>ControlName$#i</i> must not be defined in the Report Section.</li>
+							<li>Each occurrence of <i>ControlName$#i</i> must identify a different data item.</li>
+							<li>The <i>ControlName$#i</i> must not have a variable length table subordinate to it.</li>
+							<li>
+								<i>ControlName$#i</i> and FINAL specify the levels of the control break hierarchy where
+								FINAL (if specified) is the highest and the first <i>ControlName$#i</i> the next highest and
+								so on.
+							</li>
+							<li>
+								When the value in any <i>ControlName$#i</i> changes a control break occurs. The level of the
+								control break depends on the position of the <i>ControlName$#i</i> in the control break
+								hierarchy.
+							</li>
+						</ol>
+						<hr width="50%" />
+						<p align="center"><b>PAGE Rules</b></p>
+						<ol>
+							<li><i>HeadingLine#l</i> must be greater than or equal to 1.</li>
+							<li>
+								<i>HeadingLine#l</i> &lt;= <i>FirstDetailLine#l</i> &lt;= <i>LastDetailLine#l</i> &lt;=
+								<i>FootingLine#l</i> &lt;= <i>PageSize#l</i>
+							</li>
+							<li>
+								Line numbers used in a Report Heading or Page Heading group must be greater than or equal to
+								<i>HeadingLine#l</i> and less than <i>FirstDetailLine#l</i> but when a Report Heading
+								appears on a page by itself any line number between <i>HeadingLine#l</i> and
+								<i>PageSize#l</i> may be used.
+							</li>
+							<li>
+								Line numbers used in Detail or Control Heading groups must be in the range
+								<i>FirstDetailLine#l</i> to <i>LastDetailLine#l</i> inclusive.
+							</li>
+							<li>
+								Line numbers used in Control Footing groups must be in the range
+								<i>FirstDetailLine#l FootingLine#l</i> inclusive
+							</li>
+							<li>
+								Line numbers used in the Report Footing or Page Footing groups must be greater than
+								<i>FootingLine#l</i> and less than or equal to <i>PageSize#l</i> but when a Report Footing
+								appears on a page by itself any line number between <i>HeadingLine#l</i> and
+								<i>PageSize#l</i> may be used.
+							</li>
+							<li>
+								All report groups must be defined so that they can be presented on one page. The Report
+								Writer never splits a multi-line group across page boundaries.
+							</li>
+						</ol>
+						<hr />
+					</div>
+				</div>
+				<div class="section-header">
 					<h2 align="center" id="part3">Defining the Report - Report Group entries</h2>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>Introduction</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						In the Report Section each report group is represented by a report group record. As with all
-						record descriptions in COBOL a report group record starts with level number 01. Subordinate
-						items in the record describe the report lines and columns within the report group.
-					</p>
-					<p>
-						The description of a report group consists of a number of hierarchic levels. At the top must be
-						the Report Group Definition.
-					</p>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">Defining a Report Group Record - Syntax</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						<b>Report Group Definition</b>
-					</p>
-					<p><img height="512" src="Resources/pics/rwGroupType.gif" width="405" /></p>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left"><i>ReportGroupName</i> Rules</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>The <i>ReportGroupName</i> is required only when the group -</p>
-					<ol>
-						<li>
-							is a detail group referenced by a <code class="language-cobol">GENERATE</code> statement or
-							the <code class="language-cobol">UPON</code> phrase of a
-							<code class="language-cobol">SUM</code> clause.
-						</li>
-						<li>
-							is referenced in a <code class="language-cobol">USE BEFORE REPORTING</code> sentence in the
-							Declaratives
-						</li>
-						<li>is required to qualify the reference to a sum counter.</li>
-					</ol>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">The LINE NUMBER clause</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						The <code class="language-cobol">LINE NUMBER</code> clause is used to specify the vertical
-						positioning of print lines. Lines can be printed on -
-					</p>
-					<ul>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Introduction</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							In the Report Section each report group is represented by a report group record. As with all
+							record descriptions in COBOL a report group record starts with level number 01. Subordinate
+							items in the record describe the report lines and columns within the report group.
+						</p>
+						<p>
+							The description of a report group consists of a number of hierarchic levels. At the top must be
+							the Report Group Definition.
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4 align="left">Defining a Report Group Record - Syntax</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							<b>Report Group Definition</b>
+						</p>
+						<p><img height="512" src="Resources/pics/rwGroupType.gif" width="405" /></p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4 align="left"><i>ReportGroupName</i> Rules</h4>
+					</div>
+					<div class="section-content">
+						<p>The <i>ReportGroupName</i> is required only when the group -</p>
+						<ol>
+							<li>
+								is a detail group referenced by a <code class="language-cobol">GENERATE</code> statement or
+								the <code class="language-cobol">UPON</code> phrase of a
+								<code class="language-cobol">SUM</code> clause.
+							</li>
+							<li>
+								is referenced in a <code class="language-cobol">USE BEFORE REPORTING</code> sentence in the
+								Declaratives
+							</li>
+							<li>is required to qualify the reference to a sum counter.</li>
+						</ol>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4 align="left">The LINE NUMBER clause</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The <code class="language-cobol">LINE NUMBER</code> clause is used to specify the vertical
+							positioning of print lines. Lines can be printed on -
+						</p>
 						<ul>
-							<li>a specified line (absolute)</li>
-							<li>a specified line on the next page (absolute)</li>
-							<li>the current line number plus some increment (relative)</li>
+							<ul>
+								<li>a specified line (absolute)</li>
+								<li>a specified line on the next page (absolute)</li>
+								<li>the current line number plus some increment (relative)</li>
+							</ul>
 						</ul>
-					</ul>
-					<p><b>Rules:</b></p>
-					<ol>
-						<li>
-							The <code class="language-cobol">LINE NUMBER</code> clause specifies where each line is to
-							be printed so no item that contains a <code class="language-cobol">LINE NUMBER</code> clause
-							may contain a subordinate item that also contains a
-							<code class="language-cobol">LINE NUMBER</code> clause (subordinate items specify the column
-							items).
-						</li>
-						<li>
-							Where absolute <code class="language-cobol">LINE NUMBER</code> clauses are specified all
-							absolute clauses must precede all relative clauses and the line numbers specified in the
-							successive absolute clauses must be in ascending order.
-						</li>
-						<li>
-							The first <code class="language-cobol">LINE NUMBER</code> clause specified in a
-							<code class="language-cobol">PAGE FOOTING</code> group must be absolute.
-						</li>
-						<li>
-							The <code class="language-cobol">NEXT PAGE</code> clause can only appear once in a given
-							report group description and it must be in the first
-							<code class="language-cobol">LINE NUMBER</code> clause in the report group.
-						</li>
-						<li>
-							The <code class="language-cobol">NEXT PAGE</code> clause cannot appear in any
-							<code class="language-cobol">HEADING</code> group.
-						</li>
-					</ol>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">The NEXT GROUP clause</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						The <code class="language-cobol">NEXT GROUP</code> clause is used to specify the vertical
-						positioning of the start of the next group. The
-						<code class="language-cobol">NEXT GROUP</code> clause can be used to specify that the next
-						report groups should be printed on -
-					</p>
-					<ul>
+						<p><b>Rules:</b></p>
+						<ol>
+							<li>
+								The <code class="language-cobol">LINE NUMBER</code> clause specifies where each line is to
+								be printed so no item that contains a <code class="language-cobol">LINE NUMBER</code> clause
+								may contain a subordinate item that also contains a
+								<code class="language-cobol">LINE NUMBER</code> clause (subordinate items specify the column
+								items).
+							</li>
+							<li>
+								Where absolute <code class="language-cobol">LINE NUMBER</code> clauses are specified all
+								absolute clauses must precede all relative clauses and the line numbers specified in the
+								successive absolute clauses must be in ascending order.
+							</li>
+							<li>
+								The first <code class="language-cobol">LINE NUMBER</code> clause specified in a
+								<code class="language-cobol">PAGE FOOTING</code> group must be absolute.
+							</li>
+							<li>
+								The <code class="language-cobol">NEXT PAGE</code> clause can only appear once in a given
+								report group description and it must be in the first
+								<code class="language-cobol">LINE NUMBER</code> clause in the report group.
+							</li>
+							<li>
+								The <code class="language-cobol">NEXT PAGE</code> clause cannot appear in any
+								<code class="language-cobol">HEADING</code> group.
+							</li>
+						</ol>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4 align="left">The NEXT GROUP clause</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The <code class="language-cobol">NEXT GROUP</code> clause is used to specify the vertical
+							positioning of the start of the next group. The
+							<code class="language-cobol">NEXT GROUP</code> clause can be used to specify that the next
+							report groups should be printed on -
+						</p>
 						<ul>
-							<li>a specified line (absolute)</li>
-							<li>the current line number plus some increment (relative)</li>
-							<li>the next page</li>
+							<ul>
+								<li>a specified line (absolute)</li>
+								<li>the current line number plus some increment (relative)</li>
+								<li>the next page</li>
+							</ul>
 						</ul>
-					</ul>
-					<p><b>Rules</b></p>
-					<p>
-						The <code class="language-cobol">NEXT PAGE</code> option in the
-						<code class="language-cobol">NEXT GROUP</code> clause must not be specified in a page footing.
-					</p>
-					<p>
-						The <code class="language-cobol">NEXT GROUP</code> clause must not be specified in a
-						<code class="language-cobol">REPORT FOOTING</code> or
-						<code class="language-cobol">PAGE HEADING</code> group.
-					</p>
-					<p>
-						When used in a <code class="language-cobol">DETAIL</code> group the
-						<code class="language-cobol">NEXT GROUP</code> clause refers to the next
-						<code class="language-cobol">DETAIL</code> group to be printed.
-					</p>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">The TYPE clause</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						The TYPE clause specifies the type of the report group. The type of the report group governs
-						when and where will be printed in the the report (for instance, a
-						<code class="language-cobol">REPORT HEADING</code> group is printed only once - at the beginning
-						of the report).
-					</p>
-					<p><b>Rules</b></p>
-					<p>
-						Most groups are defined once for each report but control groups (other than CONTROL ..FINAL
-						groups) are defined for each control break item.
-					</p>
-					<p>
-						In <code class="language-cobol">REPORT FOOTING</code>, and
-						<code class="language-cobol">CONTROL FOOTING</code> groups,
-						<code class="language-cobol">SOURCE</code> and <code class="language-cobol">USE</code> clauses
-						must not reference any data item which contains a control break item or is subordinate to a
-						control break item.
-					</p>
-					<p>
-						<code class="language-cobol">PAGE HEADING</code> or
-						<code class="language-cobol">FOOTING</code> groups must not reference a control break item or
-						any item subordinate to a control break item.
-					</p>
-					<p>
-						<code class="language-cobol">DETAIL</code> report groups are processed when they are referenced
-						in a <code class="language-cobol">GENERATE</code> statement. All other groups are processed
-						automatically by the Report Writer. There can be more than one
-						<code class="language-cobol">DETAIL</code> group.
-					</p>
-					<p>
-						The <code class="language-cobol">REPORT HEADING</code>,
-						<code class="language-cobol">PAGE HEADING</code>,
-						<code class="language-cobol">CONTROL HEADING FINAL</code>,
-						<code class="language-cobol">CONTROL FOOTING FINAL</code>,
-						<code class="language-cobol">PAGE FOOTING</code> and
-						<code class="language-cobol">REPORT FOOTING</code> report groups can each appear only once in
-						the description of a report.
-					</p>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#993300" colspan="2" valign="top">
+						<p><b>Rules</b></p>
+						<p>
+							The <code class="language-cobol">NEXT PAGE</code> option in the
+							<code class="language-cobol">NEXT GROUP</code> clause must not be specified in a page footing.
+						</p>
+						<p>
+							The <code class="language-cobol">NEXT GROUP</code> clause must not be specified in a
+							<code class="language-cobol">REPORT FOOTING</code> or
+							<code class="language-cobol">PAGE HEADING</code> group.
+						</p>
+						<p>
+							When used in a <code class="language-cobol">DETAIL</code> group the
+							<code class="language-cobol">NEXT GROUP</code> clause refers to the next
+							<code class="language-cobol">DETAIL</code> group to be printed.
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4 align="left">The TYPE clause</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The TYPE clause specifies the type of the report group. The type of the report group governs
+							when and where will be printed in the the report (for instance, a
+							<code class="language-cobol">REPORT HEADING</code> group is printed only once - at the beginning
+							of the report).
+						</p>
+						<p><b>Rules</b></p>
+						<p>
+							Most groups are defined once for each report but control groups (other than CONTROL ..FINAL
+							groups) are defined for each control break item.
+						</p>
+						<p>
+							In <code class="language-cobol">REPORT FOOTING</code>, and
+							<code class="language-cobol">CONTROL FOOTING</code> groups,
+							<code class="language-cobol">SOURCE</code> and <code class="language-cobol">USE</code> clauses
+							must not reference any data item which contains a control break item or is subordinate to a
+							control break item.
+						</p>
+						<p>
+							<code class="language-cobol">PAGE HEADING</code> or
+							<code class="language-cobol">FOOTING</code> groups must not reference a control break item or
+							any item subordinate to a control break item.
+						</p>
+						<p>
+							<code class="language-cobol">DETAIL</code> report groups are processed when they are referenced
+							in a <code class="language-cobol">GENERATE</code> statement. All other groups are processed
+							automatically by the Report Writer. There can be more than one
+							<code class="language-cobol">DETAIL</code> group.
+						</p>
+						<p>
+							The <code class="language-cobol">REPORT HEADING</code>,
+							<code class="language-cobol">PAGE HEADING</code>,
+							<code class="language-cobol">CONTROL HEADING FINAL</code>,
+							<code class="language-cobol">CONTROL FOOTING FINAL</code>,
+							<code class="language-cobol">PAGE FOOTING</code> and
+							<code class="language-cobol">REPORT FOOTING</code> report groups can each appear only once in
+							the description of a report.
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-header">
 					<h2 align="center" id="part4">Defining the Report - Lines and Columns</h2>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">Introduction</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						The subordinate items in a report group record describe the report lines and columns within the
-						report group. There are two formats for defining items subordinate to the report group record.
-						The first is usually used to define the lines of the report group and the second to define and
-						position the elementary print items.
-					</p>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">Defining Report Lines</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						Print lines in a report group are usually defined using the format shown below. This format is
-						used to specify the vertical placement of a print line and it is always followed by subordinate
-						items that specify the columns where the data items are to be printed.
-					</p>
-					<p>As shown in the syntax diagram below the level number is from 2 to 48 inclusive.</p>
-					<p>If the <i>ReportLineName</i> is used its only purpose is to qualify a sum counter reference.</p>
-					<p><img height="74" src="Resources/pics/rwGroupDesc1.gif" width="364" /></p>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="center">Defining Elementary print items in a report group</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						Elementary print items in the print line of a report group are described using the syntactic
-						elements shown in the diagram below.
-					</p>
-					<p>
-						As we can see from the syntax diagram, the normal data description clauses such as
-						<code class="language-cobol">PIC</code>, <code class="language-cobol">USAGE</code>,
-						<code class="language-cobol">SIGN</code>, <code class="language-cobol">JUSTIFIED</code>,
-						<code class="language-cobol">BLANK WHEN ZERO</code> and
-						<code class="language-cobol">VALUE</code> may be applied when describing an elementary print
-						item. The Report Writer provides a number of additional clauses that may also be used.
-					</p>
-					<p>
-						The <i>PrintItemName</i> can only be referenced if the entry uses the
-						<code class="language-cobol">SUM</code> clause to define a sum counter.
-					</p>
-					<p><img height="456" src="Resources/pics/rwGroupDesc2.gif" width="413" /></p>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">The COLUMN NUMBER clause</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						The <code class="language-cobol">COLUMN NUMBER</code> specifies the position of a print item on
-						the print line. When this clause is used it must be subordinate to an item that contains a
-						<code class="language-cobol">LINE NUMBER</code> clause.
-					</p>
-					<p>Within a given print line the <i>ColNum#l's</i> should be in ascending sequence.</p>
-					<p>
-						<i>ColNum#l</i> specifies the column number of the leftmost character position of the print
-						item.
-					</p>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>The GROUP INDICATE clause</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						The <code class="language-cobol">GROUP INDICATE</code> is used to specify that a print item
-						should be printed only on the first occurrence of its report group after a control break or page
-						advance.
-					</p>
-					<p>
-						For instance in the full version of the example program the CityName and SalesPersonNum are
-						suppressed after their first occurrence.
-					</p>
-					<table background="Resources/pics/code.gif" border="1" width="100%">
-						<tr>
-							<td>
-								<pre class="language-cobol"><code class="language-cobol">01  DetailLine TYPE IS DETAIL.
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4 align="left">Introduction</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The subordinate items in a report group record describe the report lines and columns within the
+							report group. There are two formats for defining items subordinate to the report group record.
+							The first is usually used to define the lines of the report group and the second to define and
+							position the elementary print items.
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4 align="left">Defining Report Lines</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							Print lines in a report group are usually defined using the format shown below. This format is
+							used to specify the vertical placement of a print line and it is always followed by subordinate
+							items that specify the columns where the data items are to be printed.
+						</p>
+						<p>As shown in the syntax diagram below the level number is from 2 to 48 inclusive.</p>
+						<p>If the <i>ReportLineName</i> is used its only purpose is to qualify a sum counter reference.</p>
+						<p><img height="74" src="Resources/pics/rwGroupDesc1.gif" width="364" /></p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4 align="center">Defining Elementary print items in a report group</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							Elementary print items in the print line of a report group are described using the syntactic
+							elements shown in the diagram below.
+						</p>
+						<p>
+							As we can see from the syntax diagram, the normal data description clauses such as
+							<code class="language-cobol">PIC</code>, <code class="language-cobol">USAGE</code>,
+							<code class="language-cobol">SIGN</code>, <code class="language-cobol">JUSTIFIED</code>,
+							<code class="language-cobol">BLANK WHEN ZERO</code> and
+							<code class="language-cobol">VALUE</code> may be applied when describing an elementary print
+							item. The Report Writer provides a number of additional clauses that may also be used.
+						</p>
+						<p>
+							The <i>PrintItemName</i> can only be referenced if the entry uses the
+							<code class="language-cobol">SUM</code> clause to define a sum counter.
+						</p>
+						<p><img height="456" src="Resources/pics/rwGroupDesc2.gif" width="413" /></p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4 align="left">The COLUMN NUMBER clause</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The <code class="language-cobol">COLUMN NUMBER</code> specifies the position of a print item on
+							the print line. When this clause is used it must be subordinate to an item that contains a
+							<code class="language-cobol">LINE NUMBER</code> clause.
+						</p>
+						<p>Within a given print line the <i>ColNum#l's</i> should be in ascending sequence.</p>
+						<p>
+							<i>ColNum#l</i> specifies the column number of the leftmost character position of the print
+							item.
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>The GROUP INDICATE clause</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The <code class="language-cobol">GROUP INDICATE</code> is used to specify that a print item
+							should be printed only on the first occurrence of its report group after a control break or page
+							advance.
+						</p>
+						<p>
+							For instance in the full version of the example program the CityName and SalesPersonNum are
+							suppressed after their first occurrence.
+						</p>
+						<pre class="language-cobol"><code class="language-cobol">01  DetailLine TYPE IS DETAIL.
     02 LINE IS PLUS 1.
        03 COLUMN 1      PIC X(9)
                         SOURCE CityName(CityCode) GROUP INDICATE.
        03 COLUMN 15     PIC 9
                         SOURCE SalesPersonNum  GROUP INDICATE.
        03 COLUMN 25     PIC $$,$$$.99 SOURCE ValueOfSale.</code></pre>
-							</td>
-						</tr>
-					</table>
-					<p>
-						The <code class="language-cobol">GROUP INDICATE</code> clause can only appear in a
-						<code class="language-cobol">DETAIL</code> report group
-					</p>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>The SOURCE clause</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						The SOURCE clause is used to identify a data item that contains the value to be used when the
-						print-item is printed. For instance, the SOURCE <i>ValueOfSale</i> clause in the example above
-						specifies that the value of the item to be printed in column 25 is to be found in the data-item
-						ValueOfSale.
-					</p>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>The SUM clause</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						The SUM clause is used both to establish a sum counter and to name the data-items to be summed.
-					</p>
-					<p>Three forms of summing can be done in the Report Writer;</p>
-					<ol>
+						<p>
+							The <code class="language-cobol">GROUP INDICATE</code> clause can only appear in a
+							<code class="language-cobol">DETAIL</code> report group
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>The SOURCE clause</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The SOURCE clause is used to identify a data item that contains the value to be used when the
+							print-item is printed. For instance, the SOURCE <i>ValueOfSale</i> clause in the example above
+							specifies that the value of the item to be printed in column 25 is to be found in the data-item
+							ValueOfSale.
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>The SUM clause</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The SUM clause is used both to establish a sum counter and to name the data-items to be summed.
+						</p>
+						<p>Three forms of summing can be done in the Report Writer;</p>
 						<ol>
-							<li>Subtotalling</li>
-							<li>Rolling Forward</li>
-							<li>Cross footing</li>
+							<ol>
+								<li>Subtotalling</li>
+								<li>Rolling Forward</li>
+								<li>Cross footing</li>
+							</ol>
 						</ol>
-					</ol>
-					<hr />
-					<h4><b>Subtotalling</b></h4>
-					<p>
-						In Subtotalling, each time a <code class="language-cobol">GENERATE</code> statement is executed
-						the value to be summed is added to the sum counter.
-					</p>
-					<hr />
-					<h4><b>Rolling Forward</b></h4>
-					<p>
-						In Rolling Forward the value accumulated in the sum counter of one group is used as the value to
-						be summed in the sum counter of another group.
-					</p>
-					<p>
-						The full version of the example program contains a good example of both Subtotalling and Rolling
-						forward. The SUM clause is used to accumulate the ValueOfSale into a sum counter named as SMS
-						(Subtotalling). The SMS sum counter is used as the value to be summed into the CS sum counter
-						and CS is used as the value to be summed into the final total (Rolling Forward).
-					</p>
-					<p>
-						In the example code fragment below, each time a <code class="language-cobol">DETAIL</code> line
-						is <code class="language-cobol">GENERATED</code> the ValueOf Sale is added to the SMS sum
-						counter. When a control break occurs on SalesPersonNum the accumulated sum is printed and is
-						added to the CS sum counter. When a control break occurs on the CityCode the sum accumulated in
-						the CS sum counter is added to the final total sum counter.
-					</p>
-					<table background="Resources/pics/code.gif" border="1" width="100%">
-						<tr>
-							<td>
-								<pre class="language-cobol"><code class="language-cobol">01  SalesPersonGrp
+						<hr />
+						<h4><b>Subtotalling</b></h4>
+						<p>
+							In Subtotalling, each time a <code class="language-cobol">GENERATE</code> statement is executed
+							the value to be summed is added to the sum counter.
+						</p>
+						<hr />
+						<h4><b>Rolling Forward</b></h4>
+						<p>
+							In Rolling Forward the value accumulated in the sum counter of one group is used as the value to
+							be summed in the sum counter of another group.
+						</p>
+						<p>
+							The full version of the example program contains a good example of both Subtotalling and Rolling
+							forward. The SUM clause is used to accumulate the ValueOfSale into a sum counter named as SMS
+							(Subtotalling). The SMS sum counter is used as the value to be summed into the CS sum counter
+							and CS is used as the value to be summed into the final total (Rolling Forward).
+						</p>
+						<p>
+							In the example code fragment below, each time a <code class="language-cobol">DETAIL</code> line
+							is <code class="language-cobol">GENERATED</code> the ValueOf Sale is added to the SMS sum
+							counter. When a control break occurs on SalesPersonNum the accumulated sum is printed and is
+							added to the CS sum counter. When a control break occurs on the CityCode the sum accumulated in
+							the CS sum counter is added to the final total sum counter.
+						</p>
+						<pre class="language-cobol"><code class="language-cobol">01  SalesPersonGrp
     TYPE IS CONTROL FOOTING SalesPersonNum  NEXT GROUP PLUS 2.
                       :<i> other entries</i> :
                       :<i> other entries</i> :
@@ -707,22 +834,16 @@ RD  SalesReport
                       :<i> other entries</i> :
                       :<i> other entries</i> :
        03 COLUMN 45     PIC $$$$$,$$$.99 SUM CS.</code></pre>
-							</td>
-						</tr>
-					</table>
-					<hr />
-					<h4><b>Cross Footing</b></h4>
-					<p>
-						In Cross Footing sum counters in the same report group can be added together. In the example
-						below, each time a GENERATE statement is executed the value of the SalesPersonSale is added to
-						the SPS sum counter and the value of CounterSale is added to SCS (Subtotalling). When a control
-						break occurs on ShopNum the values of the SPS and SCS sum counters are added together to give
-						the combined total printed in column 60 (Cross Footing).
-					</p>
-					<table background="Resources/pics/code.gif" border="1" width="100%">
-						<tr>
-							<td>
-								<pre class="language-cobol"><code class="language-cobol">01  ShopTotalsGrp
+						<hr />
+						<h4><b>Cross Footing</b></h4>
+						<p>
+							In Cross Footing sum counters in the same report group can be added together. In the example
+							below, each time a GENERATE statement is executed the value of the SalesPersonSale is added to
+							the SPS sum counter and the value of CounterSale is added to SCS (Subtotalling). When a control
+							break occurs on ShopNum the values of the SPS and SCS sum counters are added together to give
+							the combined total printed in column 60 (Cross Footing).
+						</p>
+						<pre class="language-cobol"><code class="language-cobol">01  ShopTotalsGrp
     TYPE IS CONTROL FOOTING ShopNum  NEXT GROUP PLUS 2.
                       :<i> other entries</i> :
                       :<i> other entries</i> :
@@ -730,390 +851,366 @@ RD  SalesReport
        03 SCS COLUMN 40 PIC $$$,$$$.99  SUM CounterSale.
        03     COLUMN 60 PIC $$$$,$$$.99 SUM SPS, SCS.
 </code></pre>
-							</td>
-						</tr>
-					</table>
-					<h4>Rules</h4>
-					<ol>
-						<li>
-							If the the SUM..UPON <i>ReportGroupName</i> clause is used then the value is only added to
-							the sum counter when the specified report group is printed.
-						</li>
-						<li>
-							A SUM clause can appear only in the description of a
-							<code class="language-cobol">CONTROL FOOTING</code> report group.
-						</li>
-						<li>
-							Statements in the Procedure Division can be used to alter the contents of the sum counters.
-						</li>
-					</ol>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>The RESET ON clause</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						Sum counters are normally reset to zero after a control break on the control break item
-						associated with the report group but the <code class="language-cobol">RESET</code> clause can be
-						used to reset the sum counters on the break of a more senior control item.
-					</p>
-					<h4>Rules</h4>
-					<ol>
-						<li>
-							The <i>ControlBreakItem#$i</i> must be one of the data items mentioned in the
-							CONTROL/CONTROLS clause in the Report Description.
-						</li>
-					</ol>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
+						<h4>Rules</h4>
+						<ol>
+							<li>
+								If the the SUM..UPON <i>ReportGroupName</i> clause is used then the value is only added to
+								the sum counter when the specified report group is printed.
+							</li>
+							<li>
+								A SUM clause can appear only in the description of a
+								<code class="language-cobol">CONTROL FOOTING</code> report group.
+							</li>
+							<li>
+								Statements in the Procedure Division can be used to alter the contents of the sum counters.
+							</li>
+						</ol>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>The RESET ON clause</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							Sum counters are normally reset to zero after a control break on the control break item
+							associated with the report group but the <code class="language-cobol">RESET</code> clause can be
+							used to reset the sum counters on the break of a more senior control item.
+						</p>
+						<h4>Rules</h4>
+						<ol>
+							<li>
+								The <i>ControlBreakItem#$i</i> must be one of the data items mentioned in the
+								CONTROL/CONTROLS clause in the Report Description.
+							</li>
+						</ol>
+					</div>
+				</div>
+				<div class="section-header">
 					<h2 align="center" id="part5">Special Report Writer registers</h2>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>Introduction</h4>
-				</td>
-				<td valign="top" width="525">
-					<div align="center">
-						<p align="left">
-							The Report Writer maintains two special registers for each report declared in the Report
-							Section. The two registers are -
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Introduction</h4>
+					</div>
+					<div class="section-content">
+						<div align="center">
+							<p align="left">
+								The Report Writer maintains two special registers for each report declared in the Report
+								Section. The two registers are -
+							</p>
+						</div>
+						<p align="center">
+							the LINE-COUNTER<br />
+							and<br />
+							the PAGE-COUNTER
 						</p>
 					</div>
-					<p align="center">
-						the LINE-COUNTER<br />
-						and<br />
-						the PAGE-COUNTER
-					</p>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>The LINE-COUNTER register</h4>
-				</td>
-				<td valign="top" width="525">
-					<p align="left">
-						The reserved word <code class="language-cobol">LINE-COUNTER</code> can be used to access a
-						special register that the Report Writer maintains for each report in the Report Section.
-					</p>
-					<p align="left">
-						The Report Writer uses the <code class="language-cobol">LINE-COUNTER</code> register to keep
-						track of where the lines are being printed on the report. It uses this information and the
-						information specified in the <code class="language-cobol">PAGE LIMIT</code> clause in the RD
-						entry to decide when a new page is required.
-					</p>
-					<p align="left">
-						While the <code class="language-cobol">LINE-COUNTER</code> register can be used as a
-						<code class="language-cobol">SOURCE</code> item in the report no statements in the Procedure
-						Division can alter the value in the register.
-					</p>
-					<p align="left">
-						References to the <code class="language-cobol">LINE-COUNTER</code> register can be qualified by
-						referring to the name of the report given in the RD entry.
-					</p>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>The PAGE-COUNTER register</h4>
-				</td>
-				<td valign="top" width="525">
-					<div align="center">
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>The LINE-COUNTER register</h4>
+					</div>
+					<div class="section-content">
 						<p align="left">
-							The reserved word <code class="language-cobol">PAGE-COUNTER</code> can be used to access a
+							The reserved word <code class="language-cobol">LINE-COUNTER</code> can be used to access a
 							special register that the Report Writer maintains for each report in the Report Section.
 						</p>
 						<p align="left">
-							The <code class="language-cobol">PAGE-COUNTER</code> is used to count the number of pages in
-							the report.
+							The Report Writer uses the <code class="language-cobol">LINE-COUNTER</code> register to keep
+							track of where the lines are being printed on the report. It uses this information and the
+							information specified in the <code class="language-cobol">PAGE LIMIT</code> clause in the RD
+							entry to decide when a new page is required.
 						</p>
 						<p align="left">
-							The <code class="language-cobol">PAGE-COUNTER</code> register can be used as a
-							<code class="language-cobol">SOURCE</code> item in the report but the value of the
-							<code class="language-cobol">PAGE-COUNTER</code> may also be changed by statements in the
-							Procedure Division.
+							While the <code class="language-cobol">LINE-COUNTER</code> register can be used as a
+							<code class="language-cobol">SOURCE</code> item in the report no statements in the Procedure
+							Division can alter the value in the register.
 						</p>
-						<table background="Resources/pics/code.gif" border="1" width="100%">
-							<tr>
-								<td>
-									<pre class="language-cobol"><code class="language-cobol">01  TYPE IS PAGE FOOTING.
+						<p align="left">
+							References to the <code class="language-cobol">LINE-COUNTER</code> register can be qualified by
+							referring to the name of the report given in the RD entry.
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>The PAGE-COUNTER register</h4>
+					</div>
+					<div class="section-content">
+						<div align="center">
+							<p align="left">
+								The reserved word <code class="language-cobol">PAGE-COUNTER</code> can be used to access a
+								special register that the Report Writer maintains for each report in the Report Section.
+							</p>
+							<p align="left">
+								The <code class="language-cobol">PAGE-COUNTER</code> is used to count the number of pages in
+								the report.
+							</p>
+							<p align="left">
+								The <code class="language-cobol">PAGE-COUNTER</code> register can be used as a
+								<code class="language-cobol">SOURCE</code> item in the report but the value of the
+								<code class="language-cobol">PAGE-COUNTER</code> may also be changed by statements in the
+								Procedure Division.
+							</p>
+							<pre class="language-cobol"><code class="language-cobol">01  TYPE IS PAGE FOOTING.
     02 LINE IS 53.
-       03 COLUMN 1      PIC X(29) 
+       03 COLUMN 1      PIC X(29)
                         VALUE "Programmer - Michael Coughlan".
        03 COLUMN 45     PIC X(6) VALUE "Page :".
        03 COLUMN 52     PIC Z9 SOURCE PAGE-COUNTER.</code></pre>
-								</td>
-							</tr>
-						</table>
+						</div>
+						<hr />
 					</div>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
+				</div>
+				<div class="section-header">
 					<h2 align="center" id="part6">Procedure Division verbs</h2>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>Introduction</h4>
-				</td>
-				<td valign="top" width="525">
-					<div align="center">
-						<p align="left">
-							The Report Writer introduces four new verbs for processing reports. These are -
-						</p>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Introduction</h4>
 					</div>
-					<ol>
-						<li>INITIATE</li>
-						<li>GENERATE</li>
-						<li>TERMINATE</li>
-						<li>SUPPRESS PRINTING</li>
-					</ol>
-					<div align="center">
-						<p align="left">
-							The first three are normal Procedure Division verbs but the last can only be used in the
-							Declaratives Section.
-						</p>
-						<p align="left">
-							The normal Procedure Division verbs will be covered in this section. Please see the section
-							on Declaratives for the
-							<code class="language-cobol">SUPPRESS PRINTING</code> statement.
-						</p>
+					<div class="section-content">
+						<div align="center">
+							<p align="left">
+								The Report Writer introduces four new verbs for processing reports. These are -
+							</p>
+						</div>
+						<ol>
+							<li>INITIATE</li>
+							<li>GENERATE</li>
+							<li>TERMINATE</li>
+							<li>SUPPRESS PRINTING</li>
+						</ol>
+						<div align="center">
+							<p align="left">
+								The first three are normal Procedure Division verbs but the last can only be used in the
+								Declaratives Section.
+							</p>
+							<p align="left">
+								The normal Procedure Division verbs will be covered in this section. Please see the section
+								on Declaratives for the
+								<code class="language-cobol">SUPPRESS PRINTING</code> statement.
+							</p>
+						</div>
+						<hr />
 					</div>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>Syntax</h4>
-				</td>
-				<td valign="top" width="525">
-					<p><img height="144" src="Resources/pics/rwVerbs.gif" width="238" /></p>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>INITIATE</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						The <code class="language-cobol">INITIATE</code> statement starts the processing of the
-						<i>ReportName</i> report or reports.
-					</p>
-					<p>
-						The <i>ReportName</i> must be the name defined for a report in the RD entry in the Report
-						Section.
-					</p>
-					<p>The <code class="language-cobol">INITIATE</code> statement initializes -</p>
-					<ul>
-						<li>all the report's sum counters to zero</li>
-						<li>the report <code class="language-cobol">LINE-COUNTER</code> to zero</li>
-						<li>the report <code class="language-cobol">PAGE-COUNTER</code> to one</li>
-					</ul>
-					<p>
-						Before the <code class="language-cobol">INITIATE</code> statement is executed the file
-						associated with the Report must have been opened for
-						<code class="language-cobol">OUTPUT</code> or <code class="language-cobol">EXTEND</code>.
-					</p>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>GENERATE</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						The <code class="language-cobol">GENERATE</code> statement drives the production of the report.
-					</p>
-					<p>
-						The target of a <code class="language-cobol">GENERATE</code> statement is either a
-						<code class="language-cobol">DETAIL</code> report group or a Report Name.
-					</p>
-					<p>When the target is a <i>ReportName</i> then the report description must contain -</p>
-					<ul>
-						<li>a <code class="language-cobol">CONTROL</code> clause</li>
-						<li>not more than one <code class="language-cobol">DETAIL</code> group</li>
-						<li>
-							at least one group that is not a <code class="language-cobol">PAGE</code> or
-							<code class="language-cobol">REPORT</code> group.
-						</li>
-					</ul>
-					<p>
-						When all the <code class="language-cobol">GENERATE</code> statements for a particular report
-						target the <i>ReportName</i> then the report performs summary processing only and the report
-						produced is called a summary report. For instance to make a summary report from the example
-						report all we have to to is to change the <code class="language-cobol">GENERATE</code> statement
-						from -
-					</p>
-					<blockquote>
-						<p>GENERATE DetailLine.</p>
-						<p>to</p>
-						<p>GENERATE SalesReport.</p>
-					</blockquote>
-					<p>
-						If we specify <code class="language-cobol">GENERATE</code> SalesReport then the
-						<code class="language-cobol">DETAIL</code> group is never printed but the other groups are
-						printed (see the first page of the summary report shown below).
-					</p>
-					<hr />
-					<table background="Resources/pics/code.gif" border="0" width="100%">
-						<tr>
-							<td valign="top">
-								<pre
-									class="language-cobol"
-								><code class="language-cobol">          An example COBOL Report Program              
-     Bible Salesperson - Sales and Salary Report        
-                                                        
- City      Salesperson     Sale                         
- Name       Number         Value                        
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Syntax</h4>
+					</div>
+					<div class="section-content">
+						<p><img height="144" src="Resources/pics/rwVerbs.gif" width="238" /></p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>INITIATE</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The <code class="language-cobol">INITIATE</code> statement starts the processing of the
+							<i>ReportName</i> report or reports.
+						</p>
+						<p>
+							The <i>ReportName</i> must be the name defined for a report in the RD entry in the Report
+							Section.
+						</p>
+						<p>The <code class="language-cobol">INITIATE</code> statement initializes -</p>
+						<ul>
+							<li>all the report's sum counters to zero</li>
+							<li>the report <code class="language-cobol">LINE-COUNTER</code> to zero</li>
+							<li>the report <code class="language-cobol">PAGE-COUNTER</code> to one</li>
+						</ul>
+						<p>
+							Before the <code class="language-cobol">INITIATE</code> statement is executed the file
+							associated with the Report must have been opened for
+							<code class="language-cobol">OUTPUT</code> or <code class="language-cobol">EXTEND</code>.
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>GENERATE</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The <code class="language-cobol">GENERATE</code> statement drives the production of the report.
+						</p>
+						<p>
+							The target of a <code class="language-cobol">GENERATE</code> statement is either a
+							<code class="language-cobol">DETAIL</code> report group or a Report Name.
+						</p>
+						<p>When the target is a <i>ReportName</i> then the report description must contain -</p>
+						<ul>
+							<li>a <code class="language-cobol">CONTROL</code> clause</li>
+							<li>not more than one <code class="language-cobol">DETAIL</code> group</li>
+							<li>
+								at least one group that is not a <code class="language-cobol">PAGE</code> or
+								<code class="language-cobol">REPORT</code> group.
+							</li>
+						</ul>
+						<p>
+							When all the <code class="language-cobol">GENERATE</code> statements for a particular report
+							target the <i>ReportName</i> then the report performs summary processing only and the report
+							produced is called a summary report. For instance to make a summary report from the example
+							report all we have to to is to change the <code class="language-cobol">GENERATE</code> statement
+							from -
+						</p>
+						<blockquote>
+							<p>GENERATE DetailLine.</p>
+							<p>to</p>
+							<p>GENERATE SalesReport.</p>
+						</blockquote>
+						<p>
+							If we specify <code class="language-cobol">GENERATE</code> SalesReport then the
+							<code class="language-cobol">DETAIL</code> group is never printed but the other groups are
+							printed (see the first page of the summary report shown below).
+						</p>
+						<hr />
+						<pre
+								class="language-cobol"
+							><code class="language-cobol">          An example COBOL Report Program
+     Bible Salesperson - Sales and Salary Report
+
+ City      Salesperson     Sale
+ Name       Number         Value
               Sales for salesperson 1     =      $334.00
               Sales commission is         =       $16.70
               Salesperson salary is       =      $139.70
-              Current  salesperson number = 2           
-              Previous salesperson number = 1           
-                                                        
-                                                        
+              Current  salesperson number = 2
+              Previous salesperson number = 1
+
+
               Sales for salesperson 2     =    $3,667.50
               Sales commission is         =      $183.38
               Salesperson salary is       =      $504.38
-              Current  salesperson number = 3           
-              Previous salesperson number = 2           
-                                                        
-                                                        
+              Current  salesperson number = 3
+              Previous salesperson number = 2
+
+
               Sales for salesperson 3     =      $777.70
               Sales commission is         =       $38.89
               Salesperson salary is       =      $473.89
-              Current  salesperson number = 1           
-              Previous salesperson number = 3           
-                                                        
+              Current  salesperson number = 1
+              Previous salesperson number = 3
+
               Sales for Dublin            =    $4,779.20
-              Current city                = 2           
-              Previous city               = 1           
-                                                        
-                                                        
+              Current city                = 2
+              Previous city               = 1
+
+
               Sales for salesperson 1     =      $334.00
               Sales commission is         =       $16.70
               Salesperson salary is       =      $139.70
-              Current  salesperson number = 2           
-              Previous salesperson number = 1           
-                                                        
-                                                        
+              Current  salesperson number = 2
+              Previous salesperson number = 1
+
+
               Sales for salesperson 2     =    $2,334.00
               Sales commission is         =      $116.70
               Salesperson salary is       =      $458.70
-              Current  salesperson number = 3           
-              Previous salesperson number = 2           
-                                                        
-                                                        
+              Current  salesperson number = 3
+              Previous salesperson number = 2
+
+
               Sales for salesperson 3     =      $222.20
               Sales commission is         =       $11.11
               Salesperson salary is       =      $122.11
-              Current  salesperson number = 4           
-              Previous salesperson number = 3           
-                                                        
-                                                        
-                                                        
-Programmer - Michael Coughlan               Page :  1   
-                                                        
+              Current  salesperson number = 4
+              Previous salesperson number = 3
+
+
+
+Programmer - Michael Coughlan               Page :  1
+
   </code></pre>
-							</td>
-						</tr>
-					</table>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>TERMINATE</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						The <code class="language-cobol">TERMINATE</code> statement instructs the Report Writer to
-						complete the processing of the specified report. The Report Writer prints the Page and Report
-						Footings and all the <code class="language-cobol">CONTROL FOOTING</code> groups are printed as
-						if there had been a control break on the most senior control group.
-					</p>
-					<p>
-						After the report has been terminated the file associated with the report must be closed. For
-						instance in the example program the
-						<i>TERMINATE SalesReport</i> statement is followed by the <i>CLOSE PrintFile</i> statement.
-					</p>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#993300" colspan="2" valign="top">
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>TERMINATE</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The <code class="language-cobol">TERMINATE</code> statement instructs the Report Writer to
+							complete the processing of the specified report. The Report Writer prints the Page and Report
+							Footings and all the <code class="language-cobol">CONTROL FOOTING</code> groups are printed as
+							if there had been a control break on the most senior control group.
+						</p>
+						<p>
+							After the report has been terminated the file associated with the report must be closed. For
+							instance in the example program the
+							<i>TERMINATE SalesReport</i> statement is followed by the <i>CLOSE PrintFile</i> statement.
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-header">
 					<h2 align="center" id="part7">Report Writer Declaratives</h2>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>Introduction</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						Declaratives are used to extend the functionality of the Report Writer when its standard
-						operations are insufficient of create the desired report. Declaratives extend the functionality
-						of the Report Writer by performing tasks or calculations that the Report Writer can not do
-						automatically or by selectively stopping the report group from being printed (using the
-						<code class="language-cobol">SUPPRESS PRINTING</code> command).
-					</p>
-					<p>
-						When Declaratives are used with the Report Writer the
-						<code class="language-cobol">USE BEFORE REPORTING</code> phrase allows a programmer to specify
-						that the particular section of code is to be executed before some report group is printed.
-					</p>
-					<p>
-						Declaratives may also be used to handle file operation errors. In this case the USE clause
-						should use the following syntax -
-					</p>
-					<p align="center"><img height="173" src="Resources/pics/rwUSE1.gif" width="495" /></p>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>Using Declaratives with the Report Writer</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>When Declaratives are used they must appear as the first item in the Procedure Division.</p>
-					<p>
-						The Declaratives must be divided into sections and each section must be associated with a
-						particular USE statement.
-					</p>
-					<p>The USE statement governs when a particular declarative section is executed.</p>
-					<p>When Declaratives are used with the Report Writer the USE syntax shown below must be used</p>
-					<p align="center"><img height="22" src="Resources/pics/rwUSE2.gif" width="402" /></p>
-					<p align="left"><b>Rules:</b></p>
-					<p align="left">The ReportGroupName must not appear in more than one USE statement.</p>
-					<p align="left">
-						The <code class="language-cobol">GENERATE</code>,
-						<code class="language-cobol">INITIATE</code> and
-						<code class="language-cobol">TERMINATE</code> statements must not appear in the Declaratives.
-					</p>
-					<p align="left">The value of any control data items must not be altered in the Declaratives.</p>
-					<p align="left">Statements in the Declaratives must not reference non-declarative procedures.</p>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>Declaratives Example</h4>
-				</td>
-				<td valign="top" width="525">
-					<div align="center">
-						<table background="Resources/pics/code.gif" border="1" width="90%">
-							<tr>
-								<td>
-									<pre class="language-cobol"><code class="language-cobol">PROCEDURE DIVISION.
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Introduction</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							Declaratives are used to extend the functionality of the Report Writer when its standard
+							operations are insufficient of create the desired report. Declaratives extend the functionality
+							of the Report Writer by performing tasks or calculations that the Report Writer can not do
+							automatically or by selectively stopping the report group from being printed (using the
+							<code class="language-cobol">SUPPRESS PRINTING</code> command).
+						</p>
+						<p>
+							When Declaratives are used with the Report Writer the
+							<code class="language-cobol">USE BEFORE REPORTING</code> phrase allows a programmer to specify
+							that the particular section of code is to be executed before some report group is printed.
+						</p>
+						<p>
+							Declaratives may also be used to handle file operation errors. In this case the USE clause
+							should use the following syntax -
+						</p>
+						<p align="center"><img height="173" src="Resources/pics/rwUSE1.gif" width="495" /></p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Using Declaratives with the Report Writer</h4>
+					</div>
+					<div class="section-content">
+						<p>When Declaratives are used they must appear as the first item in the Procedure Division.</p>
+						<p>
+							The Declaratives must be divided into sections and each section must be associated with a
+							particular USE statement.
+						</p>
+						<p>The USE statement governs when a particular declarative section is executed.</p>
+						<p>When Declaratives are used with the Report Writer the USE syntax shown below must be used</p>
+						<p align="center"><img height="22" src="Resources/pics/rwUSE2.gif" width="402" /></p>
+						<p align="left"><b>Rules:</b></p>
+						<p align="left">The ReportGroupName must not appear in more than one USE statement.</p>
+						<p align="left">
+							The <code class="language-cobol">GENERATE</code>,
+							<code class="language-cobol">INITIATE</code> and
+							<code class="language-cobol">TERMINATE</code> statements must not appear in the Declaratives.
+						</p>
+						<p align="left">The value of any control data items must not be altered in the Declaratives.</p>
+						<p align="left">Statements in the Declaratives must not reference non-declarative procedures.</p>
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Declaratives Example</h4>
+					</div>
+					<div class="section-content">
+						<div align="center">
+							<pre class="language-cobol"><code class="language-cobol">PROCEDURE DIVISION.
 DECLARATIVES.
 Calc SECTION.
     USE BEFORE REPORTING SalesPersonGrp.
@@ -1130,38 +1227,32 @@ Begin.
     OPEN OUTPUT PrintFile.
        : etc :
        : etc : </code></pre>
-								</td>
-							</tr>
-						</table>
+						</div>
+						<hr />
 					</div>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>The SUPPRESS PRINTING statement</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						The <code class="language-cobol">SUPPRESS PRINTING</code> statement is used in a Declarative
-						section to stop a particular report group from being printed.
-					</p>
-					<p align="left">
-						The report group suppressed is the one mentioned in the USE statement associated with the
-						section containing the <code class="language-cobol">SUPPRESS PRINTING</code> statement.
-					</p>
-					<p align="left">
-						The <code class="language-cobol">SUPPRESS PRINTING</code> statement must be executed each time
-						you want to stop the report group from being printed.
-					</p>
-					<p align="left">
-						In the example below we only want to print the ShopTotalGrp if the sales for the shop are
-						greater than or equal to 10,000.
-					</p>
-					<table background="Resources/pics/code.gif" border="1" width="91%">
-						<tr>
-							<td>
-								<pre class="language-cobol"><code class="language-cobol">PROCEDURE DIVISION.
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>The SUPPRESS PRINTING statement</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The <code class="language-cobol">SUPPRESS PRINTING</code> statement is used in a Declarative
+							section to stop a particular report group from being printed.
+						</p>
+						<p align="left">
+							The report group suppressed is the one mentioned in the USE statement associated with the
+							section containing the <code class="language-cobol">SUPPRESS PRINTING</code> statement.
+						</p>
+						<p align="left">
+							The <code class="language-cobol">SUPPRESS PRINTING</code> statement must be executed each time
+							you want to stop the report group from being printed.
+						</p>
+						<p align="left">
+							In the example below we only want to print the ShopTotalGrp if the sales for the shop are
+							greater than or equal to 10,000.
+						</p>
+						<pre class="language-cobol"><code class="language-cobol">PROCEDURE DIVISION.
 DECLARATIVES.
 CheckShopSales SECTION.
     USE BEFORE REPORTING ShopTotalGrp.
@@ -1170,52 +1261,48 @@ PrintMajorShopsOnly.
        SUPPRESS PRINTING
     END-IF.
 END DECLARATIVES.</code></pre>
-							</td>
-						</tr>
-					</table>
-					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>Control Break Registers</h4>
-				</td>
-				<td valign="top" width="525">
-					<div align="center">
-						<p align="left">
-							A control break occurs when the value in a control break item changes. This causes an
-							interesting problem when the control break item is used as the
-							<code class="language-cobol">SOURCE</code> value in a control footing because by the time
-							the control footing is printed, the control break item no longer contains the correct value.
-							When we print a control footing and refer to a control break item we normally want to access
-							the previous value of the item not the current one.
-						</p>
-						<p align="left">
-							The Report Writer deals with this problem by maintaining a special control break register
-							for each control break item mentioned in the
-							<code class="language-cobol">CONTROLS ARE</code> phrase in the RD entry.
-						</p>
-						<p align="left">
-							When a control break item is referred to in a control footing or in the Declaratives the
-							Report Writer supplies the value held in the control break register and not the value in the
-							item itself.
-						</p>
-						<p align="left">
-							If a control break has just occurred the value in the control break register is the previous
-							value of the control break item.
-						</p>
+						<hr />
 					</div>
-				</td>
-			</tr>
-			<tr>
-				<td colspan="2">
-					<hr />
-					<div align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Control Break Registers</h4>
 					</div>
-					<copyright-notice></copyright-notice>
-				</td>
-			</tr>
-		</table>
+					<div class="section-content">
+						<div align="center">
+							<p align="left">
+								A control break occurs when the value in a control break item changes. This causes an
+								interesting problem when the control break item is used as the
+								<code class="language-cobol">SOURCE</code> value in a control footing because by the time
+								the control footing is printed, the control break item no longer contains the correct value.
+								When we print a control footing and refer to a control break item we normally want to access
+								the previous value of the item not the current one.
+							</p>
+							<p align="left">
+								The Report Writer deals with this problem by maintaining a special control break register
+								for each control break item mentioned in the
+								<code class="language-cobol">CONTROLS ARE</code> phrase in the RD entry.
+							</p>
+							<p align="left">
+								When a control break item is referred to in a control footing or in the Declaratives the
+								Report Writer supplies the value held in the control break register and not the value in the
+								item itself.
+							</p>
+							<p align="left">
+								If a control break has just occurred the value in the control break register is the previous
+								value of the control break item.
+							</p>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="page-footer">
+				<hr />
+				<div align="center">
+					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
+				</div>
+				<copyright-notice></copyright-notice>
+			</div>
+		</div>
 	</body>
 </html>

--- a/course/Search.html
+++ b/course/Search.html
@@ -5,26 +5,174 @@
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>Searching Tables</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
-		<style>table{max-width:100%}body>table,body>hr{margin-left:auto;margin-right:auto}img{max-width:100%;height:auto}pre{overflow-x:auto;max-width:100%}</style>
+		<style type="text/css">
+			ul.toc {
+				list-style-image: url(Resources/pics/BallGreenG.gif);
+				padding-left: 2.5em;
+				margin: 1em 0;
+			}
+
+			ul.toc > li {
+				padding-left: 0.4em;
+				margin-bottom: 0.6em;
+				font-size: smaller;
+			}
+
+			ul.toc a {
+				font-weight: bold;
+				font-size: larger;
+			}
+
+			.section-header h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			.section-sidebar h3,
+			.section-sidebar h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			.page-wrapper {
+				max-width: 715px;
+				margin: 0 auto;
+				border: 1px solid;
+				box-sizing: border-box;
+			}
+
+			.page-content {
+				padding: 2px;
+			}
+
+			.page-footer {
+				padding: 2px;
+			}
+
+			.section-grid {
+				display: grid;
+				grid-template-columns: 175px 1fr;
+			}
+
+			.section-header {
+				grid-column: 1 / -1;
+				background-color: #993300;
+				padding: 4px;
+				min-width: 0;
+				border-bottom: 1px solid;
+			}
+
+			.section-sidebar {
+				background-color: #FFFFCC;
+				padding: 4px;
+				align-self: stretch;
+				min-width: 0;
+				border-right: 1px solid;
+				border-bottom: 1px solid;
+			}
+
+			.section-content {
+				padding: 4px;
+				align-self: start;
+				min-width: 0;
+				overflow: hidden;
+				border-bottom: 1px solid;
+			}
+
+			.section-full {
+				grid-column: 1 / -1;
+				padding: 4px;
+				min-width: 0;
+				border-bottom: 1px solid;
+			}
+
+			.section-full:last-child {
+				border-bottom: none;
+			}
+
+			img {
+				max-width: 100%;
+				height: auto;
+			}
+
+			pre {
+				overflow-x: auto;
+				max-width: 100%;
+				white-space: pre-wrap;
+				word-wrap: break-word;
+				overflow-wrap: break-word;
+			}
+
+			pre[class*="language-"],
+			code[class*="language-"] {
+				white-space: pre-wrap !important;
+				overflow-wrap: break-word;
+			}
+
+			body {
+				-webkit-text-size-adjust: 100%;
+			}
+
+			@media (max-width: 600px) {
+				body {
+					margin: 4px;
+					overflow-wrap: break-word;
+					word-wrap: break-word;
+				}
+
+				.section-header h2,
+				.section-header h3 {
+					margin: 0.3em 0;
+				}
+
+				blockquote {
+					margin-left: 12px;
+					margin-right: 12px;
+				}
+
+				img,
+				iframe,
+				video,
+				embed,
+				object {
+					max-width: min(100%, calc(100vw - 16px)) !important;
+					height: auto;
+				}
+
+				pre {
+					max-width: min(100%, calc(100vw - 16px)) !important;
+				}
+
+				pre[class*="language-"] {
+					font-size: 0.8em;
+					line-height: 1.35;
+					padding: 0.6em;
+					overflow-x: auto;
+				}
+
+				.section-grid {
+					display: block;
+				}
+
+				.section-sidebar h3,
+				.section-sidebar h4,
+				.section-sidebar p {
+					margin: 0.2em 0;
+				}
+			}
+		</style>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
-		<style type="text/css">
-			/* Keep Prism code blocks within the page's 525px content cells; 510px = 525px minus 15px to account for Prism's horizontal padding/gutter and avoid widening the table layout. */
-			pre[class*="language-"] {
-				max-width: min(100%, calc(525px - 15px));
-				box-sizing: border-box;
-			}
-		</style>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
 	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
-		<table id="layout-table" border="1" width="715" cellpadding="4" cellspacing="0">
-			<tr>
-				<td align="left" bgcolor="#FFFFFF" colspan="2" valign="top">
+		<div class="page-wrapper">
+			<div class="page-content">
+				<div>
 					<center>
-						<p><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
+						<p id="top"><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
 						<h1>Searching Tables</h1>
 					</center>
 					<hr />
@@ -62,96 +210,92 @@
 						</li>
 					</ul>
 					<hr />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#993300" colspan="2" valign="top">
+				</div>
+				<div class="section-header">
 					<h2 align="center" id="intro">Introduction</h2>
-				</td>
-			</tr>
-			<tr>
-				<td bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>Aims</h4>
-				</td>
-				<td valign="top" width="525">
-					<div align="center">
-						<p align="left">
-							The task of searching a table to determine whether it contains a particular value is a
-							common operation. The method used to search a table depends heavily on how the values in the
-							table are organized.
-						</p>
-						<p align="left">
-							For instance, if the values are not ordered, the table may only be searched sequentially,
-							but if the values are ordered, then either a sequential or a binary search may be used.
-						</p>
-						<p align="left">
-							In COBOL, the <code class="language-cobol">SEARCH</code> verb is used for sequential
-							searches and the <code class="language-cobol">SEARCH ALL</code> for binary searches.
-						</p>
-						<p align="left">
-							This tutorial introduces the syntax and rules of operation of the
-							<code class="language-cobol">SEARCH</code> and
-							<code class="language-cobol">SEARCH ALL</code> verbs. It introduces the extensions to the
-							<code class="language-cobol">OCCURS</code> clause that are required when the
-							<code class="language-cobol">SEARCH</code> or
-							<code class="language-cobol">SEARCH ALL</code> is used. It shows how the SET verb may be
-							used to alter the value of an index and it demonstrates how the
-							<code class="language-cobol">SEARCH</code> and
-							<code class="language-cobol">SEARCH ALL</code> may be used to search a table.
-						</p>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Aims</h4>
 					</div>
-					<hr align="center" size="1" width="100%" />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>Objectives</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>By the end of this unit you should -</p>
-					<ol>
-						<li>
-							Know the new <code class="language-cobol">OCCURS</code> clause entries that are required
-							when the <code class="language-cobol">SEARCH</code> is used to search a table.
-						</li>
-						<li>Be able to use the <code class="language-cobol">SEARCH</code> to search a table.</li>
-						<li>Understand the restrictions that apply to manipulating a table index.</li>
-						<li>Be able to use the SET verb to change the value of a table index.</li>
-						<li>
-							Understand how the <code class="language-cobol">SEARCH</code> can be used to search a
-							multi-dimension table.
-						</li>
-						<li>
-							Know the new <code class="language-cobol">OCCURS</code> clause entries that are required
-							when the <code class="language-cobol">SEARCH ALL</code> is used to search a table.
-						</li>
-						<li>Understand how a binary search works.</li>
-					</ol>
-					<hr align="center" size="1" width="100%" />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>Prerequisites</h4>
-				</td>
-				<td valign="top" width="525">
-					<ul>
-						<li>Introduction to COBOL</li>
-						<li>Declaring data in COBOL</li>
-						<li>Basic Procedure Division Commands</li>
-						<li>Selection Constructs</li>
-						<li>Iteration Constructs</li>
-						<li>Introduction to Sequential files</li>
-						<li>Processing Sequential files</li>
-						<li>Print files and variable length records</li>
-						<li>Sorting and Merging files</li>
-						<li>Using Tables</li>
-						<li>Creating Tables - syntax and semantics</li>
-					</ul>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFFF" colspan="2" valign="top">
+					<div class="section-content">
+						<div align="center">
+							<p align="left">
+								The task of searching a table to determine whether it contains a particular value is a
+								common operation. The method used to search a table depends heavily on how the values in the
+								table are organized.
+							</p>
+							<p align="left">
+								For instance, if the values are not ordered, the table may only be searched sequentially,
+								but if the values are ordered, then either a sequential or a binary search may be used.
+							</p>
+							<p align="left">
+								In COBOL, the <code class="language-cobol">SEARCH</code> verb is used for sequential
+								searches and the <code class="language-cobol">SEARCH ALL</code> for binary searches.
+							</p>
+							<p align="left">
+								This tutorial introduces the syntax and rules of operation of the
+								<code class="language-cobol">SEARCH</code> and
+								<code class="language-cobol">SEARCH ALL</code> verbs. It introduces the extensions to the
+								<code class="language-cobol">OCCURS</code> clause that are required when the
+								<code class="language-cobol">SEARCH</code> or
+								<code class="language-cobol">SEARCH ALL</code> is used. It shows how the SET verb may be
+								used to alter the value of an index and it demonstrates how the
+								<code class="language-cobol">SEARCH</code> and
+								<code class="language-cobol">SEARCH ALL</code> may be used to search a table.
+							</p>
+						</div>
+						<hr align="center" size="1" width="100%" />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Objectives</h4>
+					</div>
+					<div class="section-content">
+						<p>By the end of this unit you should -</p>
+						<ol>
+							<li>
+								Know the new <code class="language-cobol">OCCURS</code> clause entries that are required
+								when the <code class="language-cobol">SEARCH</code> is used to search a table.
+							</li>
+							<li>Be able to use the <code class="language-cobol">SEARCH</code> to search a table.</li>
+							<li>Understand the restrictions that apply to manipulating a table index.</li>
+							<li>Be able to use the SET verb to change the value of a table index.</li>
+							<li>
+								Understand how the <code class="language-cobol">SEARCH</code> can be used to search a
+								multi-dimension table.
+							</li>
+							<li>
+								Know the new <code class="language-cobol">OCCURS</code> clause entries that are required
+								when the <code class="language-cobol">SEARCH ALL</code> is used to search a table.
+							</li>
+							<li>Understand how a binary search works.</li>
+						</ol>
+						<hr align="center" size="1" width="100%" />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Prerequisites</h4>
+					</div>
+					<div class="section-content">
+						<ul>
+							<li>Introduction to COBOL</li>
+							<li>Declaring data in COBOL</li>
+							<li>Basic Procedure Division Commands</li>
+							<li>Selection Constructs</li>
+							<li>Iteration Constructs</li>
+							<li>Introduction to Sequential files</li>
+							<li>Processing Sequential files</li>
+							<li>Print files and variable length records</li>
+							<li>Sorting and Merging files</li>
+							<li>Using Tables</li>
+							<li>Creating Tables - syntax and semantics</li>
+						</ul>
+					</div>
+				</div>
+				<div class="section-full">
 					<div align="center">
 						<hr />
 						<p>
@@ -160,106 +304,102 @@
 							/></a>
 						</p>
 					</div>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#993300" colspan="2" valign="top">
+				</div>
+				<div class="section-header">
 					<h2 align="center" id="part1">Occurs clause extensions</h2>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>Introduction</h4>
-				</td>
-				<td valign="top" width="525">
-					<p align="left">
-						When the <code class="language-cobol">SEARCH</code> and
-						<code class="language-cobol">SEARCH ALL</code> are used the normal table declarations are no
-						longer sufficient and the <code class="language-cobol">OCCURS</code> clause must be extended
-						with the <code class="language-cobol">INDEXED BY</code> phrase and, in the case of the
-						<code class="language-cobol">SEARCH ALL</code>, by the
-						<code class="language-cobol">KEY IS</code> phrase.
-					</p>
-					<p align="left">
-						The full syntax of the <code class="language-cobol">OCCURS</code> clause, including the
-						<code class="language-cobol">INDEXED BY</code> and
-						<code class="language-cobol">KEY IS</code> phrases is shown below.
-					</p>
-					<hr size="1" width="100%" />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>Full OCCURS clause syntax</h4>
-				</td>
-				<td valign="top" width="525">
-					<p align="left"><img height="122" src="Resources/pics/Search1.gif" width="331" /></p>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>INDEXED BY phrase - notes</h4>
-				</td>
-				<td valign="top" width="525">
-					<p align="left">
-						Before the <code class="language-cobol">SEARCH</code> or
-						<code class="language-cobol">SEARCH ALL</code> can be used to search a table, the table must be
-						defined as having an index item associated with it.
-					</p>
-					<p align="left">
-						The index is specified by the <i>IndexName</i> given in the
-						<code class="language-cobol">INDEXED BY</code> phrase.
-					</p>
-					<p align="left">
-						The index defined in a table declaration is associated with that table and is the subscript
-						which the <code class="language-cobol">SEARCH</code> or
-						<code class="language-cobol">SEARCH ALL</code> uses to access the table.
-					</p>
-					<p align="left">
-						Using an index makes the searching more efficient. Since the index is linked to a particular
-						table, the compiler, taking into account the size of the table, can choose the most efficient
-						representation possible for the index and this speeds up the search.
-					</p>
-					<p align="left">
-						The only entry that needs to be made for an <i>IndexName</i> is to use it in an
-						<code class="language-cobol">INDEXED BY</code> phrase. There is no need to define a picture
-						clause for it, because the compiler handles its declaration automatically.
-					</p>
-					<p align="left">
-						Because an index has a special internal representation it cannot be displayed and can only be
-						assigned a value, or have its value assigned, by the
-						<code class="language-cobol">SET</code> verb. The
-						<code class="language-cobol">MOVE</code> cannot be used with a table index.
-					</p>
-					<p align="left">
-						Normal arithmetic cannot be performed on a table index. The
-						<code class="language-cobol">SET</code> verb must be used to increment or decrement the value of
-						an index item.
-					</p>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>KEY IS phrase - notes</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						While the <code class="language-cobol">SEARCH</code> performs a sequential search on a table,
-						the <code class="language-cobol">SEARCH ALL</code> performs a binary search. But a binary search
-						requires that the table is ordered on some key field. The key field may be the element itself
-						or, where the element is a group item, a field within the element.
-					</p>
-					<p>
-						Before a table can be searched with the <code class="language-cobol">SEARCH ALL</code>, the key
-						field must be identified by using the <code class="language-cobol">KEY IS</code> phrase in the
-						table declaration. As well as identifying the key field, the
-						<code class="language-cobol">KEY IS</code> phrase specifies whether the table is in ascending or
-						descending order.
-					</p>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFFF" colspan="2" valign="top">
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Introduction</h4>
+					</div>
+					<div class="section-content">
+						<p align="left">
+							When the <code class="language-cobol">SEARCH</code> and
+							<code class="language-cobol">SEARCH ALL</code> are used the normal table declarations are no
+							longer sufficient and the <code class="language-cobol">OCCURS</code> clause must be extended
+							with the <code class="language-cobol">INDEXED BY</code> phrase and, in the case of the
+							<code class="language-cobol">SEARCH ALL</code>, by the
+							<code class="language-cobol">KEY IS</code> phrase.
+						</p>
+						<p align="left">
+							The full syntax of the <code class="language-cobol">OCCURS</code> clause, including the
+							<code class="language-cobol">INDEXED BY</code> and
+							<code class="language-cobol">KEY IS</code> phrases is shown below.
+						</p>
+						<hr size="1" width="100%" />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Full OCCURS clause syntax</h4>
+					</div>
+					<div class="section-content">
+						<p align="left"><img height="122" src="Resources/pics/Search1.gif" width="331" /></p>
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>INDEXED BY phrase - notes</h4>
+					</div>
+					<div class="section-content">
+						<p align="left">
+							Before the <code class="language-cobol">SEARCH</code> or
+							<code class="language-cobol">SEARCH ALL</code> can be used to search a table, the table must be
+							defined as having an index item associated with it.
+						</p>
+						<p align="left">
+							The index is specified by the <i>IndexName</i> given in the
+							<code class="language-cobol">INDEXED BY</code> phrase.
+						</p>
+						<p align="left">
+							The index defined in a table declaration is associated with that table and is the subscript
+							which the <code class="language-cobol">SEARCH</code> or
+							<code class="language-cobol">SEARCH ALL</code> uses to access the table.
+						</p>
+						<p align="left">
+							Using an index makes the searching more efficient. Since the index is linked to a particular
+							table, the compiler, taking into account the size of the table, can choose the most efficient
+							representation possible for the index and this speeds up the search.
+						</p>
+						<p align="left">
+							The only entry that needs to be made for an <i>IndexName</i> is to use it in an
+							<code class="language-cobol">INDEXED BY</code> phrase. There is no need to define a picture
+							clause for it, because the compiler handles its declaration automatically.
+						</p>
+						<p align="left">
+							Because an index has a special internal representation it cannot be displayed and can only be
+							assigned a value, or have its value assigned, by the
+							<code class="language-cobol">SET</code> verb. The
+							<code class="language-cobol">MOVE</code> cannot be used with a table index.
+						</p>
+						<p align="left">
+							Normal arithmetic cannot be performed on a table index. The
+							<code class="language-cobol">SET</code> verb must be used to increment or decrement the value of
+							an index item.
+						</p>
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>KEY IS phrase - notes</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							While the <code class="language-cobol">SEARCH</code> performs a sequential search on a table,
+							the <code class="language-cobol">SEARCH ALL</code> performs a binary search. But a binary search
+							requires that the table is ordered on some key field. The key field may be the element itself
+							or, where the element is a group item, a field within the element.
+						</p>
+						<p>
+							Before a table can be searched with the <code class="language-cobol">SEARCH ALL</code>, the key
+							field must be identified by using the <code class="language-cobol">KEY IS</code> phrase in the
+							table declaration. As well as identifying the key field, the
+							<code class="language-cobol">KEY IS</code> phrase specifies whether the table is in ascending or
+							descending order.
+						</p>
+					</div>
+				</div>
+				<div class="section-full">
 					<div align="center">
 						<hr />
 						<p>
@@ -268,156 +408,150 @@
 							/></a>
 						</p>
 					</div>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#993300" colspan="2" valign="top">
+				</div>
+				<div class="section-header">
 					<h2 align="center" id="part2">The SEARCH verb</h2>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>Introduction</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						When the values in a table are not ordered, the only way to find the item we seek is to search
-						through the table sequentially, element by element. In COBOL, the
-						<code class="language-cobol">SEARCH</code> verb is used to search a table sequentially.
-					</p>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>SEARCH syntax</h4>
-				</td>
-				<td valign="top" width="525">
-					<p><img height="152" src="Resources/pics/Search2.gif" width="374" /></p>
-					<p>
-						<b> <code class="language-cobol">SEARCH</code> rules </b>
-					</p>
-					<ol>
-						<li>
-							<i>TableName</i> must identify a data-item in the table hierarchy with both
-							<code class="language-cobol">OCCURS</code> and
-							<code class="language-cobol">INDEXED BY</code> clauses. The index specified in the
-							<code class="language-cobol">INDEXED BY</code> clause of <i>TableName</i> is the controlling
-							index of the <code class="language-cobol">SEARCH</code>.
-						</li>
-						<li>
-							The <code class="language-cobol">SEARCH</code> can only be used if the table to be searched
-							has an index item associated with it. An index item is associated with a table by using the
-							<code class="language-cobol">INDEXED BY</code> phrase in the table declaration. The index
-							item is known as the table index. The table index is the subscript which the
-							<code class="language-cobol">SEARCH</code> uses to access the table.
-						</li>
-					</ol>
-					<p>
-						<b> <code class="language-cobol">SEARCH</code> notes </b>
-					</p>
-					<ul>
-						<li>
-							The <code class="language-cobol">SEARCH</code> searches a table sequentially starting at the
-							element pointed to by the table index.
-						</li>
-						<li>
-							The starting value of the table index is under the control of the programmer. The programmer
-							must ensure that, when the
-							<code class="language-cobol">SEARCH</code> executes, the table index points to some element
-							in the table (for instance, it cannot have a value of 0 or be greater than the size of the
-							table).
-						</li>
-						<li>
-							The <code class="language-cobol">VARYING</code> phrase is only required when we require
-							data-item to mirror the values of the table index. When the
-							<code class="language-cobol">VARYING</code> phrase is used, and the associated data-item is
-							not the table index, then the data-item is varied along with the index.
-						</li>
-						<li>
-							The <code class="language-cobol">AT END</code> phrase allows the programmer to specify an
-							action to be taken if the searched for item is not found in the table.
-						</li>
-						<li>
-							When the <code class="language-cobol">AT END</code> is specified, and the index is
-							incremented beyond the highest legal occurrence for the table (i.e. the item has not been
-							found), then the statements following the <code class="language-cobol">AT END</code> will be
-							executed and the <code class="language-cobol">SEARCH</code> will terminate.
-						</li>
-						<li>
-							The conditions attached to the <code class="language-cobol">SEARCH</code> are evaluated in
-							turn and as soon as one is true the statements following the
-							<code class="language-cobol">WHEN</code> phrase are executed and the
-							<code class="language-cobol">SEARCH</code> ends.
-						</li>
-					</ul>
-					<hr size="1" width="100%" />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>The SET verb syntax</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						The <code class="language-cobol">SET</code> verb is used for a number of unrelated purposes. We
-						have already seen how the <code class="language-cobol">SET</code> verb may be used to set a
-						condition name to true. This section introduces the versions of the
-						<code class="language-cobol">SET</code> verb used to manipulate table indexes.
-					</p>
-					<p>
-						Because an index item has a special internal representation designed to optimize searching, it
-						cannot be used in any type of normal arithmetic operation (<code class="language-cobol"
-							>ADD</code
-						>, <code class="language-cobol">SUBTRACT</code> etc.) or even in a
-						<code class="language-cobol">MOVE</code> or
-						<code class="language-cobol">DISPLAY</code> statement. For index items, all these operations
-						must be handled by the <code class="language-cobol">SET</code> verb.
-					</p>
-					<p>
-						The versions of the <code class="language-cobol">SET</code> verb shown below are used to assign
-						a value to an index item, to assign the value of an index item to a variable, and to increment
-						or decrement the value of an index item.
-					</p>
-					<p><img height="148" src="Resources/pics/Search4.gif" width="326" /></p>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>SEARCH example 1</h4>
-					<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						The example program below accepts an upper case letter from the user and then uses the
-						<code class="language-cobol">SEARCH</code> verb to searche a pre-filled table of letters to find
-						and display the position of the letter in the alphabet.
-					</p>
-					<p>
-						Because a table index can be tricky to manipulate (can't display it, can't move it) the program
-						uses the <code class="language-cobol">VARYING</code> phrase to vary an ordinary numeric value
-						along with the index. When the letter is found in the table, this item will contain the same
-						value as the index and we can display it without the complications we might encounter with the
-						index item. For instance, to display the value of the index item we would require following code
-						-
-					</p>
-					<pre class="language-cobol"><code class="language-cobol">SET LetterPos TO LetterIdx
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Introduction</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							When the values in a table are not ordered, the only way to find the item we seek is to search
+							through the table sequentially, element by element. In COBOL, the
+							<code class="language-cobol">SEARCH</code> verb is used to search a table sequentially.
+						</p>
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>SEARCH syntax</h4>
+					</div>
+					<div class="section-content">
+						<p><img height="152" src="Resources/pics/Search2.gif" width="374" /></p>
+						<p>
+							<b> <code class="language-cobol">SEARCH</code> rules </b>
+						</p>
+						<ol>
+							<li>
+								<i>TableName</i> must identify a data-item in the table hierarchy with both
+								<code class="language-cobol">OCCURS</code> and
+								<code class="language-cobol">INDEXED BY</code> clauses. The index specified in the
+								<code class="language-cobol">INDEXED BY</code> clause of <i>TableName</i> is the controlling
+								index of the <code class="language-cobol">SEARCH</code>.
+							</li>
+							<li>
+								The <code class="language-cobol">SEARCH</code> can only be used if the table to be searched
+								has an index item associated with it. An index item is associated with a table by using the
+								<code class="language-cobol">INDEXED BY</code> phrase in the table declaration. The index
+								item is known as the table index. The table index is the subscript which the
+								<code class="language-cobol">SEARCH</code> uses to access the table.
+							</li>
+						</ol>
+						<p>
+							<b> <code class="language-cobol">SEARCH</code> notes </b>
+						</p>
+						<ul>
+							<li>
+								The <code class="language-cobol">SEARCH</code> searches a table sequentially starting at the
+								element pointed to by the table index.
+							</li>
+							<li>
+								The starting value of the table index is under the control of the programmer. The programmer
+								must ensure that, when the
+								<code class="language-cobol">SEARCH</code> executes, the table index points to some element
+								in the table (for instance, it cannot have a value of 0 or be greater than the size of the
+								table).
+							</li>
+							<li>
+								The <code class="language-cobol">VARYING</code> phrase is only required when we require
+								data-item to mirror the values of the table index. When the
+								<code class="language-cobol">VARYING</code> phrase is used, and the associated data-item is
+								not the table index, then the data-item is varied along with the index.
+							</li>
+							<li>
+								The <code class="language-cobol">AT END</code> phrase allows the programmer to specify an
+								action to be taken if the searched for item is not found in the table.
+							</li>
+							<li>
+								When the <code class="language-cobol">AT END</code> is specified, and the index is
+								incremented beyond the highest legal occurrence for the table (i.e. the item has not been
+								found), then the statements following the <code class="language-cobol">AT END</code> will be
+								executed and the <code class="language-cobol">SEARCH</code> will terminate.
+							</li>
+							<li>
+								The conditions attached to the <code class="language-cobol">SEARCH</code> are evaluated in
+								turn and as soon as one is true the statements following the
+								<code class="language-cobol">WHEN</code> phrase are executed and the
+								<code class="language-cobol">SEARCH</code> ends.
+							</li>
+						</ul>
+						<hr size="1" width="100%" />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>The SET verb syntax</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The <code class="language-cobol">SET</code> verb is used for a number of unrelated purposes. We
+							have already seen how the <code class="language-cobol">SET</code> verb may be used to set a
+							condition name to true. This section introduces the versions of the
+							<code class="language-cobol">SET</code> verb used to manipulate table indexes.
+						</p>
+						<p>
+							Because an index item has a special internal representation designed to optimize searching, it
+							cannot be used in any type of normal arithmetic operation (<code class="language-cobol"
+								>ADD</code
+							>, <code class="language-cobol">SUBTRACT</code> etc.) or even in a
+							<code class="language-cobol">MOVE</code> or
+							<code class="language-cobol">DISPLAY</code> statement. For index items, all these operations
+							must be handled by the <code class="language-cobol">SET</code> verb.
+						</p>
+						<p>
+							The versions of the <code class="language-cobol">SET</code> verb shown below are used to assign
+							a value to an index item, to assign the value of an index item to a variable, and to increment
+							or decrement the value of an index item.
+						</p>
+						<p><img height="148" src="Resources/pics/Search4.gif" width="326" /></p>
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>SEARCH example 1</h4>
+						<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
+					</div>
+					<div class="section-content">
+						<p>
+							The example program below accepts an upper case letter from the user and then uses the
+							<code class="language-cobol">SEARCH</code> verb to searche a pre-filled table of letters to find
+							and display the position of the letter in the alphabet.
+						</p>
+						<p>
+							Because a table index can be tricky to manipulate (can't display it, can't move it) the program
+							uses the <code class="language-cobol">VARYING</code> phrase to vary an ordinary numeric value
+							along with the index. When the letter is found in the table, this item will contain the same
+							value as the index and we can display it without the complications we might encounter with the
+							index item. For instance, to display the value of the index item we would require following code
+							-
+						</p>
+						<pre class="language-cobol"><code class="language-cobol">SET LetterPos TO LetterIdx
 MOVE LetterPos TO PrnPos
 DISPLAY LetterIn, " is in position ", PrnPos
 </code></pre>
-					<p>
-						The example below is not meant to be a practical example of how to find the position of a letter
-						in the alphabet. Nowadays, this task would be accomplished in much the same way as it would in C
-						or Modula-2 except that, in COBOL, we would use the Intrinsic Function - ORD - as shown below.
-					</p>
-					<pre
-						class="language-cobol"
-					><code class="language-cobol">COMPUTE PrnIdx = FUNCTION ORD(LetterIn) - FUNCTION ORD("A") + 1 </code></pre>
-					<table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="475">
-						<tr>
-							<td>
-								<pre
-									class="language-cobol"
-								><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+						<p>
+							The example below is not meant to be a practical example of how to find the position of a letter
+							in the alphabet. Nowadays, this task would be accomplished in much the same way as it would in C
+							or Modula-2 except that, in COBOL, we would use the Intrinsic Function - ORD - as shown below.
+						</p>
+						<pre
+							class="language-cobol"
+						><code class="language-cobol">COMPUTE PrnIdx = FUNCTION ORD(LetterIn) - FUNCTION ORD("A") + 1 </code></pre>
+						<pre
+								class="language-cobol"
+							><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. LetterSearch.
 AUTHOR. Michael Coughlan.
@@ -429,12 +563,12 @@ DATA DIVISION.
 WORKING-STORAGE SECTION.
 01  LetterTable.
     02 LetterValues.
-       03 FILLER PIC X(13) 
+       03 FILLER PIC X(13)
           VALUE "ABCDEFGHIJKLM".
        03 FILLER PIC X(13)
           VALUE "NOPQRSTUVWXYZ".
     02 FILLER REDEFINES LetterValues.
-       03 Letter PIC X OCCURS 26 TIMES 
+       03 Letter PIC X OCCURS 26 TIMES
                        INDEXED BY LetterIdx.
 
 01 LetterIn      PIC X.
@@ -449,44 +583,38 @@ Begin.
     SET LetterIdx LetterPos TO 1
     SEARCH Letter VARYING LetterPos
        AT END DISPLAY "Letter " LetterIn " not found!"
-       WHEN Letter(LetterIdx) = LetterIn 
+       WHEN Letter(LetterIdx) = LetterIn
             MOVE LetterPos TO PrnPos
             DISPLAY LetterIn, " is in position ", PrnPos
     END-SEARCH
     STOP RUN.</code></pre>
-							</td>
-						</tr>
-					</table>
-					<hr size="1" width="100%" />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>Example program 2</h4>
-					<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						In this example below, we return to the County Tax Report problem. In the last question we posed
-						in the <i>Using Tables</i> tutorial we asked how the County Tax report problem could be solved
-						if the tax record contained a county name instead of a county code. We noted that the county
-						name had to be converted into a numeric value that we could use as a subscript. In the
-						<i>Using Tables</i> tutorial we used a <code class="language-cobol">PERFORM</code> to search
-						through the table to find the numeric equivalent of the county name. In this example we use the
-						<code class="language-cobol">SEARCH</code>.
-					</p>
-					<p>
-						The <code class="language-cobol">VARYING</code> phrase is used in this
-						<code class="language-cobol">SEARCH</code> example so that we don't have to set the
-						<i>Idx</i> to the <i>CountyIdx</i>. We can not use <i>CountyIdx</i> as a subscript for the
-						<i>CountyTaxTable</i> because it is bound to the <i>CountyNameTable</i>.
-					</p>
-					<table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="475">
-						<tr>
-							<td>
-								<pre
-									class="language-cobol"
-								><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+						<hr size="1" width="100%" />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Example program 2</h4>
+						<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
+					</div>
+					<div class="section-content">
+						<p>
+							In this example below, we return to the County Tax Report problem. In the last question we posed
+							in the <i>Using Tables</i> tutorial we asked how the County Tax report problem could be solved
+							if the tax record contained a county name instead of a county code. We noted that the county
+							name had to be converted into a numeric value that we could use as a subscript. In the
+							<i>Using Tables</i> tutorial we used a <code class="language-cobol">PERFORM</code> to search
+							through the table to find the numeric equivalent of the county name. In this example we use the
+							<code class="language-cobol">SEARCH</code>.
+						</p>
+						<p>
+							The <code class="language-cobol">VARYING</code> phrase is used in this
+							<code class="language-cobol">SEARCH</code> example so that we don't have to set the
+							<i>Idx</i> to the <i>CountyIdx</i>. We can not use <i>CountyIdx</i> as a subscript for the
+							<i>CountyTaxTable</i> because it is bound to the <i>CountyNameTable</i>.
+						</p>
+						<pre
+								class="language-cobol"
+							><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. CountyTaxTable.
 AUTHOR. Michael Coughlan.
@@ -508,7 +636,7 @@ FD TaxFile.
 WORKING-STORAGE SECTION.
 01 CountyTaxTable.
    02 CountyTaxDetails OCCURS 26 TIMES.
-      03 CountyTax   PIC 9(8)V99.  
+      03 CountyTax   PIC 9(8)V99.
       03 PayerCount  PIC 9(7).
          88 NoOnePaidTax VALUE ZEROS.
 
@@ -585,13 +713,9 @@ DisplayCountyTaxes.
       MOVE PayerCount(Idx) TO PrnPayers
       DISPLAY CountyTaxLine
    END-IF.</code></pre>
-							</td>
-						</tr>
-					</table>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFFF" colspan="2" valign="top">
+					</div>
+				</div>
+				<div class="section-full">
 					<div align="center">
 						<hr />
 						<p>
@@ -600,77 +724,71 @@ DisplayCountyTaxes.
 							/></a>
 						</p>
 					</div>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#993300" colspan="2" valign="top">
+				</div>
+				<div class="section-header">
 					<h2 align="center" id="part3">Searching multi-dimension tables</h2>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>Introduction</h4>
-				</td>
-				<td valign="top" width="525">
-					<p align="left">
-						When the <code class="language-cobol">SEARCH</code> verb is used, the target of the
-						<code class="language-cobol">SEARCH</code> must be an item in the table with both an
-						<code class="language-cobol">OCCURS</code> clause and an
-						<code class="language-cobol">INDEXED BY</code> phrase. The index item specified in the
-						<code class="language-cobol">INDEXED BY</code> phrase is the controlling index of the search.
-						The controlling index governs the submission of the elements, or element items, for examination
-						by the <code class="language-cobol">WHEN</code> phrase of the
-						<code class="language-cobol">SEARCH</code>. A <code class="language-cobol">SEARCH</code> can
-						only have one controlling index.
-					</p>
-					<p align="left">
-						Because a <code class="language-cobol">SEARCH</code> can only have one controlling index it can
-						only be used to search a single dimension of a table at a time. If the table to be searched is a
-						multi-dimension table then the programmer must control the indexes of the other dimensions.
-					</p>
-					<p align="left">
-						For instance, suppose a hotel keeps an Occupancy Table showing which rooms in the hotel are
-						currently occupied. The table might be described as -
-					</p>
-					<pre class="language-cobol" align="left"><code class="language-cobol">01 HotelOccupanyTable.
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Introduction</h4>
+					</div>
+					<div class="section-content">
+						<p align="left">
+							When the <code class="language-cobol">SEARCH</code> verb is used, the target of the
+							<code class="language-cobol">SEARCH</code> must be an item in the table with both an
+							<code class="language-cobol">OCCURS</code> clause and an
+							<code class="language-cobol">INDEXED BY</code> phrase. The index item specified in the
+							<code class="language-cobol">INDEXED BY</code> phrase is the controlling index of the search.
+							The controlling index governs the submission of the elements, or element items, for examination
+							by the <code class="language-cobol">WHEN</code> phrase of the
+							<code class="language-cobol">SEARCH</code>. A <code class="language-cobol">SEARCH</code> can
+							only have one controlling index.
+						</p>
+						<p align="left">
+							Because a <code class="language-cobol">SEARCH</code> can only have one controlling index it can
+							only be used to search a single dimension of a table at a time. If the table to be searched is a
+							multi-dimension table then the programmer must control the indexes of the other dimensions.
+						</p>
+						<p align="left">
+							For instance, suppose a hotel keeps an Occupancy Table showing which rooms in the hotel are
+							currently occupied. The table might be described as -
+						</p>
+						<pre class="language-cobol" align="left"><code class="language-cobol">01 HotelOccupanyTable.
    02 Floor OCCURS 5 TIMES INDEXED BY Fidx.
       03 Room OCCURS 25 TIMES INDEXED BY Ridx.
          04 CustomerId  PIC 9(6).
          04 NumOfOccupants PIC 9.</code></pre>
-					<p align="left">and we can represent this diagrammatically as follows -</p>
-					<div align="center">
-						<img
-							alt="Diagram of the hotel occupancy table showing floors and rooms"
-							height="170"
-							src="Resources/pics/Search5.gif"
-							width="411"
-						/>
+						<p align="left">and we can represent this diagrammatically as follows -</p>
+						<div align="center">
+							<img
+								alt="Diagram of the hotel occupancy table showing floors and rooms"
+								height="170"
+								src="Resources/pics/Search5.gif"
+								width="411"
+							/>
+						</div>
+						<p align="left">
+							Suppose we want to search the table to discover which room is occupied by customer 126789. We
+							can't use the <code class="language-cobol">SEARCH</code> to search the whole two-dimension table
+							directly but we can use the <code class="language-cobol">SEARCH</code> to search the table floor
+							by floor. In other words, we can treat the table as if it were a collection of floor tables and
+							we use the <code class="language-cobol">SEARCH</code> to search all the rooms in a particular
+							floor table.
+						</p>
+						<p align="left">
+							The example program below demonstrates how the <code class="language-cobol">SEARCH</code> verb
+							may be used to search the two-dimension <i>HotelOccupancyTable</i>.
+						</p>
 					</div>
-					<p align="left">
-						Suppose we want to search the table to discover which room is occupied by customer 126789. We
-						can't use the <code class="language-cobol">SEARCH</code> to search the whole two-dimension table
-						directly but we can use the <code class="language-cobol">SEARCH</code> to search the table floor
-						by floor. In other words, we can treat the table as if it were a collection of floor tables and
-						we use the <code class="language-cobol">SEARCH</code> to search all the rooms in a particular
-						floor table.
-					</p>
-					<p align="left">
-						The example program below demonstrates how the <code class="language-cobol">SEARCH</code> verb
-						may be used to search the two-dimension <i>HotelOccupancyTable</i>.
-					</p>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
-				</td>
-				<td valign="top" width="525">
-					<table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="475">
-						<tr>
-							<td>
-								<pre
-									class="language-cobol"
-								><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
+					</div>
+					<div class="section-content">
+						<pre
+								class="language-cobol"
+							><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. HotelSearch.
 AUTHOR. Michael Coughlan.
@@ -702,7 +820,7 @@ WORKING-STORAGE SECTION.
 
 PROCEDURE DIVISION.
 Begin.
-   PERFORM LoadTable 
+   PERFORM LoadTable
    DISPLAY "Enter Customer Id  - " WITH NO ADVANCING
    ACCEPT CustId
    PERFORM VARYING Fidx FROM 1 BY 1 UNTIL Fidx &gt; 5
@@ -722,7 +840,7 @@ Begin.
    END-IF
    STOP RUN.
 
-LoadTable.   
+LoadTable.
    OPEN INPUT OccupancyFile
    READ OccupancyFile
       AT END SET EndOfFile TO TRUE
@@ -734,53 +852,47 @@ LoadTable.
       END-READ
    END-PERFORM
    CLOSE OccupancyFile.</code></pre>
-							</td>
-						</tr>
-					</table>
-					<hr size="1" width="100%" />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>The Race Results Example program</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						This example demonstrates how the <code class="language-cobol">SEARCH</code> may be used to
-						search either of the dimensions of a two-dimension table.
-					</p>
-					<p>
-						Suppose that we want to use a two-dimension table to hold the finishing positions of drivers in
-						fifteen races. The table to hold these details may be described as -
-					</p>
-					<pre class="language-cobol"><code class="language-cobol">01 RaceResultsTable. 
+						<hr size="1" width="100%" />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>The Race Results Example program</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							This example demonstrates how the <code class="language-cobol">SEARCH</code> may be used to
+							search either of the dimensions of a two-dimension table.
+						</p>
+						<p>
+							Suppose that we want to use a two-dimension table to hold the finishing positions of drivers in
+							fifteen races. The table to hold these details may be described as -
+						</p>
+						<pre class="language-cobol"><code class="language-cobol">01 RaceResultsTable.
    02 Race OCCURS 15 TIMES INDEXED BY Ridx.
       03 Venue  PIC X(20).
       03 RacePos OCCURS 50 TIMES INDEXED BY Pidx.
          04 DriverId    PIC 9(4).
-      
+
 
 </code></pre>
-					<p>We can represent this diagramatically as follows -</p>
-					<p align="center"><img height="109" src="Resources/pics/Search6.gif" width="469" /></p>
-					<p>
-						In the example program below, the first dimension of the table is searched to find the results
-						for a particular venue and then the second dimension, representing the results fo the race at
-						that venue, are searched to find the finishing position of a particular driver.
-					</p>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
-				</td>
-				<td valign="top" width="525">
-					<table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="475">
-						<tr>
-							<td>
-								<pre
-									class="language-cobol"
-								><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+						<p>We can represent this diagramatically as follows -</p>
+						<p align="center"><img height="109" src="Resources/pics/Search6.gif" width="469" /></p>
+						<p>
+							In the example program below, the first dimension of the table is searched to find the results
+							for a particular venue and then the second dimension, representing the results fo the race at
+							that venue, are searched to find the finishing position of a particular driver.
+						</p>
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
+					</div>
+					<div class="section-content">
+						<pre
+								class="language-cobol"
+							><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. RaceSearch.
 AUTHOR. Michael Coughlan.
@@ -800,7 +912,7 @@ FD RaceResultsFile.
 *&gt;Each record represents one row of the table
 
 WORKING-STORAGE SECTION.
-01 RaceResultsTable. 
+01 RaceResultsTable.
    02 Race OCCURS 15 TIMES INDEXED BY Ridx.
       03 Venue  PIC X(20).
       03 RacePos OCCURS 50 TIMES INDEXED BY Pidx.
@@ -812,7 +924,7 @@ WORKING-STORAGE SECTION.
 
 PROCEDURE DIVISION.
 Begin.
-   PERFORM LoadTable 
+   PERFORM LoadTable
    DISPLAY "Enter Venue name - " WITH NO ADVANCING
    ACCEPT VenueName
    DISPLAY "Enter the drivers id  - "WITH NO ADVANCING
@@ -820,7 +932,7 @@ Begin.
    SET Ridx TO 1
    SEARCH Race
       AT END DISPLAY "Venue not found."
-      WHEN Venue(Ridx) = VenueName 
+      WHEN Venue(Ridx) = VenueName
            PERFORM SearchForDriver
    END-SEARCH
    STOP RUN.
@@ -834,9 +946,9 @@ SearchForDriver.
             DISPLAY "In the race at " VenueName
             DISPLAY "Driver " DriverIdNum
                     "finished in position " PosNum
-   END-SEARCH.     
+   END-SEARCH.
 
-LoadTable.   
+LoadTable.
    OPEN INPUT RaceResultsFile
    READ RaceResultsFile
       AT END SET EndOfFile TO TRUE
@@ -848,19 +960,16 @@ LoadTable.
       END-READ
    END-PERFORM
    CLOSE RaceResultsFile.</code></pre>
-							</td>
-						</tr>
-					</table>
-					<p>
-						In the example above an out-of-line perform was used for the second
-						<code class="language-cobol">SEARCH</code>. This was not strictly necessary. The same result
-						could have been achieved with nested <code class="language-cobol">SEARCH</code> statements. For
-						instance -
-					</p>
-					<pre class="language-cobol"><code class="language-cobol">SET Ridx TO 1
+						<p>
+							In the example above an out-of-line perform was used for the second
+							<code class="language-cobol">SEARCH</code>. This was not strictly necessary. The same result
+							could have been achieved with nested <code class="language-cobol">SEARCH</code> statements. For
+							instance -
+						</p>
+						<pre class="language-cobol"><code class="language-cobol">SET Ridx TO 1
 SEARCH Race
    AT END DISPLAY "Venue not found."
-   WHEN Venue(Ridx) = VenueName 
+   WHEN Venue(Ridx) = VenueName
      SET Pidx TO 1
      SEARCH RacePos
         AT END DISPLAY "Driver not in top 50 finishers"
@@ -871,10 +980,9 @@ SEARCH Race
                      " finished in position " PosNum
      END-SEARCH
 END-SEARCH</code></pre>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFFF" colspan="2" valign="top">
+					</div>
+				</div>
+				<div class="section-full">
 					<div align="center">
 						<hr />
 						<p>
@@ -883,154 +991,142 @@ END-SEARCH</code></pre>
 							/></a>
 						</p>
 					</div>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#993300" colspan="2" valign="top">
+				</div>
+				<div class="section-header">
 					<h2 align="center" id="part4">The SEARCH ALL verb</h2>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4 align="left">Introduction</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						The <code class="language-cobol">SEARCH ALL</code> is used when a binary search is required. For
-						this reason, the <code class="language-cobol">SEARCH ALL</code> will only work on an ordered
-						table. The table must be ordered on some some key field. The key field may be the element itself
-						or, where the element is a group item, a field within the element. The key field must be
-						identified by using the <code class="language-cobol">KEY IS</code> phrase in the table
-						declaration.
-					</p>
-					<hr size="1" />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>SEARCH ALL syntax</h4>
-				</td>
-				<td valign="top" width="525">
-					<p align="left"><img height="302" src="Resources/pics/Search3.gif" width="492" /></p>
-					<p align="left">
-						<b> <code class="language-cobol">SEARCH ALL</code> rules </b>
-					</p>
-					<ol>
-						<li>
-							The <code class="language-cobol">OCCURS</code> clause of the table to be searched must have
-							a <code class="language-cobol">KEY IS</code> clause in addition to an
-							<code class="language-cobol">INDEXED BY</code> clause.
-						</li>
-						<li>
-							The <i>ElementIdentifier</i> must be the item referenced by the
-							<code class="language-cobol">KEY IS</code> phrase of the table's
-							<code class="language-cobol">OCCURS</code> clause.
-						</li>
-						<li>
-							The <i>ConditionName</i> must have only one value and it must be associated with a data-item
-							referenced by the <code class="language-cobol">KEY IS</code> phrase of the table's
-							<code class="language-cobol">OCCURS</code> clause.
-						</li>
-					</ol>
-					<p align="left">
-						<b> <code class="language-cobol">SEARCH ALL</code> notes<br /> </b> The
-						<code class="language-cobol">KEY IS</code> phrase identifies the data-item upon which the table
-						is ordered.
-					</p>
-					<p align="left">
-						When the <code class="language-cobol">SEARCH ALL</code> is used, the programmer does not need to
-						set the table index to a starting value because the
-						<code class="language-cobol">SEARCH ALL</code> controls it automatically.
-					</p>
-					<p align="left">
-						<b>Some problems using the <code class="language-cobol">SEARCH ALL</code></b
-						><br />
-						If the table to be searched is only partially populated, the
-						<code class="language-cobol">SEARCH ALL</code> may not work correctly. If the table is ordered
-						in ascending sequence then, to get the <code class="language-cobol">SEARCH ALL</code> to
-						function correctly, the unpopulated elements must be filled with
-						<code class="language-cobol">HIGH-VALUES</code>. If the table is in descending sequence, the
-						unpopulated elements should be filled with <code class="language-cobol">LOW-VALUES</code>.
-					</p>
-					<hr size="1" width="100%" />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>How a binary search works</h4>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						A binary search requires that the table to be searched is ordered on some key field. A binary
-						search works by repeatedly dividing the search area into a top and bottom half, deciding which
-						half contains the required item, and then making that half the new search area. It continues
-						halving the search area like this until the required item is found or it discovers that the item
-						is not in the table.
-					</p>
-					<p>The algorithm for the binary search is -</p>
-					<table align="center" bgcolor="#E1FFE1" border="1" cellpadding="5" width="93%">
-						<tr>
-							<td>
-								<pre
-									class="language-cobol"
-								><code class="language-cobol">PERFORM UNTIL ItemFound OR ItemNotInTable
-  COMPUTE Middle = (Lower + Upper) / 2 
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4 align="left">Introduction</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The <code class="language-cobol">SEARCH ALL</code> is used when a binary search is required. For
+							this reason, the <code class="language-cobol">SEARCH ALL</code> will only work on an ordered
+							table. The table must be ordered on some some key field. The key field may be the element itself
+							or, where the element is a group item, a field within the element. The key field must be
+							identified by using the <code class="language-cobol">KEY IS</code> phrase in the table
+							declaration.
+						</p>
+						<hr size="1" />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>SEARCH ALL syntax</h4>
+					</div>
+					<div class="section-content">
+						<p align="left"><img height="302" src="Resources/pics/Search3.gif" width="492" /></p>
+						<p align="left">
+							<b> <code class="language-cobol">SEARCH ALL</code> rules </b>
+						</p>
+						<ol>
+							<li>
+								The <code class="language-cobol">OCCURS</code> clause of the table to be searched must have
+								a <code class="language-cobol">KEY IS</code> clause in addition to an
+								<code class="language-cobol">INDEXED BY</code> clause.
+							</li>
+							<li>
+								The <i>ElementIdentifier</i> must be the item referenced by the
+								<code class="language-cobol">KEY IS</code> phrase of the table's
+								<code class="language-cobol">OCCURS</code> clause.
+							</li>
+							<li>
+								The <i>ConditionName</i> must have only one value and it must be associated with a data-item
+								referenced by the <code class="language-cobol">KEY IS</code> phrase of the table's
+								<code class="language-cobol">OCCURS</code> clause.
+							</li>
+						</ol>
+						<p align="left">
+							<b> <code class="language-cobol">SEARCH ALL</code> notes<br /> </b> The
+							<code class="language-cobol">KEY IS</code> phrase identifies the data-item upon which the table
+							is ordered.
+						</p>
+						<p align="left">
+							When the <code class="language-cobol">SEARCH ALL</code> is used, the programmer does not need to
+							set the table index to a starting value because the
+							<code class="language-cobol">SEARCH ALL</code> controls it automatically.
+						</p>
+						<p align="left">
+							<b>Some problems using the <code class="language-cobol">SEARCH ALL</code></b
+							><br />
+							If the table to be searched is only partially populated, the
+							<code class="language-cobol">SEARCH ALL</code> may not work correctly. If the table is ordered
+							in ascending sequence then, to get the <code class="language-cobol">SEARCH ALL</code> to
+							function correctly, the unpopulated elements must be filled with
+							<code class="language-cobol">HIGH-VALUES</code>. If the table is in descending sequence, the
+							unpopulated elements should be filled with <code class="language-cobol">LOW-VALUES</code>.
+						</p>
+						<hr size="1" width="100%" />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>How a binary search works</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							A binary search requires that the table to be searched is ordered on some key field. A binary
+							search works by repeatedly dividing the search area into a top and bottom half, deciding which
+							half contains the required item, and then making that half the new search area. It continues
+							halving the search area like this until the required item is found or it discovers that the item
+							is not in the table.
+						</p>
+						<p>The algorithm for the binary search is -</p>
+						<pre
+								class="language-cobol"
+							><code class="language-cobol">PERFORM UNTIL ItemFound OR ItemNotInTable
+  COMPUTE Middle = (Lower + Upper) / 2
   EVALUATE TRUE
     WHEN Key(Middle) &lt; SearchItem COMPUTE Lower = Middle + 1
     WHEN Key(Middle) &gt; SearchItem COMPUTE Upper = Middle -1
     WHEN Key(Middle) = SearchItem SET ItemFound TO TRUE
     WHEN Lower &gt; Upper THEN SET ItemNotInTable TO TRUE
-  END-EVALUATE 
+  END-EVALUATE
 END-PERFORM</code></pre>
-							</td>
-						</tr>
-					</table>
-					<p>
-						The animation below demonstrates how the binary search works. It uses a search of the letter
-						table described in one of the examples above, as an example. To allow the table to be searched
-						with the <code class="language-cobol">SEARCH ALL</code> the description of the table has to be
-						amended to include a <code class="language-cobol">KEY IS</code> phrase as shown below.
-					</p>
-					<pre class="language-cobol"><code class="language-cobol">01  LetterTable.
+						<p>
+							The animation below demonstrates how the binary search works. It uses a search of the letter
+							table described in one of the examples above, as an example. To allow the table to be searched
+							with the <code class="language-cobol">SEARCH ALL</code> the description of the table has to be
+							amended to include a <code class="language-cobol">KEY IS</code> phrase as shown below.
+						</p>
+						<pre class="language-cobol"><code class="language-cobol">01  LetterTable.
     02 LetterValues.
-       03 FILLER PIC X(13) 
+       03 FILLER PIC X(13)
           VALUE "ABCDEFGHIJKLM".
        03 FILLER PIC X(13)
           VALUE "NOPQRSTUVWXYZ".
     02 FILLER REDEFINES LetterValues.
-       03 Letter PIC X OCCURS 26 TIMES 
+       03 Letter PIC X OCCURS 26 TIMES
                        ASCENDING KEY IS Letter
                        INDEXED BY LetterIdx.
 </code></pre>
-					<p>
-						When the table description contains a KEY IS phrase we can search it using the following
-						statement -
-					</p>
-					<pre class="language-cobol"><code class="language-cobol">SEARCH ALL Letter
+						<p>
+							When the table description contains a KEY IS phrase we can search it using the following
+							statement -
+						</p>
+						<pre class="language-cobol"><code class="language-cobol">SEARCH ALL Letter
   AT END DISPLAY "Letter " SearchLetter " was not found!"
   WHEN Letter(LetterIdx) = SearchLetter
        SET LetterPos TO LetterIdx
        DISPLAY SearchLetter " is in position " LetterPos
 END-SEARCH.</code></pre>
-					<p align="center">
-						<a href="Resources/ppz/TC-Search2.html"
-							><img border="0" height="62" src="Resources/pics/i-Animation.gif" width="62"
-						/></a>
-					</p>
-					<p align="left">The full program for searching the letter table is given below.</p>
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
-				</td>
-				<td valign="top" width="525">
-					<table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="475">
-						<tr>
-							<td>
-								<pre
-									class="language-cobol"
-								><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+						<p align="center">
+							<a href="Resources/ppz/TC-Search2.html"
+								><img border="0" height="62" src="Resources/pics/i-Animation.gif" width="62"
+							/></a>
+						</p>
+						<p align="left">The full program for searching the letter table is given below.</p>
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
+					</div>
+					<div class="section-content">
+						<pre
+								class="language-cobol"
+							><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. LetterSearchAll.
 AUTHOR. Michael Coughlan.
@@ -1042,12 +1138,12 @@ DATA DIVISION.
 WORKING-STORAGE SECTION.
 01  LetterTable.
     02 LetterValues.
-       03 FILLER PIC X(13) 
+       03 FILLER PIC X(13)
           VALUE "ABCDEFGHIJKLM".
        03 FILLER PIC X(13)
           VALUE "NOPQRSTUVWXYZ".
     02 FILLER REDEFINES LetterValues.
-       03 Letter PIC X OCCURS 26 TIMES 
+       03 Letter PIC X OCCURS 26 TIMES
                        ASCENDING KEY IS Letter
                        INDEXED BY LetterIdx.
 
@@ -1068,29 +1164,23 @@ Begin.
     END-SEARCH
     STOP RUN.
 </code></pre>
-							</td>
-						</tr>
-					</table>
-					<hr size="1" width="100%" />
-				</td>
-			</tr>
-			<tr>
-				<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-					<h4>Example program</h4>
-					<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
-				</td>
-				<td valign="top" width="525">
-					<p>
-						In this example, we revisit the County Tax Report program once more. This time we use the
-						<code class="language-cobol">SEARCH ALL</code> to search the pre-filled table of county names.
-					</p>
-					<p>The new parts of the program are coloured red.</p>
-					<table align="center" background="Resources/pics/code.gif" border="1" cellpadding="5" width="475">
-						<tr>
-							<td>
-								<pre
-									class="language-cobol"
-								><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+						<hr size="1" width="100%" />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Example program</h4>
+						<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
+					</div>
+					<div class="section-content">
+						<p>
+							In this example, we revisit the County Tax Report program once more. This time we use the
+							<code class="language-cobol">SEARCH ALL</code> to search the pre-filled table of county names.
+						</p>
+						<p>The new parts of the program are coloured red.</p>
+						<pre
+								class="language-cobol"
+							><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. CountyTaxTable4.
 AUTHOR. Michael Coughlan.
@@ -1112,7 +1202,7 @@ FD TaxFile.
 WORKING-STORAGE SECTION.
 01 CountyTaxTable.
    02 CountyTaxDetails OCCURS 26 TIMES.
-      03 CountyTax   PIC 9(8)V99.  
+      03 CountyTax   PIC 9(8)V99.
       03 PayerCount  PIC 9(7).
          88 NoOnePaidTax VALUE ZEROS.
 
@@ -1190,20 +1280,16 @@ DisplayCountyTaxes.
       MOVE PayerCount(Idx) TO PrnPayers
       DISPLAY CountyTaxLine
    END-IF.</code></pre>
-							</td>
-						</tr>
-					</table>
-				</td>
-			</tr>
-			<tr>
-				<td colspan="2">
-					<hr />
-					<div align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
 					</div>
-					<copyright-notice></copyright-notice>
-				</td>
-			</tr>
-		</table>
+				</div>
+			</div>
+			<div class="page-footer">
+				<hr />
+				<div align="center">
+					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
+				</div>
+				<copyright-notice></copyright-notice>
+			</div>
+		</div>
 	</body>
 </html>


### PR DESCRIPTION
## Summary

- Replace all layout `<table>` elements in `course/ReportWriterSS.html` and `course/Search.html` with CSS grid/flexbox divs (same pattern used in `ReportWriter.html` and `SequentialFiles1.html`)
- Remove unnecessary wrapper divs (`div.section-code-bg`, `div.section-code-green`) that were wrapping `<pre>` COBOL code blocks
- Apply `white-space: pre-wrap` at all viewport sizes (not just mobile) so long COBOL lines reflow to the next line instead of producing a horizontal scrollbar; use `!important` to override Prism.js's default `white-space: pre`

## Reviewer notes

No actual data tables were changed — all modified `<table>` elements were purely presentational layout tables. The two-column grid collapses to a single column at `max-width: 600px` for mobile, matching the established pattern across the course files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)