### PR TITLE
Fix Copy.html grid overflow and viewport meta position

### DIFF
--- a/course/Copy.html
+++ b/course/Copy.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
 	<head>
+		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>The COPY verb</title>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
-		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<style type="text/css">
 			img {
 				max-width: 100%;
@@ -36,6 +36,7 @@
 
 			.layout-grid > * {
 				padding: 4px;
+				min-width: 0;
 			}
 
 			.layout-full {


### PR DESCRIPTION
## Summary
- Move `<meta name="viewport">` to first in `<head>` to prevent FOUC from layout reflow
- Add `min-width: 0` to `.layout-grid > *` to fix CSS Grid `1fr` track inflation

## Details
Without `min-width: 0` on grid children, the spanning `.layout-full` items were inflating the second (`1fr`) track from the correct 540px to 588px, causing 48px of horizontal overflow. This manifested as content spilling beyond the 715px page frame boundary. Adding `min-width: 0` allows grid items to shrink to their allocated track size, keeping the total at the expected 175px + 540px = 715px.

## Test plan
- [x] Desktop (1280px): grid tracks compute to `175px 540px`, no scroll overflow
- [x] Mobile (375px): single-column layout, no horizontal overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)