### PR TITLE
Consolidate shared section/page CSS into course.css

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -4,24 +4,11 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>Introduction to COBOL</title>
+		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" charset="utf-8" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" charset="utf-8" defer></script>
 		<style type="text/css">
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			table {
-				max-width: 100%;
-			}
-
-			body > hr {
-				margin-left: auto;
-				margin-right: auto;
-			}
-
 			#page-layout {
 				display: grid;
 				grid-template-columns: 175px 1fr;
@@ -154,22 +141,6 @@
 				}
 			}
 
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
 		</style>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -6,43 +6,12 @@
 		<title>Basic Procedure Division commands</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style type="text/css">
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
-			}
-
 			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
 				min-width: 0;
 				border-bottom: 1px solid;
 			}
 
 			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
 				align-self: stretch;
 				min-width: 0;
 				border-right: 1px solid;
@@ -50,7 +19,6 @@
 			}
 
 			.section-content {
-				padding: 4px;
 				align-self: start;
 				min-width: 0;
 				overflow: hidden;
@@ -58,8 +26,6 @@
 			}
 
 			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
 				min-width: 0;
 				border-bottom: 1px solid;
 			}
@@ -72,22 +38,6 @@
 			.section-content code[class*="language-"] {
 				white-space: pre-wrap;
 				overflow-wrap: break-word;
-			}
-
-			@media (max-width: 600px) {
-				.section-header h2,
-				.section-header h3 {
-					margin: 0.3em 0;
-				}
-
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
 			}
 		</style>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -4,24 +4,11 @@
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>The COPY verb</title>
+		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<style type="text/css">
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			pre {
-				overflow-x: auto;
-				max-width: 100%;
-			}
-
-			body {
-				-webkit-text-size-adjust: 100%;
-			}
-
 			.page-frame {
 				border: 1px solid black;
 				max-width: 715px;
@@ -68,89 +55,18 @@
 				background-color: #FFFFFF;
 			}
 
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
-
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
 			.sidebar h4 {
 				color: #800000;
 				font-family: Arial, Helvetica, sans-serif;
 			}
 
 			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				hr[width] {
-					width: 100% !important;
-				}
-
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					white-space: pre-wrap;
-					word-wrap: break-word;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"],
-				code[class*="language-"] {
-					white-space: pre-wrap !important;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
-				}
-
 				.page-frame {
 					border: none;
 				}
 
 				.layout-grid {
 					grid-template-columns: 1fr;
-				}
-
-				.section-header h2,
-				.section-header h3 {
-					margin: 0.3em 0;
 				}
 
 				.sidebar > h4:not(:first-child):not(:has(img)),

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -4,28 +4,11 @@
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>Declaring Data in COBOL</title>
+		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<style type="text/css">
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			table {
-				max-width: 100%;
-			}
-
-			pre {
-				overflow-x: auto;
-				max-width: 100%;
-			}
-
-			body {
-				-webkit-text-size-adjust: 100%;
-			}
-
 			.page-layout {
 				display: grid;
 				grid-template-columns: 175px 1fr;
@@ -102,30 +85,7 @@
 				padding-top: 0.15em;
 			}
 
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
-
 			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
 				.page-layout {
 					grid-template-columns: 1fr;
 					border-right: 1px solid black;
@@ -139,44 +99,6 @@
 				.sidebar h4,
 				.sidebar p {
 					margin: 0.2em 0;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				hr[width] {
-					width: 100% !important;
-				}
-
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					white-space: pre-wrap;
-					word-wrap: break-word;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"],
-				code[class*="language-"] {
-					white-space: pre-wrap !important;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
 				}
 
 				.code-record {

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -8,26 +8,16 @@
 		<style type="text/css">
 			ul.toc {
 				list-style-type: disc;
-				padding-left: 2.5em;
-				margin: 1em 0;
 			}
 
 			ul.toc > li {
-				margin-bottom: 0.6em;
+				padding-left: 0;
+				font-size: inherit;
 			}
 
 			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
 				text-align: center;
 				margin: 0.3em 0;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
 			}
 
 			.page-content {
@@ -38,22 +28,12 @@
 				padding: 4px;
 			}
 
-			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
-			}
-
 			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
 				min-width: 0;
 				border-bottom: 1px solid;
 			}
 
 			.section-sidebar {
-				background-color: #ffffcc;
-				padding: 4px;
 				align-self: stretch;
 				min-width: 0;
 				border-right: 1px solid;
@@ -61,7 +41,6 @@
 			}
 
 			.section-content {
-				padding: 4px;
 				align-self: start;
 				min-width: 0;
 				overflow: hidden;
@@ -69,87 +48,12 @@
 			}
 
 			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
 				min-width: 0;
 				border-bottom: 1px solid;
 			}
 
 			.section-full:last-child {
 				border-bottom: none;
-			}
-
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			pre {
-				overflow-x: auto;
-				max-width: 100%;
-			}
-
-			table {
-				max-width: 100%;
-			}
-
-			body {
-				-webkit-text-size-adjust: 100%;
-			}
-
-			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
-				.section-header h2 {
-					margin: 0.3em 0;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					white-space: pre-wrap;
-					word-wrap: break-word;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"],
-				code[class*="language-"] {
-					white-space: pre-wrap !important;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
-				}
-
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
 			}
 		</style>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -4,172 +4,18 @@
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>Indexed Files</title>
+		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<style type="text/css">
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
-
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.page-footer {
-				padding: 2px;
-			}
-
-			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
-			}
-
-			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-			}
-
 			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
 				align-self: stretch;
 			}
 
-			.section-content {
-				padding: 4px;
-			}
-
-			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
-			}
-
-		</style>
-		<style type="text/css">
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			table {
-				max-width: 100%;
-			}
-
 			pre {
-				overflow-x: auto;
 				max-width: 700px;
 				box-sizing: border-box;
-			}
-
-			body {
-				-webkit-text-size-adjust: 100%;
-			}
-
-			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
-				table[width] {
-					width: 100% !important;
-					height: auto !important;
-				}
-
-				td[width],
-				th[width],
-				td[height],
-				th[height] {
-					width: auto !important;
-					height: auto !important;
-				}
-
-				.section-header h2,
-				.section-header h3 {
-					margin: 0.3em 0;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				hr[width] {
-					width: 100% !important;
-				}
-
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					white-space: pre-wrap;
-					word-wrap: break-word;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"],
-				code[class*="language-"] {
-					white-space: pre-wrap !important;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
-				}
-
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
 			}
 		</style>
 		<script src="../components/copyright-notice.js" defer></script>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -4,15 +4,13 @@
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>Introduction to Direct Access Files</title>
+		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<style type="text/css">
-			/* === Page layout === */
 			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
+				box-sizing: content-box;
 			}
 
 			.page-content {
@@ -32,33 +30,7 @@
 				text-align: center;
 			}
 
-			/* === TOC === */
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
-
-			/* === Section layout === */
-			.section-header {
-				background-color: #993300;
-				padding: 4px;
-			}
-
 			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
 				text-align: center;
 				margin: 0.3em 0;
 			}
@@ -119,33 +91,7 @@
 				text-align: center;
 			}
 
-			/* === Shared === */
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			table {
-				max-width: 100%;
-			}
-
-			pre {
-				overflow-x: auto;
-				max-width: 100%;
-			}
-
-			body {
-				-webkit-text-size-adjust: 100%;
-			}
-
-			/* === Mobile === */
 			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
 				.section-row {
 					grid-template-columns: 1fr;
 				}
@@ -161,53 +107,6 @@
 
 				.two-col {
 					flex-direction: column;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					white-space: pre-wrap;
-					word-wrap: break-word;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"],
-				code[class*="language-"] {
-					white-space: pre-wrap !important;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
-				}
-
-				table[width] {
-					width: 100% !important;
-					height: auto !important;
-				}
-
-				td[width],
-				th[width],
-				td[height],
-				th[height] {
-					width: auto !important;
-					height: auto !important;
 				}
 			}
 		</style>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -6,61 +6,12 @@
 		<title>COBOL Interation Constructs</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style type="text/css">
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
-
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
-			}
-
 			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
 				min-width: 0;
 				border-bottom: 1px solid;
 			}
 
 			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
 				align-self: stretch;
 				min-width: 0;
 				border-right: 1px solid;
@@ -68,15 +19,12 @@
 			}
 
 			.section-content {
-				padding: 4px;
 				align-self: start;
 				min-width: 0;
 				border-bottom: 1px solid;
 			}
 
 			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
 				min-width: 0;
 				border-bottom: 1px solid;
 			}
@@ -139,84 +87,7 @@
 				vertical-align: top;
 			}
 
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			pre {
-				max-width: 100%;
-				white-space: pre-wrap;
-				word-wrap: break-word;
-				overflow-wrap: break-word;
-			}
-
-			pre[class*="language-"],
-			code[class*="language-"] {
-				white-space: pre-wrap !important;
-				overflow-wrap: break-word;
-			}
-
-			body {
-				-webkit-text-size-adjust: 100%;
-			}
-
 			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
-				.section-header h2,
-				.section-header h3 {
-					margin: 0.3em 0;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					white-space: pre-wrap;
-					word-wrap: break-word;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"],
-				code[class*="language-"] {
-					white-space: pre-wrap !important;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
-				}
-
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
-
 				.saq-row {
 					display: block;
 					border-bottom: 2px solid #999;

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -6,51 +6,11 @@
 		<title>Reference Modification</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style>
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.page-footer {
-				padding: 2px;
-			}
-
 			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
 				align-items: stretch;
 			}
 
-			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-			}
-
-			.section-sidebar {
-				background-color: #ffffcc;
-				padding: 4px;
-			}
-
 			.section-content {
-				padding: 4px;
 				min-width: 0;
 			}
 
@@ -73,11 +33,6 @@
 				overflow-wrap: break-word;
 			}
 
-			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
-			}
-
 			.results-box {
 				background-color: #ddffff;
 				border: 2px solid;
@@ -97,27 +52,7 @@
 				gap: 1em;
 			}
 
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			pre {
-				overflow-x: auto;
-				max-width: 100%;
-			}
-
 			@media (max-width: 600px) {
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
-
 				.results-two-col {
 					flex-direction: column;
 					gap: 0;

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -6,65 +6,12 @@
 		<title>Relative Files</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style type="text/css">
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
-
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.page-footer {
-				padding: 2px;
-			}
-
-			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
-			}
-
 			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
 				min-width: 0;
 				border-bottom: 1px solid;
 			}
 
 			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
 				align-self: stretch;
 				min-width: 0;
 				border-right: 1px solid;
@@ -72,7 +19,6 @@
 			}
 
 			.section-content {
-				padding: 4px;
 				align-self: start;
 				min-width: 0;
 				overflow: hidden;
@@ -80,8 +26,6 @@
 			}
 
 			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
 				min-width: 0;
 				border-bottom: 1px solid;
 			}
@@ -106,14 +50,7 @@
 				justify-content: center;
 			}
 
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
 			pre {
-				overflow-x: auto;
-				max-width: 100%;
 				white-space: pre-wrap;
 				word-wrap: break-word;
 				overflow-wrap: break-word;
@@ -125,57 +62,7 @@
 				overflow-wrap: break-word;
 			}
 
-			body {
-				-webkit-text-size-adjust: 100%;
-			}
-
 			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
-				.section-header h2,
-				.section-header h3 {
-					margin: 0.3em 0;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
-				}
-
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
-
 				.declaratives-layout {
 					flex-direction: column;
 				}
@@ -184,7 +71,6 @@
 					justify-content: flex-start;
 					width: 100%;
 				}
-
 			}
 		</style>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -6,65 +6,12 @@
 		<title>COBOL Report Writer</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style type="text/css">
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
-
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.page-footer {
-				padding: 2px;
-			}
-
-			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
-			}
-
 			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
 				min-width: 0;
 				border-bottom: 1px solid;
 			}
 
 			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
 				align-self: stretch;
 				min-width: 0;
 				border-right: 1px solid;
@@ -72,7 +19,6 @@
 			}
 
 			.section-content {
-				padding: 4px;
 				align-self: start;
 				min-width: 0;
 				overflow: hidden;
@@ -80,8 +26,6 @@
 			}
 
 			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
 				min-width: 0;
 				border-bottom: 1px solid;
 			}
@@ -93,77 +37,6 @@
 			.iframe-wrapper {
 				text-align: center;
 				border: 1px solid;
-			}
-
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			pre {
-				overflow-x: auto;
-				max-width: 100%;
-			}
-
-			body {
-				-webkit-text-size-adjust: 100%;
-			}
-
-			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
-				.section-header h2,
-				.section-header h3 {
-					margin: 0.3em 0;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					white-space: pre-wrap;
-					word-wrap: break-word;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"],
-				code[class*="language-"] {
-					white-space: pre-wrap !important;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
-				}
-
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
 			}
 		</style>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -6,65 +6,12 @@
 		<title>COBOL Report Writer - Syntax and Semantics</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style type="text/css">
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
-
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.page-footer {
-				padding: 2px;
-			}
-
-			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
-			}
-
 			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
 				min-width: 0;
 				border-bottom: 1px solid;
 			}
 
 			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
 				align-self: stretch;
 				min-width: 0;
 				border-right: 1px solid;
@@ -72,7 +19,6 @@
 			}
 
 			.section-content {
-				padding: 4px;
 				align-self: start;
 				min-width: 0;
 				overflow: hidden;
@@ -80,8 +26,6 @@
 			}
 
 			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
 				min-width: 0;
 				border-bottom: 1px solid;
 			}
@@ -90,14 +34,7 @@
 				border-bottom: none;
 			}
 
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
 			pre {
-				overflow-x: auto;
-				max-width: 100%;
 				white-space: pre-wrap;
 				word-wrap: break-word;
 				overflow-wrap: break-word;
@@ -107,58 +44,6 @@
 			code[class*="language-"] {
 				white-space: pre-wrap !important;
 				overflow-wrap: break-word;
-			}
-
-			body {
-				-webkit-text-size-adjust: 100%;
-			}
-
-			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
-				.section-header h2,
-				.section-header h3 {
-					margin: 0.3em 0;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
-				}
-
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
 			}
 		</style>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/Resources/css/course.css
+++ b/course/Resources/css/course.css
@@ -136,3 +136,71 @@ td[bgcolor="#FFFFCC"] h4 {
 	color: #800000;
 	font-family: Arial, Helvetica, sans-serif;
 }
+
+.section-header h2 {
+	color: #ffff00;
+	font-family: Arial, Helvetica, sans-serif;
+}
+
+.section-sidebar h3,
+.section-sidebar h4 {
+	color: #800000;
+	font-family: Arial, Helvetica, sans-serif;
+}
+
+.page-wrapper {
+	max-width: 715px;
+	margin: 0 auto;
+	border: 1px solid;
+	box-sizing: border-box;
+}
+
+.page-content {
+	padding: 2px;
+}
+
+.page-footer {
+	padding: 2px;
+}
+
+.section-grid {
+	display: grid;
+	grid-template-columns: 175px 1fr;
+}
+
+.section-header {
+	grid-column: 1 / -1;
+	background-color: #993300;
+	padding: 4px;
+}
+
+.section-sidebar {
+	background-color: #FFFFCC;
+	padding: 4px;
+}
+
+.section-content {
+	padding: 4px;
+}
+
+.section-full {
+	grid-column: 1 / -1;
+	padding: 4px;
+}
+
+@media (max-width: 600px) {
+	.section-header h2,
+	.section-header h3 {
+		margin: 0.3em 0;
+	}
+
+	.section-grid {
+		display: block;
+	}
+
+	.section-sidebar h3,
+	.section-sidebar h4,
+	.section-sidebar p {
+		margin: 0.2em 0;
+	}
+}

--- a/course/Search.html
+++ b/course/Search.html
@@ -6,65 +6,12 @@
 		<title>Searching Tables</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style type="text/css">
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
-
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.page-footer {
-				padding: 2px;
-			}
-
-			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
-			}
-
 			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
 				min-width: 0;
 				border-bottom: 1px solid;
 			}
 
 			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
 				align-self: stretch;
 				min-width: 0;
 				border-right: 1px solid;
@@ -72,7 +19,6 @@
 			}
 
 			.section-content {
-				padding: 4px;
 				align-self: start;
 				min-width: 0;
 				overflow: hidden;
@@ -80,8 +26,6 @@
 			}
 
 			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
 				min-width: 0;
 				border-bottom: 1px solid;
 			}
@@ -90,14 +34,7 @@
 				border-bottom: none;
 			}
 
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
 			pre {
-				overflow-x: auto;
-				max-width: 100%;
 				white-space: pre-wrap;
 				word-wrap: break-word;
 				overflow-wrap: break-word;
@@ -107,58 +44,6 @@
 			code[class*="language-"] {
 				white-space: pre-wrap !important;
 				overflow-wrap: break-word;
-			}
-
-			body {
-				-webkit-text-size-adjust: 100%;
-			}
-
-			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
-				.section-header h2,
-				.section-header h3 {
-					margin: 0.3em 0;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
-				}
-
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
 			}
 		</style>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -6,65 +6,12 @@
 		<title>COBOL Selection Constructs</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style type="text/css">
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
-
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.page-footer {
-				padding: 2px;
-			}
-
-			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
-			}
-
 			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
 				min-width: 0;
 				border-bottom: 1px solid;
 			}
 
 			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
 				align-self: stretch;
 				min-width: 0;
 				border-right: 1px solid;
@@ -72,7 +19,6 @@
 			}
 
 			.section-content {
-				padding: 4px;
 				align-self: start;
 				min-width: 0;
 				overflow: hidden;
@@ -80,8 +26,6 @@
 			}
 
 			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
 				min-width: 0;
 				border-bottom: 1px solid;
 			}
@@ -90,14 +34,7 @@
 				border-bottom: none;
 			}
 
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
 			pre {
-				overflow-x: auto;
-				max-width: 100%;
 				white-space: pre-wrap;
 				word-wrap: break-word;
 				overflow-wrap: break-word;
@@ -125,10 +62,6 @@
 			code[class*="language-"] {
 				white-space: pre-wrap !important;
 				overflow-wrap: break-word;
-			}
-
-			body {
-				-webkit-text-size-adjust: 100%;
 			}
 
 			.code-compare {
@@ -162,46 +95,6 @@
 			}
 
 			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
-				.section-header h2,
-				.section-header h3 {
-					margin: 0.3em 0;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
-				}
-
-				.section-grid {
-					grid-template-columns: 1fr;
-				}
-
 				.section-header {
 					grid-column: 1;
 				}

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -6,57 +6,12 @@
 		<title>Introduction to Sequential Files</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style>
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.page-footer {
-				padding: 2px;
-			}
-
 			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
 				align-items: stretch;
 			}
 
-			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-			}
-
-			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
-			}
-
 			.section-content {
-				padding: 4px;
 				min-width: 0;
-			}
-
-			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
 			}
 
 			.code-block {
@@ -72,16 +27,6 @@
 			}
 
 			@media (max-width: 600px) {
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
-
 				.code-block {
 					width: 100%;
 				}

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -6,57 +6,12 @@
 		<title>Processing Sequential Files</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style>
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.page-footer {
-				padding: 2px;
-			}
-
 			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
 				align-items: stretch;
 			}
 
-			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-			}
-
-			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
-			}
-
 			.section-content {
-				padding: 4px;
 				min-width: 0;
-			}
-
-			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
 			}
 
 			.qa-form {

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -6,69 +6,12 @@
 		<title>Print files and variable-length records</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style>
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.page-footer {
-				padding: 2px;
-			}
-
 			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
 				align-items: stretch;
 			}
 
-			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-			}
-
-			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
-			}
-
 			.section-content {
-				padding: 4px;
 				min-width: 0;
-			}
-
-			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
-			}
-
-			@media (max-width: 600px) {
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
 			}
 		</style>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -6,46 +6,7 @@
 		<title>Sorting and Merging files</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style>
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
-			}
-
-			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-			}
-
-			.section-sidebar {
-				background-color: #ffffcc;
-				padding: 4px;
-			}
-
 			.section-content {
-				padding: 4px;
 				min-width: 0;
 			}
 

--- a/course/String.html
+++ b/course/String.html
@@ -3,43 +3,13 @@
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>The STRING verb</title>
+		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<style type="text/css">
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
-
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
 			.page-wrapper {
-				border: 1px solid;
-				max-width: 715px;
-				margin-left: auto;
-				margin-right: auto;
+				box-sizing: content-box;
 			}
 
 			.page-header {
@@ -48,27 +18,19 @@
 			}
 
 			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
 				max-width: 710px;
 				margin: 0 auto;
 			}
 
 			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
 				text-align: left;
 			}
 
 			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
 				text-align: left;
 			}
 
 			.section-content {
-				padding: 4px;
 				min-width: 0;
 			}
 
@@ -79,92 +41,11 @@
 		</style>
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<style type="text/css">
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			table {
-				max-width: 100%;
-			}
-
-			pre {
-				overflow-x: auto;
-				max-width: 100%;
-			}
-
-			body {
-				-webkit-text-size-adjust: 100%;
-			}
-
 			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
-				table[width],
 				table[width] > tbody,
-				table[width] > tbody > tr,
-				table[width] > tbody > tr > td {
+				table[width] > tbody > tr {
 					width: auto !important;
 					height: auto !important;
-				}
-
-				td[width],
-				th[width],
-				td[height],
-				th[height] {
-					width: auto !important;
-					height: auto !important;
-				}
-
-				.section-header h2,
-				.section-header h3 {
-					margin: 0.3em 0;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				hr[width] {
-					width: 100% !important;
-				}
-
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					white-space: pre-wrap;
-					word-wrap: break-word;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"],
-				code[class*="language-"] {
-					white-space: pre-wrap !important;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
-				}
-
-				.section-grid {
-					grid-template-columns: 1fr;
 				}
 
 				.section-header {

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -6,51 +6,6 @@
 		<title>Contained and external sub-programs</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style>
-			img { max-width: 100%; height: auto; }
-			pre { overflow-x: auto; max-width: 100%; }
-			body { -webkit-text-size-adjust: 100%; }
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content { padding: 2px; }
-			.page-footer { padding: 2px; }
-
-			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
-			}
-
-			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-			}
-
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-content {
-				padding: 4px;
-			}
-
 			.code-run-pair {
 				display: flex;
 				border: 1px solid;
@@ -69,57 +24,6 @@
 			}
 
 			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
-				.section-header h2,
-				.section-header h3 {
-					margin: 0.3em 0;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				hr[width] { width: 100% !important; }
-
-				img, iframe, video, embed, object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					white-space: pre-wrap;
-					word-wrap: break-word;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"],
-				code[class*="language-"] {
-					white-space: pre-wrap !important;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
-				}
-
-				.section-grid { display: block; }
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
-
 				.code-run-pair { flex-direction: column; }
 				.code-run-pair .run-part { border-left: none; border-top: 1px solid; }
 			}

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -6,83 +6,12 @@
 		<title>Using Tables</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style>
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.page-footer {
-				padding: 2px;
-			}
-
 			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
 				align-items: stretch;
 			}
 
-			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-			}
-
-			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
-			}
-
 			.section-content {
-				padding: 4px;
 				min-width: 0;
-			}
-
-			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
-			}
-
-			table {
-				max-width: 100%;
-			}
-
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			pre {
-				overflow-x: auto;
-				max-width: 100%;
-			}
-
-			@media (max-width: 600px) {
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
 			}
 		</style>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -6,52 +6,12 @@
 		<title>Creating tables - syntax and semantics</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style>
-			table { max-width: 100%; }
-			img { max-width: 100%; height: auto; }
-
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
 			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
 				align-items: stretch;
 			}
 
-			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-			}
-
-			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
-			}
-
 			.section-content {
-				padding: 4px;
 				min-width: 0;
-			}
-
-			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
 			}
 
 			form select {
@@ -60,16 +20,6 @@
 			}
 
 			@media (max-width: 600px) {
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
-
 				form select {
 					max-width: 100%;
 					width: 100%;

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -3,170 +3,20 @@
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>The UNSTRING verb</title>
+		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<style type="text/css">
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
-
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.page-footer {
-				padding: 2px;
-			}
-
-			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
-			}
-
-			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-			}
-
 			.section-sidebar {
-				background-color: #ffffcc;
-				padding: 4px;
 				align-self: stretch;
 			}
 
 			.section-content {
-				padding: 4px;
 				align-self: start;
 			}
-
 		</style>
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
-		<style type="text/css">
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			table {
-				max-width: 100%;
-			}
-
-			pre {
-				overflow-x: auto;
-				max-width: 100%;
-			}
-
-			body {
-				-webkit-text-size-adjust: 100%;
-			}
-
-			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
-				table[width] {
-					width: 100% !important;
-					height: auto !important;
-				}
-
-				td[width],
-				th[width],
-				td[height],
-				th[height] {
-					width: auto !important;
-					height: auto !important;
-				}
-
-				.section-header h2,
-				.section-header h3 {
-					margin: 0.3em 0;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				hr[width] {
-					width: 100% !important;
-				}
-
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					white-space: pre-wrap;
-					word-wrap: break-word;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"],
-				code[class*="language-"] {
-					white-space: pre-wrap !important;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
-				}
-
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
-			}
-		</style>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -4,158 +4,27 @@
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>The USAGE clause</title>
+		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<style type="text/css">
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			table {
-				max-width: 100%;
-			}
-
-			pre {
-				overflow-x: auto;
-				max-width: 100%;
-			}
-
-			body {
-				-webkit-text-size-adjust: 100%;
-			}
-
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
-
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
 			.page-footer {
 				padding: 4px;
 			}
 
 			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
-				padding: 4px;
-			}
-
-			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-			}
-
-			.section-sidebar {
-				background-color: #FFFFCC;
 				padding: 4px;
 			}
 
 			.section-content {
-				padding: 4px;
 				align-self: start;
 			}
 
-			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
-			}
-
-
 			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				hr[width] {
-					width: 100% !important;
-				}
-
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					white-space: pre-wrap;
-					word-wrap: break-word;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"],
-				code[class*="language-"] {
-					white-space: pre-wrap !important;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
-				}
-
-				.section-grid {
-					display: block;
-				}
-
-				.section-header h2,
-				.section-header h3 {
-					margin: 0.3em 0;
-				}
-
 				.section-sidebar h4:not(:first-child):not(:has(img)),
 				h4:has(> img[src*="PanelLine"]) {
 					display: none;
-				}
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
 				}
 			}
 		</style>


### PR DESCRIPTION
## Summary

- Moved the section-grid / section-header / section-sidebar / section-content / section-full layout, page-wrapper / page-content / page-footer chrome, and the shared mobile media query rules into `course/Resources/css/course.css`.
- Per-page `<style>` blocks now keep only their genuine variations (extra borders, custom breakpoints, page-specific components like `.qa-form`, `.code-compare`, `.spec-block`, `.code-block`, etc.).
- Added the `course.css` `<link>` to eight pages that previously didn't load it: COBOLIntro, Copy, DataDeclaration, IndexedFiles, Intro2DirectAccess, String, Unstring, Usage.

Net: **+81 / -2190 lines** across 24 course pages and the shared stylesheet.

## Why

The course HTML files had drifted into duplicating ~80 lines of nearly identical CSS each. Centralizing the common base lets future tweaks (e.g. brown header tone, sidebar background, mobile breakpoint) happen in one place.

`Inspect.html` is intentionally left untouched — it uses a different `course-section-*` namespace and is self-contained.

## Test plan

- [x] `Tables1.html`, `Selection.html`, `Inspect.html`, `RefMod.html`, `Iteration.html` render correctly via local http-server (section header brown/yellow, sidebar beige/maroon, page-wrapper border, TOC bullets all intact).
- [ ] Spot-check pages with custom variations: `EditedPics.html` (overrides for h2 alignment), `SortMerge.html` (750px breakpoint instead of 600px), `String.html` and `Intro2DirectAccess.html` (different page-wrapper sizing — kept `box-sizing: content-box` override).
- [ ] Verify pages that gained the `course.css` link (Copy, DataDeclaration, COBOLIntro, etc.) didn't gain unintended styling from the shared `.section-*` rules — those pages use different class names (`.layout-grid`, `.page-layout`, `.section-row`, etc.) so there should be no collision.