### PR TITLE
Remove code.gif greenbar wrappers around Prism code blocks

### DIFF
--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -441,15 +441,6 @@ Begin.
     DISPLAY "The time is " CurrentHour ":" CurrentMinute.
     STOP RUN.
 </code></pre>
-					<div
-						style="
-							background-color: #e1ffe1;
-							background-image: url(&quot;Resources/pics/code.gif&quot;);
-							width: 67%;
-							margin: 0 auto;
-							border: 3px double black;
-						"
-					>
 						<p align="center">
 							<b>Results of running ACCEPT.CBL</b>
 						</p>
@@ -464,7 +455,6 @@ Today is day 060 of the year
 The time is 14:41
 </pre
 						>
-					</div>
 				</div>
 			</div>
 

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -55,12 +55,6 @@
 				padding: 4px;
 			}
 
-			.code-example-box {
-				background-image: url(Resources/pics/code.gif);
-				border: 1px solid black;
-				width: 100%;
-			}
-
 			.code-section {
 				padding: 5px;
 				overflow-x: auto;
@@ -168,11 +162,6 @@
 				.sidebar > h4,
 				.sidebar > p {
 					margin: 0.2em 0;
-				}
-
-				.code-example-box {
-					max-width: 100% !important;
-					width: 100% !important;
 				}
 			}
 		</style>
@@ -667,7 +656,6 @@ COPY CopyFile4 IN EGLIB.</code></pre>
 					</p>
 				</div>
 				<div>
-					<div class="code-example-box">
 						<div class="code-section">
 							<div align="center">
 								<b>Source Text</b>
@@ -762,7 +750,6 @@ BeginProg.
    END-PERFORM
    STOP RUN.</code></pre>
 						</div>
-					</div>
 					<hr align="center" size="1" width="100%" />
 				</div>
 				<!-- Example 2 -->
@@ -815,7 +802,6 @@ BeginProg.
 					<p align="left"><img height="1" src="Resources/pics/PanelLine.gif" width="175" /></p>
 				</div>
 				<div>
-					<div class="code-example-box">
 						<div class="code-section">
 							<div align="center">
 								<b>Source Text</b>
@@ -950,7 +936,6 @@ BeginProg.
 STOP RUN.
 </code></pre>
 						</div>
-					</div>
 					<hr align="center" size="1" width="100%" />
 				</div>
 				<!-- Example 3 -->
@@ -1011,7 +996,6 @@ STOP RUN.
 					</aside>
 				</div>
 				<div>
-					<div class="code-example-box">
 						<div class="code-section">
 							<div align="center">
 								<b>Source Text</b>
@@ -1119,7 +1103,6 @@ BeginProg.
    STOP RUN.
 </code></pre>
 						</div>
-					</div>
 					<hr align="center" size="1" width="100%" />
 				</div>
 				<!-- Example 4 -->
@@ -1143,7 +1126,6 @@ BeginProg.
 					</aside>
 				</div>
 				<div>
-					<div class="code-example-box">
 						<div class="code-section">
 							<div align="center">
 								<b>Source Text</b>
@@ -1227,7 +1209,6 @@ COPY CopyFile7 REPLACING N1 BY Num1
     ADD Num1, Num2 GIVING Result.
     STOP RUN.</code></pre>
 						</div>
-					</div>
 				</div>
 			</div>
 			<!-- Footer -->

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -77,9 +77,6 @@
 				padding: 4px;
 			}
 
-			.section-code-bg {
-				background-image: url(Resources/pics/code.gif);
-			}
 		</style>
 		<style type="text/css">
 			img {
@@ -1110,10 +1107,9 @@ END-IF</code></pre>
 						<hr />
 						<h2 align="center">Example program</h2>
 					</div>
-					<div class="section-full section-code-bg">
-						<pre
-							class="language-cobol"
-						><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+					<pre
+						class="section-full language-cobol"
+					><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.   WirthMemLib.
 AUTHOR.  Michael Coughlan.
@@ -1313,8 +1309,7 @@ ProcessOneBook.
 
 
 </code></pre>
-						<hr />
-					</div>
+					<hr />
 					<div class="section-full">
 						<div align="center">
 							<p>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -369,7 +369,6 @@
 								been accumulated.
 							</li>
 						</ul>
-						<div style="background-image: url('Resources/pics/code.gif');">
 							<pre
 								class="language-cobol"
 							><code class="language-cobol">PROCEDURE DIVISION.
@@ -397,7 +396,6 @@ Begin.
     CLOSE TextFile
     STOP RUN.
 </code></pre>
-						</div>
 						<hr />
 					</div>
 				</div>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -85,13 +85,7 @@
 				border-bottom: none;
 			}
 
-			.section-code-bg {
-				background-image: url(Resources/pics/code.gif);
-			}
-
-
 			.processing-template {
-				background-color: #E1FFE1;
 				border: 1px solid;
 				padding: 0;
 				width: 75%;

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -106,16 +106,6 @@
 				justify-content: center;
 			}
 
-			.code-display-box {
-				border: 5px solid;
-				padding: 10px;
-				width: 89%;
-				background-image: url(Resources/pics/code.gif);
-				min-height: 365px;
-				vertical-align: top;
-				box-sizing: border-box;
-			}
-
 			img {
 				max-width: 100%;
 				height: auto;
@@ -195,9 +185,6 @@
 					width: 100%;
 				}
 
-				.code-display-box {
-					width: 100%;
-				}
 			}
 		</style>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
@@ -876,7 +863,6 @@ Enter supplier key (2 digits)-&gt; 05
 							</p>
 						</div>
 						<div class="declaratives-code">
-							<div class="code-display-box">
 								<pre
 									class="language-cobol"
 								><code class="language-cobol">PROCEDURE DIVISION.
@@ -901,7 +887,6 @@ ParSectTwo2.
 END-DECLARATIVES.
 Main SECTION.
 Begin.</code></pre>
-							</div>
 						</div>
 					</div>
 					<hr />
@@ -942,7 +927,6 @@ Begin.</code></pre>
 				<div class="section-sidebar">
 					<h3 align="center">Example program - fragment</h3>
 				</div>
-				<div class="section-content" style="background-image: url(Resources/pics/code.gif);">
 					<pre class="language-cobol"><code class="language-cobol"> PROCEDURE DIVISION.
  DECLARATIVES.
  FileError SECTION.
@@ -956,7 +940,6 @@ Begin.</code></pre>
  END-DECLARATIVES.
  Main SECTION.
  Begin.</code></pre>
-				</div>
 			</div>
 			<div class="page-footer">
 				<hr />

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -90,10 +90,6 @@
 				border-bottom: none;
 			}
 
-			.section-code-bg {
-				background-image: url(Resources/pics/code.gif);
-			}
-
 			.iframe-wrapper {
 				text-align: center;
 				border: 1px solid;
@@ -358,7 +354,6 @@
 						</p>
 						<p>All the work of printing the report is being done in just 10 statements.</p>
 						<hr />
-						<div class="section-code-bg">
 							<pre class="language-cobol"><code class="language-cobol">PROCEDURE DIVISION.
 Begin.
     OPEN INPUT SalesFile.
@@ -378,7 +373,6 @@ PrintSalaryReport.
     READ SalesFile
           AT END SET EndOfFile TO TRUE
     END-READ.                                                       </code></pre>
-						</div>
 						<hr />
 					</div>
 
@@ -584,10 +578,7 @@ PrintSalaryReport.
 								The first page produced by the simple report program we are going to write is shown below.
 								In the section that follows we will examine the program that created the report.
 							</p>
-							<div class="section-code-bg" style="border: 1px solid">
-								<pre
-									class="language-cobol"
-								><code class="language-cobol">           An example COBOL Report Program
+								<pre><code>           An example COBOL Report Program
      Bible Salesperson - Sales and Salary Report
 
  City      Salesperson     Sale
@@ -641,7 +632,6 @@ Cork          1           $333.50
 
 Programmer - Michael Coughlan               Page :  1
                                                     </code></pre>
-							</div>
 						</div>
 						<hr />
 					</div>
@@ -724,7 +714,6 @@ Programmer - Michael Coughlan               Page :  1
 					</div>
 					<div class="section-content">
 						<hr />
-						<div class="section-code-bg">
 							<pre class="language-cobol"><code class="language-cobol">REPORT SECTION.
 RD  SalesReport
     CONTROLS ARE FINAL
@@ -796,7 +785,6 @@ RD  SalesReport
        03 COLUMN 52     PIC Z9 SOURCE PAGE-COUNTER.
 
 </code></pre>
-						</div>
 						<hr />
 					</div>
 
@@ -907,7 +895,6 @@ RD  SalesReport
 					</div>
 					<div class="section-content">
 						<p>Changes from the simple version are shown in red.</p>
-						<div class="section-code-bg">
 							<pre
 								class="language-cobol"
 							><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
@@ -1110,12 +1097,8 @@ PrintSalaryReport.
     READ SalesFile
           AT END SET EndOfFile TO TRUE
     END-READ.</code></pre>
-						</div>
 						<hr />
-						<div class="section-code-bg">
-							<pre
-								class="language-cobol"
-							><code class="language-cobol">           An example COBOL Report Program
+							<pre><code>           An example COBOL Report Program
      Bible Salesperson - Sales and Salary Report
 
  City      Salesperson     Sale
@@ -1168,7 +1151,6 @@ Belfast       1           $111.50
 
 
 Programmer - Michael Coughlan               Page :  1 </code></pre>
-						</div>
 						<hr />
 					</div>
 

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -1073,9 +1073,7 @@ RD  SalesReport
 							printed (see the first page of the summary report shown below).
 						</p>
 						<hr />
-						<pre
-								class="language-cobol"
-							><code class="language-cobol">          An example COBOL Report Program
+						<pre><code>          An example COBOL Report Program
      Bible Salesperson - Sales and Salary Report
 
  City      Salesperson     Sale

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -59,20 +59,12 @@
 				padding: 4px;
 			}
 
-			.section-code-bg {
-				background-image: url(Resources/pics/code.gif);
-			}
-
 			.code-block {
 				border: 1px solid;
 				padding: 5px;
 				width: 58%;
 				margin: 0 auto;
 				display: block;
-			}
-
-			.code-block-green {
-				background-color: #E1FFE1;
 			}
 
 			.code-block-wide {
@@ -421,14 +413,12 @@
 						The fields described above are individual data items but we must collect them together into a
 						record structure as follows;
 					</p>
-					<div class="code-block code-block-green">
 						<pre class="language-cobol"><code class="language-cobol">01 StudentRec.
    02 StudentId         PIC 9(7).
    02 StudentName       PIC X(10).
    02 DateOfBirth       PIC 9(8).
    02 CourseCode        PIC X(4).
    02 Gender            PIC X.</code></pre>
-					</div>
 					<p>
 						The record description above is correct as far as it goes. It reserves the correct amount of
 						storage for the record buffer. But it does not allow us to access all the individual parts of
@@ -439,7 +429,6 @@
 						consists of 4 digits for the year, 2 digits for the month and 2 digits for the day .
 					</p>
 					<p>To allow us to access these fields individually we need to declare the record as follows;</p>
-					<div class="code-block code-block-green">
 						<pre class="language-cobol"><code class="language-cobol">01 StudentRec.
    02 StudentId         PIC 9(7).
    02 StudentName.
@@ -451,7 +440,6 @@
       03 DOBirth        PIC 99.
    02 CourseCode        PIC X(4).
    02 Gender            PIC X.</code></pre>
-					</div>
 					<p>
 						In this description, StudentName is a group item consisting of Surname and Initials, and
 						DateOfBirth consists of YOBirth, MOBirth and DOBirth.
@@ -472,7 +460,6 @@
 						file.
 					</p>
 					<p>So the full file description for the students file might be;.</p>
-					<div class="code-block section-code-bg">
 						<pre class="language-cobol"><code class="language-cobol">DATA DIVISION.
 FILE SECTION.
 FD StudentFile.
@@ -487,7 +474,6 @@ FD StudentFile.
       03 DOBirth        PIC 99.
    02 CourseCode        PIC X(4).
    02 Gender            PIC X.</code></pre>
-					</div>
 					<p>
 						Note that we have assigned the name StudentFile as the internal file name. The actual name of
 						the file on disk is <i>Students.Dat</i>.
@@ -514,7 +500,6 @@ FD StudentFile.
 						<code class="language-cobol">INPUT-OUTPUT SECTION</code> in the
 						<code class="language-cobol">ENVIRONMENT DIVISION</code>.
 					</p>
-					<div class="code-block section-code-bg">
 						<pre class="language-cobol"><code class="language-cobol">ENVIRONMENT DIVISION.
 INPUT-OUTPUT SECTION.
 FILE-CONTROL.
@@ -534,7 +519,6 @@ FD StudentFile.
       03 DOBirth        PIC 99.
    02 CourseCode        PIC X(4).
    02 Gender            PIC X.</code></pre>
-					</div>
 				</div>
 				<div class="section-sidebar">
 					<h4>SELECT and ASSIGN syntax for Sequential files</h4>
@@ -744,7 +728,6 @@ SELECT StudentFile
 						to true. Since the condition name is set up as shown below, setting it to true fills the whole
 						record with <code class="language-cobol">HIGH</code>-<code class="language-cobol">VALUES</code>.
 					</p>
-					<div class="code-block code-block-green">
 						<pre class="language-cobol"><code class="language-cobol">FD StudentFile.
 01 StudentRec.
    88 EndOfFile     VALUE HIGH-VALUES.
@@ -752,7 +735,6 @@ SELECT StudentFile
    02 StudentId     PIC 9(7).
        etc
 </code></pre>
-					</div>
 					<p align="center">
 						<a href="Resources/ppz/TC-SeqFile1.html"
 							><img border="0" height="62" src="Resources/pics/i-Animation.gif" width="62"
@@ -827,7 +809,6 @@ SELECT StudentFile
 						The example program below demonstrates the items discussed above. The program gets records from
 						the user and writes them to a file. It then reads the file and displays part of each record.
 					</p>
-					<div class="code-block code-block-wide section-code-bg">
 						<pre
 							class="language-cobol"
 						><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
@@ -894,7 +875,6 @@ GetStudentRecord.
     ACCEPT  StudentRec.
 
  </code></pre>
-					</div>
 				</div>
 			</div>
 			<div class="page-footer">

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -46,15 +46,7 @@
 
 			.section-content {
 				padding: 4px;
-			}
-
-			.code-block {
-				background-image: url(Resources/pics/code.gif);
-				border: 1px solid;
-				padding: 5px;
-				max-width: 475px;
-				margin: 0 auto;
-				box-sizing: border-box;
+				min-width: 0;
 			}
 
 			.spec-block {
@@ -63,14 +55,6 @@
 				padding: 10px;
 				max-width: 500px;
 				margin: 0 auto;
-				box-sizing: border-box;
-			}
-
-			.template-block {
-				background-color: #e1ffe1;
-				border: 1px solid;
-				padding: 10px;
-				display: inline-block;
 				box-sizing: border-box;
 			}
 
@@ -90,9 +74,7 @@
 					margin: 0.2em 0;
 				}
 
-				.code-block,
-				.spec-block,
-				.template-block {
+				.spec-block {
 					max-width: 100%;
 				}
 			}
@@ -500,7 +482,6 @@ SORT WorkFile ON ASCENDING ProvinceCode
 								<b> <code class="language-cobol">SORT</code> example </b>
 							</p>
 						</div>
-						<div class="code-block">
 							<pre class="language-cobol"><code class="language-cobol">ENVIRONMENT DIVISION.
 INPUT-OUTPUT SECTION.
 FILE-CONTROL.
@@ -543,7 +524,6 @@ Begin.
         etc.
 
 </code></pre>
-						</div>
 					</div>
 					<div class="section-sidebar">
 						<h4>How a simple SORT works</h4>
@@ -873,7 +853,6 @@ SORT WorkFile ON ASCENDING CountryNameWF, CustomerNameWF
 							file, is shown in the table below.
 						</p>
 						<div align="center">
-							<div class="template-block">
 								<pre class="language-cobol"><code class="language-cobol">OPEN INPUT InFileName
 READ InFileName
 PERFORM UNTIL TerminatingCondition
@@ -882,7 +861,6 @@ PERFORM UNTIL TerminatingCondition
    READ InFileName
 END-PERFORM
 CLOSE InFileName</code></pre>
-							</div>
 						</div>
 						<hr align="center" size="1" width="100%" />
 					</div>
@@ -921,7 +899,6 @@ CLOSE InFileName</code></pre>
 							records supplied to the sort process. Since the new records are only 20 characters in size,
 							rather than 80 characters, the amount of data that has to be sorted is substantially reduced.
 						</p>
-						<div class="code-block">
 							<pre
 								class="language-cobol"
 							><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
@@ -1042,7 +1019,6 @@ PrintReportBody.
    WRITE PrintLine FROM CountryLine
          AFTER ADVANCING 1 LINE.
 </code></pre>
-						</div>
 						<hr align="center" size="1" width="100%" />
 					</div>
 					<div class="section-sidebar">
@@ -1065,7 +1041,6 @@ PrintReportBody.
 							<p align="center">
 								<img height="295" src="Resources/pics/Sort6.gif" width="515" />
 							</p>
-							<div class="code-block">
 								<pre
 									class="language-cobol"
 								><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
@@ -1129,7 +1104,6 @@ GetStudentDetails.
        RELEASE WorkRec
        ACCEPT WorkRec
     END-PERFORM.</code></pre>
-							</div>
 						</div>
 					</div>
 				</div>
@@ -1284,7 +1258,6 @@ SORT WorkFile ON ASCENDING KEY SalespersonNumWF
 							the <code class="language-cobol">SORT</code>.
 						</p>
 						<div align="center">
-							<div class="template-block">
 								<pre class="language-cobol"><code class="language-cobol">OPEN OUTPUT OutFile
 RETURN SDWorkFile RECORD
 PERFORM UNTIL TerminatingCondition
@@ -1294,7 +1267,6 @@ PERFORM UNTIL TerminatingCondition
 END-PERFORM
 CLOSE OutFile
 </code></pre>
-							</div>
 						</div>
 						<hr align="center" size="1" width="100%" />
 					</div>
@@ -1310,7 +1282,6 @@ CLOSE OutFile
 							<code class="language-cobol">OUTPUT PROCEDURE</code> is used, because until the records have
 							been sorted into salesperson number order, the salesperson records cannot be summarized.
 						</p>
-						<div class="code-block">
 							<pre
 								class="language-cobol"
 							><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
@@ -1371,7 +1342,6 @@ SummariseSales.
     END-PERFORM
     CLOSE SalesSummaryFile.
 </code></pre>
-						</div>
 						<hr align="center" size="1" width="100%" />
 					</div>
 					<div class="section-sidebar">
@@ -1386,7 +1356,6 @@ SummariseSales.
 							making the program simpler and shorter, since we no longer need all the sorted file
 							declarations.
 						</p>
-						<div class="code-block">
 							<pre
 								class="language-cobol"
 							><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
@@ -1499,7 +1468,6 @@ PrintReportBody.
    WRITE PrintLine FROM CountryLine
          AFTER ADVANCING 1 LINE.
 </code></pre>
-						</div>
 					</div>
 				</div>
 				<div align="center">
@@ -1607,7 +1575,6 @@ PrintReportBody.
 							an ordered master file, we have used the
 							<code class="language-cobol">MERGE</code> verb to merge the files.
 						</p>
-						<div class="code-block">
 							<pre
 								class="language-cobol"
 							><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
@@ -1656,7 +1623,6 @@ Begin.
        GIVING NewStudentFile.
     STOP RUN.
 </code></pre>
-						</div>
 					</div>
 				</div>
 				<div>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -51,14 +51,6 @@
 				padding: 4px;
 			}
 
-			.code-block {
-				background-image: url(Resources/pics/code.gif);
-				border: 1px solid;
-				padding: 5px;
-				box-sizing: border-box;
-				max-width: 100%;
-			}
-
 			.code-run-pair {
 				display: flex;
 				border: 1px solid;
@@ -66,7 +58,6 @@
 			}
 
 			.code-run-pair .code-part {
-				background-image: url(Resources/pics/code.gif);
 				padding: 5px;
 				flex: 1;
 			}
@@ -464,17 +455,14 @@
 						The example fragments below show how a <code class="language-cobol">CALL</code> statement is
 						made in a calling program to invoke and pass parameters to a subprogram (shown in outline).
 					</p>
-					<div class="code-block" style="max-width: 399px; margin: 0 auto;">
 						<pre class="language-cobol"><code class="language-cobol">
 CALL "DateValidate"
      USING BY CONTENT TempDate
      USING BY REFERENCE DateCheckResult.
 </code></pre>
-					</div>
 					<div align="center">
 						The <code class="language-cobol">CALL</code> statement in the calling program.<br />
 					</div>
-					<div class="code-block" style="max-width: 374px; margin: 0 auto;">
 						<pre class="language-cobol"><code class="language-cobol">
 IDENTIFICATION DIVISION.
 PROGRAM-ID DateValidate IS INITIAL.
@@ -493,7 +481,6 @@ Begin.
        ? ? ? ? ? ? ? ? ? ? ? ?
 
 </code></pre>
-					</div>
 					<div align="center">
 						<p>Outline of the called program</p>
 						<p align="left">
@@ -579,7 +566,6 @@ Begin.
 						previous call, will produce different results when called with the same value.
 					</p>
 					<div align="center">
-						<div class="code-block" style="max-width: 412px; margin: 0 auto;">
 							<pre class="language-cobol"><code class="language-cobol">
 ? ? ? ? ? ? ? ? ? ?
 MOVE 12 TO IncrementVal.
@@ -601,7 +587,6 @@ MOVE 12 TO IncrementVal.
 CALL "Fickle" USING BY CONTENT IncrementVal.
 ? ? ? ? ? ? ? ? ? ?
 </code></pre>
-						</div>
 						Statements in the calling program<br />
 					</div>
 					<div class="code-run-pair" style="max-width: 439px; margin: 0 auto;">
@@ -908,7 +893,6 @@ CALL "Fickle" USING BY CONTENT IncValue.</code></pre>
 						The <code class="language-cobol">IS GLOBAL</code> clause specifies that the data item is to be
 						visible within any subordinate contained subprograms.
 					</p>
-					<div class="code-block" style="max-width: 383px; margin: 0 auto;">
 						<pre
 							class="language-cobol"
 						><code class="language-cobol">      &gt;&gt;SOURCE FORMAT IS FREE
@@ -942,7 +926,6 @@ PROGRAM-ID. ReportFromTable.
    EXIT PROGRAM
 END-PROGRAM ReportFromTable.
 END-PROGRAM ContainerProgram.</code></pre>
-					</div>
 					<hr size="1" width="100%" />
 				</div>
 				<div class="section-sidebar">
@@ -1036,7 +1019,6 @@ END-PROGRAM ContainerProgram.</code></pre>
 						Microfocus NetExpress telling the compiler to expect contained subprograms. It is not standard
 						COBOL.
 					</p>
-					<div class="code-block" style="max-width: 374px; margin: 0 auto;">
 						<pre
 							class="language-cobol"
 						><code class="language-cobol">      &gt;&gt;SOURCE FORMAT IS FREE
@@ -1071,7 +1053,6 @@ END PROGRAM DisplayData.
 
 END PROGRAM MainProgram.
 </code></pre>
-					</div>
 					<hr size="1" width="100%" />
 				</div>
 				<div class="section-sidebar">
@@ -1093,8 +1074,6 @@ END PROGRAM MainProgram.
 						<code class="language-cobol">CANCEL</code> command is used to initialize "Fickle" so that the
 						next number may be computed.
 					</p>
-					<div style="max-width: 374px; margin: 0 auto; border: 1px solid; box-sizing: border-box;">
-						<div style="background-image: url(Resources/pics/code.gif); padding: 5px;">
 							<pre
 								class="language-cobol"
 							><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
@@ -1177,7 +1156,6 @@ Begin.
   EXIT PROGRAM.
 END PROGRAM DisplayTotal.
 END PROGRAM Counter.</code></pre>
-						</div>
 						<div style="background-color: #FFFFFF; padding: 5px; border-top: 1px solid;">
 							<div align="center">
 								<h3><b>Example Run</b></h3>
@@ -1215,7 +1193,6 @@ Fickle total =  6
 Fickle total =  9
 Value - 0</code></pre>
 						</div>
-					</div>
 					<hr size="1" width="100%" />
 				</div>
 				<div class="section-sidebar">

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -72,12 +72,6 @@
 				align-self: start;
 			}
 
-			.code-bg-box {
-				background-image: url(Resources/pics/code.gif);
-				border: 1px solid #c0c0c0;
-				padding: 10px;
-				box-sizing: border-box;
-			}
 		</style>
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<style type="text/css">
@@ -619,7 +613,6 @@ END-UNSTRING.</code></pre>
 							and writes the unpacked record to a new file.
 						</p>
 						<div align="center">
-							<div class="code-bg-box">
 								<pre
 									class="language-cobol"
 								><code class="language-cobol">IDENTIFICATION DIVISION.
@@ -676,7 +669,6 @@ Begin.
     END-PERFORM
     CLOSE CommaDelimitedFile, CustomerFile
     STOP RUN.</code></pre>
-							</div>
 						</div>
 					</div>
 				</div>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -92,16 +92,6 @@
 				padding: 4px;
 			}
 
-			.code-fragment {
-				background-image: url(Resources/pics/code.gif);
-				border: 1px solid;
-				padding: 5px;
-				margin: 0 auto;
-				overflow-x: auto;
-				display: block;
-				width: fit-content;
-				max-width: 100%;
-			}
 
 			@media (max-width: 600px) {
 				body {
@@ -383,7 +373,6 @@
 						Consider the following program fragment. What would happen if computations were done
 						directly on numbers stored in this format?
 					</p>
-					<div class="code-fragment">
 						<pre
 							class="language-cobol"
 						><code class="language-cobol">   ? ? ? ? ? ? ? ? ? ? ? ?
@@ -398,7 +387,6 @@ Begin.
    ? ? ? ? ? ? ? ? ? ? ? ?
    ADD Num1, Num2 GIVING Num3
    ? ? ? ? ? ? ? ? ? ? ? ?</code></pre>
-					</div>
 					<p>
 						Since none of the data items have an explicit
 						<code class="language-cobol">USAGE</code> clause they default to -
@@ -2378,7 +2366,6 @@ Begin.
 						</li>
 					</ol>
 					<p><b>USAGE examples</b></p>
-					<div class="code-fragment">
 						<pre class="language-cobol"><code class="language-cobol">
 01 Num1 PIC 9(5)V99 USAGE IS COMP.
 01 Num2 PIC 99 USAGE IS PACKED-DECIMAL.
@@ -2393,7 +2380,6 @@ Begin.
    02 NumItem1 PIC 9(3)V99 USAGE IS COMP.
    02 NumItem2 PIC 99V99   USAGE IS COMP.
 </code></pre>
-					</div>
 					<p>
 						<b>COMP/COMPUTATIONAL/BINARY</b><br />
 						<code class="language-cobol">COMP</code> items are held in memory as pure binary


### PR DESCRIPTION
## Summary

The course pages had divs/tables wrapping COBOL `<pre>` blocks with `Resources/pics/code.gif` as a greenbar background, layered on top of Prism's own theme. This PR unwraps those wrappers across 12 pages so Prism's styling applies cleanly, and removes the now-dead CSS rules.

## Pages touched

`COBOLcommands`, `Copy`, `IndexedFiles`, `Inspect`, `Iteration`, `RelativeFiles`, `ReportWriter`, `ReportWriterSS`, `SequentialFiles1`, `SortMerge`, `Subprograms`, `Unstring`, `Usage`.

## Notable judgement calls / collateral fixes

- **IndexedFiles**: the wrapper combined `section-full` (grid-spanning layout) with `section-code-bg`. Moved `section-full` onto the inner `<pre>` so the example program still spans the full content column.
- **Iteration**: also dropped the green background from `.processing-template` (per follow-up request).
- **ReportWriter / ReportWriterSS**: the plain-text sample output reports were marked `language-cobol` and Prism was tokenizing them. Switched them to plain `<pre><code>`.
- **SequentialFiles1**: unwrapped the three `code-block code-block-green` divs and removed the dead `.code-block-green` rule.
- **SortMerge**: added `min-width: 0` to `.section-content` so wide `<pre>` blocks honour `overflow-x: auto` instead of expanding the grid track; unwrapped the two `template-block` greenbg divs.
- **Subprograms**: removed the `max-width: 374px` wrapper around the Counter example. Restored the `.code-part` wrapper inside `.code-run-pair` (with the code.gif background omitted) so the stacked Steadfast/Fickle `<pre>`s share one flex column beside the Example Runs panel — matches the deployed layout.

## Test plan

- [ ] Spot-check each touched course page in a desktop browser; confirm no greenbar background under code blocks.
- [ ] Confirm Prism syntax highlighting still renders.
- [ ] On `SortMerge`, confirm the wide SORT example no longer overflows the right edge.
- [ ] On `Subprograms`, confirm the Steadfast/Fickle blocks render with code on the left and Example Runs on the right (not all squished into separate columns).
- [ ] On `ReportWriter` / `ReportWriterSS`, confirm the plain-text sample report renders as plain monospace (no Prism tokenization).