### PR TITLE
Refactor ReportWriterSSWeb.html layout tables to CSS grid/flexbox

### DIFF
--- a/lectures/ReportWriterSSWeb.html
+++ b/lectures/ReportWriterSSWeb.html
@@ -1,141 +1,10 @@
 <!doctype html>
 <html>
 	<head>
+		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>COBOL Report Writer - Syntax and Semantics</title>
-		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<style type="text/css">
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			table {
-				max-width: 100%;
-			}
-
-			pre {
-				overflow-x: auto;
-				max-width: 100%;
-			}
-
-			body {
-				-webkit-text-size-adjust: 100%;
-			}
-
-			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
-				table[width] {
-					width: 100% !important;
-					height: auto !important;
-				}
-
-				td[width],
-				th[width],
-				td[height],
-				th[height] {
-					width: auto !important;
-					height: auto !important;
-				}
-
-				td[bgcolor="#993300"] > h2,
-				td[bgcolor="#993300"] > h3 {
-					margin: 0.3em 0;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				hr[width] {
-					width: 100% !important;
-				}
-
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					white-space: pre-wrap;
-					word-wrap: break-word;
-					overflow-wrap: break-word;
-				}
-
-				table[width="715"],
-				table[width="725"],
-				table[width="715"] > tbody,
-				table[width="725"] > tbody,
-				table[width="715"] > tbody > tr,
-				table[width="725"] > tbody > tr,
-				table[width="715"] > tbody > tr > td,
-				table[width="725"] > tbody > tr > td,
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])),
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])) > tbody,
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])) > tbody > tr,
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])) > tbody > tr > td {
-					display: block;
-					width: auto !important;
-				}
-
-				table[width="710"]:has(> tbody > tr > td[width="93%"]),
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody {
-					display: block;
-					width: 100% !important;
-				}
-
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr {
-					display: flex;
-					align-items: baseline;
-					gap: 0.4em;
-					margin: 0.4em 0;
-				}
-
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr > td[width="3%"] {
-					display: none;
-				}
-
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr > td[width="4%"] {
-					display: block;
-					flex: 0 0 auto;
-					width: auto !important;
-					padding: 0;
-				}
-
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr > td[width="93%"] {
-					display: block;
-					flex: 1 1 auto;
-					width: auto !important;
-					padding: 0;
-				}
-
-				td[width="175"] > h4:not(:first-child):not(:has(img)),
-				td[width="160"] > h4:not(:first-child):not(:has(img)),
-				h4:has(> img[src*="PanelLine"]) {
-					display: none;
-				}
-
-				td[width="175"] > h3,
-				td[width="175"] > h4,
-				td[width="175"] > p,
-				td[width="160"] > h3,
-				td[width="160"] > h4,
-				td[width="160"] > p {
-					margin: 0.2em 0;
-				}
-			}
-
 			ul.toc {
 				list-style-image: url(Ballgreeng.gif);
 				padding-left: 2.5em;
@@ -151,192 +20,291 @@
 				font-weight: bold;
 			}
 
-			td[bgcolor="#993300"] h2 {
+			.section-header h2 {
 				color: #ffff00;
 				font-family: Arial, Helvetica, sans-serif;
 			}
 
-			td[bgcolor="#FFFFCC"] h3,
-			td[bgcolor="#FFFFCC"] h4 {
+			.section-sidebar h3,
+			.section-sidebar h4 {
 				color: #800000;
 				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			.page-wrapper {
+				max-width: 715px;
+				margin: 0 auto;
+				border: 1px solid;
+				box-sizing: border-box;
+			}
+
+			.page-content {
+				padding: 2px;
+			}
+
+			.page-footer {
+				padding: 2px;
+			}
+
+			.section-grid {
+				display: grid;
+				grid-template-columns: 175px 1fr;
+			}
+
+			.section-header {
+				grid-column: 1 / -1;
+				background-color: #993300;
+				padding: 4px;
+				min-width: 0;
+				border-bottom: 1px solid;
+			}
+
+			.section-sidebar {
+				background-color: #FFFFCC;
+				padding: 4px;
+				align-self: stretch;
+				min-width: 0;
+				border-right: 1px solid;
+				border-bottom: 1px solid;
+			}
+
+			.section-content {
+				padding: 4px;
+				align-self: start;
+				min-width: 0;
+				overflow: hidden;
+				border-bottom: 1px solid;
+			}
+
+			.section-full {
+				grid-column: 1 / -1;
+				padding: 4px;
+				min-width: 0;
+				border-bottom: 1px solid;
+			}
+
+			.section-full:last-child {
+				border-bottom: none;
+			}
+
+			img {
+				max-width: 100%;
+				height: auto;
+			}
+
+			pre {
+				overflow-x: auto;
+				max-width: 100%;
+				white-space: pre-wrap;
+				word-wrap: break-word;
+				overflow-wrap: break-word;
+			}
+
+			body {
+				-webkit-text-size-adjust: 100%;
+			}
+
+			@media (max-width: 600px) {
+				body {
+					margin: 4px;
+					overflow-wrap: break-word;
+					word-wrap: break-word;
+				}
+
+				.section-header h2,
+				.section-header h3 {
+					margin: 0.3em 0;
+				}
+
+				blockquote {
+					margin-left: 12px;
+					margin-right: 12px;
+				}
+
+				img,
+				iframe,
+				video,
+				embed,
+				object {
+					max-width: min(100%, calc(100vw - 16px)) !important;
+					height: auto;
+				}
+
+				pre {
+					max-width: min(100%, calc(100vw - 16px)) !important;
+				}
+
+				.section-grid {
+					display: block;
+				}
+
+				.section-sidebar h3,
+				.section-sidebar h4,
+				.section-sidebar p {
+					margin: 0.2em 0;
+				}
 			}
 		</style>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
-		<table border="1" width="715">
-			<tr>
-				<td>
-					<table border="0" cellpadding="4" cellspacing="0" width="710">
-						<tr>
-							<td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
-								<center>
-									<h2>
-										<img
-											align="middle"
-											alt="Cobol Course"
-											border="0"
-											height="56"
-											src="t-cobolcourse.gif"
-											width="161"
-										/>
-									</h2>
-								</center>
-								<center>
-									<h2><b>The COBOL Report Writer - Syntax and Semantics</b></h2>
-									<hr />
-								</center>
-								<ul class="toc">
-									<li>
-										<a href="#intro">Introduction</a><br />
-										Unit aims, objectives and prerequisites.
-									</li>
-									<li>
-										<a href="#part1">Defining the Report - Report File entries</a><br />
-										This section examines the
-										<code class="language-cobol">ENVIRONMENT DIVISION</code> and File Section
-										entries required when we create<br />
-										a Report Writer program.
-									</li>
-									<li>
-										<a href="#part2">Defining the Report - Report Description (RD) entries</a><br />
-										In this section we examine the Report Section and the Report Description (RD)
-										entries required to<br />
-										define a report.
-									</li>
-									<li>
-										<a href="#part3">Defining the Report - Report Group entries</a><br />
-										This section examines the entries required to define a report group record.
-									</li>
-									<li>
-										<a href="#part4">Defining the Report - Lines and Columns</a><br />
-										This section examines the entries the vertical and horizontal placement of print
-										items. It examines<br />
-										clauses such as - LINE NUMBER, COLUMN NUMBER, GROUP INDICATE , SOURCE and SUM.
-									</li>
-									<li>
-										<a href="#part5">Special Report Writer registers</a><br />
-										In this section the LINE-COUNTER and PAGE-COUNTER registers are examined.
-									</li>
-									<li>
-										<a href="#part6">The Procedure Division Verbs</a><br />
-										This section introduces the INITIATE, GENERATE and TERMINATE verbs.
-									</li>
-									<li>
-										<a href="#part7">Report Writer Declaratives</a><br />
-										In this section elements of the Declaratives, such as USE BEFORE REPORTING,
-										SUPPRESS PRINTING and<br />
-										control break registers, are examined.
-									</li>
-								</ul>
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-								<h2 align="center" id="intro">Introduction</h2>
-							</td>
-						</tr>
-						<tr>
-							<td bgcolor="#FFFFCC" valign="top" width="160">
-								<h4>Aims</h4>
-							</td>
-							<td width="540">
-								<p>
-									The unit provides a Report Writer reference. The syntax elements of the Report
-									Writer are presented and the semantics of their operation discussed.
-								</p>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-								<h4>Objectives</h4>
-							</td>
-							<td width="540">
-								<p>By the end of this unit you should -</p>
-								<ol>
-									<li>
-										Know how to set up a report file in the
-										<code class="language-cobol">ENVIRONMENT DIVISION</code> and the File Section.
-									</li>
-									<li>
-										Be able to define a report and the appropriate report groups in the Report
-										Section.
-									</li>
-									<li>
-										Understand how Declaratives may be used to extend the functionality of the
-										Report Writer.
-									</li>
-									<li>
-										Be able to write the Procedure Division code (using the INITIATE, GENERATE and
-										TERMINATE verbs) to create a report.
-									</li>
-								</ol>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-								<h4>Prerequisites</h4>
-							</td>
-							<td width="525">
-								<p>You should be familiar with the material covered in the units;</p>
-								<ul>
-									<li>Sequential files</li>
-									<li>Data Declaration</li>
-									<li>The Report Writer</li>
-								</ul>
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFFF" colspan="2" valign="top" width="700">
-								<div align="center">
-									<hr />
-									<p>
-										<a href="#top"
-											><img border="0" height="38" src="i-pagetop.gif" width="132"
-										/></a>
-									</p>
-								</div>
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-								<h2 align="center" id="part1">Defining the Report - Report File entries</h2>
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="160">
-								<h4><code class="language-cobol">ENVIRONMENT DIVISION</code> entries</h4>
-							</td>
-							<td valign="top" width="540">
-								<p>
-									Just like ordinary reports, the reports generated by the Report Writer are written
-									to an external device - usually a report file.
-								</p>
-								<p>
-									The <code class="language-cobol">ENVIRONMENT DIVISION</code> entries for a report
-									file are the same as those for an ordinary file. The same Select and Assign clauses
-									apply.
-								</p>
-								<p>
-									For instance, in the program fragment below, the Select and Assign for the final
-									example program (given in the previous Report Writer unit) is shown.
-								</p>
-								<p>
-									When the Report Writer generates this report it will be stored in the file
-									SALESREPORT.LPT.
-								</p>
-								<table background="lectures/cobol/pics/code.gif" border="1" width="100%">
-									<tr>
-										<td>
-											<pre>ENVIRONMENT DIVISION.
+		<div class="page-wrapper">
+			<div class="page-content">
+				<div>
+					<center>
+						<h2>
+							<img
+								align="middle"
+								alt="Cobol Course"
+								border="0"
+								height="56"
+								src="t-cobolcourse.gif"
+								width="161"
+							/>
+						</h2>
+						<h2><b>The COBOL Report Writer - Syntax and Semantics</b></h2>
+						<hr />
+					</center>
+					<ul class="toc">
+						<li>
+							<a href="#intro">Introduction</a><br />
+							Unit aims, objectives and prerequisites.
+						</li>
+						<li>
+							<a href="#part1">Defining the Report - Report File entries</a><br />
+							This section examines the
+							<code class="language-cobol">ENVIRONMENT DIVISION</code> and File Section
+							entries required when we create<br />
+							a Report Writer program.
+						</li>
+						<li>
+							<a href="#part2">Defining the Report - Report Description (RD) entries</a><br />
+							In this section we examine the Report Section and the Report Description (RD)
+							entries required to<br />
+							define a report.
+						</li>
+						<li>
+							<a href="#part3">Defining the Report - Report Group entries</a><br />
+							This section examines the entries required to define a report group record.
+						</li>
+						<li>
+							<a href="#part4">Defining the Report - Lines and Columns</a><br />
+							This section examines the entries the vertical and horizontal placement of print
+							items. It examines<br />
+							clauses such as - LINE NUMBER, COLUMN NUMBER, GROUP INDICATE , SOURCE and SUM.
+						</li>
+						<li>
+							<a href="#part5">Special Report Writer registers</a><br />
+							In this section the LINE-COUNTER and PAGE-COUNTER registers are examined.
+						</li>
+						<li>
+							<a href="#part6">The Procedure Division Verbs</a><br />
+							This section introduces the INITIATE, GENERATE and TERMINATE verbs.
+						</li>
+						<li>
+							<a href="#part7">Report Writer Declaratives</a><br />
+							In this section elements of the Declaratives, such as USE BEFORE REPORTING,
+							SUPPRESS PRINTING and<br />
+							control break registers, are examined.
+						</li>
+					</ul>
+				</div>
+				<div class="section-header">
+					<h2 align="center" id="intro">Introduction</h2>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Aims</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The unit provides a Report Writer reference. The syntax elements of the Report
+							Writer are presented and the semantics of their operation discussed.
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Objectives</h4>
+					</div>
+					<div class="section-content">
+						<p>By the end of this unit you should -</p>
+						<ol>
+							<li>
+								Know how to set up a report file in the
+								<code class="language-cobol">ENVIRONMENT DIVISION</code> and the File Section.
+							</li>
+							<li>
+								Be able to define a report and the appropriate report groups in the Report
+								Section.
+							</li>
+							<li>
+								Understand how Declaratives may be used to extend the functionality of the
+								Report Writer.
+							</li>
+							<li>
+								Be able to write the Procedure Division code (using the INITIATE, GENERATE and
+								TERMINATE verbs) to create a report.
+							</li>
+						</ol>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Prerequisites</h4>
+					</div>
+					<div class="section-content">
+						<p>You should be familiar with the material covered in the units;</p>
+						<ul>
+							<li>Sequential files</li>
+							<li>Data Declaration</li>
+							<li>The Report Writer</li>
+						</ul>
+					</div>
+				</div>
+				<div class="section-full">
+					<div align="center">
+						<hr />
+						<p>
+							<a href="#top"
+								><img border="0" height="38" src="i-pagetop.gif" width="132"
+							/></a>
+						</p>
+					</div>
+				</div>
+				<div class="section-header">
+					<h2 align="center" id="part1">Defining the Report - Report File entries</h2>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4><code class="language-cobol">ENVIRONMENT DIVISION</code> entries</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							Just like ordinary reports, the reports generated by the Report Writer are written
+							to an external device - usually a report file.
+						</p>
+						<p>
+							The <code class="language-cobol">ENVIRONMENT DIVISION</code> entries for a report
+							file are the same as those for an ordinary file. The same Select and Assign clauses
+							apply.
+						</p>
+						<p>
+							For instance, in the program fragment below, the Select and Assign for the final
+							example program (given in the previous Report Writer unit) is shown.
+						</p>
+						<p>
+							When the Report Writer generates this report it will be stored in the file
+							SALESREPORT.LPT.
+						</p>
+						<pre>ENVIRONMENT DIVISION.
 INPUT-OUTPUT SECTION.
 FILE-CONTROL.
     SELECT SalesFile ASSIGN TO "GBPAY.DAT"
            ORGANIZATION IS LINE SEQUENTIAL.
-   <span style="color: #FF0000"><b> SELECT PrintFile ASSIGN TO "SALESREPORT.LPT".</b></span>
+    <span style="color: #FF0000"><b>SELECT PrintFile ASSIGN TO "SALESREPORT.LPT".</b></span>
 
 
 DATA DIVISION.
@@ -365,524 +333,506 @@ REPORT SECTION.
     LAST DETAIL 42
     FOOTING 52.
 </pre>
-										</td>
-									</tr>
-								</table>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4 align="left">File Section entries</h4>
-							</td>
-							<td valign="top" width="525">
-								<p>
-									Although the entries in the
-									<code class="language-cobol">ENVIRONMENT DIVISION</code> are the same as those for
-									ordinary print files, in the File Section the normal file description is replaced by
-									phrase which points to the Report Description (RD) in the Report Section. The syntax
-									of the phrase is -
-								</p>
-								<p align="center"><img height="48" src="rwReportIS.gif" width="222" /></p>
-								<p>
-									The <i>ReportName</i> must be the same as the <i>ReportName</i> used in the Report
-									Description (RD) entry.
-								</p>
-								<p>
-									You can see this in the program fragment above where the <b>REPORT IS</b>
-									<b>SalesReport</b> phrase links the PrintFile with the Report Description(RD) in the
-									Report Section.
-								</p>
-								<p><b>Notes:</b></p>
-								<p>
-									Before the report can be used it must be opened for output. For instance in the
-									example above the PrintFile must be opened for output before the SalesReport can be
-									generated.
-								</p>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#993300" colspan="2" valign="top">
-								<h2 align="center" id="part2">Defining the Report - Report Description (RD) Entries</h2>
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>Introduction</h4>
-							</td>
-							<td valign="top" width="525">
-								<p>
-									Every report generated by the Report Writer must have a Report Description (RD)
-									entry in the Report Section.
-								</p>
-								<p>
-									The RD entry names the report and specifies the format of the printed page and
-									identifies the control break items.
-								</p>
-								<p>
-									Each RD entry is followed by one or more 01 level-number entries. Each 01
-									level-number entry identifies a report group and consists of a hierarchical
-									structure similar to a COBOL record.
-								</p>
-								<p>
-									Each report group is a unit consisting of one or more print lines and cannot be
-									split across pages.
-								</p>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4 align="left">The Report Description (RD) entries - Syntax</h4>
-							</td>
-							<td valign="top" width="525">
-								<p>The syntax for the Report Description (RD) entries is shown below -</p>
-								<p align="center"><img height="277" src="rwRD.gif" width="360" /></p>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4 align="left">The Report Description (RD) entries - Semantics</h4>
-							</td>
-							<td valign="top" width="525">
-								<p align="center"><b>RD Rules</b></p>
-								<ol>
-									<li>The <i>ReportName</i> can only appear in one RD entry.</li>
-									<li>
-										When more than one report is declared in the Report Section the
-										<i>ReportName</i> can be used to qualify the LINE-COUNTER and PAGE-COUNTER
-										report registers.
-									</li>
-								</ol>
-								<hr width="50%" />
-								<p align="center"><b>CONTROL Rules</b></p>
-								<ol>
-									<li>The <i>ControlName$#i</i> must not be defined in the Report Section.</li>
-									<li>
-										Each occurrence of <i>ControlName$#i</i> must identify a different data item.
-									</li>
-									<li>
-										The <i>ControlName$#i</i> must not have a variable length table subordinate to
-										it.
-									</li>
-									<li>
-										<i>ControlName$#i</i> and FINAL specify the levels of the control break
-										hierarchy where FINAL (if specified) is the highest and the first
-										<i>ControlName$#i</i> the next highest and so on.
-									</li>
-									<li>
-										When the value in any <i>ControlName$#i</i> changes a control break occurs. The
-										level of the control break depends on the position of the
-										<i>ControlName$#i</i> in the control break hierarchy.
-									</li>
-								</ol>
-								<hr width="50%" />
-								<p align="center"><b>PAGE Rules</b></p>
-								<ol>
-									<li><i>HeadingLine#l</i> must be greater than or equal to 1.</li>
-									<li>
-										<i>HeadingLine#l</i> &lt;= <i>FirstDetailLine#l</i> &lt;=
-										<i>LastDetailLine#l</i> &lt;= <i>FootingLine#l</i> &lt;= <i>PageSize#l</i>
-									</li>
-									<li>
-										Line numbers used in a Report Heading or Page Heading group must be greater than
-										or equal to <i>HeadingLine#l</i> and less than <i>FirstDetailLine#l</i> but when
-										a Report Heading appears on a page by itself any line number between
-										<i>HeadingLine#l</i> and <i>PageSize#l</i> may be used.
-									</li>
-									<li>
-										Line numbers used in Detail or Control Heading groups must be in the range
-										<i>FirstDetailLine#l</i> to <i>LastDetailLine#l</i> inclusive.
-									</li>
-									<li>
-										Line numbers used in Control Footing groups must be in the range
-										<i>FirstDetailLine#l FootingLine#l</i> inclusive
-									</li>
-									<li>
-										Line numbers used in the Report Footing or Page Footing groups must be greater
-										than <i>FootingLine#l</i> and less than or equal to <i>PageSize#l</i> but when a
-										Report Footing appears on a page by itself any line number between
-										<i>HeadingLine#l</i> and <i>PageSize#l</i> may be used.
-									</li>
-									<li>
-										All report groups must be defined so that they can be presented on one page. The
-										Report Writer never splits a multi-line group across page boundaries.
-									</li>
-								</ol>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#993300" colspan="2" valign="top">
-								<h2 align="center" id="part3">Defining the Report - Report Group entries</h2>
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>Introduction</h4>
-							</td>
-							<td valign="top" width="525">
-								<p>
-									In the Report Section each report group is represented by a report group record. As
-									with all record descriptions in COBOL a report group record starts with level number
-									01. Subordinate items in the record describe the report lines and columns within the
-									report group.
-								</p>
-								<p>
-									The description of a report group consists of a number of hierarchic levels. At the
-									top must be the Report Group Definition.
-								</p>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4 align="left">Defining a Report Group Record - Syntax</h4>
-							</td>
-							<td valign="top" width="525">
-								<p>
-									<b>Report Group Definition</b>
-								</p>
-								<p><img height="512" src="rwGroupType.gif" width="405" /></p>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4 align="left"><i>ReportGroupName</i> Rules</h4>
-							</td>
-							<td valign="top" width="525">
-								<p>The <i>ReportGroupName</i> is required only when the group -</p>
-								<ol>
-									<li>
-										is a detail group referenced by a
-										<code class="language-cobol">GENERATE</code> statement or the
-										<code class="language-cobol">UPON</code> phrase of a
-										<code class="language-cobol">SUM</code> clause.
-									</li>
-									<li>
-										is referenced in a
-										<code class="language-cobol">USE BEFORE REPORTING</code> sentence in the
-										Declaratives
-									</li>
-									<li>is required to qualify the reference to a sum counter.</li>
-								</ol>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4 align="left">The LINE NUMBER clause</h4>
-							</td>
-							<td valign="top" width="525">
-								<p>
-									The <code class="language-cobol">LINE NUMBER</code> clause is used to specify the
-									vertical positioning of print lines. Lines can be printed on -
-								</p>
-								<ul>
-									<ul>
-										<li>a specified line (absolute)</li>
-										<li>a specified line on the next page (absolute)</li>
-										<li>the current line number plus some increment (relative)</li>
-									</ul>
-								</ul>
-								<p><b>Rules:</b></p>
-								<ol>
-									<li>
-										The <code class="language-cobol">LINE NUMBER</code> clause specifies where each
-										line is to be printed so no item that contains a
-										<code class="language-cobol">LINE NUMBER</code> clause may contain a subordinate
-										item that also contains a <code class="language-cobol">LINE NUMBER</code> clause
-										(subordinate items specify the column items).
-									</li>
-									<li>
-										Where absolute <code class="language-cobol">LINE NUMBER</code> clauses are
-										specified all absolute clauses must precede all relative clauses and the line
-										numbers specified in the successive absolute clauses must be in ascending order.
-									</li>
-									<li>
-										The first <code class="language-cobol">LINE NUMBER</code> clause specified in a
-										<code class="language-cobol">PAGE FOOTING</code> group must be absolute.
-									</li>
-									<li>
-										The <code class="language-cobol">NEXT PAGE</code> clause can only appear once in
-										a given report group description and it must be in the first
-										<code class="language-cobol">LINE NUMBER</code> clause in the report group.
-									</li>
-									<li>
-										The <code class="language-cobol">NEXT PAGE</code> clause cannot appear in any
-										<code class="language-cobol">HEADING</code> group.
-									</li>
-								</ol>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4 align="left">The NEXT GROUP clause</h4>
-							</td>
-							<td valign="top" width="525">
-								<p>
-									The <code class="language-cobol">NEXT GROUP</code> clause is used to specify the
-									vertical positioning of the start of the next group. The
-									<code class="language-cobol">NEXT GROUP</code> clause can be used to specify that
-									the next report groups should be printed on -
-								</p>
-								<ul>
-									<ul>
-										<li>a specified line (absolute)</li>
-										<li>the current line number plus some increment (relative)</li>
-										<li>the next page</li>
-									</ul>
-								</ul>
-								<p><b>Rules</b></p>
-								<p>
-									The <code class="language-cobol">NEXT PAGE</code> option in the
-									<code class="language-cobol">NEXT GROUP</code> clause must not be specified in a
-									page footing.
-								</p>
-								<p>
-									The <code class="language-cobol">NEXT GROUP</code> clause must not be specified in a
-									<code class="language-cobol">REPORT FOOTING</code> or
-									<code class="language-cobol">PAGE HEADING</code> group.
-								</p>
-								<p>
-									When used in a <code class="language-cobol">DETAIL</code> group the
-									<code class="language-cobol">NEXT GROUP</code> clause refers to the next
-									<code class="language-cobol">DETAIL</code> group to be printed.
-								</p>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4 align="left">The TYPE clause</h4>
-							</td>
-							<td valign="top" width="525">
-								<p>
-									The TYPE clause specifies the type of the report group. The type of the report group
-									governs when and where will be printed in the the report (for instance, a
-									<code class="language-cobol">REPORT HEADING</code> group is printed only once - at
-									the beginning of the report).
-								</p>
-								<p><b>Rules</b></p>
-								<p>
-									Most groups are defined once for each report but control groups (other than CONTROL
-									..FINAL groups) are defined for each control break item.
-								</p>
-								<p>
-									In <code class="language-cobol">REPORT FOOTING</code>, and
-									<code class="language-cobol">CONTROL FOOTING</code> groups,
-									<code class="language-cobol">SOURCE</code> and
-									<code class="language-cobol">USE</code> clauses must not reference any data item
-									which contains a control break item or is subordinate to a control break item.
-								</p>
-								<p>
-									<code class="language-cobol">PAGE HEADING</code> or
-									<code class="language-cobol">FOOTING</code> groups must not reference a control
-									break item or any item subordinate to a control break item.
-								</p>
-								<p>
-									<code class="language-cobol">DETAIL</code> report groups are processed when they are
-									referenced in a <code class="language-cobol">GENERATE</code> statement. All other
-									groups are processed automatically by the Report Writer. There can be more than one
-									<code class="language-cobol">DETAIL</code> group.
-								</p>
-								<p>
-									The <code class="language-cobol">REPORT HEADING</code>,
-									<code class="language-cobol">PAGE HEADING</code>,
-									<code class="language-cobol">CONTROL HEADING FINAL</code>,
-									<code class="language-cobol">CONTROL FOOTING FINAL</code>,
-									<code class="language-cobol">PAGE FOOTING</code> and
-									<code class="language-cobol">REPORT FOOTING</code> report groups can each appear
-									only once in the description of a report.
-								</p>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#993300" colspan="2" valign="top">
-								<h2 align="center" id="part4">Defining the Report - Lines and Columns</h2>
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4 align="left">Introduction</h4>
-							</td>
-							<td valign="top" width="525">
-								<p>
-									The subordinate items in a report group record describe the report lines and columns
-									within the report group. There are two formats for defining items subordinate to the
-									report group record. The first is usually used to define the lines of the report
-									group and the second to define and position the elementary print items.
-								</p>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4 align="left">Defining Report Lines</h4>
-							</td>
-							<td valign="top" width="525">
-								<p>
-									Print lines in a report group are usually defined using the format shown below. This
-									format is used to specify the vertical placement of a print line and it is always
-									followed by subordinate items that specify the columns where the data items are to
-									be printed.
-								</p>
-								<p>As shown in the syntax diagram below the level number is from 2 to 48 inclusive.</p>
-								<p>
-									If the <i>ReportLineName</i> is used its only purpose is to qualify a sum counter
-									reference.
-								</p>
-								<p><img height="74" src="rwGroupDesc1.gif" width="364" /></p>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4 align="center">Defining Elementary print items in a report group</h4>
-							</td>
-							<td valign="top" width="525">
-								<p>
-									Elementary print items in the print line of a report group are described using the
-									syntactic elements shown in the diagram below.
-								</p>
-								<p>
-									As we can see from the syntax diagram, the normal data description clauses such as
-									<code class="language-cobol">PIC</code>, <code class="language-cobol">USAGE</code>,
-									<code class="language-cobol">SIGN</code>,
-									<code class="language-cobol">JUSTIFIED</code>,
-									<code class="language-cobol">BLANK WHEN ZERO</code> and
-									<code class="language-cobol">VALUE</code> may be applied when describing an
-									elementary print item. The Report Writer provides a number of additional clauses
-									that may also be used.
-								</p>
-								<p>
-									The <i>PrintItemName</i> can only be referenced if the entry uses the
-									<code class="language-cobol">SUM</code> clause to define a sum counter.
-								</p>
-								<p><img height="456" src="rwGroupDesc2.gif" width="413" /></p>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4 align="left">The COLUMN NUMBER clause</h4>
-							</td>
-							<td valign="top" width="525">
-								<p>
-									The <code class="language-cobol">COLUMN NUMBER</code> specifies the position of a
-									print item on the print line. When this clause is used it must be subordinate to an
-									item that contains a <code class="language-cobol">LINE NUMBER</code> clause.
-								</p>
-								<p>Within a given print line the <i>ColNum#l's</i> should be in ascending sequence.</p>
-								<p>
-									<i>ColNum#l</i> specifies the column number of the leftmost character position of
-									the print item.
-								</p>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>The GROUP INDICATE clause</h4>
-							</td>
-							<td valign="top" width="525">
-								<p>
-									The <code class="language-cobol">GROUP INDICATE</code> is used to specify that a
-									print item should be printed only on the first occurrence of its report group after
-									a control break or page advance.
-								</p>
-								<p>
-									For instance in the full version of the example program the CityName and
-									SalesPersonNum are suppressed after their first occurrence.
-								</p>
-								<table background="lectures/cobol/pics/code.gif" border="1" width="100%">
-									<tr>
-										<td>
-											<pre>01  DetailLine TYPE IS DETAIL.
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4 align="left">File Section entries</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							Although the entries in the
+							<code class="language-cobol">ENVIRONMENT DIVISION</code> are the same as those for
+							ordinary print files, in the File Section the normal file description is replaced by
+							phrase which points to the Report Description (RD) in the Report Section. The syntax
+							of the phrase is -
+						</p>
+						<p align="center"><img height="48" src="rwReportIS.gif" width="222" /></p>
+						<p>
+							The <i>ReportName</i> must be the same as the <i>ReportName</i> used in the Report
+							Description (RD) entry.
+						</p>
+						<p>
+							You can see this in the program fragment above where the <b>REPORT IS</b>
+							<b>SalesReport</b> phrase links the PrintFile with the Report Description(RD) in the
+							Report Section.
+						</p>
+						<p><b>Notes:</b></p>
+						<p>
+							Before the report can be used it must be opened for output. For instance in the
+							example above the PrintFile must be opened for output before the SalesReport can be
+							generated.
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-header">
+					<h2 align="center" id="part2">Defining the Report - Report Description (RD) Entries</h2>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Introduction</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							Every report generated by the Report Writer must have a Report Description (RD)
+							entry in the Report Section.
+						</p>
+						<p>
+							The RD entry names the report and specifies the format of the printed page and
+							identifies the control break items.
+						</p>
+						<p>
+							Each RD entry is followed by one or more 01 level-number entries. Each 01
+							level-number entry identifies a report group and consists of a hierarchical
+							structure similar to a COBOL record.
+						</p>
+						<p>
+							Each report group is a unit consisting of one or more print lines and cannot be
+							split across pages.
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4 align="left">The Report Description (RD) entries - Syntax</h4>
+					</div>
+					<div class="section-content">
+						<p>The syntax for the Report Description (RD) entries is shown below -</p>
+						<p align="center"><img height="277" src="rwRD.gif" width="360" /></p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4 align="left">The Report Description (RD) entries - Semantics</h4>
+					</div>
+					<div class="section-content">
+						<p align="center"><b>RD Rules</b></p>
+						<ol>
+							<li>The <i>ReportName</i> can only appear in one RD entry.</li>
+							<li>
+								When more than one report is declared in the Report Section the
+								<i>ReportName</i> can be used to qualify the LINE-COUNTER and PAGE-COUNTER
+								report registers.
+							</li>
+						</ol>
+						<hr width="50%" />
+						<p align="center"><b>CONTROL Rules</b></p>
+						<ol>
+							<li>The <i>ControlName$#i</i> must not be defined in the Report Section.</li>
+							<li>
+								Each occurrence of <i>ControlName$#i</i> must identify a different data item.
+							</li>
+							<li>
+								The <i>ControlName$#i</i> must not have a variable length table subordinate to
+								it.
+							</li>
+							<li>
+								<i>ControlName$#i</i> and FINAL specify the levels of the control break
+								hierarchy where FINAL (if specified) is the highest and the first
+								<i>ControlName$#i</i> the next highest and so on.
+							</li>
+							<li>
+								When the value in any <i>ControlName$#i</i> changes a control break occurs. The
+								level of the control break depends on the position of the
+								<i>ControlName$#i</i> in the control break hierarchy.
+							</li>
+						</ol>
+						<hr width="50%" />
+						<p align="center"><b>PAGE Rules</b></p>
+						<ol>
+							<li><i>HeadingLine#l</i> must be greater than or equal to 1.</li>
+							<li>
+								<i>HeadingLine#l</i> &lt;= <i>FirstDetailLine#l</i> &lt;=
+								<i>LastDetailLine#l</i> &lt;= <i>FootingLine#l</i> &lt;= <i>PageSize#l</i>
+							</li>
+							<li>
+								Line numbers used in a Report Heading or Page Heading group must be greater than
+								or equal to <i>HeadingLine#l</i> and less than <i>FirstDetailLine#l</i> but when
+								a Report Heading appears on a page by itself any line number between
+								<i>HeadingLine#l</i> and <i>PageSize#l</i> may be used.
+							</li>
+							<li>
+								Line numbers used in Detail or Control Heading groups must be in the range
+								<i>FirstDetailLine#l</i> to <i>LastDetailLine#l</i> inclusive.
+							</li>
+							<li>
+								Line numbers used in Control Footing groups must be in the range
+								<i>FirstDetailLine#l FootingLine#l</i> inclusive
+							</li>
+							<li>
+								Line numbers used in the Report Footing or Page Footing groups must be greater
+								than <i>FootingLine#l</i> and less than or equal to <i>PageSize#l</i> but when a
+								Report Footing appears on a page by itself any line number between
+								<i>HeadingLine#l</i> and <i>PageSize#l</i> may be used.
+							</li>
+							<li>
+								All report groups must be defined so that they can be presented on one page. The
+								Report Writer never splits a multi-line group across page boundaries.
+							</li>
+						</ol>
+						<hr />
+					</div>
+				</div>
+				<div class="section-header">
+					<h2 align="center" id="part3">Defining the Report - Report Group entries</h2>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Introduction</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							In the Report Section each report group is represented by a report group record. As
+							with all record descriptions in COBOL a report group record starts with level number
+							01. Subordinate items in the record describe the report lines and columns within the
+							report group.
+						</p>
+						<p>
+							The description of a report group consists of a number of hierarchic levels. At the
+							top must be the Report Group Definition.
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4 align="left">Defining a Report Group Record - Syntax</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							<b>Report Group Definition</b>
+						</p>
+						<p><img height="512" src="rwGroupType.gif" width="405" /></p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4 align="left"><i>ReportGroupName</i> Rules</h4>
+					</div>
+					<div class="section-content">
+						<p>The <i>ReportGroupName</i> is required only when the group -</p>
+						<ol>
+							<li>
+								is a detail group referenced by a
+								<code class="language-cobol">GENERATE</code> statement or the
+								<code class="language-cobol">UPON</code> phrase of a
+								<code class="language-cobol">SUM</code> clause.
+							</li>
+							<li>
+								is referenced in a
+								<code class="language-cobol">USE BEFORE REPORTING</code> sentence in the
+								Declaratives
+							</li>
+							<li>is required to qualify the reference to a sum counter.</li>
+						</ol>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4 align="left">The LINE NUMBER clause</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The <code class="language-cobol">LINE NUMBER</code> clause is used to specify the
+							vertical positioning of print lines. Lines can be printed on -
+						</p>
+						<ul>
+							<ul>
+								<li>a specified line (absolute)</li>
+								<li>a specified line on the next page (absolute)</li>
+								<li>the current line number plus some increment (relative)</li>
+							</ul>
+						</ul>
+						<p><b>Rules:</b></p>
+						<ol>
+							<li>
+								The <code class="language-cobol">LINE NUMBER</code> clause specifies where each
+								line is to be printed so no item that contains a
+								<code class="language-cobol">LINE NUMBER</code> clause may contain a subordinate
+								item that also contains a <code class="language-cobol">LINE NUMBER</code> clause
+								(subordinate items specify the column items).
+							</li>
+							<li>
+								Where absolute <code class="language-cobol">LINE NUMBER</code> clauses are
+								specified all absolute clauses must precede all relative clauses and the line
+								numbers specified in the successive absolute clauses must be in ascending order.
+							</li>
+							<li>
+								The first <code class="language-cobol">LINE NUMBER</code> clause specified in a
+								<code class="language-cobol">PAGE FOOTING</code> group must be absolute.
+							</li>
+							<li>
+								The <code class="language-cobol">NEXT PAGE</code> clause can only appear once in
+								a given report group description and it must be in the first
+								<code class="language-cobol">LINE NUMBER</code> clause in the report group.
+							</li>
+							<li>
+								The <code class="language-cobol">NEXT PAGE</code> clause cannot appear in any
+								<code class="language-cobol">HEADING</code> group.
+							</li>
+						</ol>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4 align="left">The NEXT GROUP clause</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The <code class="language-cobol">NEXT GROUP</code> clause is used to specify the
+							vertical positioning of the start of the next group. The
+							<code class="language-cobol">NEXT GROUP</code> clause can be used to specify that
+							the next report groups should be printed on -
+						</p>
+						<ul>
+							<ul>
+								<li>a specified line (absolute)</li>
+								<li>the current line number plus some increment (relative)</li>
+								<li>the next page</li>
+							</ul>
+						</ul>
+						<p><b>Rules</b></p>
+						<p>
+							The <code class="language-cobol">NEXT PAGE</code> option in the
+							<code class="language-cobol">NEXT GROUP</code> clause must not be specified in a
+							page footing.
+						</p>
+						<p>
+							The <code class="language-cobol">NEXT GROUP</code> clause must not be specified in a
+							<code class="language-cobol">REPORT FOOTING</code> or
+							<code class="language-cobol">PAGE HEADING</code> group.
+						</p>
+						<p>
+							When used in a <code class="language-cobol">DETAIL</code> group the
+							<code class="language-cobol">NEXT GROUP</code> clause refers to the next
+							<code class="language-cobol">DETAIL</code> group to be printed.
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4 align="left">The TYPE clause</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The TYPE clause specifies the type of the report group. The type of the report group
+							governs when and where will be printed in the the report (for instance, a
+							<code class="language-cobol">REPORT HEADING</code> group is printed only once - at
+							the beginning of the report).
+						</p>
+						<p><b>Rules</b></p>
+						<p>
+							Most groups are defined once for each report but control groups (other than CONTROL
+							..FINAL groups) are defined for each control break item.
+						</p>
+						<p>
+							In <code class="language-cobol">REPORT FOOTING</code>, and
+							<code class="language-cobol">CONTROL FOOTING</code> groups,
+							<code class="language-cobol">SOURCE</code> and
+							<code class="language-cobol">USE</code> clauses must not reference any data item
+							which contains a control break item or is subordinate to a control break item.
+						</p>
+						<p>
+							<code class="language-cobol">PAGE HEADING</code> or
+							<code class="language-cobol">FOOTING</code> groups must not reference a control
+							break item or any item subordinate to a control break item.
+						</p>
+						<p>
+							<code class="language-cobol">DETAIL</code> report groups are processed when they are
+							referenced in a <code class="language-cobol">GENERATE</code> statement. All other
+							groups are processed automatically by the Report Writer. There can be more than one
+							<code class="language-cobol">DETAIL</code> group.
+						</p>
+						<p>
+							The <code class="language-cobol">REPORT HEADING</code>,
+							<code class="language-cobol">PAGE HEADING</code>,
+							<code class="language-cobol">CONTROL HEADING FINAL</code>,
+							<code class="language-cobol">CONTROL FOOTING FINAL</code>,
+							<code class="language-cobol">PAGE FOOTING</code> and
+							<code class="language-cobol">REPORT FOOTING</code> report groups can each appear
+							only once in the description of a report.
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-header">
+					<h2 align="center" id="part4">Defining the Report - Lines and Columns</h2>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4 align="left">Introduction</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The subordinate items in a report group record describe the report lines and columns
+							within the report group. There are two formats for defining items subordinate to the
+							report group record. The first is usually used to define the lines of the report
+							group and the second to define and position the elementary print items.
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4 align="left">Defining Report Lines</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							Print lines in a report group are usually defined using the format shown below. This
+							format is used to specify the vertical placement of a print line and it is always
+							followed by subordinate items that specify the columns where the data items are to
+							be printed.
+						</p>
+						<p>As shown in the syntax diagram below the level number is from 2 to 48 inclusive.</p>
+						<p>
+							If the <i>ReportLineName</i> is used its only purpose is to qualify a sum counter
+							reference.
+						</p>
+						<p><img height="74" src="rwGroupDesc1.gif" width="364" /></p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4 align="center">Defining Elementary print items in a report group</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							Elementary print items in the print line of a report group are described using the
+							syntactic elements shown in the diagram below.
+						</p>
+						<p>
+							As we can see from the syntax diagram, the normal data description clauses such as
+							<code class="language-cobol">PIC</code>, <code class="language-cobol">USAGE</code>,
+							<code class="language-cobol">SIGN</code>,
+							<code class="language-cobol">JUSTIFIED</code>,
+							<code class="language-cobol">BLANK WHEN ZERO</code> and
+							<code class="language-cobol">VALUE</code> may be applied when describing an
+							elementary print item. The Report Writer provides a number of additional clauses
+							that may also be used.
+						</p>
+						<p>
+							The <i>PrintItemName</i> can only be referenced if the entry uses the
+							<code class="language-cobol">SUM</code> clause to define a sum counter.
+						</p>
+						<p><img height="456" src="rwGroupDesc2.gif" width="413" /></p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4 align="left">The COLUMN NUMBER clause</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The <code class="language-cobol">COLUMN NUMBER</code> specifies the position of a
+							print item on the print line. When this clause is used it must be subordinate to an
+							item that contains a <code class="language-cobol">LINE NUMBER</code> clause.
+						</p>
+						<p>Within a given print line the <i>ColNum#l's</i> should be in ascending sequence.</p>
+						<p>
+							<i>ColNum#l</i> specifies the column number of the leftmost character position of
+							the print item.
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>The GROUP INDICATE clause</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The <code class="language-cobol">GROUP INDICATE</code> is used to specify that a
+							print item should be printed only on the first occurrence of its report group after
+							a control break or page advance.
+						</p>
+						<p>
+							For instance in the full version of the example program the CityName and
+							SalesPersonNum are suppressed after their first occurrence.
+						</p>
+						<pre>01  DetailLine TYPE IS DETAIL.
     02 LINE IS PLUS 1.
        03 COLUMN 1      PIC X(9)
                         SOURCE CityName(CityCode) <span style="color: #FF0000"><b>GROUP INDICATE</b></span>.
        03 COLUMN 15     PIC 9
                         SOURCE SalesPersonNum  <b><span style="color: #FF0000">GROUP INDICATE</span></b>.
        03 COLUMN 25     PIC $$,$$$.99 SOURCE ValueOfSale.</pre>
-										</td>
-									</tr>
-								</table>
-								<p>
-									The <code class="language-cobol">GROUP INDICATE</code> clause can only appear in a
-									<code class="language-cobol">DETAIL</code> report group
-								</p>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>The SOURCE clause</h4>
-							</td>
-							<td valign="top" width="525">
-								<p>
-									The SOURCE clause is used to identify a data item that contains the value to be used
-									when the print-item is printed. For instance, the SOURCE <i>ValueOfSale</i> clause
-									in the example above specifies that the value of the item to be printed in column 25
-									is to be found in the data-item ValueOfSale.
-								</p>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>The SUM clause</h4>
-							</td>
-							<td valign="top" width="525">
-								<p>
-									The SUM clause is used both to establish a sum counter and to name the data-items to
-									be summed.
-								</p>
-								<p>Three forms of summing can be done in the Report Writer;</p>
-								<ol>
-									<ol>
-										<li>Subtotalling</li>
-										<li>Rolling Forward</li>
-										<li>Cross footing</li>
-									</ol>
-								</ol>
-								<hr />
-								<h4><b>Subtotalling</b></h4>
-								<p>
-									In Subtotalling, each time a <code class="language-cobol">GENERATE</code> statement
-									is executed the value to be summed is added to the sum counter.
-								</p>
-								<hr />
-								<h4><b>Rolling Forward</b></h4>
-								<p>
-									In Rolling Forward the value accumulated in the sum counter of one group is used as
-									the value to be summed in the sum counter of another group.
-								</p>
-								<p>
-									The full version of the example program contains a good example of both Subtotalling
-									and Rolling forward. The SUM clause is used to accumulate the ValueOfSale into a sum
-									counter named as SMS (Subtotalling). The SMS sum counter is used as the value to be
-									summed into the CS sum counter and CS is used as the value to be summed into the
-									final total (Rolling Forward).
-								</p>
-								<p>
-									In the example code fragment below, each time a
-									<code class="language-cobol">DETAIL</code> line is
-									<code class="language-cobol">GENERATED</code> the ValueOf Sale is added to the SMS
-									sum counter. When a control break occurs on SalesPersonNum the accumulated sum is
-									printed and is added to the CS sum counter. When a control break occurs on the
-									CityCode the sum accumulated in the CS sum counter is added to the final total sum
-									counter.
-								</p>
-								<table background="lectures/cobol/pics/code.gif" border="1" width="100%">
-									<tr>
-										<td>
-											<pre>01  SalesPersonGrp
+						<p>
+							The <code class="language-cobol">GROUP INDICATE</code> clause can only appear in a
+							<code class="language-cobol">DETAIL</code> report group
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>The SOURCE clause</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The SOURCE clause is used to identify a data item that contains the value to be used
+							when the print-item is printed. For instance, the SOURCE <i>ValueOfSale</i> clause
+							in the example above specifies that the value of the item to be printed in column 25
+							is to be found in the data-item ValueOfSale.
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>The SUM clause</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The SUM clause is used both to establish a sum counter and to name the data-items to
+							be summed.
+						</p>
+						<p>Three forms of summing can be done in the Report Writer;</p>
+						<ol>
+							<ol>
+								<li>Subtotalling</li>
+								<li>Rolling Forward</li>
+								<li>Cross footing</li>
+							</ol>
+						</ol>
+						<hr />
+						<h4><b>Subtotalling</b></h4>
+						<p>
+							In Subtotalling, each time a <code class="language-cobol">GENERATE</code> statement
+							is executed the value to be summed is added to the sum counter.
+						</p>
+						<hr />
+						<h4><b>Rolling Forward</b></h4>
+						<p>
+							In Rolling Forward the value accumulated in the sum counter of one group is used as
+							the value to be summed in the sum counter of another group.
+						</p>
+						<p>
+							The full version of the example program contains a good example of both Subtotalling
+							and Rolling forward. The SUM clause is used to accumulate the ValueOfSale into a sum
+							counter named as SMS (Subtotalling). The SMS sum counter is used as the value to be
+							summed into the CS sum counter and CS is used as the value to be summed into the
+							final total (Rolling Forward).
+						</p>
+						<p>
+							In the example code fragment below, each time a
+							<code class="language-cobol">DETAIL</code> line is
+							<code class="language-cobol">GENERATED</code> the ValueOf Sale is added to the SMS
+							sum counter. When a control break occurs on SalesPersonNum the accumulated sum is
+							printed and is added to the CS sum counter. When a control break occurs on the
+							CityCode the sum accumulated in the CS sum counter is added to the final total sum
+							counter.
+						</p>
+						<pre>01  SalesPersonGrp
     TYPE IS CONTROL FOOTING SalesPersonNum  NEXT GROUP PLUS 2.
                       :<i> other entries</i> :
                       :<i> other entries</i> :
@@ -901,23 +851,17 @@ REPORT SECTION.
                       :<i> other entries</i> :
                       :<i> other entries</i> :
        03 COLUMN 45     PIC $$$$$,$$$.99 <b><span style="color: #FF0000">SUM CS</span></b>.</pre>
-										</td>
-									</tr>
-								</table>
-								<hr />
-								<h4><b>Cross Footing</b></h4>
-								<p>
-									In Cross Footing sum counters in the same report group can be added together. In the
-									example below, each time a GENERATE statement is executed the value of the
-									SalesPersonSale is added to the SPS sum counter and the value of CounterSale is
-									added to SCS (Subtotalling). When a control break occurs on ShopNum the values of
-									the SPS and SCS sum counters are added together to give the combined total printed
-									in column 60 (Cross Footing).
-								</p>
-								<table background="lectures/cobol/pics/code.gif" border="1" width="100%">
-									<tr>
-										<td>
-											<pre>01  ShopTotalsGrp
+						<hr />
+						<h4><b>Cross Footing</b></h4>
+						<p>
+							In Cross Footing sum counters in the same report group can be added together. In the
+							example below, each time a GENERATE statement is executed the value of the
+							SalesPersonSale is added to the SPS sum counter and the value of CounterSale is
+							added to SCS (Subtotalling). When a control break occurs on ShopNum the values of
+							the SPS and SCS sum counters are added together to give the combined total printed
+							in column 60 (Cross Footing).
+						</p>
+						<pre>01  ShopTotalsGrp
     TYPE IS CONTROL FOOTING ShopNum  NEXT GROUP PLUS 2.
                       :<i> other entries</i> :
                       :<i> other entries</i> :
@@ -925,438 +869,394 @@ REPORT SECTION.
        03 <span style="color: #FF0000"><b>SCS</b></span> COLUMN 40 PIC $$$,$$$.99  <span style="color: #FF0000"><b>SUM CounterSale</b></span>.
        03     COLUMN 60 PIC $$$$,$$$.99 <span style="color: #FF0000"><b>SUM SPS, SCS</b></span>.
 </pre>
-										</td>
-									</tr>
-								</table>
-								<h4>Rules</h4>
-								<ol>
-									<li>
-										If the the SUM..UPON <i>ReportGroupName</i> clause is used then the value is
-										only added to the sum counter when the specified report group is printed.
-									</li>
-									<li>
-										A SUM clause can appear only in the description of a
-										<code class="language-cobol">CONTROL FOOTING</code> report group.
-									</li>
-									<li>
-										Statements in the Procedure Division can be used to alter the contents of the
-										sum counters.
-									</li>
-								</ol>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>The RESET ON clause</h4>
-							</td>
-							<td valign="top" width="525">
-								<p>
-									Sum counters are normally reset to zero after a control break on the control break
-									item associated with the report group but the
-									<code class="language-cobol">RESET</code> clause can be used to reset the sum
-									counters on the break of a more senior control item.
-								</p>
-								<h4>Rules</h4>
-								<ol>
-									<li>
-										The <i>ControlBreakItem#$i</i> must be one of the data items mentioned in the
-										CONTROL/CONTROLS clause in the Report Description.
-									</li>
-								</ol>
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-								<h2 align="center" id="part5">Special Report Writer registers</h2>
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>Introduction</h4>
-							</td>
-							<td valign="top" width="525">
-								<div align="center">
-									<p align="left">
-										The Report Writer maintains two special registers for each report declared in
-										the Report Section. The two registers are -
-									</p>
-								</div>
-								<div align="left">
-									<blockquote>
-										<blockquote>
-											<blockquote>
-												<p align="center">
-													the LINE-COUNTER<br />
-													and<br />
-													the PAGE-COUNTER
-												</p>
-											</blockquote>
-										</blockquote>
-									</blockquote>
-								</div>
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>The LINE-COUNTER register</h4>
-							</td>
-							<td valign="top" width="525">
-								<p align="left">
-									The reserved word <code class="language-cobol">LINE-COUNTER</code> can be used to
-									access a special register that the Report Writer maintains for each report in the
-									Report Section.
-								</p>
-								<p align="left">
-									The Report Writer uses the <code class="language-cobol">LINE-COUNTER</code> register
-									to keep track of where the lines are being printed on the report. It uses this
-									information and the information specified in the
-									<code class="language-cobol">PAGE LIMIT</code> clause in the RD entry to decide when
-									a new page is required.
-								</p>
-								<p align="left">
-									While the <code class="language-cobol">LINE-COUNTER</code> register can be used as a
-									<code class="language-cobol">SOURCE</code> item in the report no statements in the
-									Procedure Division can alter the value in the register.
-								</p>
-								<p align="left">
-									References to the <code class="language-cobol">LINE-COUNTER</code> register can be
-									qualified by referring to the name of the report given in the RD entry.
-								</p>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>The PAGE-COUNTER register</h4>
-							</td>
-							<td valign="top" width="525">
-								<div align="center">
-									<p align="left">
-										The reserved word <code class="language-cobol">PAGE-COUNTER</code> can be used
-										to access a special register that the Report Writer maintains for each report in
-										the Report Section.
-									</p>
-									<p align="left">
-										The <code class="language-cobol">PAGE-COUNTER</code> is used to count the number
-										of pages in the report.
-									</p>
-									<p align="left">
-										The <code class="language-cobol">PAGE-COUNTER</code> register can be used as a
-										<code class="language-cobol">SOURCE</code> item in the report but the value of
-										the <code class="language-cobol">PAGE-COUNTER</code> may also be changed by
-										statements in the Procedure Division.
-									</p>
-									<table background="lectures/cobol/pics/code.gif" border="1" width="100%">
-										<tr>
-											<td>
-												<pre>01  TYPE IS PAGE FOOTING.
+						<h4>Rules</h4>
+						<ol>
+							<li>
+								If the the SUM..UPON <i>ReportGroupName</i> clause is used then the value is
+								only added to the sum counter when the specified report group is printed.
+							</li>
+							<li>
+								A SUM clause can appear only in the description of a
+								<code class="language-cobol">CONTROL FOOTING</code> report group.
+							</li>
+							<li>
+								Statements in the Procedure Division can be used to alter the contents of the
+								sum counters.
+							</li>
+						</ol>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>The RESET ON clause</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							Sum counters are normally reset to zero after a control break on the control break
+							item associated with the report group but the
+							<code class="language-cobol">RESET</code> clause can be used to reset the sum
+							counters on the break of a more senior control item.
+						</p>
+						<h4>Rules</h4>
+						<ol>
+							<li>
+								The <i>ControlBreakItem#$i</i> must be one of the data items mentioned in the
+								CONTROL/CONTROLS clause in the Report Description.
+							</li>
+						</ol>
+					</div>
+				</div>
+				<div class="section-header">
+					<h2 align="center" id="part5">Special Report Writer registers</h2>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Introduction</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The Report Writer maintains two special registers for each report declared in the
+							Report Section. The two registers are -
+						</p>
+						<p align="center">
+							the LINE-COUNTER<br />
+							and<br />
+							the PAGE-COUNTER
+						</p>
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>The LINE-COUNTER register</h4>
+					</div>
+					<div class="section-content">
+						<p align="left">
+							The reserved word <code class="language-cobol">LINE-COUNTER</code> can be used to
+							access a special register that the Report Writer maintains for each report in the
+							Report Section.
+						</p>
+						<p align="left">
+							The Report Writer uses the <code class="language-cobol">LINE-COUNTER</code> register
+							to keep track of where the lines are being printed on the report. It uses this
+							information and the information specified in the
+							<code class="language-cobol">PAGE LIMIT</code> clause in the RD entry to decide when
+							a new page is required.
+						</p>
+						<p align="left">
+							While the <code class="language-cobol">LINE-COUNTER</code> register can be used as a
+							<code class="language-cobol">SOURCE</code> item in the report no statements in the
+							Procedure Division can alter the value in the register.
+						</p>
+						<p align="left">
+							References to the <code class="language-cobol">LINE-COUNTER</code> register can be
+							qualified by referring to the name of the report given in the RD entry.
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>The PAGE-COUNTER register</h4>
+					</div>
+					<div class="section-content">
+						<p align="left">
+							The reserved word <code class="language-cobol">PAGE-COUNTER</code> can be used to
+							access a special register that the Report Writer maintains for each report in the
+							Report Section.
+						</p>
+						<p align="left">
+							The <code class="language-cobol">PAGE-COUNTER</code> is used to count the number of
+							pages in the report.
+						</p>
+						<p align="left">
+							The <code class="language-cobol">PAGE-COUNTER</code> register can be used as a
+							<code class="language-cobol">SOURCE</code> item in the report but the value of the
+							<code class="language-cobol">PAGE-COUNTER</code> may also be changed by statements
+							in the Procedure Division.
+						</p>
+						<pre>01  TYPE IS PAGE FOOTING.
     02 LINE IS 53.
-       03 COLUMN 1      PIC X(29) 
+       03 COLUMN 1      PIC X(29)
                         VALUE "Programmer - Michael Coughlan".
        03 COLUMN 45     PIC X(6) VALUE "Page :".
        03 COLUMN 52     PIC Z9 SOURCE<b><span style="color: #FF0000"> PAGE-COUNTER.</span></b></pre>
-											</td>
-										</tr>
-									</table>
-								</div>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#993300" colspan="2" valign="top" width="700">
-								<h2 align="center" id="part6">Procedure Division verbs</h2>
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>Introduction</h4>
-							</td>
-							<td valign="top" width="525">
-								<div align="center">
-									<p align="left">
-										The Report Writer introduces four new verbs for processing reports. These are -
-									</p>
-								</div>
-								<div align="left">
+						<hr />
+					</div>
+				</div>
+				<div class="section-header">
+					<h2 align="center" id="part6">Procedure Division verbs</h2>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Introduction</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The Report Writer introduces four new verbs for processing reports. These are -
+						</p>
+						<ol>
+							<ol>
+								<ol>
 									<ol>
-										<ol>
-											<ol>
-												<ol>
-													<li>INITIATE</li>
-													<li>GENERATE</li>
-													<li>TERMINATE</li>
-													<li>SUPPRESS PRINTING</li>
-												</ol>
-											</ol>
-										</ol>
+										<li>INITIATE</li>
+										<li>GENERATE</li>
+										<li>TERMINATE</li>
+										<li>SUPPRESS PRINTING</li>
 									</ol>
-								</div>
-								<div align="center">
-									<p align="left">
-										The first three are normal Procedure Division verbs but the last can only be
-										used in the Declaratives Section.
-									</p>
-									<p align="left">
-										The normal Procedure Division verbs will be covered in this section. Please see
-										the section on Declaratives for the
-										<code class="language-cobol">SUPPRESS PRINTING</code> statement.
-									</p>
-								</div>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>Syntax</h4>
-							</td>
-							<td valign="top" width="525">
-								<p><img height="144" src="rwVerbs.gif" width="238" /></p>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>INITIATE</h4>
-							</td>
-							<td valign="top" width="525">
-								<p>
-									The <code class="language-cobol">INITIATE</code> statement starts the processing of
-									the <i>ReportName</i> report or reports.
-								</p>
-								<p>
-									The <i>ReportName</i> must be the name defined for a report in the RD entry in the
-									Report Section.
-								</p>
-								<p>The <code class="language-cobol">INITIATE</code> statement initializes -</p>
-								<ul>
-									<li>all the report's sum counters to zero</li>
-									<li>the report <code class="language-cobol">LINE-COUNTER</code> to zero</li>
-									<li>the report <code class="language-cobol">PAGE-COUNTER</code> to one</li>
-								</ul>
-								<p>
-									Before the <code class="language-cobol">INITIATE</code> statement is executed the
-									file associated with the Report must have been opened for
-									<code class="language-cobol">OUTPUT</code> or
-									<code class="language-cobol">EXTEND</code>.
-								</p>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>GENERATE</h4>
-							</td>
-							<td valign="top" width="525">
-								<p>
-									The <code class="language-cobol">GENERATE</code> statement drives the production of
-									the report.
-								</p>
-								<p>
-									The target of a <code class="language-cobol">GENERATE</code> statement is either a
-									<code class="language-cobol">DETAIL</code> report group or a Report Name.
-								</p>
-								<p>When the target is a <i>ReportName</i> then the report description must contain -</p>
-								<ul>
-									<li>a <code class="language-cobol">CONTROL</code> clause</li>
-									<li>not more than one <code class="language-cobol">DETAIL</code> group</li>
-									<li>
-										at least one group that is not a <code class="language-cobol">PAGE</code> or
-										<code class="language-cobol">REPORT</code> group.
-									</li>
-								</ul>
-								<p>
-									When all the <code class="language-cobol">GENERATE</code> statements for a
-									particular report target the <i>ReportName</i> then the report performs summary
-									processing only and the report produced is called a summary report. For instance to
-									make a summary report from the example report all we have to to is to change the
-									<code class="language-cobol">GENERATE</code> statement from -
-								</p>
+								</ol>
+							</ol>
+						</ol>
+						<p>
+							The first three are normal Procedure Division verbs but the last can only be
+							used in the Declaratives Section.
+						</p>
+						<p>
+							The normal Procedure Division verbs will be covered in this section. Please see
+							the section on Declaratives for the
+							<code class="language-cobol">SUPPRESS PRINTING</code> statement.
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Syntax</h4>
+					</div>
+					<div class="section-content">
+						<p><img height="144" src="rwVerbs.gif" width="238" /></p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>INITIATE</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The <code class="language-cobol">INITIATE</code> statement starts the processing of
+							the <i>ReportName</i> report or reports.
+						</p>
+						<p>
+							The <i>ReportName</i> must be the name defined for a report in the RD entry in the
+							Report Section.
+						</p>
+						<p>The <code class="language-cobol">INITIATE</code> statement initializes -</p>
+						<ul>
+							<li>all the report's sum counters to zero</li>
+							<li>the report <code class="language-cobol">LINE-COUNTER</code> to zero</li>
+							<li>the report <code class="language-cobol">PAGE-COUNTER</code> to one</li>
+						</ul>
+						<p>
+							Before the <code class="language-cobol">INITIATE</code> statement is executed the
+							file associated with the Report must have been opened for
+							<code class="language-cobol">OUTPUT</code> or
+							<code class="language-cobol">EXTEND</code>.
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>GENERATE</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The <code class="language-cobol">GENERATE</code> statement drives the production of
+							the report.
+						</p>
+						<p>
+							The target of a <code class="language-cobol">GENERATE</code> statement is either a
+							<code class="language-cobol">DETAIL</code> report group or a Report Name.
+						</p>
+						<p>When the target is a <i>ReportName</i> then the report description must contain -</p>
+						<ul>
+							<li>a <code class="language-cobol">CONTROL</code> clause</li>
+							<li>not more than one <code class="language-cobol">DETAIL</code> group</li>
+							<li>
+								at least one group that is not a <code class="language-cobol">PAGE</code> or
+								<code class="language-cobol">REPORT</code> group.
+							</li>
+						</ul>
+						<p>
+							When all the <code class="language-cobol">GENERATE</code> statements for a
+							particular report target the <i>ReportName</i> then the report performs summary
+							processing only and the report produced is called a summary report. For instance to
+							make a summary report from the example report all we have to to is to change the
+							<code class="language-cobol">GENERATE</code> statement from -
+						</p>
+						<blockquote>
+							<blockquote>
 								<blockquote>
 									<blockquote>
+										<p>GENERATE DetailLine.</p>
 										<blockquote>
 											<blockquote>
-												<p>GENERATE DetailLine.</p>
-												<blockquote>
-													<blockquote>
-														<p>to</p>
-													</blockquote>
-												</blockquote>
-												<p>GENERATE SalesReport.</p>
+												<p>to</p>
 											</blockquote>
 										</blockquote>
+										<p>GENERATE SalesReport.</p>
 									</blockquote>
 								</blockquote>
-								<p>
-									If we specify <code class="language-cobol">GENERATE</code> SalesReport then the
-									<code class="language-cobol">DETAIL</code> group is never printed but the other
-									groups are printed (see the first page of the summary report shown below).
-								</p>
-								<hr />
-								<table background="lectures/cobol/pics/code.gif" border="0" width="100%">
-									<tr>
-										<td valign="top">
-											<pre>
-          An example COBOL Report Program              
-     Bible Salesperson - Sales and Salary Report        
-                                                        
- City      Salesperson     Sale                         
- Name       Number         Value                        
+							</blockquote>
+						</blockquote>
+						<p>
+							If we specify <code class="language-cobol">GENERATE</code> SalesReport then the
+							<code class="language-cobol">DETAIL</code> group is never printed but the other
+							groups are printed (see the first page of the summary report shown below).
+						</p>
+						<hr />
+						<pre>
+          An example COBOL Report Program
+     Bible Salesperson - Sales and Salary Report
+
+ City      Salesperson     Sale
+ Name       Number         Value
               Sales for salesperson 1     =      $334.00
               Sales commission is         =       $16.70
               Salesperson salary is       =      $139.70
-              Current  salesperson number = 2           
-              Previous salesperson number = 1           
-                                                        
-                                                        
+              Current  salesperson number = 2
+              Previous salesperson number = 1
+
+
               Sales for salesperson 2     =    $3,667.50
               Sales commission is         =      $183.38
               Salesperson salary is       =      $504.38
-              Current  salesperson number = 3           
-              Previous salesperson number = 2           
-                                                        
-                                                        
+              Current  salesperson number = 3
+              Previous salesperson number = 2
+
+
               Sales for salesperson 3     =      $777.70
               Sales commission is         =       $38.89
               Salesperson salary is       =      $473.89
-              Current  salesperson number = 1           
-              Previous salesperson number = 3           
-                                                        
+              Current  salesperson number = 1
+              Previous salesperson number = 3
+
               Sales for Dublin            =    $4,779.20
-              Current city                = 2           
-              Previous city               = 1           
-                                                        
-                                                        
+              Current city                = 2
+              Previous city               = 1
+
+
               Sales for salesperson 1     =      $334.00
               Sales commission is         =       $16.70
               Salesperson salary is       =      $139.70
-              Current  salesperson number = 2           
-              Previous salesperson number = 1           
-                                                        
-                                                        
+              Current  salesperson number = 2
+              Previous salesperson number = 1
+
+
               Sales for salesperson 2     =    $2,334.00
               Sales commission is         =      $116.70
               Salesperson salary is       =      $458.70
-              Current  salesperson number = 3           
-              Previous salesperson number = 2           
-                                                        
-                                                        
+              Current  salesperson number = 3
+              Previous salesperson number = 2
+
+
               Sales for salesperson 3     =      $222.20
               Sales commission is         =       $11.11
               Salesperson salary is       =      $122.11
-              Current  salesperson number = 4           
-              Previous salesperson number = 3           
-                                                        
-                                                        
-                                                        
-Programmer - Michael Coughlan               Page :  1   
-                                                        
-  </pre
-											>
-										</td>
-									</tr>
-								</table>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>TERMINATE</h4>
-							</td>
-							<td valign="top" width="525">
-								<p>
-									The <code class="language-cobol">TERMINATE</code> statement instructs the Report
-									Writer to complete the processing of the specified report. The Report Writer prints
-									the Page and Report Footings and all the
-									<code class="language-cobol">CONTROL FOOTING</code> groups are printed as if there
-									had been a control break on the most senior control group.
-								</p>
-								<p>
-									After the report has been terminated the file associated with the report must be
-									closed. For instance in the example program the
-									<i>TERMINATE SalesReport</i> statement is followed by the
-									<i>CLOSE PrintFile</i> statement.
-								</p>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#993300" colspan="2" valign="top">
-								<h2 align="center" id="part7">Report Writer Declaratives</h2>
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>Introduction</h4>
-							</td>
-							<td valign="top" width="525">
-								<p>
-									Declaratives are used to extend the functionality of the Report Writer when its
-									standard operations are insufficient of create the desired report. Declaratives
-									extend the functionality of the Report Writer by performing tasks or calculations
-									that the Report Writer can not do automatically or by selectively stopping the
-									report group from being printed (using the
-									<code class="language-cobol">SUPPRESS PRINTING</code> command).
-								</p>
-								<p>
-									When Declaratives are used with the Report Writer the
-									<code class="language-cobol">USE BEFORE REPORTING</code> phrase allows a programmer
-									to specify that the particular section of code is to be executed before some report
-									group is printed.
-								</p>
-								<p>
-									Declaratives may also be used to handle file operation errors. In this case the USE
-									clause should use the following syntax -
-								</p>
-								<p align="center"><img height="173" src="rwUSE1.gif" width="495" /></p>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>Using Declaratives with the Report Writer</h4>
-							</td>
-							<td valign="top" width="525">
-								<p>
-									When Declaratives are used they must appear as the first item in the Procedure
-									Division.
-								</p>
-								<p>
-									The Declaratives must be divided into sections and each section must be associated
-									with a particular USE statement.
-								</p>
-								<p>The USE statement governs when a particular declarative section is executed.</p>
-								<p>
-									When Declaratives are used with the Report Writer the USE syntax shown below must be
-									used
-								</p>
-								<p align="center"><img height="22" src="rwUSE2.gif" width="402" /></p>
-								<p align="left"><b>Rules:</b></p>
-								<p align="left">The ReportGroupName must not appear in more than one USE statement.</p>
-								<p align="left">
-									The <code class="language-cobol">GENERATE</code>,
-									<code class="language-cobol">INITIATE</code> and
-									<code class="language-cobol">TERMINATE</code> statements must not appear in the
-									Declaratives.
-								</p>
-								<p align="left">
-									The value of any control data items must not be altered in the Declaratives.
-								</p>
-								<p align="left">
-									Statements in the Declaratives must not reference non-declarative procedures.
-								</p>
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>Declaratives Example</h4>
-							</td>
-							<td valign="top" width="525">
-								<div align="center">
-									<table background="lectures/cobol/pics/code.gif" border="1" width="90%">
-										<tr>
-											<td>
-												<pre>PROCEDURE DIVISION.
+              Current  salesperson number = 4
+              Previous salesperson number = 3
+
+
+
+Programmer - Michael Coughlan               Page :  1
+
+  </pre>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>TERMINATE</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The <code class="language-cobol">TERMINATE</code> statement instructs the Report
+							Writer to complete the processing of the specified report. The Report Writer prints
+							the Page and Report Footings and all the
+							<code class="language-cobol">CONTROL FOOTING</code> groups are printed as if there
+							had been a control break on the most senior control group.
+						</p>
+						<p>
+							After the report has been terminated the file associated with the report must be
+							closed. For instance in the example program the
+							<i>TERMINATE SalesReport</i> statement is followed by the
+							<i>CLOSE PrintFile</i> statement.
+						</p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-header">
+					<h2 align="center" id="part7">Report Writer Declaratives</h2>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Introduction</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							Declaratives are used to extend the functionality of the Report Writer when its
+							standard operations are insufficient of create the desired report. Declaratives
+							extend the functionality of the Report Writer by performing tasks or calculations
+							that the Report Writer can not do automatically or by selectively stopping the
+							report group from being printed (using the
+							<code class="language-cobol">SUPPRESS PRINTING</code> command).
+						</p>
+						<p>
+							When Declaratives are used with the Report Writer the
+							<code class="language-cobol">USE BEFORE REPORTING</code> phrase allows a programmer
+							to specify that the particular section of code is to be executed before some report
+							group is printed.
+						</p>
+						<p>
+							Declaratives may also be used to handle file operation errors. In this case the USE
+							clause should use the following syntax -
+						</p>
+						<p align="center"><img height="173" src="rwUSE1.gif" width="495" /></p>
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Using Declaratives with the Report Writer</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							When Declaratives are used they must appear as the first item in the Procedure
+							Division.
+						</p>
+						<p>
+							The Declaratives must be divided into sections and each section must be associated
+							with a particular USE statement.
+						</p>
+						<p>The USE statement governs when a particular declarative section is executed.</p>
+						<p>
+							When Declaratives are used with the Report Writer the USE syntax shown below must be
+							used
+						</p>
+						<p align="center"><img height="22" src="rwUSE2.gif" width="402" /></p>
+						<p align="left"><b>Rules:</b></p>
+						<p align="left">The ReportGroupName must not appear in more than one USE statement.</p>
+						<p align="left">
+							The <code class="language-cobol">GENERATE</code>,
+							<code class="language-cobol">INITIATE</code> and
+							<code class="language-cobol">TERMINATE</code> statements must not appear in the
+							Declaratives.
+						</p>
+						<p align="left">
+							The value of any control data items must not be altered in the Declaratives.
+						</p>
+						<p align="left">
+							Statements in the Declaratives must not reference non-declarative procedures.
+						</p>
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Declaratives Example</h4>
+					</div>
+					<div class="section-content">
+						<pre>PROCEDURE DIVISION.
 <b><span style="color: #FF0000">DECLARATIVES.
 Calc SECTION.
     USE BEFORE REPORTING SalesPersonGrp.
@@ -1373,39 +1273,32 @@ Begin.
     OPEN OUTPUT PrintFile.
        : etc :
        : etc : </pre>
-											</td>
-										</tr>
-									</table>
-								</div>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>The SUPPRESS PRINTING statement</h4>
-							</td>
-							<td valign="top" width="525">
-								<p>
-									The <code class="language-cobol">SUPPRESS PRINTING</code> statement is used in a
-									Declarative section to stop a particular report group from being printed.
-								</p>
-								<p align="left">
-									The report group suppressed is the one mentioned in the USE statement associated
-									with the section containing the
-									<code class="language-cobol">SUPPRESS PRINTING</code> statement.
-								</p>
-								<p align="left">
-									The <code class="language-cobol">SUPPRESS PRINTING</code> statement must be executed
-									each time you want to stop the report group from being printed.
-								</p>
-								<p align="left">
-									In the example below we only want to print the ShopTotalGrp if the sales for the
-									shop are greater than or equal to 10,000.
-								</p>
-								<table background="lectures/cobol/pics/code.gif" border="1" width="91%">
-									<tr>
-										<td>
-											<pre>PROCEDURE DIVISION.
+						<hr />
+					</div>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>The SUPPRESS PRINTING statement</h4>
+					</div>
+					<div class="section-content">
+						<p>
+							The <code class="language-cobol">SUPPRESS PRINTING</code> statement is used in a
+							Declarative section to stop a particular report group from being printed.
+						</p>
+						<p align="left">
+							The report group suppressed is the one mentioned in the USE statement associated
+							with the section containing the
+							<code class="language-cobol">SUPPRESS PRINTING</code> statement.
+						</p>
+						<p align="left">
+							The <code class="language-cobol">SUPPRESS PRINTING</code> statement must be executed
+							each time you want to stop the report group from being printed.
+						</p>
+						<p align="left">
+							In the example below we only want to print the ShopTotalGrp if the sales for the
+							shop are greater than or equal to 10,000.
+						</p>
+						<pre>PROCEDURE DIVISION.
 DECLARATIVES.
 CheckShopSales SECTION.
     USE BEFORE REPORTING ShopTotalGrp.
@@ -1414,56 +1307,47 @@ PrintMajorShopsOnly.
        <span style="color: #FF3300">SUPPRESS PRINTING</span>
 </b>    END-IF.
 END DECLARATIVES.</pre>
-										</td>
-									</tr>
-								</table>
-								<hr />
-							</td>
-						</tr>
-						<tr>
-							<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-								<h4>Control Break Registers</h4>
-							</td>
-							<td valign="top" width="525">
-								<div align="center">
-									<p align="left">
-										A control break occurs when the value in a control break item changes. This
-										causes an interesting problem when the control break item is used as the
-										<code class="language-cobol">SOURCE</code> value in a control footing because by
-										the time the control footing is printed, the control break item no longer
-										contains the correct value. When we print a control footing and refer to a
-										control break item we normally want to access the previous value of the item not
-										the current one.
-									</p>
-									<p align="left">
-										The Report Writer deals with this problem by maintaining a special control break
-										register for each control break item mentioned in the
-										<code class="language-cobol">CONTROLS ARE</code> phrase in the RD entry.
-									</p>
-									<p align="left">
-										When a control break item is referred to in a control footing or in the
-										Declaratives the Report Writer supplies the value held in the control break
-										register and not the value in the item itself.
-									</p>
-									<p align="left">
-										If a control break has just occurred the value in the control break register is
-										the previous value of the control break item.
-									</p>
-								</div>
-							</td>
-						</tr>
-					</table>
-				</td>
-			</tr>
-			<tr>
-				<td colspan="2">
-					<hr />
-					<div align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
+						<hr />
 					</div>
-					<copyright-notice></copyright-notice>
-				</td>
-			</tr>
-		</table>
+				</div>
+				<div class="section-grid">
+					<div class="section-sidebar">
+						<h4>Control Break Registers</h4>
+					</div>
+					<div class="section-content">
+						<p align="left">
+							A control break occurs when the value in a control break item changes. This
+							causes an interesting problem when the control break item is used as the
+							<code class="language-cobol">SOURCE</code> value in a control footing because by
+							the time the control footing is printed, the control break item no longer
+							contains the correct value. When we print a control footing and refer to a
+							control break item we normally want to access the previous value of the item not
+							the current one.
+						</p>
+						<p align="left">
+							The Report Writer deals with this problem by maintaining a special control break
+							register for each control break item mentioned in the
+							<code class="language-cobol">CONTROLS ARE</code> phrase in the RD entry.
+						</p>
+						<p align="left">
+							When a control break item is referred to in a control footing or in the
+							Declaratives the Report Writer supplies the value held in the control break
+							register and not the value in the item itself.
+						</p>
+						<p align="left">
+							If a control break has just occurred the value in the control break register is
+							the previous value of the control break item.
+						</p>
+					</div>
+				</div>
+			</div>
+			<div class="page-footer">
+				<hr />
+				<div align="center">
+					<a href="#top"><img border="0" height="38" src="i-pagetop.gif" width="132" /></a>
+				</div>
+				<copyright-notice></copyright-notice>
+			</div>
+		</div>
 	</body>
 </html>


### PR DESCRIPTION
## Summary

- Replaces all table-based layouts with CSS grid using `.section-header`, `.section-sidebar`, `.section-content`, and `.section-full` classes — consistent with the pattern used in `course/ReportWriterSS.html`
- Code samples now use plain `<pre>` elements directly, removing the `<table background="code.gif">` greenbar wrapper
- Moves `<meta name="viewport">` to be first in `<head>` to prevent FOUC from layout reflow
- Fixes the page-top image path in the footer (`Resources/pics/i-pagetop.gif` → `i-pagetop.gif`) to match the actual lectures directory structure
- Removes the large mobile media query that targeted table `width` attributes — no longer needed with CSS grid

## Test plan

- [ ] Open `lectures/ReportWriterSSWeb.html` and verify section headers appear with brown background and yellow text
- [ ] Verify sidebar panels appear with cream (#FFFFCC) background
- [ ] Verify code samples render as plain preformatted text with no greenbar background
- [ ] Verify page-top image renders in the footer
- [ ] Resize viewport below 600px and confirm grid collapses to single column

🤖 Generated with [Claude Code](https://claude.com/claude-code)