### PR TITLE
Refactor RelativeFiles.html layout tables to CSS grid/flexbox

### DIFF
--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -1,11 +1,10 @@
 <!doctype html>
 <html>
 	<head>
+		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>Relative Files</title>
-		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
-		<script src="Resources/vendor/prism/prism.min.js" defer></script>
-		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style type="text/css">
 			ul.toc {
 				list-style-image: url(Resources/pics/BallGreenG.gif);
@@ -22,6 +21,73 @@
 			ul.toc a {
 				font-weight: bold;
 				font-size: larger;
+			}
+
+			.section-header h2 {
+				color: #ffff00;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			.section-sidebar h3,
+			.section-sidebar h4 {
+				color: #800000;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+
+			.page-wrapper {
+				max-width: 715px;
+				margin: 0 auto;
+				border: 1px solid;
+				box-sizing: border-box;
+			}
+
+			.page-content {
+				padding: 2px;
+			}
+
+			.page-footer {
+				padding: 2px;
+			}
+
+			.section-grid {
+				display: grid;
+				grid-template-columns: 175px 1fr;
+			}
+
+			.section-header {
+				grid-column: 1 / -1;
+				background-color: #993300;
+				padding: 4px;
+				min-width: 0;
+				border-bottom: 1px solid;
+			}
+
+			.section-sidebar {
+				background-color: #FFFFCC;
+				padding: 4px;
+				align-self: stretch;
+				min-width: 0;
+				border-right: 1px solid;
+				border-bottom: 1px solid;
+			}
+
+			.section-content {
+				padding: 4px;
+				align-self: start;
+				min-width: 0;
+				overflow: hidden;
+				border-bottom: 1px solid;
+			}
+
+			.section-full {
+				grid-column: 1 / -1;
+				padding: 4px;
+				min-width: 0;
+				border-bottom: 1px solid;
+			}
+
+			.section-full:last-child {
+				border-bottom: none;
 			}
 
 			.declaratives-layout {
@@ -50,90 +116,44 @@
 				box-sizing: border-box;
 			}
 
-			@media (max-width: 760px) {
-				.declaratives-layout {
-					flex-direction: column;
-				}
-
-				.declaratives-code {
-					justify-content: flex-start;
-					width: 100%;
-				}
-
-				.code-display-box {
-					width: 100%;
-				}
-			}
-
-			td[bgcolor="#993300"] h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			td[bgcolor="#FFFFCC"] h3,
-			td[bgcolor="#FFFFCC"] h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-		</style>
-		<meta content="width=device-width, initial-scale=1" name="viewport" />
-		<style type="text/css">
 			img {
 				max-width: 100%;
 				height: auto;
 			}
 
-			table {
-				max-width: 100%;
-			}
-
-			body > table,
-			body > hr {
-				margin-left: auto;
-				margin-right: auto;
-			}
-
 			pre {
 				overflow-x: auto;
 				max-width: 100%;
+				white-space: pre-wrap;
+				word-wrap: break-word;
+				overflow-wrap: break-word;
+			}
+
+			pre[class*="language-"],
+			code[class*="language-"] {
+				white-space: pre-wrap !important;
+				overflow-wrap: break-word;
 			}
 
 			body {
 				-webkit-text-size-adjust: 100%;
 			}
 
-			@media (max-width: 760px) {
+			@media (max-width: 600px) {
 				body {
 					margin: 4px;
 					overflow-wrap: break-word;
 					word-wrap: break-word;
 				}
 
-				table[width] {
-					width: 100% !important;
-					height: auto !important;
-				}
-
-				td[width],
-				th[width],
-				td[height],
-				th[height] {
-					width: auto !important;
-					height: auto !important;
-				}
-
-				td[bgcolor="#993300"] > h2,
-				td[bgcolor="#993300"] > h3 {
+				.section-header h2,
+				.section-header h3 {
 					margin: 0.3em 0;
 				}
 
 				blockquote {
 					margin-left: 12px;
 					margin-right: 12px;
-				}
-
-				hr[width] {
-					width: 100% !important;
 				}
 
 				img,
@@ -147,15 +167,6 @@
 
 				pre {
 					max-width: min(100%, calc(100vw - 16px)) !important;
-					white-space: pre-wrap;
-					word-wrap: break-word;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"],
-				code[class*="language-"] {
-					white-space: pre-wrap !important;
-					overflow-wrap: break-word;
 				}
 
 				pre[class*="language-"] {
@@ -165,273 +176,208 @@
 					overflow-x: auto;
 				}
 
-				table[width="715"],
-				table[width="725"],
-				table[width="715"] > tbody,
-				table[width="725"] > tbody,
-				table[width="715"] > tbody > tr,
-				table[width="725"] > tbody > tr,
-				table[width="715"] > tbody > tr > td,
-				table[width="725"] > tbody > tr > td,
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])),
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])) > tbody,
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])) > tbody > tr,
-				table[width="710"]:not(:has(> tbody > tr > td[width="93%"])) > tbody > tr > td {
+				.section-grid {
 					display: block;
-					width: auto !important;
 				}
 
-				table[width="710"]:has(> tbody > tr > td[width="93%"]),
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody {
-					display: block;
-					width: 100% !important;
-				}
-
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr {
-					display: flex;
-					align-items: baseline;
-					gap: 0.4em;
-					margin: 0.4em 0;
-				}
-
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr > td[width="3%"] {
-					display: none;
-				}
-
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr > td[width="4%"] {
-					display: block;
-					flex: 0 0 auto;
-					width: auto !important;
-					padding: 0;
-				}
-
-				table[width="710"]:has(> tbody > tr > td[width="93%"]) > tbody > tr > td[width="93%"] {
-					display: block;
-					flex: 1 1 auto;
-					width: auto !important;
-					padding: 0;
-				}
-
-				td[width="175"] > h4:not(:first-child):not(:has(img)),
-				td[width="160"] > h4:not(:first-child):not(:has(img)),
-				h4:has(> img[src*="PanelLine"]) {
-					display: none;
-				}
-
-				td[width="175"] > h3,
-				td[width="175"] > h4,
-				td[width="175"] > p,
-				td[width="160"] > h3,
-				td[width="160"] > h4,
-				td[width="160"] > p {
+				.section-sidebar h3,
+				.section-sidebar h4,
+				.section-sidebar p {
 					margin: 0.2em 0;
+				}
+
+				.declaratives-layout {
+					flex-direction: column;
+				}
+
+				.declaratives-code {
+					justify-content: flex-start;
+					width: 100%;
+				}
+
+				.code-display-box {
+					width: 100%;
 				}
 			}
 		</style>
+		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
+		<script src="Resources/vendor/prism/prism.min.js" defer></script>
+		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
-		<table border="1" width="715">
-			<tbody>
-				<tr>
-					<td>
-						<center>
-							<div align="left">
-								<table border="0" width="710">
-									<tr>
-										<td>
-											<center>
-												<p id="top">
-													<img
-														alt=""
-														height="59"
-														src="Resources/pics/t-CobolTut.gif"
-														width="173"
-													/>
-												</p>
-											</center>
-											<center>
-												<h1>Relative Files</h1>
-											</center>
-											<hr />
-										</td>
-									</tr>
-								</table>
-							</div>
-						</center>
-						<div align="left">
-							<ul class="toc">
-								<li>
-									<a href="#intro">Introduction</a><br />
-									Unit aims, objectives and prerequisites.
-								</li>
-								<li>
-									<a href="#progs">A look at some programs that use Relative files</a><br />
-									We begin with two example programs. The first creates a Relative File from a
-									Sequential file and the second reads and displays records from the Relative file.
-								</li>
-								<li>
-									<a href="#declar">Relative file - declarations</a><br />
-									Examines the declarations required for a Relative file including the SELECT and
-									ASSIGN clause and the key.
-								</li>
-								<li>
-									<a href="#verbs">Relative file - file processing verbs</a><br />
-									Examines the Procedure Division verbs used to process Relative files - OPEN, CLOSE,
-									READ, WRITE, REWRITE, DELETE, START
-								</li>
-								<li>
-									<a href="#declaratives">Introduction to Declaratives</a><br />
-									Introduces Declaratives, showing when and how to use them.
-								</li>
-							</ul>
-						</div>
-						<table border="0" cellpadding="4" cellspacing="0" width="710">
-							<tr>
-								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="intro">Introduction</h2>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Aims</h3>
-								</td>
-								<td width="550">
-									<p>
-										The aim of this unit is to provide you with a solid understanding of
-										declarations required for Relative files and the Procedure Division verbs used
-										to process them.
-									</p>
-									<p>
-										An additional aim is to introduce you to the uses of Declaratives and
-										declarations required for them.
-									</p>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Objectives</h3>
-								</td>
-								<td width="550">
-									<p>By the end of this unit you should:</p>
-									<ol>
-										<li>
-											Be able to write the
-											<code class="language-cobol">ENVIRONMENT DIVISION</code> and Data Division
-											declarations required for a Relative file.
-										</li>
-										<li>
-											Understand the difference between a file's access mode and its organization.
-										</li>
-										<li>
-											Be able to used the use the START, OPEN, CLOSE, READ, WRITE, REWRITE and
-											<code class="language-cobol">DELETE</code>
-											Procedure Division verbs required to process Relative files.
-										</li>
-										<li>Be able to process a Relative file directly or sequentially.</li>
-										<li>Understand when, and how, to use Declaratives.</li>
-									</ol>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Prerequisites</h3>
-								</td>
-								<td width="550">
-									<p>You should be familiar with the material covered in the unit;</p>
-									<ul>
-										<li>Introduction to direct access files</li>
-									</ul>
-								</td>
-							</tr>
-						</table>
-						<table border="0" width="710">
-							<tr>
-								<td>
-									<hr />
-									<p align="center">
-										<a href="#top"
-											><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-										/></a>
-									</p>
-								</td>
-							</tr>
-						</table>
-						<table border="0" cellpadding="4" cellspacing="0" width="710">
-							<tr>
-								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="progs">A look at some programs that use Relative files</h2>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="left">Example program - Creating a Relative file</h3>
-								</td>
-								<td width="525">
-									<p>
-												We'll start by looking at some example programs. In the first
-												program, a Relative file is created by reading records from a
-												Sequential file and writing them to the Relative file. The second
-												program demonstrates how a Relative file may be read directly and
-												sequentially.
-											</p>
-									<p>
-										<iframe
-											height="541"
-											src="Resources/pdf-viewer.html?src=ppz/RelFile1.pdf"
-											style="
-												border: 1px solid #ccc;
-												width: 100%;
-												aspect-ratio: 520/541;
-											"
-											width="520"
-										></iframe>
-									</p>
-									<p>
-										It is a good idea to download the program and use the animator to
-										watch how the Relative file is created. You can download both the
-										program and the sequential data file it uses.
-									</p>
-									<p>
-										<a href="Resources/progs/REL-EG1.CBL"
-											>Download Relative file example program 1</a
-										>
-									</p>
-									<p>
-										<a href="Resources/progs/INSUPP.DAT"
-											>Download the Sequential data file</a
-										>
-									</p>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Example program - Reading a Relative file</h3>
-								</td>
-								<td width="525">
-									<p>
-										In this example we see how a Relative file may be read. The program
-										allows the file to be read either directly, using a key, or
-										sequentially.
-									</p>
-									<p>
-										<iframe
-											height="541"
-											src="Resources/pdf-viewer.html?src=ppz/RelFile2.pdf"
-											style="
-												border: 1px solid #ccc;
-												width: 100%;
-												aspect-ratio: 520/541;
-											"
-											width="520"
-										></iframe>
-									</p>
-									<p>Below we see the results produced by two runs of the program.</p>
-									<pre
-										class="language-none"
-									><code class="language-none">RUN USING SEQUENTIAL READING
+		<div class="page-wrapper">
+			<div class="page-content">
+				<div>
+					<center>
+						<p id="top">
+							<img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173" />
+						</p>
+						<h1>Relative Files</h1>
+					</center>
+					<hr />
+					<ul class="toc">
+						<li>
+							<a href="#intro">Introduction</a><br />
+							Unit aims, objectives and prerequisites.
+						</li>
+						<li>
+							<a href="#progs">A look at some programs that use Relative files</a><br />
+							We begin with two example programs. The first creates a Relative File from a
+							Sequential file and the second reads and displays records from the Relative file.
+						</li>
+						<li>
+							<a href="#declar">Relative file - declarations</a><br />
+							Examines the declarations required for a Relative file including the SELECT and
+							ASSIGN clause and the key.
+						</li>
+						<li>
+							<a href="#verbs">Relative file - file processing verbs</a><br />
+							Examines the Procedure Division verbs used to process Relative files - OPEN, CLOSE,
+							READ, WRITE, REWRITE, DELETE, START
+						</li>
+						<li>
+							<a href="#declaratives">Introduction to Declaratives</a><br />
+							Introduces Declaratives, showing when and how to use them.
+						</li>
+					</ul>
+				</div>
+			</div>
+			<div class="section-header">
+				<h2 align="center" id="intro">Introduction</h2>
+			</div>
+			<div class="section-grid">
+				<div class="section-sidebar">
+					<h3>Aims</h3>
+				</div>
+				<div class="section-content">
+					<p>
+						The aim of this unit is to provide you with a solid understanding of
+						declarations required for Relative files and the Procedure Division verbs used
+						to process them.
+					</p>
+					<p>
+						An additional aim is to introduce you to the uses of Declaratives and
+						declarations required for them.
+					</p>
+					<hr />
+				</div>
+			</div>
+			<div class="section-grid">
+				<div class="section-sidebar">
+					<h3>Objectives</h3>
+				</div>
+				<div class="section-content">
+					<p>By the end of this unit you should:</p>
+					<ol>
+						<li>
+							Be able to write the
+							<code class="language-cobol">ENVIRONMENT DIVISION</code> and Data Division
+							declarations required for a Relative file.
+						</li>
+						<li>
+							Understand the difference between a file's access mode and its organization.
+						</li>
+						<li>
+							Be able to used the use the START, OPEN, CLOSE, READ, WRITE, REWRITE and
+							<code class="language-cobol">DELETE</code>
+							Procedure Division verbs required to process Relative files.
+						</li>
+						<li>Be able to process a Relative file directly or sequentially.</li>
+						<li>Understand when, and how, to use Declaratives.</li>
+					</ol>
+				</div>
+			</div>
+			<div class="section-grid">
+				<div class="section-sidebar">
+					<h3>Prerequisites</h3>
+				</div>
+				<div class="section-content">
+					<p>You should be familiar with the material covered in the unit;</p>
+					<ul>
+						<li>Introduction to direct access files</li>
+					</ul>
+				</div>
+			</div>
+			<div class="section-full">
+				<hr />
+				<p align="center">
+					<a href="#top"
+						><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
+					/></a>
+				</p>
+			</div>
+			<div class="section-header">
+				<h2 align="center" id="progs">A look at some programs that use Relative files</h2>
+			</div>
+			<div class="section-grid">
+				<div class="section-sidebar">
+					<h3 align="left">Example program - Creating a Relative file</h3>
+				</div>
+				<div class="section-content">
+					<p>
+						We'll start by looking at some example programs. In the first
+						program, a Relative file is created by reading records from a
+						Sequential file and writing them to the Relative file. The second
+						program demonstrates how a Relative file may be read directly and
+						sequentially.
+					</p>
+					<p>
+						<iframe
+							height="541"
+							src="Resources/pdf-viewer.html?src=ppz/RelFile1.pdf"
+							style="
+								border: 1px solid #ccc;
+								width: 100%;
+								aspect-ratio: 520/541;
+							"
+							width="520"
+						></iframe>
+					</p>
+					<p>
+						It is a good idea to download the program and use the animator to
+						watch how the Relative file is created. You can download both the
+						program and the sequential data file it uses.
+					</p>
+					<p>
+						<a href="Resources/progs/REL-EG1.CBL"
+							>Download Relative file example program 1</a
+						>
+					</p>
+					<p>
+						<a href="Resources/progs/INSUPP.DAT"
+							>Download the Sequential data file</a
+						>
+					</p>
+					<hr />
+				</div>
+			</div>
+			<div class="section-grid">
+				<div class="section-sidebar">
+					<h3>Example program - Reading a Relative file</h3>
+				</div>
+				<div class="section-content">
+					<p>
+						In this example we see how a Relative file may be read. The program
+						allows the file to be read either directly, using a key, or
+						sequentially.
+					</p>
+					<p>
+						<iframe
+							height="541"
+							src="Resources/pdf-viewer.html?src=ppz/RelFile2.pdf"
+							style="
+								border: 1px solid #ccc;
+								width: 100%;
+								aspect-ratio: 520/541;
+							"
+							width="520"
+						></iframe>
+					</p>
+					<p>Below we see the results produced by two runs of the program.</p>
+					<pre
+						class="language-none"
+					><code class="language-none">RUN USING SEQUENTIAL READING
 Enter Read type (Direct=1, Seq=2)-&gt; 2
   01  VESTRON VIDEOS        OVER THE SEA SOMEWHERE IN LONDON
   02  EMI STUDIOS           HOLLYWOOD, CALIFORNIA, USA
@@ -445,541 +391,495 @@ RUN USING DIRECT READ
 Enter Read type (Direct=1, Seq=2)-&gt; 1
 Enter supplier key (2 digits)-&gt; 05
   05  YACHTING MONTHLY      TREE HOUSE, LONDON, ENGLAND</code></pre>
-									<hr />
-									<p>
-										If you downloaded the first example program and its data file you
-										should already have the Relative file (it was produced when you ran
-										the first example program). You can use this file with the second
-										Relative file example program.&nbsp;
-									</p>
-									<p>
-										<a href="Resources/progs/REL-EG2.CBL"
-											>Download Relative file example program 2</a
-										>
-									</p>
-								</td>
-							</tr>
-						</table>
-						<table border="0" width="710">
-							<tr>
-								<td>
-									<hr />
-									<p align="center">
-										<a href="#top"
-											><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-										/></a>
-									</p>
-								</td>
-							</tr>
-						</table>
-						<table border="0" cellpadding="4" cellspacing="0" width="710">
-							<tr>
-								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="declar">Relative file - Declarations</h2>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Introduction</h3>
-								</td>
-								<td width="525">
-									<p>
-										As we have seen in the example programs when Relative files are used a number of
-										new entries for the <code class="language-cobol">SELECT</code> and
-										<code class="language-cobol">ASSIGN</code> clause are required.
-									</p>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Select and Assign clause syntax</h3>
-								</td>
-								<td width="525">
-									<p><img height="189" src="Resources/pics/I-DFrel1.gif" width="507" /></p>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>The Optional phrase</h3>
-								</td>
-								<td width="525">
-									<div align="center">
-										<div align="left">
-											<p>
-												The OPTIONAL phrase must be specified for files opened for INPUT, I-O,
-												or EXTEND that need not be present when the program runs.
-											</p>
-										</div>
-									</div>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>The Access Mode</h3>
-								</td>
-								<td width="525">
-									<p>
-										The ACCESS MODE of a file refers to the way in which the file is to be used. If
-										an ACCESS MODE of SEQUENTIAL is specified then it will only be possible to
-										process the records in the file sequentially. If RANDOM is specified it will
-										only be possible to access the file directly. If DYNAMIC is specified, the file
-										may be accessed both directly and sequentially.
-									</p>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>The Record Key phrase</h3>
-								</td>
-								<td width="525">
-									<div align="center">
-										<div align="left">
-											<p>
-												The RECORD KEY phrase is used to define the relative key. There can be
-												only one key in a Relative File. The
-												<i>UniqueRecKey</i> must be a numeric data item and must not be part of
-												the file's record description although it may be part of another file's
-												record description. It is normally described in the WORKING-STORAGE
-												SECTION.
-											</p>
-										</div>
-									</div>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>The File Status</h3>
-								</td>
-								<td width="525">
-									<div align="center">
-										<div align="left">
-											<p>
-												The FILE STATUS clause identifies a two character area of storage that
-												holds the result of every I-O operation for the file. The FILE STATUS
-												data item is declared as PIC X(2) in the WORKING-STORAGE SECTION.
-												Whenever an I-O operation is performed, some value will be returned to
-												<i>FileStatus</i> indicating whether or not the operation was
-												successful.
-											</p>
-										</div>
-									</div>
-									<div align="center">
-										<div align="left">
-											There are a large number of FILE STATUS values but three of major interest
-											are;
-										</div>
-									</div>
-									<blockquote>
-										<p>00 = Operation successful.</p>
-										<p>22 = Duplicate key. i.e. The record already exists.</p>
-										<p>23 = Record not found</p>
-									</blockquote>
-									<div align="center">
-										<div align="left">
-											<p>
-												22 may occur after an attempt to write a record and 23 after trying to
-												READ or DELETE a record.
-											</p>
-											<p>
-												Note that although a code of 00 generally means the operation was
-												successful there are other codes that also indicate success.
-											</p>
-										</div>
-									</div>
-								</td>
-							</tr>
-						</table>
-						<table border="0" width="710">
-							<tr>
-								<td>
-									<hr />
-									<p align="center">
-										<a href="#top"
-											><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-										/></a>
-									</p>
-								</td>
-							</tr>
-						</table>
-						<table border="0" cellpadding="4" cellspacing="0" width="710">
-							<tr>
-								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="verbs">Relative file - file processing verbs</h2>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Introduction</h3>
-								</td>
-								<td width="525">
-									<p>
-										Direct access files can support a far greater range of operations than
-										Sequential files. Just like Sequential files, direct access files support the
-										OPEN, CLOSE, READ and WRITE operations. But in addition to these, direct access
-										files also support the DELETE, REWRITE and START operations.
-									</p>
-									<p>
-										In this section we examine these new operations and any changes to the
-										operations we are already familiar with.
-									</p>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>The Invalid Key clause</h3>
-								</td>
-								<td width="525">
-									<p>
-										When any of the file processing verbs are used for direct access, the INVALID
-										KEY clause must be used unless declaratives have been specified.
-									</p>
-									<p>
-										When the INVALID KEY clause is specified, any I-O error, such as attempting to
-										read a record that does not exist or write a record that already exists, will
-										activate the clause and cause the statement block following it to be executed.
-									</p>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>OPEN/CLOSE verbs</h3>
-								</td>
-								<td width="525">
-									<div align="center">
-										<p align="left">
-											The syntax for the CLOSE is the same for all file organizations.
-										</p>
-										<p align="left">
-											The full syntax for the OPEN verbs is shown below. Note the new I-O entry.
-											This is used with direct access files when we intend to update or both read
-											and write to the file.
-										</p>
-										<p align="left"><img src="Resources/pics/I-DFrel2.gif" /></p>
-										<p align="left">
-											<b>Notes<br /></b> If the file is opened for input then only READ and START
-											will be allowed.
-										</p>
-										<p align="left">
-											If the file is opened for output then only WRITE will be allowed.
-										</p>
-										<p align="left">
-											If the file is opened for I-O then READ, WRITE, START, REWRITE and DELETE
-											will be allowed.&nbsp;
-										</p>
-										<p align="left">
-											If OPEN INPUT is used, and the file does not possess the OPTIONAL tag, then
-											the file must exist or the OPEN will fail. &nbsp;
-										</p>
-										<p align="left">
-											If OPEN OUTPUT or I-O is used then the file will be created if it does not
-											already exist as long as the file possesses the OPTIONAL tag.
-										</p>
-									</div>
-									<div align="center">
-										<hr />
-									</div>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>The READ verb</h3>
-								</td>
-								<td width="525">
-									<p>
-										When a Relative file has an ACCESS MODE of SEQUENTIAL , the format of the READ
-										is the same as for Sequential files, but when the ACCESS MODE is DYNAMIC or
-										RANDOM, the READ has a different format.
-									</p>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Reading using a key</h3>
-								</td>
-								<td width="525">
-									<p><img src="Resources/pics/I-DFrel3.gif" /></p>
-									<p>
-										<b>Operation<br /></b> To read a record directly from a Relative file
-									</p>
-									<ol>
-										<li>
-											The key value must be placed in the <i>KeyName</i> data item (the
-											<i>KeyName</i> data item is the area of storage identified as the relative
-											key in the RECORD KEY IS phrase of the SELECT and ASSIGN clause).
-										</li>
-										<li>Then the READ must be executed.</li>
-									</ol>
-									<p>
-										When the READ is executed, the record with the Relative Record Number equal to
-										the present value of the relative key (i.e.<i>KeyName</i>) will be read into the
-										file's record buffer (defined in the FD entry).
-									</p>
-									<p>
-										If the record does not exist the INVALID KEY clause will activate and the
-										statement block following the clause will be executed.
-									</p>
-									<p>
-										After the record has been read the next record pointer will be pointing to the
-										next record in the file.
-									</p>
-									<p>
-										<b>Notes<br /></b> The file must have an ACCESS MODE declaration for the file
-										specifying an ACCESS MODE DYNAMIC or RANDOM.
-									</p>
-									<p>The file must be opened for I-O or INPUT.&nbsp;</p>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>Reading Sequentially</h3>
-								</td>
-								<td width="525">
-									<p>
-										When the ACCESS MODE is DYNAMIC and we wish to read the file sequentially then
-										we must use the format below for the READ. There is very little difference
-										between this format and the format of the ordinary sequential READ except that
-										in this format the NEXT RECORD phrase is used.
-									</p>
-									<p><img src="Resources/pics/I-DFrel4.gif" /></p>
-									<p>
-										<b>Notes<br /></b> This format is used to access a Relative file sequentially
-										when the ACCESS MODE has been declared as DYNAMIC and the file has been opened
-										for INPUT or I-O.
-									</p>
-									<p>
-										For Relative files the next record pointer may be positioned by the START verb
-										or by doing a direct READ .
-									</p>
-									<p>
-										The READ NEXT will read the record pointed to by the next record pointer (This
-										will be the current record if positioned by the START and the next record if
-										positioned by a direct READ).
-									</p>
-									<p>The AT END statement is activated when the end of the file has been reached</p>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="left">The WRITE verb</h3>
-								</td>
-								<td width="525">
-									<p>
-										The format for writing sequentially to a Relative file is the same as that used
-										for writing to a Sequential file, but to write directly to a Relative file a key
-										must be used and this requires a different WRITE format.
-									</p>
-									<p><img src="Resources/pics/I-DFrel5.gif" /></p>
-									<p>
-										<b>Operation<br /></b> To write a record directly to a Relative file
-									</p>
-									<ol>
-										<li>The record value must be placed in the files record buffer.</li>
-										<li>The key value must be placed in the file's relative key.</li>
-										<li>The WRITE must be executed.</li>
-									</ol>
-									<p>
-										When the WRITE is executed the data in the record buffer is written to the
-										record position with a Relative Record Number equal to the present value of the
-										key.
-									</p>
-									<p>
-										<b>Notes<br /></b> The INVALID KEY clause must be used for direct access to
-										Relative files. If the record being written already 'exists' the INVALID KEY
-										clause will be activate and the statement following the clause will be done. Any
-										other I-O error will also activate the INVALID KEY clause.
-									</p>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="left">The REWRITE verb</h3>
-								</td>
-								<td width="525">
-									<p>
-										The REWRITE is used to update a record in situ by overwriting it. The format of
-										the REWRITE verb is shown below.
-									</p>
-									<p><img src="Resources/pics/I-DFrel6.gif" /></p>
-									<p>
-										<b>Operation<br /></b> The REWRITE is normally used in the following way;
-									</p>
-									<ol>
-										<li>
-											The record we wish to update is read directly into the record buffer (place
-											the key value in the key are and execute the READ).
-										</li>
-										<li>The required changes are made to the record in the buffer.</li>
-										<li>The record in the buffer is rewritten to the file.</li>
-									</ol>
-									<p>
-										<b>Notes<br /></b> If the file has an ACCESS MODE of SEQUENTIAL then the INVALID
-										KEY clause cannot be used but if the ACCESS MODE is RANDOM or DYNAMIC the
-										INVALID KEY clause must be present (unless declaratives are being used).
-									</p>
-									<p>
-										When the file has ACCESS MODE IS SEQUENTIAL the record that is replaced must
-										have been the subject of a READ or START before the REWRITE is used.
-									</p>
-									<p>For all access modes the file must be opened for I-O.</p>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="left">The DELETE verb</h3>
-								</td>
-								<td width="525">
-									<p><img src="Resources/pics/I-DFrel7.gif" /></p>
-									<p>
-										<b>Operation<br /></b> To delete a record
-									</p>
-									<ol>
-										<li>
-											The Relative Record Number of the record to be deleted must be placed in the
-											file's relative key.
-										</li>
-										<li>Then the DELETE must be executed.</li>
-									</ol>
-									<p>
-										The record with the Relative Record number equal to the current value of the key
-										are will be deleted.
-									</p>
-									<p>
-										<b>Notes<br /></b> To use the DELETE, the file must have been opened for I-O.
-									</p>
-									<p>
-										When the ACCESS MODE IS SEQUENTIAL a READ statement must access the record to be
-										deleted.
-									</p>
-									<p>
-										When the ACCESS MODE IS RANDOM or DYNAMIC the record to be deleted is identified
-										by the file's Relative key.
-									</p>
-									<p>If the record does not exist the INVALID KEY statement will be activated.</p>
-									<p>
-										Note that when a record is deleted its space does not become available to other
-										records.
-									</p>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3>The START verb</h3>
-								</td>
-								<td width="525">
-									<p>
-										In Relative files, the only thing the the START verb is used for, is to control
-										the position of the next record pointer. Where the START verb appears in a
-										program it is usually followed by a sequential READ or WRITE .
-									</p>
-									<p><img src="Resources/pics/I-DFrel8.gif" /></p>
-									<p>
-										<b>Operation<br /></b> To position the Next Record Pointer at a particular
-										record
-									</p>
-									<ol>
-										<li>
-											Move the Relative Record Number of the record to the file's relative key.
-										</li>
-										<li>Execute the START..KEY IS EQUAL TO</li>
-									</ol>
-									<p>To position the Next Record Pointer at the first record in the file</p>
-									<ol>
-										<li>Move zeros to the file's relative key.</li>
-										<li>Execute the START..KEY IS GREATER THAN</li>
-									</ol>
-									<p>To position the pointer at the last record in the file</p>
-									<ol>
-										<li>Move all 9's to the file's relative key.</li>
-										<li>Execute the START..KEY IS LESS THAN</li>
-									</ol>
-									<p>
-										<b>Notes<br /></b> <i>KeyDataName</i> is the file's relative key. It is the key
-										of comparison.
-									</p>
-									<p>The file must be opened for INPUT or I-O when the START is executed.</p>
-									<p>
-										Execution of the START statement does not change the contents of the record area
-										(i.e. the START does not actually read the record it merely positions the next
-										record pointer).
-									</p>
-									<p>
-										When the START is executed the Next Record Pointer is set to the first record in
-										the file whose key satisfies the condition. If no record satisfies the condition
-										then the INVALID KEY clause is activated.
-									</p>
-								</td>
-							</tr>
-						</table>
-						<table border="0" width="710">
-							<tr>
-								<td>
-									<hr />
-									<p align="center">
-										<a href="#top"
-											><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-										/></a>
-									</p>
-								</td>
-							</tr>
-						</table>
-						<table border="0" cellpadding="4" cellspacing="0" width="710">
-							<tr>
-								<td align="left" bgcolor="#993300" colspan="2" valign="top" width="100%">
-									<h2 align="center" id="declaratives">Introduction to Declaratives</h2>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="left">Introduction</h3>
-								</td>
-								<td width="525">
-									<p>
-										Declaratives allow us to define exception handling procedures for files. When
-										there are declaratives for a file the INVALID KEY clause is not required.
-									</p>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="left">The Declaratives template</h3>
-								</td>
-								<td width="525">
-									<div class="declaratives-layout">
-										<div class="declaratives-text">
-											<p>The template opposite shows how declaratives are set up.</p>
-											<p>
-												Declaratives must be defined at the start of the PROCEDURE DIVISION.
-											</p>
-											<p>
-												They must start with the DECLARATIVES keyword and end with the
-												keyword END-DECLARATIVES .
-											</p>
-											<p>
-												Declaratives are divided into sections and each section is
-												associated with a particular USE phrase.
-											</p>
-											<p>
-												The sections and USE phrases allow us to specify a separate
-												exception procedure for each file.
-											</p>
-											<p>
-												We can also specify general exception procedures for all INPUT,
-												OUTPUT, I-O and EXTEND errors.
-											</p>
-										</div>
-										<div class="declaratives-code">
-											<div class="code-display-box">
-												<pre
-													class="language-cobol"
-												><code class="language-cobol">PROCEDURE DIVISION.
+					<hr />
+					<p>
+						If you downloaded the first example program and its data file you
+						should already have the Relative file (it was produced when you ran
+						the first example program). You can use this file with the second
+						Relative file example program.&nbsp;
+					</p>
+					<p>
+						<a href="Resources/progs/REL-EG2.CBL"
+							>Download Relative file example program 2</a
+						>
+					</p>
+				</div>
+			</div>
+			<div class="section-full">
+				<hr />
+				<p align="center">
+					<a href="#top"
+						><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
+					/></a>
+				</p>
+			</div>
+			<div class="section-header">
+				<h2 align="center" id="declar">Relative file - Declarations</h2>
+			</div>
+			<div class="section-grid">
+				<div class="section-sidebar">
+					<h3>Introduction</h3>
+				</div>
+				<div class="section-content">
+					<p>
+						As we have seen in the example programs when Relative files are used a number of
+						new entries for the <code class="language-cobol">SELECT</code> and
+						<code class="language-cobol">ASSIGN</code> clause are required.
+					</p>
+					<hr />
+				</div>
+			</div>
+			<div class="section-grid">
+				<div class="section-sidebar">
+					<h3>Select and Assign clause syntax</h3>
+				</div>
+				<div class="section-content">
+					<p><img height="189" src="Resources/pics/I-DFrel1.gif" width="507" /></p>
+				</div>
+			</div>
+			<div class="section-grid">
+				<div class="section-sidebar">
+					<h3>The Optional phrase</h3>
+				</div>
+				<div class="section-content">
+					<p>
+						The OPTIONAL phrase must be specified for files opened for INPUT, I-O,
+						or EXTEND that need not be present when the program runs.
+					</p>
+				</div>
+			</div>
+			<div class="section-grid">
+				<div class="section-sidebar">
+					<h3>The Access Mode</h3>
+				</div>
+				<div class="section-content">
+					<p>
+						The ACCESS MODE of a file refers to the way in which the file is to be used. If
+						an ACCESS MODE of SEQUENTIAL is specified then it will only be possible to
+						process the records in the file sequentially. If RANDOM is specified it will
+						only be possible to access the file directly. If DYNAMIC is specified, the file
+						may be accessed both directly and sequentially.
+					</p>
+				</div>
+			</div>
+			<div class="section-grid">
+				<div class="section-sidebar">
+					<h3>The Record Key phrase</h3>
+				</div>
+				<div class="section-content">
+					<p>
+						The RECORD KEY phrase is used to define the relative key. There can be
+						only one key in a Relative File. The
+						<i>UniqueRecKey</i> must be a numeric data item and must not be part of
+						the file's record description although it may be part of another file's
+						record description. It is normally described in the WORKING-STORAGE
+						SECTION.
+					</p>
+				</div>
+			</div>
+			<div class="section-grid">
+				<div class="section-sidebar">
+					<h3>The File Status</h3>
+				</div>
+				<div class="section-content">
+					<p>
+						The FILE STATUS clause identifies a two character area of storage that
+						holds the result of every I-O operation for the file. The FILE STATUS
+						data item is declared as PIC X(2) in the WORKING-STORAGE SECTION.
+						Whenever an I-O operation is performed, some value will be returned to
+						<i>FileStatus</i> indicating whether or not the operation was
+						successful.
+					</p>
+					<p>
+						There are a large number of FILE STATUS values but three of major interest
+						are;
+					</p>
+					<blockquote>
+						<p>00 = Operation successful.</p>
+						<p>22 = Duplicate key. i.e. The record already exists.</p>
+						<p>23 = Record not found</p>
+					</blockquote>
+					<p>
+						22 may occur after an attempt to write a record and 23 after trying to
+						READ or DELETE a record.
+					</p>
+					<p>
+						Note that although a code of 00 generally means the operation was
+						successful there are other codes that also indicate success.
+					</p>
+				</div>
+			</div>
+			<div class="section-full">
+				<hr />
+				<p align="center">
+					<a href="#top"
+						><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
+					/></a>
+				</p>
+			</div>
+			<div class="section-header">
+				<h2 align="center" id="verbs">Relative file - file processing verbs</h2>
+			</div>
+			<div class="section-grid">
+				<div class="section-sidebar">
+					<h3>Introduction</h3>
+				</div>
+				<div class="section-content">
+					<p>
+						Direct access files can support a far greater range of operations than
+						Sequential files. Just like Sequential files, direct access files support the
+						OPEN, CLOSE, READ and WRITE operations. But in addition to these, direct access
+						files also support the DELETE, REWRITE and START operations.
+					</p>
+					<p>
+						In this section we examine these new operations and any changes to the
+						operations we are already familiar with.
+					</p>
+					<hr />
+				</div>
+			</div>
+			<div class="section-grid">
+				<div class="section-sidebar">
+					<h3>The Invalid Key clause</h3>
+				</div>
+				<div class="section-content">
+					<p>
+						When any of the file processing verbs are used for direct access, the INVALID
+						KEY clause must be used unless declaratives have been specified.
+					</p>
+					<p>
+						When the INVALID KEY clause is specified, any I-O error, such as attempting to
+						read a record that does not exist or write a record that already exists, will
+						activate the clause and cause the statement block following it to be executed.
+					</p>
+					<hr />
+				</div>
+			</div>
+			<div class="section-grid">
+				<div class="section-sidebar">
+					<h3>OPEN/CLOSE verbs</h3>
+				</div>
+				<div class="section-content">
+					<p>
+						The syntax for the CLOSE is the same for all file organizations.
+					</p>
+					<p>
+						The full syntax for the OPEN verbs is shown below. Note the new I-O entry.
+						This is used with direct access files when we intend to update or both read
+						and write to the file.
+					</p>
+					<p><img src="Resources/pics/I-DFrel2.gif" /></p>
+					<p>
+						<b>Notes<br /></b> If the file is opened for input then only READ and START
+						will be allowed.
+					</p>
+					<p>
+						If the file is opened for output then only WRITE will be allowed.
+					</p>
+					<p>
+						If the file is opened for I-O then READ, WRITE, START, REWRITE and DELETE
+						will be allowed.&nbsp;
+					</p>
+					<p>
+						If OPEN INPUT is used, and the file does not possess the OPTIONAL tag, then
+						the file must exist or the OPEN will fail. &nbsp;
+					</p>
+					<p>
+						If OPEN OUTPUT or I-O is used then the file will be created if it does not
+						already exist as long as the file possesses the OPTIONAL tag.
+					</p>
+					<hr />
+				</div>
+			</div>
+			<div class="section-grid">
+				<div class="section-sidebar">
+					<h3>The READ verb</h3>
+				</div>
+				<div class="section-content">
+					<p>
+						When a Relative file has an ACCESS MODE of SEQUENTIAL , the format of the READ
+						is the same as for Sequential files, but when the ACCESS MODE is DYNAMIC or
+						RANDOM, the READ has a different format.
+					</p>
+				</div>
+			</div>
+			<div class="section-grid">
+				<div class="section-sidebar">
+					<h3>Reading using a key</h3>
+				</div>
+				<div class="section-content">
+					<p><img src="Resources/pics/I-DFrel3.gif" /></p>
+					<p>
+						<b>Operation<br /></b> To read a record directly from a Relative file
+					</p>
+					<ol>
+						<li>
+							The key value must be placed in the <i>KeyName</i> data item (the
+							<i>KeyName</i> data item is the area of storage identified as the relative
+							key in the RECORD KEY IS phrase of the SELECT and ASSIGN clause).
+						</li>
+						<li>Then the READ must be executed.</li>
+					</ol>
+					<p>
+						When the READ is executed, the record with the Relative Record Number equal to
+						the present value of the relative key (i.e.<i>KeyName</i>) will be read into the
+						file's record buffer (defined in the FD entry).
+					</p>
+					<p>
+						If the record does not exist the INVALID KEY clause will activate and the
+						statement block following the clause will be executed.
+					</p>
+					<p>
+						After the record has been read the next record pointer will be pointing to the
+						next record in the file.
+					</p>
+					<p>
+						<b>Notes<br /></b> The file must have an ACCESS MODE declaration for the file
+						specifying an ACCESS MODE DYNAMIC or RANDOM.
+					</p>
+					<p>The file must be opened for I-O or INPUT.&nbsp;</p>
+				</div>
+			</div>
+			<div class="section-grid">
+				<div class="section-sidebar">
+					<h3>Reading Sequentially</h3>
+				</div>
+				<div class="section-content">
+					<p>
+						When the ACCESS MODE is DYNAMIC and we wish to read the file sequentially then
+						we must use the format below for the READ. There is very little difference
+						between this format and the format of the ordinary sequential READ except that
+						in this format the NEXT RECORD phrase is used.
+					</p>
+					<p><img src="Resources/pics/I-DFrel4.gif" /></p>
+					<p>
+						<b>Notes<br /></b> This format is used to access a Relative file sequentially
+						when the ACCESS MODE has been declared as DYNAMIC and the file has been opened
+						for INPUT or I-O.
+					</p>
+					<p>
+						For Relative files the next record pointer may be positioned by the START verb
+						or by doing a direct READ .
+					</p>
+					<p>
+						The READ NEXT will read the record pointed to by the next record pointer (This
+						will be the current record if positioned by the START and the next record if
+						positioned by a direct READ).
+					</p>
+					<p>The AT END statement is activated when the end of the file has been reached</p>
+					<hr />
+				</div>
+			</div>
+			<div class="section-grid">
+				<div class="section-sidebar">
+					<h3 align="left">The WRITE verb</h3>
+				</div>
+				<div class="section-content">
+					<p>
+						The format for writing sequentially to a Relative file is the same as that used
+						for writing to a Sequential file, but to write directly to a Relative file a key
+						must be used and this requires a different WRITE format.
+					</p>
+					<p><img src="Resources/pics/I-DFrel5.gif" /></p>
+					<p>
+						<b>Operation<br /></b> To write a record directly to a Relative file
+					</p>
+					<ol>
+						<li>The record value must be placed in the files record buffer.</li>
+						<li>The key value must be placed in the file's relative key.</li>
+						<li>The WRITE must be executed.</li>
+					</ol>
+					<p>
+						When the WRITE is executed the data in the record buffer is written to the
+						record position with a Relative Record Number equal to the present value of the
+						key.
+					</p>
+					<p>
+						<b>Notes<br /></b> The INVALID KEY clause must be used for direct access to
+						Relative files. If the record being written already 'exists' the INVALID KEY
+						clause will be activate and the statement following the clause will be done. Any
+						other I-O error will also activate the INVALID KEY clause.
+					</p>
+					<hr />
+				</div>
+			</div>
+			<div class="section-grid">
+				<div class="section-sidebar">
+					<h3 align="left">The REWRITE verb</h3>
+				</div>
+				<div class="section-content">
+					<p>
+						The REWRITE is used to update a record in situ by overwriting it. The format of
+						the REWRITE verb is shown below.
+					</p>
+					<p><img src="Resources/pics/I-DFrel6.gif" /></p>
+					<p>
+						<b>Operation<br /></b> The REWRITE is normally used in the following way;
+					</p>
+					<ol>
+						<li>
+							The record we wish to update is read directly into the record buffer (place
+							the key value in the key are and execute the READ).
+						</li>
+						<li>The required changes are made to the record in the buffer.</li>
+						<li>The record in the buffer is rewritten to the file.</li>
+					</ol>
+					<p>
+						<b>Notes<br /></b> If the file has an ACCESS MODE of SEQUENTIAL then the INVALID
+						KEY clause cannot be used but if the ACCESS MODE is RANDOM or DYNAMIC the
+						INVALID KEY clause must be present (unless declaratives are being used).
+					</p>
+					<p>
+						When the file has ACCESS MODE IS SEQUENTIAL the record that is replaced must
+						have been the subject of a READ or START before the REWRITE is used.
+					</p>
+					<p>For all access modes the file must be opened for I-O.</p>
+					<hr />
+				</div>
+			</div>
+			<div class="section-grid">
+				<div class="section-sidebar">
+					<h3 align="left">The DELETE verb</h3>
+				</div>
+				<div class="section-content">
+					<p><img src="Resources/pics/I-DFrel7.gif" /></p>
+					<p>
+						<b>Operation<br /></b> To delete a record
+					</p>
+					<ol>
+						<li>
+							The Relative Record Number of the record to be deleted must be placed in the
+							file's relative key.
+						</li>
+						<li>Then the DELETE must be executed.</li>
+					</ol>
+					<p>
+						The record with the Relative Record number equal to the current value of the key
+						are will be deleted.
+					</p>
+					<p>
+						<b>Notes<br /></b> To use the DELETE, the file must have been opened for I-O.
+					</p>
+					<p>
+						When the ACCESS MODE IS SEQUENTIAL a READ statement must access the record to be
+						deleted.
+					</p>
+					<p>
+						When the ACCESS MODE IS RANDOM or DYNAMIC the record to be deleted is identified
+						by the file's Relative key.
+					</p>
+					<p>If the record does not exist the INVALID KEY statement will be activated.</p>
+					<p>
+						Note that when a record is deleted its space does not become available to other
+						records.
+					</p>
+					<hr />
+				</div>
+			</div>
+			<div class="section-grid">
+				<div class="section-sidebar">
+					<h3>The START verb</h3>
+				</div>
+				<div class="section-content">
+					<p>
+						In Relative files, the only thing the the START verb is used for, is to control
+						the position of the next record pointer. Where the START verb appears in a
+						program it is usually followed by a sequential READ or WRITE .
+					</p>
+					<p><img src="Resources/pics/I-DFrel8.gif" /></p>
+					<p>
+						<b>Operation<br /></b> To position the Next Record Pointer at a particular
+						record
+					</p>
+					<ol>
+						<li>
+							Move the Relative Record Number of the record to the file's relative key.
+						</li>
+						<li>Execute the START..KEY IS EQUAL TO</li>
+					</ol>
+					<p>To position the Next Record Pointer at the first record in the file</p>
+					<ol>
+						<li>Move zeros to the file's relative key.</li>
+						<li>Execute the START..KEY IS GREATER THAN</li>
+					</ol>
+					<p>To position the pointer at the last record in the file</p>
+					<ol>
+						<li>Move all 9's to the file's relative key.</li>
+						<li>Execute the START..KEY IS LESS THAN</li>
+					</ol>
+					<p>
+						<b>Notes<br /></b> <i>KeyDataName</i> is the file's relative key. It is the key
+						of comparison.
+					</p>
+					<p>The file must be opened for INPUT or I-O when the START is executed.</p>
+					<p>
+						Execution of the START statement does not change the contents of the record area
+						(i.e. the START does not actually read the record it merely positions the next
+						record pointer).
+					</p>
+					<p>
+						When the START is executed the Next Record Pointer is set to the first record in
+						the file whose key satisfies the condition. If no record satisfies the condition
+						then the INVALID KEY clause is activated.
+					</p>
+				</div>
+			</div>
+			<div class="section-full">
+				<hr />
+				<p align="center">
+					<a href="#top"
+						><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
+					/></a>
+				</p>
+			</div>
+			<div class="section-header">
+				<h2 align="center" id="declaratives">Introduction to Declaratives</h2>
+			</div>
+			<div class="section-grid">
+				<div class="section-sidebar">
+					<h3 align="left">Introduction</h3>
+				</div>
+				<div class="section-content">
+					<p>
+						Declaratives allow us to define exception handling procedures for files. When
+						there are declaratives for a file the INVALID KEY clause is not required.
+					</p>
+					<hr />
+				</div>
+			</div>
+			<div class="section-grid">
+				<div class="section-sidebar">
+					<h3 align="left">The Declaratives template</h3>
+				</div>
+				<div class="section-content">
+					<div class="declaratives-layout">
+						<div class="declaratives-text">
+							<p>The template opposite shows how declaratives are set up.</p>
+							<p>
+								Declaratives must be defined at the start of the PROCEDURE DIVISION.
+							</p>
+							<p>
+								They must start with the DECLARATIVES keyword and end with the
+								keyword END-DECLARATIVES .
+							</p>
+							<p>
+								Declaratives are divided into sections and each section is
+								associated with a particular USE phrase.
+							</p>
+							<p>
+								The sections and USE phrases allow us to specify a separate
+								exception procedure for each file.
+							</p>
+							<p>
+								We can also specify general exception procedures for all INPUT,
+								OUTPUT, I-O and EXTEND errors.
+							</p>
+						</div>
+						<div class="declaratives-code">
+							<div class="code-display-box">
+								<pre
+									class="language-cobol"
+								><code class="language-cobol">PROCEDURE DIVISION.
 DECLARATIVES.
 SectionOne SECTION.
     USE clause for file1.
@@ -1001,82 +901,72 @@ ParSectTwo2.
 END-DECLARATIVES.
 Main SECTION.
 Begin.</code></pre>
-											</div>
-										</div>
-									</div>
-									<hr />
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="left">The Use phrase</h3>
-								</td>
-								<td width="525">
-									<div align="center">
-										<div align="left">
-											<p><img src="Resources/pics/I-DFrel9.gif" /></p>
-											<p><b>Notes</b></p>
-											<p>
-												A USE statement can be used only in a sentence immediately after a
-												section header in the PROCEDURE DIVISION declaratives area. It must be
-												the only statement in the sentence.
-											</p>
-											<p>ERROR and EXCEPTION are synonyms.</p>
-											<p>
-												A Declarative cannot refer to a non-Declarative procedure. However, the
-												PERFORM can transfer control from a Declarative procedure to another
-												Declarative procedure or from a non-Declarative procedure to a
-												Declarative procedure.
-											</p>
-											<p>
-												A Declarative executes automatically whenever an I-O condition occurs
-												that would result in a non-zero value in the FILE STATUS data item.
-											</p>
-											<p>
-												When USE phrases refer to both a
-												<i>FileName</i> and the more general INPUT, OUTPUT, I-O and EXTEND then
-												the <i>FileName</i> procedure takes precedence.
-											</p>
-											<hr />
-										</div>
-									</div>
-								</td>
-							</tr>
-							<tr>
-								<td align="left" bgcolor="#FFFFCC" valign="top" width="175">
-									<h3 align="center">Example program - fragment</h3>
-								</td>
-								<td background="Resources/pics/code.gif" width="525">
-									<pre class="language-cobol"><code class="language-cobol"> PROCEDURE DIVISION. 
- DECLARATIVES. 
+							</div>
+						</div>
+					</div>
+					<hr />
+				</div>
+			</div>
+			<div class="section-grid">
+				<div class="section-sidebar">
+					<h3 align="left">The Use phrase</h3>
+				</div>
+				<div class="section-content">
+					<p><img src="Resources/pics/I-DFrel9.gif" /></p>
+					<p><b>Notes</b></p>
+					<p>
+						A USE statement can be used only in a sentence immediately after a
+						section header in the PROCEDURE DIVISION declaratives area. It must be
+						the only statement in the sentence.
+					</p>
+					<p>ERROR and EXCEPTION are synonyms.</p>
+					<p>
+						A Declarative cannot refer to a non-Declarative procedure. However, the
+						PERFORM can transfer control from a Declarative procedure to another
+						Declarative procedure or from a non-Declarative procedure to a
+						Declarative procedure.
+					</p>
+					<p>
+						A Declarative executes automatically whenever an I-O condition occurs
+						that would result in a non-zero value in the FILE STATUS data item.
+					</p>
+					<p>
+						When USE phrases refer to both a
+						<i>FileName</i> and the more general INPUT, OUTPUT, I-O and EXTEND then
+						the <i>FileName</i> procedure takes precedence.
+					</p>
+					<hr />
+				</div>
+			</div>
+			<div class="section-grid">
+				<div class="section-sidebar">
+					<h3 align="center">Example program - fragment</h3>
+				</div>
+				<div class="section-content" style="background-image: url(Resources/pics/code.gif);">
+					<pre class="language-cobol"><code class="language-cobol"> PROCEDURE DIVISION.
+ DECLARATIVES.
  FileError SECTION.
     USE AFTER ERROR PROCEDURE ON RelativeFile.
  CheckFileStatus.
-    EVALUATE TRUE 
-      WHEN RecordDoesNotExist  DISPLAY "Record does not exist" 
+    EVALUATE TRUE
+      WHEN RecordDoesNotExist  DISPLAY "Record does not exist"
       WHEN RecordAlreadyExists DISPLAY "Record already exists"
-      WHEN FileNotOpen OPEN I-O RelativeFile 
-    END-EVALUATE. 
+      WHEN FileNotOpen OPEN I-O RelativeFile
+    END-EVALUATE.
  END-DECLARATIVES.
  Main SECTION.
  Begin.</code></pre>
-								</td>
-							</tr>
-						</table>
-					</td>
-				</tr>
-				<tr>
-					<td>
-						<hr />
-						<div align="center">
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</div>
-						<copyright-notice></copyright-notice>
-					</td>
-				</tr>
-			</tbody>
-		</table>
+				</div>
+			</div>
+			<div class="page-footer">
+				<hr />
+				<div align="center">
+					<a href="#top"
+						><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
+					/></a>
+				</div>
+				<copyright-notice></copyright-notice>
+			</div>
+		</div>
 	</body>
 </html>


### PR DESCRIPTION
## Summary

- Replace all layout `<table>` elements with CSS grid/flexbox divs using the established `page-wrapper`, `section-grid`, `section-header`, `section-sidebar`, `section-content`, `section-full`, and `page-footer` classes
- Consolidate two separate `<style>` blocks into one unified block, integrating the existing `declaratives-layout` flexbox CSS with its responsive rules
- Convert deprecated `background=` attribute on `<td>` to `background-image` inline style on the `.section-content` div
- Move `<meta viewport>` to first in `<head>` to prevent FOUC from layout reflow
- Add `course.css` link
- Apply `white-space: pre-wrap` so COBOL code reflows on narrow viewports instead of causing horizontal scroll

## Test plan

- [ ] Verify page renders correctly at desktop width (~715px)
- [ ] Verify page collapses to single-column layout on mobile (< 600px)
- [ ] Confirm declaratives template flex layout displays code box alongside text
- [ ] Check code background image renders on the "Example program - fragment" row
- [ ] Confirm TOC anchor links navigate to correct sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)