### PR TITLE
Fix left sidebar not stretching full row height in three course pages

### DIFF
--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -59,7 +59,7 @@
 
 			.sidebar {
 				background-color: #FFFFCC;
-				align-self: start;
+				align-self: stretch;
 			}
 
 			.sidebar h4 {

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
 	<head>
+		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>Indexed Files</title>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
@@ -64,12 +65,11 @@
 			.section-sidebar {
 				background-color: #FFFFCC;
 				padding: 4px;
-				align-self: start;
+				align-self: stretch;
 			}
 
 			.section-content {
 				padding: 4px;
-				align-self: start;
 			}
 
 			.section-full {
@@ -81,7 +81,6 @@
 				background-image: url(Resources/pics/code.gif);
 			}
 		</style>
-		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<style type="text/css">
 			img {
 				max-width: 100%;

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
 	<head>
+		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>The INSPECT verb</title>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
@@ -36,7 +37,6 @@
 				font-family: Arial, Helvetica, sans-serif;
 			}
 		</style>
-		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<style type="text/css">
 			img {
 				max-width: 100%;
@@ -81,12 +81,12 @@
 			.course-section-row {
 				display: grid;
 				grid-template-columns: 175px 1fr;
-				align-items: start;
 			}
 
 			.course-section-label {
 				background-color: #FFFFCC;
 				padding: 4px;
+				align-self: stretch;
 			}
 
 			.course-section-content {


### PR DESCRIPTION
## Summary

- `course/Inspect.html`: removed `align-items: start` from `.course-section-row` and added `align-self: stretch` to `.course-section-label` so the yellow `#FFFFCC` sidebar background fills the full row height; moved viewport meta to first in `<head>`
- `course/IndexedFiles.html`: changed `align-self: start` → `align-self: stretch` on `.section-sidebar`, removed `align-self: start` from `.section-content`; moved viewport meta to first in `<head>`
- `course/DataDeclaration.html`: changed `align-self: start` → `align-self: stretch` on `.sidebar`

## Root cause

All three pages explicitly set `align-self: start` (or `align-items: start`) on the grid row or sidebar element, overriding the CSS grid default of `stretch`. This caused the yellow left column to end at its own content height rather than matching the taller right column.

## Reviewer notes

Same pattern fixed in recent commits to `ReportWriterWeb.html` and others — this brings these three course pages in line with that approach.