### PR TITLE
Refactor CSISEvalForm.html layout tables to CSS grid/flexbox

### DIFF
--- a/exercises/Proj-CSISEvalform/CSISEvalForm.html
+++ b/exercises/Proj-CSISEvalform/CSISEvalForm.html
@@ -1,39 +1,83 @@
 <!doctype html>
-<html>
+<html lang="en-GB">
 	<head>
-		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
-		<link href="CSISEvalForm_files/editdata.mso" rel="Edit-Time-Data" />
-		<link href="CSISEvalForm_files/oledata.mso" rel="OLE-Object-Data" />
-		<title>Zoom taxis DP291 Cobol project</title>
-
-		<style>
-			<!--
-			.Normal
-			        {font-size:12.0pt;
-			        font-family:"Times New Roman";}
-			.TableHead
-			        {text-align:center;
-			        font-size:12.0pt;
-			        font-family:Times;
-			        font-variant:small-caps;
-			        font-weight:bold;}
-			-->
-		</style>
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
-		<style type="text/css">
+		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
+		<title>Zoom taxis DP291 Cobol project</title>
+		<style>
+			body {
+				font-size: 12pt;
+				font-family: "Times New Roman", serif;
+				background-color: #ffffff;
+				margin: 0;
+				padding: 0;
+				-webkit-text-size-adjust: 100%;
+			}
+			a:link { color: blue; }
+			a:visited { color: purple; }
 			img {
 				max-width: 100%;
 				height: auto;
 			}
-			table {
-				max-width: 100%;
-			}
 			pre {
 				overflow-x: auto;
 				max-width: 100%;
+				white-space: pre;
+				overflow-wrap: normal;
+				word-wrap: normal;
 			}
-			body {
-				-webkit-text-size-adjust: 100%;
+			.page-wrapper {
+				max-width: 800px;
+				margin: 0 auto;
+				border: 1px solid #000;
+			}
+			.page-header {
+				background-color: #990000;
+				padding: 10px 5px;
+				text-align: center;
+			}
+			.page-header h2 {
+				margin: 0;
+				font-size: 12pt;
+				font-family: "Times New Roman", serif;
+			}
+			.meta-table {
+				width: 100%;
+				margin: 0;
+			}
+			.meta-table td {
+				border: 1px solid #000;
+				padding: 5px;
+				vertical-align: top;
+			}
+			.meta-table .meta-label {
+				width: 21%;
+				font-weight: bold;
+				white-space: nowrap;
+			}
+			.main-content {
+				padding: 5px;
+			}
+			table {
+				border-collapse: collapse;
+				margin: 0 auto;
+				max-width: 100%;
+			}
+			th, td {
+				border: 1px solid #000;
+				padding: 4px;
+				font-size: 12pt;
+				font-family: "Times New Roman", serif;
+			}
+			thead tr {
+				background-color: #ffffcc;
+			}
+			thead th {
+				font-variant: small-caps;
+				text-align: center;
+			}
+			.center {
+				text-align: center;
 			}
 			@media (max-width: 600px) {
 				body {
@@ -41,466 +85,244 @@
 					overflow-wrap: break-word;
 					word-wrap: break-word;
 				}
-				table[width] {
+				.meta-table tr,
+				.meta-table td {
+					display: block;
 					width: 100% !important;
-					height: auto !important;
 				}
-				td[width],
-				th[width],
-				td[height],
-				th[height] {
-					width: auto !important;
-					height: auto !important;
-				}
-				td[bgcolor="#993300"] > h2,
-				td[bgcolor="#993300"] > h3 {
-					margin: 0.3em 0;
+				.meta-table .meta-label {
+					border-bottom: none;
+					white-space: normal;
 				}
 				blockquote {
 					margin-left: 12px;
 					margin-right: 12px;
 				}
-				hr[width] {
-					width: 100% !important;
-				}
-				img,
-				iframe,
-				video,
-				embed,
-				object {
+				img, iframe, video, embed, object {
 					max-width: min(100%, calc(100vw - 16px)) !important;
 					height: auto;
-				}
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					white-space: pre-wrap;
-					word-wrap: break-word;
-					overflow-wrap: break-word;
-				}
-				table[width="715"],
-				table[width="725"],
-				table[width="715"] > tbody,
-				table[width="725"] > tbody,
-				table[width="715"] > tbody > tr,
-				table[width="725"] > tbody > tr,
-				table[width="715"] > tbody > tr > td,
-				table[width="725"] > tbody > tr > td,
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])),
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])) > tbody,
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])) > tbody > tr,
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])) > tbody > tr > td {
-					display: block;
-					width: auto !important;
-				}
-				table[width="710"]:has(> tbody > tr > td[width="93%"]),
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody {
-					display: block;
-					width: 100% !important;
-				}
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr {
-					display: flex;
-					align-items: baseline;
-					gap: 0.4em;
-					margin: 0.4em 0;
-				}
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr > td[width="3%"] {
-					display: none;
-				}
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr > td[width="4%"] {
-					display: block;
-					flex: 0 0 auto;
-					width: auto !important;
-					padding: 0;
-				}
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr > td[width="93%"] {
-					display: block;
-					flex: 1 1 auto;
-					width: auto !important;
-					padding: 0;
-				}
-				td[width="175"] > h4:not(:first-child):not(:has(img)),
-				td[width="160"] > h4:not(:first-child):not(:has(img)),
-				h4:has(> img[src*="PanelLine"]) {
-					display: none;
-				}
-				td[width="175"] > h3,
-				td[width="175"] > h4,
-				td[width="175"] > p,
-				td[width="160"] > h3,
-				td[width="160"] > h4,
-				td[width="160"] > p {
-					margin: 0.2em 0;
 				}
 			}
 		</style>
 		<script src="../../components/copyright-notice.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" class="Normal" lang="EN-GB" link="blue" vlink="purple">
-		<table border="1" cellpadding="5" cellspacing="0" width="800">
-			<tr>
-				<td bgcolor="#990000" colspan="2" height="59" valign="middle">
-					<h2 align="center">
-						<b>CSIS WebSite<br /></b>
-						<b>Evaluation Form Report</b>
-					</h2>
-				</td>
-			</tr>
-			<tr>
-				<td height="2" valign="middle" width="21%"><b>Time to complete</b></td>
-				<td height="2" valign="middle" width="79%">Allow 30 hours continuous</td>
-			</tr>
-			<tr>
-				<td height="9" valign="top" width="21%"><b>Input Data Files</b></td>
-				<td height="9" valign="top" width="79%">
-					<p>
-						<a href="Occupations.dat">Occupations.dat</a><br />
-						(On each country line, the name of the most common occupation of visitors from that country must
-						be displayed. But records in the Evaluation Form file only contain a code that represents the
-						visitor occupation so this code must be converted into the name of the
-						occupation.&nbsp;&nbsp;&nbsp; The occupation codes and their corresponding names are contained
-						in a sequential file (Occupations.Dat). )
-					</p>
-					<p>
-						<i><a href="EVALFORM.DAT">EvalForm.Dat</a></i
-						><br />
-						The Evaluation Form File, is an unordered sequential file that contains the results from the
-						Evaluation Form on the CSIS web site.
-					</p>
-				</td>
-			</tr>
-			<tr>
-				<td colspan="2" valign="top">
-					<h3>
-						<br />
-						<span style="font-variant: normal; text-transform: uppercase">Introduction</span>
-					</h3>
-					<p>
-						Visitors to the <span style="font-size: 11pt">CSIS</span> web site are asked to fill in an
-						evaluation form. The form requests the name of the visitor, his/her country of origin, his/her
-						occupation, an evaluation of the web site, and an optional comment. These fields are stored as a
-						fixed length record in an Evaluation Form file (EvalForm.Dat).
-					</p>
-					<p>
-						A program is required which will produce a report from the Evaluation Form file.&nbsp; For each
-						country from which the site has been visited the report should show-
-					</p>
-					<blockquote>
-						<blockquote>
-							<p>
-								<span style="font-family: Symbol"
-									>·<span style="font: 7pt &quot;Times New Roman&quot;"
-										>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span
-									></span
-								>
-								The name of the country
-							</p>
-							<p>
-								<span style="font-family: Symbol"
-									>·<span style="font: 7pt &quot;Times New Roman&quot;"
-										>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span
-									></span
-								>
-								The number of visitors from this country
-							</p>
-							<p>
-								<span style="font-family: Symbol"
-									>·<span style="font: 7pt &quot;Times New Roman&quot;"
-										>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span
-									></span
-								>
-								Most common occupation of visitors from this country
-							</p>
-							<p>
-								<span style="font-family: Symbol"
-									>·<span style="font: 7pt &quot;Times New Roman&quot;"
-										>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span
-									></span
-								>
-								The average evaluation of the web site by visitors from this country.
-							</p>
-						</blockquote>
-					</blockquote>
-					<p>
-						The report must be implemented as an <span style="font-size: 11pt">HTML</span> web page and the
-						information on the page should appear in ascending country name sequence.
-					</p>
-					<p>
-						In the course of creating the <span style="font-size: 11pt">HTML</span> web page, the program
-						must produce a sorted file containing the VistorCountryName, VisitorOccupation and
-						SiteEvaluation fields.<br />
-						<br />
-					</p>
-					<h4><span style="font-variant: normal; text-transform: uppercase">Evaluation Form File</span></h4>
-					<p>
-						The Evaluation Form File (EvalForm.Dat), is an unordered sequential file, with the following
-						record description;
-					</p>
-					<div align="center">
-						<table border="1" cellpadding="0" cellspacing="0">
-							<tr bgcolor="#FFFFCC">
-								<td class="Normal" valign="top" width="163">
-									<p align="center" style="text-align: center">
-										<b><span style="text-transform: uppercase">FieldName</span></b>
-									</p>
-								</td>
-								<td class="Normal" valign="top" width="60">
-									<p align="center" style="text-align: center">
-										<b><span style="text-transform: uppercase">Type</span></b>
-									</p>
-								</td>
-								<td class="Normal" valign="top" width="78">
-									<p align="center" style="text-align: center">
-										<b><span style="text-transform: uppercase">Length</span></b>
-									</p>
-								</td>
-								<td class="Normal" valign="top" width="84">
-									<p align="center" style="text-align: center">
-										<b><span style="text-transform: uppercase">Value</span></b>
-									</p>
-								</td>
-							</tr>
-							<tr>
-								<td class="Normal" valign="top" width="163">
-									<p>VisitorName</p>
-								</td>
-								<td class="Normal" valign="top" width="60">
-									<p align="center" style="text-align: center">X</p>
-								</td>
-								<td class="Normal" valign="top" width="78">
-									<p align="center" style="text-align: center">20</p>
-								</td>
-								<td class="Normal" valign="top" width="84">
-									<p align="center" style="text-align: center">-</p>
-								</td>
-							</tr>
-							<tr>
-								<td class="Normal" valign="top" width="163">
-									<p>VisitorCountryName</p>
-								</td>
-								<td class="Normal" valign="top" width="60">
-									<p align="center" style="text-align: center">X</p>
-								</td>
-								<td class="Normal" valign="top" width="78">
-									<p align="center" style="text-align: center">20</p>
-								</td>
-								<td class="Normal" valign="top" width="84">
-									<p align="center" style="text-align: center">-</p>
-								</td>
-							</tr>
-							<tr>
-								<td class="Normal" valign="top" width="163">
-									<p>VisitorOccupation</p>
-								</td>
-								<td class="Normal" valign="top" width="60">
-									<p align="center" style="text-align: center">X</p>
-								</td>
-								<td class="Normal" valign="top" width="78">
-									<p align="center" style="text-align: center">2</p>
-								</td>
-								<td class="Normal" valign="top" width="84">
-									<p align="center" style="text-align: center">-</p>
-								</td>
-							</tr>
-							<tr>
-								<td class="Normal" valign="top" width="163">
-									<p>SiteEvaluation</p>
-								</td>
-								<td class="Normal" valign="top" width="60">
-									<p align="center" style="text-align: center">9</p>
-								</td>
-								<td class="Normal" valign="top" width="78">
-									<p align="center" style="text-align: center">1</p>
-								</td>
-								<td class="Normal" valign="top" width="84">
-									<p align="center" style="text-align: center">1-5</p>
-								</td>
-							</tr>
-							<tr>
-								<td class="Normal" valign="top" width="163">
-									<p>VisitorComment</p>
-								</td>
-								<td class="Normal" valign="top" width="60">
-									<p align="center" style="text-align: center">X</p>
-								</td>
-								<td class="Normal" valign="top" width="78">
-									<p align="center" style="text-align: center">35</p>
-								</td>
-								<td class="Normal" valign="top" width="84">
-									<p align="center" style="text-align: center">-</p>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<h3><span style="font-variant: normal; text-transform: uppercase">File Conversions</span></h3>
-					<h4><span style="font-variant: normal; text-transform: uppercase">Visitor Occupation</span></h4>
-					<p>
-						On each country line, the name of the most common occupation of visitors from that country must
-						be displayed. But records in the Evaluation Form file only contain a code that represents the
-						visitor occupation so this code must be converted into the name of the
-						occupation.&nbsp;&nbsp;&nbsp; The occupation codes and their corresponding names are contained
-						in a sequential file (Occupations.Dat). To allow an efficient conversion of the occupation code
-						to the occupation name this file must be loaded into a table in memory.&nbsp;&nbsp; There are
-						currently 25 occupations in the file but you must write your program so that it is easy to
-						extend the number of occupations.&nbsp;<br />
-						<br />
-					</p>
-					<h4>Occupation File</h4>
-					<p>
-						The Occupation File (Occupations.Dat)is a sequential file ordered on ascending
-						OccupationCode.&nbsp;&nbsp; Each record contains a CountryCode and its corresponding
-						CountryName.
-					</p>
-					<div align="center">
-						<table border="1" cellpadding="0" cellspacing="0">
-							<tr bgcolor="#FFFFCC">
-								<td class="Normal" valign="top" width="139">
-									<p class="TableHead">
-										<span style="font-variant: normal; text-transform: uppercase">Field</span>
-									</p>
-								</td>
-								<td class="Normal" valign="top" width="57">
-									<p class="TableHead">
-										<span style="font-variant: normal; text-transform: uppercase">Type</span>
-									</p>
-								</td>
-								<td class="Normal" valign="top" width="76">
-									<p class="TableHead">
-										<span style="font-variant: normal; text-transform: uppercase">Length</span>
-									</p>
-								</td>
-								<td class="Normal" valign="top" width="85">
-									<p class="TableHead">
-										<span style="font-variant: normal; text-transform: uppercase">Value</span>
-									</p>
-								</td>
-							</tr>
-							<tr>
-								<td class="Normal" valign="top" width="139">
-									<p>OccupationCode</p>
-								</td>
-								<td class="Normal" valign="top" width="57">
-									<p align="center" style="text-align: center">X</p>
-								</td>
-								<td class="Normal" valign="top" width="76">
-									<p align="center" style="text-align: center">2</p>
-								</td>
-								<td class="Normal" valign="top" width="85">
-									<p align="center" style="text-align: center">-</p>
-								</td>
-							</tr>
-							<tr>
-								<td class="Normal" valign="top" width="139">
-									<p>OccupationName</p>
-								</td>
-								<td class="Normal" valign="top" width="57">
-									<p align="center" style="text-align: center">X</p>
-								</td>
-								<td class="Normal" valign="top" width="76">
-									<p align="center" style="text-align: center">23</p>
-								</td>
-								<td class="Normal" valign="top" width="85">
-									<p align="center" style="text-align: center">-</p>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<h4><span style="font-variant: normal; text-transform: uppercase">Site Evaluation</span></h4>
-					<p>
-						The SiteEvaluation field is a numeric value.&nbsp;&nbsp; In the report, the rounded average of
-						the evaluations for a particular country must be shown.&nbsp;&nbsp; But the average must be
-						printed as text, not as a numeric value.&nbsp; The evaluation values and their text equivalents
-						are given below and must be set up as a predefined table of values in your program.
-					</p>
-					<div align="center">
-						<table border="1" cellpadding="0" cellspacing="0">
-							<tr bgcolor="#FFFFCC">
-								<td class="Normal" valign="top" width="64">
-									<p align="center" style="text-align: center"><b>Value</b></p>
-								</td>
-								<td class="Normal" valign="top" width="143">
-									<p align="center" style="text-align: center"><b>Text Equivalent</b></p>
-								</td>
-							</tr>
-							<tr>
-								<td class="Normal" valign="top" width="64">
-									<p align="center" style="text-align: center">1</p>
-								</td>
-								<td class="Normal" valign="top" width="143">
-									<p align="center" style="text-align: center">Excellent</p>
-								</td>
-							</tr>
-							<tr>
-								<td class="Normal" valign="top" width="64">
-									<p align="center" style="text-align: center">2</p>
-								</td>
-								<td class="Normal" valign="top" width="143">
-									<p align="center" style="text-align: center">Very Good</p>
-								</td>
-							</tr>
-							<tr>
-								<td class="Normal" valign="top" width="64">
-									<p align="center" style="text-align: center">3</p>
-								</td>
-								<td class="Normal" valign="top" width="143">
-									<p align="center" style="text-align: center">Good</p>
-								</td>
-							</tr>
-							<tr>
-								<td class="Normal" valign="top" width="64">
-									<p align="center" style="text-align: center">4</p>
-								</td>
-								<td class="Normal" valign="top" width="143">
-									<p align="center" style="text-align: center">Poor</p>
-								</td>
-							</tr>
-							<tr>
-								<td class="Normal" valign="top" width="64">
-									<p align="center" style="text-align: center">5</p>
-								</td>
-								<td class="Normal" valign="top" width="143">
-									<p align="center" style="text-align: center">Very Poor</p>
-								</td>
-							</tr>
-						</table>
-						<br />
-					</div>
-					<p>
-						The report also requires an overall evaluation.&nbsp; This is the average of the evaluations of
-						all the visitors to the site.<br />
-						<br />
-					</p>
-					<h3>The&nbsp; HTML report page</h3>
-					<p>
-						The report must be produced as an HTML page to be viewed in a web browser.&nbsp;&nbsp; In the
-						&lt;TITLE&gt; tag, the title of the page should be <i>CSIS Evaluation Form Report</i>.&nbsp; In
-						the &lt;BODY&gt; tag the background colour should be white – i.e. #FFFFFF.&nbsp;&nbsp; The other
-						colours and fonts used are left to the discretion of the programmer but they should make the
-						report as easy to read as possible.&nbsp;&nbsp; Reports that are easy to read, because they make
-						good use of font, colour and text alignment, will tend to attract marks.
-					</p>
-					<p>
-						The country lines of the report must appear in ascending country name sequence.&nbsp; Numeric
-						values must be zero suppressed up to but not including the last digit and should have commas
-						inserted where appropriate.&nbsp;
-					</p>
-					<p>
-						The structure of the report should generally conform to the outline shown below but the exact
-						placement of items is left to the discretion of the programmer.
-					</p>
-					<p><span>&nbsp;</span></p>
-					<pre><span>     <b>                                       </b></span><b>CSIS Web Site<br></b><b><span>                                       </span>Evaluation Form Report</b></pre>
-					<pre><b>CountryName                         Visitors    Occupation                                             Evaluation </b></pre>
-					<pre><b>XXXXXXXXXXXXXXXXXXXX  XX,XXX  XXXXXXXXXXXXXXXXXXXXXXX           XXXXXXXXX</b></pre>
-					<pre><b>XXXXXXXXXXXXXXXXXXXX  XX,XXX  XXXXXXXXXXXXXXXXXXXXXXX           XXXXXXXXX</b></pre>
-					<pre><b>XXXXXXXXXXXXXXXXXXXX  XX,XXX  XXXXXXXXXXXXXXXXXXXXXXX           XXXXXXXXX</b></pre>
-					<pre><b>XXXXXXXXXXXXXXXXXXXX  XX,XXX  XXXXXXXXXXXXXXXXXXXXXXX           XXXXXXXXX</b></pre>
-					<pre><b>XXXXXXXXXXXXXXXXXXXX  XX,XXX  XXXXXXXXXXXXXXXXXXXXXXX           XXXXXXXXX</b></pre>
-					<pre><b><span style="font-size:10.0pt;font-family:&quot;Courier New&quot;,&quot;Times New Roman&quot;">-----------------------------------------------------------------</span></b></pre>
-					<pre><b>Total Visitors           -      XXX,XXX    </b></pre>
-					<pre><b>Overall Evaluation  - XXXXXXXXX</b></pre>
-					<copyright-notice type="project"></copyright-notice>
-				</td>
-			</tr>
-		</table>
+	<body>
+		<div class="page-wrapper">
+			<div class="page-header">
+				<h2>CSIS WebSite<br />Evaluation Form Report</h2>
+			</div>
+			<table class="meta-table">
+				<tr>
+					<td class="meta-label">Time to complete</td>
+					<td>Allow 30 hours continuous</td>
+				</tr>
+				<tr>
+					<td class="meta-label">Input Data Files</td>
+					<td>
+						<p>
+							<a href="Occupations.dat">Occupations.dat</a><br />
+							(On each country line, the name of the most common occupation of visitors from that country must
+							be displayed. But records in the Evaluation Form file only contain a code that represents the
+							visitor occupation so this code must be converted into the name of the
+							occupation.&nbsp;&nbsp;&nbsp; The occupation codes and their corresponding names are contained
+							in a sequential file (Occupations.Dat). )
+						</p>
+						<p>
+							<i><a href="EVALFORM.DAT">EvalForm.Dat</a></i><br />
+							The Evaluation Form File, is an unordered sequential file that contains the results from the
+							Evaluation Form on the CSIS web site.
+						</p>
+					</td>
+				</tr>
+			</table>
+			<div class="main-content">
+				<h3>Introduction</h3>
+				<p>
+					Visitors to the CSIS web site are asked to fill in an evaluation form. The form requests the name
+					of the visitor, his/her country of origin, his/her occupation, an evaluation of the web site, and
+					an optional comment. These fields are stored as a fixed length record in an Evaluation Form file
+					(EvalForm.Dat).
+				</p>
+				<p>
+					A program is required which will produce a report from the Evaluation Form file.&nbsp; For each
+					country from which the site has been visited the report should show-
+				</p>
+				<ul>
+					<li>The name of the country</li>
+					<li>The number of visitors from this country</li>
+					<li>Most common occupation of visitors from this country</li>
+					<li>The average evaluation of the web site by visitors from this country.</li>
+				</ul>
+				<p>
+					The report must be implemented as an HTML web page and the information on the page should appear
+					in ascending country name sequence.
+				</p>
+				<p>
+					In the course of creating the HTML web page, the program must produce a sorted file containing
+					the VistorCountryName, VisitorOccupation and SiteEvaluation fields.
+				</p>
+				<h4>Evaluation Form File</h4>
+				<p>
+					The Evaluation Form File (EvalForm.Dat), is an unordered sequential file, with the following
+					record description;
+				</p>
+				<table>
+					<thead>
+						<tr>
+							<th>FieldName</th>
+							<th>Type</th>
+							<th>Length</th>
+							<th>Value</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>VisitorName</td>
+							<td class="center">X</td>
+							<td class="center">20</td>
+							<td class="center">-</td>
+						</tr>
+						<tr>
+							<td>VisitorCountryName</td>
+							<td class="center">X</td>
+							<td class="center">20</td>
+							<td class="center">-</td>
+						</tr>
+						<tr>
+							<td>VisitorOccupation</td>
+							<td class="center">X</td>
+							<td class="center">2</td>
+							<td class="center">-</td>
+						</tr>
+						<tr>
+							<td>SiteEvaluation</td>
+							<td class="center">9</td>
+							<td class="center">1</td>
+							<td class="center">1-5</td>
+						</tr>
+						<tr>
+							<td>VisitorComment</td>
+							<td class="center">X</td>
+							<td class="center">35</td>
+							<td class="center">-</td>
+						</tr>
+					</tbody>
+				</table>
+				<h3>File Conversions</h3>
+				<h4>Visitor Occupation</h4>
+				<p>
+					On each country line, the name of the most common occupation of visitors from that country must
+					be displayed. But records in the Evaluation Form file only contain a code that represents the
+					visitor occupation so this code must be converted into the name of the
+					occupation.&nbsp;&nbsp;&nbsp; The occupation codes and their corresponding names are contained
+					in a sequential file (Occupations.Dat). To allow an efficient conversion of the occupation code
+					to the occupation name this file must be loaded into a table in memory.&nbsp;&nbsp; There are
+					currently 25 occupations in the file but you must write your program so that it is easy to
+					extend the number of occupations.&nbsp;
+				</p>
+				<h4>Occupation File</h4>
+				<p>
+					The Occupation File (Occupations.Dat) is a sequential file ordered on ascending
+					OccupationCode.&nbsp;&nbsp; Each record contains a CountryCode and its corresponding
+					CountryName.
+				</p>
+				<table>
+					<thead>
+						<tr>
+							<th>Field</th>
+							<th>Type</th>
+							<th>Length</th>
+							<th>Value</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>OccupationCode</td>
+							<td class="center">X</td>
+							<td class="center">2</td>
+							<td class="center">-</td>
+						</tr>
+						<tr>
+							<td>OccupationName</td>
+							<td class="center">X</td>
+							<td class="center">23</td>
+							<td class="center">-</td>
+						</tr>
+					</tbody>
+				</table>
+				<h4>Site Evaluation</h4>
+				<p>
+					The SiteEvaluation field is a numeric value.&nbsp;&nbsp; In the report, the rounded average of
+					the evaluations for a particular country must be shown.&nbsp;&nbsp; But the average must be
+					printed as text, not as a numeric value.&nbsp; The evaluation values and their text equivalents
+					are given below and must be set up as a predefined table of values in your program.
+				</p>
+				<table>
+					<thead>
+						<tr>
+							<th>Value</th>
+							<th>Text Equivalent</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td class="center">1</td>
+							<td class="center">Excellent</td>
+						</tr>
+						<tr>
+							<td class="center">2</td>
+							<td class="center">Very Good</td>
+						</tr>
+						<tr>
+							<td class="center">3</td>
+							<td class="center">Good</td>
+						</tr>
+						<tr>
+							<td class="center">4</td>
+							<td class="center">Poor</td>
+						</tr>
+						<tr>
+							<td class="center">5</td>
+							<td class="center">Very Poor</td>
+						</tr>
+					</tbody>
+				</table>
+				<p>
+					The report also requires an overall evaluation.&nbsp; This is the average of the evaluations of
+					all the visitors to the site.
+				</p>
+				<h3>The HTML report page</h3>
+				<p>
+					The report must be produced as an HTML page to be viewed in a web browser.&nbsp;&nbsp; In the
+					&lt;TITLE&gt; tag, the title of the page should be <i>CSIS Evaluation Form Report</i>.&nbsp; In
+					the &lt;BODY&gt; tag the background colour should be white &ndash; i.e. #FFFFFF.&nbsp;&nbsp; The
+					other colours and fonts used are left to the discretion of the programmer but they should make
+					the report as easy to read as possible.&nbsp;&nbsp; Reports that are easy to read, because they
+					make good use of font, colour and text alignment, will tend to attract marks.
+				</p>
+				<p>
+					The country lines of the report must appear in ascending country name sequence.&nbsp; Numeric
+					values must be zero suppressed up to but not including the last digit and should have commas
+					inserted where appropriate.&nbsp;
+				</p>
+				<p>
+					The structure of the report should generally conform to the outline shown below but the exact
+					placement of items is left to the discretion of the programmer.
+				</p>
+<pre>                              <b>CSIS Web Site</b>
+                          <b>Evaluation Form Report</b>
+
+<b>CountryName          Visitors       Occupation                 Evaluation</b>
+<b>XXXXXXXXXXXXXXXXXXXX  XX,XXX  XXXXXXXXXXXXXXXXXXXXXXX           XXXXXXXXX</b>
+<b>XXXXXXXXXXXXXXXXXXXX  XX,XXX  XXXXXXXXXXXXXXXXXXXXXXX           XXXXXXXXX</b>
+<b>XXXXXXXXXXXXXXXXXXXX  XX,XXX  XXXXXXXXXXXXXXXXXXXXXXX           XXXXXXXXX</b>
+<b>XXXXXXXXXXXXXXXXXXXX  XX,XXX  XXXXXXXXXXXXXXXXXXXXXXX           XXXXXXXXX</b>
+<b>XXXXXXXXXXXXXXXXXXXX  XX,XXX  XXXXXXXXXXXXXXXXXXXXXXX           XXXXXXXXX</b>
+<b>-----------------------------------------------------------------</b>
+<b>Total Visitors           -      XXX,XXX</b>
+<b>Overall Evaluation  - XXXXXXXXX</b></pre>
+				<copyright-notice type="project"></copyright-notice>
+			</div>
+		</div>
 	</body>
 </html>


### PR DESCRIPTION
## Summary

- Replaced the outer layout table with a `.page-wrapper` div + `.page-header` div for the dark-red banner, and a proper `<table>` for the two-column metadata rows (Time to complete / Input Data Files)
- Replaced Symbol-font bullet points (`·` with `font-family: Symbol`) with semantic `<ul><li>` list items
- Consolidated multiple separate `<pre>` blocks into a single element; fixed leading-space centering of the report title and column headers so they align over their respective data columns
- Kept the three data tables (EvalForm fields, Occupation fields, Site Evaluation ratings) as semantic tables but cleaned them up: proper `<thead>`/`<tbody>`, `font-variant: small-caps` via CSS, pixel widths removed
- Removed MS Office artifacts (`editdata.mso`, `oledata.mso` links) and the legacy HTML4 `<!-- -->` CSS comment wrapper
- Simplified responsive CSS: removed all `table[width="..."]` hacks; `pre` now explicitly sets `white-space: pre; overflow-wrap: normal` so the report layout block scrolls horizontally on mobile rather than reflowing

## Reviewer notes

The `pre` block is an intentional fixed-width monospace report mockup — it should not reflow on mobile, hence the explicit `overflow-wrap: normal` override against the body's mobile `overflow-wrap: break-word` rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)