### PR TITLE
Remove div.code-frame wrappers from COBOLIntro.html pre blocks

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -94,12 +94,6 @@
 				padding: 4px;
 			}
 
-			.code-frame {
-				border: 1px solid;
-				background-image: url(Resources/pics/code.gif);
-				padding: 5px;
-				overflow-x: auto;
-			}
 
 			@media (max-width: 600px) {
 				body {
@@ -1217,11 +1211,9 @@ other entries here</code></pre>
 					names.
 				</p>
 				<p>Here's a typical program fragment:</p>
-				<div class="code-frame">
-					<pre class="language-cobol"><code class="language-cobol">IDENTIFICATION DIVISION.
+				<pre class="language-cobol"><code class="language-cobol">IDENTIFICATION DIVISION.
 PROGRAM-ID. SequenceProgram.
 AUTHOR. Michael Coughlan.</code></pre>
-				</div>
 				<hr size="1" width="100%" />
 			</div>
 			<div class="sidebar-cell">
@@ -1281,8 +1273,7 @@ AUTHOR. Michael Coughlan.</code></pre>
 					<br />
 					Below is a sample program fragment -
 				</p>
-				<div class="code-frame">
-					<pre class="language-cobol"><code class="language-cobol">IDENTIFICATION DIVISION.
+				<pre class="language-cobol"><code class="language-cobol">IDENTIFICATION DIVISION.
 PROGRAM-ID. SequenceProgram.
 AUTHOR. Michael Coughlan.
 
@@ -1291,7 +1282,6 @@ WORKING-STORAGE SECTION.
 01 Num1   PIC 9  VALUE ZEROS.
 01 Num2   PIC 9  VALUE ZEROS.
 01 Result PIC 99 VALUE ZEROS.</code></pre>
-				</div>
 				<hr size="1" width="100%" />
 			</div>
 			<div class="sidebar-cell">
@@ -1319,8 +1309,7 @@ WORKING-STORAGE SECTION.
 					<br />
 					<b>Sample Program</b>
 				</p>
-				<div class="code-frame">
-					<pre class="language-cobol"><code class="language-cobol">IDENTIFICATION DIVISION.
+				<pre class="language-cobol"><code class="language-cobol">IDENTIFICATION DIVISION.
 PROGRAM-ID. SequenceProgram.
 AUTHOR. Michael Coughlan.
 
@@ -1338,7 +1327,6 @@ CalculateResult.
        GIVING Result.
    DISPLAY "Result is = ", Result.
    STOP RUN.</code></pre>
-				</div>
 				<p>
 					Some COBOL compilers require that all the divisions be present in a program while others only
 					require the <code class="language-cobol">IDENTIFICATION DIVISION</code> and the
@@ -1346,15 +1334,13 @@ CalculateResult.
 					perfectly valid when compiled with the Microfocus NetExpress compiler.
 				</p>
 				<p align="center"><b>Minimum COBOL program</b></p>
-				<div class="code-frame">
-					<pre class="language-cobol"><code class="language-cobol">IDENTIFICATION DIVISION.
+				<pre class="language-cobol"><code class="language-cobol">IDENTIFICATION DIVISION.
 PROGRAM-ID. SmallestProgram.
 
 PROCEDURE DIVISION.
 DisplayGreeting.
    DISPLAY "Hello world".
    STOP RUN.</code></pre>
-				</div>
 			</div>
 			<div class="full-width">
 				<hr />


### PR DESCRIPTION
## Summary

- Unwrapped four COBOL `<pre>` blocks that were nested inside `<div class="code-frame">` containers, promoting each `<pre>` directly to its parent
- Removed the now-unused `.code-frame` CSS rule (border, background-image, padding, overflow-x)

## Reviewer notes

The `div.code-frame` divs added a decorative border and `code.gif` background behind the code blocks. With the wrappers removed, the `<pre>` blocks rely on the existing `pre` styles already defined in the stylesheet.