### PR TITLE
Unify course-page layout vocabulary and centralize shared CSS

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -4,27 +4,17 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>Introduction to COBOL</title>
+		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" charset="utf-8" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" charset="utf-8" defer></script>
 		<style type="text/css">
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			table {
-				max-width: 100%;
-			}
-
 			body > hr {
 				margin-left: auto;
 				margin-right: auto;
 			}
 
-			#page-layout {
-				display: grid;
-				grid-template-columns: 175px 1fr;
+			.section-grid {
 				max-width: 715px;
 				margin-left: auto;
 				margin-right: auto;
@@ -32,39 +22,18 @@
 				border-left: 1px solid;
 			}
 
-			#page-layout > * {
+			.section-grid > * {
 				border-right: 1px solid;
 				border-bottom: 1px solid;
-				padding: 4px;
-				min-width: 0;
 			}
 
-			.full-width {
-				grid-column: 1 / -1;
-			}
-
-			.sidebar-cell {
-				background-color: #FFFFCC;
-			}
-
-			.section-header {
-				background-color: #993300;
-			}
-
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.sidebar-cell h4 {
-				font-family: Arial, Helvetica, sans-serif;
-				color: #800000;
+			.section-sidebar h4 {
 				font-weight: bold;
 				font-size: 1.17em;
 				line-height: 1.2;
 			}
 
-			.sidebar-cell h4 b {
+			.section-sidebar h4 b {
 				font-weight: inherit;
 			}
 
@@ -96,48 +65,21 @@
 
 
 			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-				}
-
-				#page-layout {
-					grid-template-columns: 1fr;
-				}
-
-				.sidebar-cell,
-				.content-cell {
-					grid-column: 1 / -1;
+				.section-sidebar,
+				.section-content {
 					padding: 8px 12px;
 				}
 
-				.content-cell {
+				.section-content {
 					word-wrap: break-word;
 					overflow-wrap: break-word;
 				}
 
-				.sidebar-cell h4 {
+				.section-sidebar h4 {
 					margin: 0;
 				}
 
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				pre {
-					overflow-x: auto;
-				}
-
-				pre[class*="language-"],
-				code[class*="language-"] {
-					white-space: pre-wrap !important;
-					overflow-wrap: break-word;
-				}
-
 				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
 					max-width: min(100%, calc(100vw - 16px));
 				}
 
@@ -153,30 +95,13 @@
 					font-size: 1.4em;
 				}
 			}
-
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
 		</style>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
 	<body text="#000000" bgcolor="#FFFFFF" link="#0000FF" vlink="#FF0000" alink="#009B00">
-		<div id="page-layout">
-			<div class="full-width">
+		<div class="section-grid">
+			<div class="section-full">
 				<center>
 					<p><img src="Resources/pics/t-CobolTut.gif" width="173" height="59" /></p>
 					<h1>Introduction to COBOL</h1>
@@ -211,13 +136,13 @@
 				</ul>
 				<hr />
 			</div>
-			<div class="full-width section-header">
+			<div class="section-full section-header">
 				<h2 align="center" id="intro">Introduction</h2>
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4>Aims</h4>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<div align="center">
 					<p align="left">
 						To provide a brief introduction to the programming language COBOL. To provide a context in
@@ -228,10 +153,10 @@
 				</div>
 				<hr width="100%" align="center" size="1" />
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4>Objectives</h4>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<p>By the end of this unit you should -</p>
 				<ol>
 					<li>Know what the acronym COBOL stands for.</li>
@@ -249,13 +174,13 @@
 				</ol>
 				<hr width="100%" align="center" size="1" />
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4>Prerequisites</h4>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<p>None. This is the first unit in the course.</p>
 			</div>
-			<div class="full-width">
+			<div class="section-full">
 				<div align="center">
 					<hr />
 					<p>
@@ -265,13 +190,13 @@
 					</p>
 				</div>
 			</div>
-			<div class="full-width section-header">
+			<div class="section-full section-header">
 				<h2 align="center" id="part1">What is COBOL?</h2>
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4>Introduction</h4>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<p>
 					COBOL is a high-level programming language first developed by the CODASYL Committee
 					(<b>Co</b>nference on <b>Da</b>ta <b>Sy</b>stems <b>L</b>anguages) in 1960. Since then,
@@ -291,10 +216,10 @@
 				</p>
 				<hr width="100%" align="center" size="1" />
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4>How widely used is COBOL?</h4>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<p>
 					For over four decades COBOL has been the dominant programming language in the business computing
 					domain. In that time it has seen off the challenges of a number of other languages such as PL1,
@@ -326,10 +251,10 @@
 				</blockquote>
 				<hr width="100%" align="center" size="1" />
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4>Surprised by COBOL's success?</h4>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<p>
 					People are often surprised when presented with the evidence for COBOL's dominance in the market
 					place. The hype that surrounds some computer languages would persuade you to believe that most
@@ -377,10 +302,10 @@
 				</p>
 				<hr width="100%" align="center" size="1" />
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4>Some characteristics of COBOL applications</h4>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<p>
 					As exemplified by the DoD MRP II example above, COBOL applications are often very large. Many
 					COBOL applications consist of more than 1,000,000 lines of code - with 6,000,000+ line
@@ -408,10 +333,10 @@
 				</p>
 				<hr width="100%" align="center" size="1" />
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4>Some characteristics that contribute to COBOL's success</h4>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<p>
 					<b>COBOL is self-documenting</b><br />
 					One of the design goals for COBOL was to make it possible for non-programmers such as
@@ -507,10 +432,10 @@
 				</p>
 				<hr width="100%" align="center" size="1" />
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4>References and further reading</h4>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<p>
 					In this semi-formal document I have not been fastidious in referencing all the souces I have
 					used. Because of that I would like to acknowledge that most of factual material and some of the
@@ -591,7 +516,7 @@
 				</p>
 				<p>Wilkinson,Stephanie - From the Dustbin, Cobol Rises (May, 2001)- eWeek</p>
 			</div>
-			<div class="full-width">
+			<div class="section-full">
 				<div align="center">
 					<hr />
 					<p>
@@ -601,13 +526,13 @@
 					</p>
 				</div>
 			</div>
-			<div class="full-width section-header">
+			<div class="section-full section-header">
 				<h2 align="center" id="part2">Introduction to Programming</h2>
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4>Introduction</h4>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<p align="left">
 					In this section a gentle introduction to programing in general, and to programming in COBOL in
 					particular, is provided. This is done by writing some simple COBOL programs that use the three
@@ -619,10 +544,10 @@
 				</p>
 				<hr size="1" width="100%" />
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4>Let's write a program</h4>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<p align="left">
 					A program is a collection of statements written in a language the computer understands.<br />
 				</p>
@@ -645,10 +570,10 @@
 				</p>
 				<hr size="1" width="100%" />
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4>Sequence Program Specification</h4>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<p align="left">
 					We want to write a program which will accept two numbers from the users keyboard, multiply them
 					together and display the result on the computer screen.<br />
@@ -664,10 +589,10 @@
 				</ol>
 				<hr size="1" width="100%" />
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4>Program Statements and Data items</h4>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<p align="left">
 					What COBOL program statements will we need to do the job specified above and what data items
 					will we need to access?<br />
@@ -704,10 +629,10 @@
 				</blockquote>
 				<hr size="1" width="100%" />
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4>Getting the Algorithm right</h4>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<p>
 					Now all we need to do to have a working program is to declare the items needed to store the data
 					and to place the statements shown above in the correct order.
@@ -766,10 +691,10 @@
 				</p>
 				<hr size="1" width="100%" />
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4>An annotated look at the COBOL program</h4>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<p>
 					Click on the animation below for an annotated version of the program. Click anywhere in the
 					animation to see the first and subsequent annotations.
@@ -782,7 +707,7 @@
 				</p>
 				<hr size="1" width="100%" />
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4>Selection Program Specification</h4>
 				<aside>
 					<p align="center">
@@ -793,7 +718,7 @@
 					</p>
 				</aside>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<p>
 					Write a program that accepts two numbers and an operator from the user and then performs the
 					appropriate calculation for that operator. The operator must be either the addition (+) or the
@@ -808,10 +733,10 @@
 				</p>
 				<hr size="1" width="100%" />
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4>Iteration Program Specification</h4>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<p>
 					Write a program that accepts two numbers and an operator from the user and then performs the
 					appropriate calculation for that operator. The operator must be either the addition (+) or the
@@ -828,7 +753,7 @@
 					/></a>
 				</p>
 			</div>
-			<div class="full-width">
+			<div class="section-full">
 				<div align="center">
 					<hr />
 					<p>
@@ -838,13 +763,13 @@
 					</p>
 				</div>
 			</div>
-			<div class="full-width section-header">
+			<div class="section-full section-header">
 				<h2 align="center" id="part3">COBOL basics</h2>
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4>Introduction</h4>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<p>
 					This section presents the fundamentals of constructing COBOL programs. It explains the notation
 					used in COBOL syntax diagrams and enumerates the COBOL coding rules. It shows how user-defined
@@ -852,10 +777,10 @@
 				</p>
 				<hr size="1" width="100%" />
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4 align="left">COBOL idiosyncrasies</h4>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<p>
 					COBOL is one of the oldest programming languages in use. As a result it has some idiosyncrasies
 					which programmers used to other languages may find irritating.
@@ -880,10 +805,10 @@
 				</p>
 				<hr size="1" width="100%" />
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4>COBOL syntax</h4>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<p>COBOL syntax is defined using particular notation sometimes called the COBOL MetaLanguage.</p>
 				<p>
 					In this notation, words in uppercase are reserved words. When underlined they are mandatory.
@@ -909,10 +834,10 @@
 				</p>
 				<hr size="1" width="100%" />
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4>Some notes on syntax diagrams</h4>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<p>
 					To simplify the syntax diagrams and reduce the number of rules that must be explained, in some
 					diagrams special operand endings have been used (note that this is my own extension - it is not
@@ -954,7 +879,7 @@
 					</table>
 				</blockquote>
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4>An example syntax diagram</h4>
 				<aside>
 					<p align="center">
@@ -965,7 +890,7 @@
 					</p>
 				</aside>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<p>
 					In COBOL, evaluating an arithmetic expression and assigning the result to a data item is
 					achieved by means of the COMPUTE statement. The syntax diagram for the COMPUTE is shown below.
@@ -1006,10 +931,10 @@
 				</p>
 				<hr width="100%" size="1" />
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4>COBOL coding rules</h4>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<p>
 					Traditionally, COBOL programs were written on coding forms and then punched on to punch cards.
 					Although nowadays most programs are entered directly into a computer, some COBOL formatting
@@ -1044,10 +969,10 @@
 				</p>
 				<hr width="100%" size="1" />
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4>Name construction</h4>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<p>
 					All user-defined names, such as data names, paragraph names, section names condition names and
 					mnemonic names, must adhere to the following rules:
@@ -1067,10 +992,10 @@
 				</ol>
 				<hr width="100%" size="1" />
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4>The structure of COBOL programs</h4>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<p>
 					COBOL programs are hierarchical in structure. Each element of the hierarchy consists of one or
 					more subordinate elements.
@@ -1131,7 +1056,7 @@ PROGRAM-ID.</code></pre>
 					class="language-cobol"
 				><code class="language-cobol">SUBTRACT Tax FROM GrossPay GIVING NetPay</code></pre>
 			</div>
-			<div class="full-width">
+			<div class="section-full">
 				<div align="center">
 					<hr />
 					<p>
@@ -1141,13 +1066,13 @@ PROGRAM-ID.</code></pre>
 					</p>
 				</div>
 			</div>
-			<div class="full-width section-header">
+			<div class="section-full section-header">
 				<h2 align="center" id="part4">The Four Divisions</h2>
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4>Introduction</h4>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<p>
 					At the top of the COBOL hierarchy are the four divisions. These divide the program into distinct
 					structural elements. Although some of the divisions may be omitted, the sequence in which they
@@ -1174,10 +1099,10 @@ PROGRAM-ID.</code></pre>
 				</blockquote>
 				<hr width="100%" size="1" />
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4 align="left">The IDENTIFICATION DIVISION</h4>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<p>
 					The <code class="language-cobol">IDENTIFICATION DIVISION</code> supplies information about the
 					program to the programmer and the compiler.
@@ -1216,10 +1141,10 @@ PROGRAM-ID. SequenceProgram.
 AUTHOR. Michael Coughlan.</code></pre>
 				<hr size="1" width="100%" />
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4 align="left">The <code class="language-cobol">ENVIRONMENT DIVISION</code></h4>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<p>
 					The <code class="language-cobol">ENVIRONMENT DIVISION</code> is used to describe the environment
 					in which the program will run.
@@ -1240,10 +1165,10 @@ AUTHOR. Michael Coughlan.</code></pre>
 				</p>
 				<hr size="1" width="100%" />
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4 align="left">The DATA DIVISION</h4>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<p>
 					As the name suggests, the <code class="language-cobol">DATA DIVISION</code> provides
 					descriptions of the data-items processed by the program.
@@ -1284,10 +1209,10 @@ WORKING-STORAGE SECTION.
 01 Result PIC 99 VALUE ZEROS.</code></pre>
 				<hr size="1" width="100%" />
 			</div>
-			<div class="sidebar-cell">
+			<div class="section-sidebar">
 				<h4 align="left">The PROCEDURE DIVISION</h4>
 			</div>
-			<div class="content-cell">
+			<div class="section-content">
 				<p>
 					The <code class="language-cobol">PROCEDURE DIVISION</code> contains the code used to manipulate
 					the data described in the <code class="language-cobol">DATA DIVISION</code>. It is here that the
@@ -1342,7 +1267,7 @@ DisplayGreeting.
    DISPLAY "Hello world".
    STOP RUN.</code></pre>
 			</div>
-			<div class="full-width">
+			<div class="section-full">
 				<hr />
 				<div align="center">
 					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -6,61 +6,23 @@
 		<title>Basic Procedure Division commands</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style type="text/css">
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
-			}
-
 			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-				min-width: 0;
 				border-bottom: 1px solid;
 			}
 
 			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
 				align-self: stretch;
-				min-width: 0;
 				border-right: 1px solid;
 				border-bottom: 1px solid;
 			}
 
 			.section-content {
-				padding: 4px;
 				align-self: start;
-				min-width: 0;
 				overflow: hidden;
 				border-bottom: 1px solid;
 			}
 
 			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
-				min-width: 0;
 				border-bottom: 1px solid;
 			}
 
@@ -72,22 +34,6 @@
 			.section-content code[class*="language-"] {
 				white-space: pre-wrap;
 				overflow-wrap: break-word;
-			}
-
-			@media (max-width: 600px) {
-				.section-header h2,
-				.section-header h3 {
-					margin: 0.3em 0;
-				}
-
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
 			}
 		</style>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -4,54 +4,12 @@
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>The COPY verb</title>
+		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<style type="text/css">
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			pre {
-				overflow-x: auto;
-				max-width: 100%;
-			}
-
-			body {
-				-webkit-text-size-adjust: 100%;
-			}
-
-			.page-frame {
-				border: 1px solid black;
-				max-width: 715px;
-				margin-left: auto;
-				margin-right: auto;
-			}
-
-			.layout-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
-			}
-
-			.layout-grid > * {
-				padding: 4px;
-				min-width: 0;
-			}
-
-			.layout-full {
-				grid-column: 1 / -1;
-			}
-
-			.section-header {
-				background-color: #993300;
-			}
-
-			.sidebar {
-				background-color: #FFFFCC;
-			}
-
-			.page-footer {
+			.section-grid > * {
 				padding: 4px;
 			}
 
@@ -68,99 +26,19 @@
 				background-color: #FFFFFF;
 			}
 
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
-
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
 			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				hr[width] {
-					width: 100% !important;
-				}
-
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					white-space: pre-wrap;
-					word-wrap: break-word;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"],
-				code[class*="language-"] {
-					white-space: pre-wrap !important;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
-				}
-
-				.page-frame {
+				.page-wrapper {
 					border: none;
 				}
 
-				.layout-grid {
-					grid-template-columns: 1fr;
-				}
-
-				.section-header h2,
-				.section-header h3 {
-					margin: 0.3em 0;
-				}
-
-				.sidebar > h4:not(:first-child):not(:has(img)),
+				.section-sidebar > h4:not(:first-child):not(:has(img)),
 				h4:has(> img[src*="PanelLine"]) {
 					display: none;
 				}
 
-				.sidebar > h3,
-				.sidebar > h4,
-				.sidebar > p {
+				.section-sidebar > h3,
+				.section-sidebar > h4,
+				.section-sidebar > p {
 					margin: 0.2em 0;
 				}
 			}
@@ -169,10 +47,10 @@
 	</head>
 
 	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
-		<div class="page-frame">
-			<div class="layout-grid">
+		<div class="page-wrapper">
+			<div class="section-grid">
 				<!-- Header -->
-				<div class="layout-full">
+				<div class="section-full">
 					<center>
 						<p><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
 						<h1>The COPY verb</h1>
@@ -207,10 +85,10 @@
 					<hr />
 				</div>
 				<!-- Section: Introduction -->
-				<div class="layout-full section-header">
+				<div class="section-full section-header">
 					<h2 align="center" id="intro">Introduction</h2>
 				</div>
-				<div class="sidebar">
+				<div class="section-sidebar">
 					<h4>Aims</h4>
 					<h4><img height="1" src="Resources/pics/PanelLine.gif" width="175" /></h4>
 				</div>
@@ -243,7 +121,7 @@
 					</div>
 					<hr align="center" size="1" width="100%" />
 				</div>
-				<div class="sidebar">
+				<div class="section-sidebar">
 					<h4>Objectives</h4>
 				</div>
 				<div>
@@ -265,7 +143,7 @@
 					</ol>
 					<hr align="center" size="1" width="100%" />
 				</div>
-				<div class="sidebar">
+				<div class="section-sidebar">
 					<h4>Prerequisites</h4>
 				</div>
 				<div>
@@ -291,7 +169,7 @@
 					</ul>
 				</div>
 				<!-- Navigation -->
-				<div class="layout-full">
+				<div class="section-full">
 					<div align="center">
 						<hr />
 						<p>
@@ -302,10 +180,10 @@
 					</div>
 				</div>
 				<!-- Section: Using the COPY verb -->
-				<div class="layout-full section-header">
+				<div class="section-full section-header">
 					<h2 align="center" id="part1">Using the COPY verb</h2>
 				</div>
-				<div class="sidebar">
+				<div class="section-sidebar">
 					<h4>Introduction</h4>
 					<h4><img height="1" src="Resources/pics/PanelLine.gif" width="175" /></h4>
 				</div>
@@ -344,7 +222,7 @@
 					</div>
 					<hr align="center" size="1" width="100%" />
 				</div>
-				<div class="sidebar">
+				<div class="section-sidebar">
 					<h4>
 						<b>Using the COPY verb in large software systems</b>
 					</h4>
@@ -389,7 +267,7 @@
 					<hr align="center" size="1" width="100%" />
 				</div>
 				<!-- Navigation -->
-				<div class="layout-full">
+				<div class="section-full">
 					<div align="center">
 						<hr />
 						<p>
@@ -400,7 +278,7 @@
 					</div>
 				</div>
 				<!-- Section: COPY Syntax and Semantics -->
-				<div class="layout-full section-header">
+				<div class="section-full section-header">
 					<h2 align="center" id="part2">
 						<b
 							>The COPY verb<br />
@@ -408,7 +286,7 @@
 						>
 					</h2>
 				</div>
-				<div class="sidebar">
+				<div class="section-sidebar">
 					<h4>COPY Syntax</h4>
 					<aside>
 						<p align="center">
@@ -511,7 +389,7 @@
 					</div>
 					<hr align="center" size="1" width="100%" />
 				</div>
-				<div class="sidebar">
+				<div class="section-sidebar">
 					<h4>
 						<b>How the COPY works</b>
 					</h4>
@@ -537,7 +415,7 @@ COPY CopyFile5 REPLACING ==X(3)== BY ==X(19)==.
 COPY CopyFile4 IN EGLIB.</code></pre>
 					<hr align="center" size="1" width="100%" />
 				</div>
-				<div class="sidebar">
+				<div class="section-sidebar">
 					<h4>How the REPLACING phrase works</h4>
 				</div>
 				<div>
@@ -561,7 +439,7 @@ COPY CopyFile4 IN EGLIB.</code></pre>
 					</p>
 					<hr align="center" size="1" width="100%" />
 				</div>
-				<div class="sidebar">
+				<div class="section-sidebar">
 					<h4>COPY Rules</h4>
 				</div>
 				<div>
@@ -610,7 +488,7 @@ COPY CopyFile4 IN EGLIB.</code></pre>
 					<hr align="center" size="1" width="100%" />
 				</div>
 				<!-- Navigation -->
-				<div class="layout-full">
+				<div class="section-full">
 					<div align="center">
 						<hr />
 						<p>
@@ -621,11 +499,11 @@ COPY CopyFile4 IN EGLIB.</code></pre>
 					</div>
 				</div>
 				<!-- Section: COPY examples -->
-				<div class="layout-full section-header">
+				<div class="section-full section-header">
 					<h2 align="center" id="part3">COPY examples</h2>
 				</div>
 				<!-- Example 1 -->
-				<div class="sidebar">
+				<div class="section-sidebar">
 					<p>
 						<b>COPY Example1</b>
 					</p>
@@ -753,7 +631,7 @@ BeginProg.
 					<hr align="center" size="1" width="100%" />
 				</div>
 				<!-- Example 2 -->
-				<div class="sidebar">
+				<div class="section-sidebar">
 					<p>
 						<b>COPY Example2</b>
 					</p>
@@ -939,7 +817,7 @@ STOP RUN.
 					<hr align="center" size="1" width="100%" />
 				</div>
 				<!-- Example 3 -->
-				<div class="sidebar">
+				<div class="section-sidebar">
 					<p>
 						<b>COPY Example3</b>
 					</p>
@@ -1106,7 +984,7 @@ BeginProg.
 					<hr align="center" size="1" width="100%" />
 				</div>
 				<!-- Example 4 -->
-				<div class="sidebar">
+				<div class="section-sidebar">
 					<p>
 						<b>COPY Example4</b>
 					</p>

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -4,31 +4,12 @@
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>Declaring Data in COBOL</title>
+		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<style type="text/css">
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			table {
-				max-width: 100%;
-			}
-
-			pre {
-				overflow-x: auto;
-				max-width: 100%;
-			}
-
-			body {
-				-webkit-text-size-adjust: 100%;
-			}
-
-			.page-layout {
-				display: grid;
-				grid-template-columns: 175px 1fr;
+			.section-grid {
 				max-width: 715px;
 				margin: 0 auto;
 				border: 1px solid black;
@@ -36,7 +17,7 @@
 				border-bottom: none;
 			}
 
-			.page-layout > div {
+			.section-grid > div {
 				padding: 4px;
 				border-right: 1px solid black;
 				border-bottom: 1px solid black;
@@ -44,27 +25,8 @@
 				box-sizing: border-box;
 			}
 
-			.full-width {
-				grid-column: 1 / -1;
-			}
-
-			.section-header {
-				background-color: #993300;
-			}
-
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.sidebar {
-				background-color: #FFFFCC;
+			.section-sidebar {
 				align-self: stretch;
-			}
-
-			.sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
 			}
 
 			.code-record {
@@ -102,81 +64,13 @@
 				padding-top: 0.15em;
 			}
 
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
-
 			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
-				.page-layout {
-					grid-template-columns: 1fr;
+				.section-grid {
 					border-right: 1px solid black;
 				}
 
-				.sidebar h4:not(:first-child):not(:has(img)) {
+				.section-sidebar h4:not(:first-child):not(:has(img)) {
 					display: none;
-				}
-
-				.sidebar h3,
-				.sidebar h4,
-				.sidebar p {
-					margin: 0.2em 0;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				hr[width] {
-					width: 100% !important;
-				}
-
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					white-space: pre-wrap;
-					word-wrap: break-word;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"],
-				code[class*="language-"] {
-					white-space: pre-wrap !important;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
 				}
 
 				.code-record {
@@ -192,8 +86,8 @@
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
-		<div class="page-layout">
-			<div class="full-width">
+		<div class="section-grid">
+			<div class="section-full">
 				<center>
 					<p><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
 					<h1>Declaring Data in COBOL</h1>
@@ -221,10 +115,10 @@
 					</li>
 				</ul>
 			</div>
-			<div class="full-width section-header">
+			<div class="section-full section-header">
 				<h2 align="center" id="intro">Introduction</h2>
 			</div>
-			<div class="sidebar">
+			<div class="section-sidebar">
 				<h4>Aims</h4>
 			</div>
 			<div>
@@ -234,7 +128,7 @@
 				</p>
 				<hr width="50%" />
 			</div>
-			<div class="sidebar">
+			<div class="section-sidebar">
 				<h4>Objectives</h4>
 			</div>
 			<div>
@@ -251,7 +145,7 @@
 				</ol>
 				<hr width="50%" />
 			</div>
-			<div class="sidebar">
+			<div class="section-sidebar">
 				<h4>Prerequisites</h4>
 			</div>
 			<div>
@@ -263,7 +157,7 @@
 					<li>The USAGE clause</li>
 				</ul>
 			</div>
-			<div class="sidebar">
+			<div class="section-sidebar">
 				<h4>Further reading</h4>
 			</div>
 			<div>
@@ -274,7 +168,7 @@
 					<li>The USAGE clause</li>
 				</ul>
 			</div>
-			<div class="full-width">
+			<div class="section-full">
 				<div align="center">
 					<hr />
 					<p>
@@ -284,10 +178,10 @@
 					</p>
 				</div>
 			</div>
-			<div class="full-width section-header">
+			<div class="section-full section-header">
 				<h2 align="center" id="part1">Categories of COBOL data</h2>
 			</div>
-			<div class="sidebar">
+			<div class="section-sidebar">
 				<h4 align="left">Introduction</h4>
 			</div>
 			<div>
@@ -299,7 +193,7 @@
 				</ul>
 				<hr width="50%" />
 			</div>
-			<div class="sidebar">
+			<div class="section-sidebar">
 				<h4 align="left">Variables</h4>
 			</div>
 			<div>
@@ -317,7 +211,7 @@
 					in the variable. This is known as the variable's data type.
 				</p>
 			</div>
-			<div class="sidebar">
+			<div class="section-sidebar">
 				<h4 align="left">Variable Data types</h4>
 				<aside>
 					<p align="center">
@@ -358,7 +252,7 @@
 				</p>
 				<hr width="50%" />
 			</div>
-			<div class="sidebar">
+			<div class="section-sidebar">
 				<h4 align="left">Literals</h4>
 			</div>
 			<div>
@@ -372,14 +266,14 @@
 					<li>Numeric Literals</li>
 				</ul>
 			</div>
-			<div class="sidebar">
+			<div class="section-sidebar">
 				<h4 align="left">String Literals</h4>
 			</div>
 			<div>
 				<p>String/Alphanumeric literals are enclosed in quotes and consist of alphanumeric characters.</p>
 				<p>For example: "Michael Ryan", "-123", "123.45"</p>
 			</div>
-			<div class="sidebar">
+			<div class="section-sidebar">
 				<h4 align="left">Numeric Literals</h4>
 			</div>
 			<div>
@@ -390,7 +284,7 @@
 				<p>For example: 123, 123.45, -256, +2987</p>
 				<hr width="50%" />
 			</div>
-			<div class="sidebar">
+			<div class="section-sidebar">
 				<h4 align="left">Figurative Constants</h4>
 				<aside>
 					<p align="center">
@@ -484,7 +378,7 @@
 				</ul>
 				<hr width="50%" />
 			</div>
-			<div class="sidebar">
+			<div class="section-sidebar">
 				<h4 align="left">Using COBOL data — examples</h4>
 			</div>
 			<div>
@@ -503,7 +397,7 @@
 					/></a>
 				</p>
 			</div>
-			<div class="full-width">
+			<div class="section-full">
 				<div align="center">
 					<hr />
 					<p>
@@ -513,10 +407,10 @@
 					</p>
 				</div>
 			</div>
-			<div class="full-width section-header">
+			<div class="section-full section-header">
 				<h2 align="center" id="part2">Declaring Data-Items in COBOL</h2>
 			</div>
-			<div class="sidebar">
+			<div class="section-sidebar">
 				<h4>Introduction</h4>
 			</div>
 			<div>
@@ -540,7 +434,7 @@
 				</ul>
 				<hr width="50%" />
 			</div>
-			<div class="sidebar">
+			<div class="section-sidebar">
 				<h4 align="left">COBOL picture clauses</h4>
 				<aside>
 					<p align="center">
@@ -626,7 +520,7 @@
 				</table>
 				<hr width="50%" />
 			</div>
-			<div class="sidebar">
+			<div class="section-sidebar">
 				<h4 align="left">Picture clause notes</h4>
 			</div>
 			<div>
@@ -645,7 +539,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 				<p>Numeric values can have a maximum of 18 (eighteen) digits.</p>
 				<p>The limit on string values is usually system dependent.</p>
 			</div>
-			<div class="full-width">
+			<div class="section-full">
 				<div align="center">
 					<hr />
 					<p>
@@ -655,10 +549,10 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 					</p>
 				</div>
 			</div>
-			<div class="full-width section-header">
+			<div class="section-full section-header">
 				<h2 align="center" id="part3">Group and Elementary data-items</h2>
 			</div>
-			<div class="sidebar">
+			<div class="section-sidebar">
 				<h4>Introduction</h4>
 			</div>
 			<div>
@@ -674,7 +568,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 					</p>
 				</div>
 			</div>
-			<div class="sidebar">
+			<div class="section-sidebar">
 				<h4 align="left">Elementary items</h4>
 				<aside>
 					<p align="center">
@@ -715,7 +609,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 01 CustDiscount   PIC V99 VALUE .25.</code></pre>
 				<hr width="50%" />
 			</div>
-			<div class="sidebar">
+			<div class="section-sidebar">
 				<h4>Group items</h4>
 			</div>
 			<div>
@@ -759,7 +653,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 				</p>
 				<hr width="50%" />
 			</div>
-			<div class="sidebar">
+			<div class="section-sidebar">
 				<h4>Level Numbers</h4>
 				<aside>
 					<p align="center">
@@ -814,7 +708,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 </code></pre>
 				</div>
 			</div>
-			<div class="sidebar">
+			<div class="section-sidebar">
 				<h4 align="left">Some observations on Record-A</h4>
 			</div>
 			<div>
@@ -849,7 +743,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 					</div>
 				</div>
 			</div>
-			<div class="sidebar">
+			<div class="section-sidebar">
 				<h4 align="left">Level number notes</h4>
 			</div>
 			<div>
@@ -876,7 +770,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 				</div>
 				<hr width="50%" />
 			</div>
-			<div class="sidebar">
+			<div class="section-sidebar">
 				<h4>Building a record structure</h4>
 			</div>
 			<div>
@@ -897,7 +791,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 					</p>
 				</div>
 			</div>
-			<div class="full-width">
+			<div class="section-full">
 				<hr />
 				<div align="center">
 					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -6,150 +6,38 @@
 		<title>Edited Pictures</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style type="text/css">
-			ul.toc {
-				list-style-type: disc;
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-
-			ul.toc > li {
-				margin-bottom: 0.6em;
-			}
-
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-				text-align: center;
-				margin: 0.3em 0;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 4px;
-			}
-
+			.page-content,
 			.page-footer {
 				padding: 4px;
 			}
 
-			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
-			}
-
 			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-				min-width: 0;
 				border-bottom: 1px solid;
 			}
 
+			.section-header h2 {
+				text-align: center;
+				margin: 0.3em 0;
+			}
+
 			.section-sidebar {
-				background-color: #ffffcc;
-				padding: 4px;
 				align-self: stretch;
-				min-width: 0;
 				border-right: 1px solid;
 				border-bottom: 1px solid;
 			}
 
 			.section-content {
-				padding: 4px;
 				align-self: start;
-				min-width: 0;
 				overflow: hidden;
 				border-bottom: 1px solid;
 			}
 
 			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
-				min-width: 0;
 				border-bottom: 1px solid;
 			}
 
 			.section-full:last-child {
 				border-bottom: none;
-			}
-
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			pre {
-				overflow-x: auto;
-				max-width: 100%;
-			}
-
-			table {
-				max-width: 100%;
-			}
-
-			body {
-				-webkit-text-size-adjust: 100%;
-			}
-
-			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
-				.section-header h2 {
-					margin: 0.3em 0;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					white-space: pre-wrap;
-					word-wrap: break-word;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"],
-				code[class*="language-"] {
-					white-space: pre-wrap !important;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
-				}
-
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
 			}
 		</style>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -4,172 +4,18 @@
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>Indexed Files</title>
+		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<style type="text/css">
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
-
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.page-footer {
-				padding: 2px;
-			}
-
-			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
-			}
-
-			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-			}
-
-			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
-				align-self: stretch;
-			}
-
-			.section-content {
-				padding: 4px;
-			}
-
-			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
-			}
-
-		</style>
-		<style type="text/css">
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			table {
-				max-width: 100%;
-			}
-
 			pre {
-				overflow-x: auto;
 				max-width: 700px;
 				box-sizing: border-box;
 			}
 
-			body {
-				-webkit-text-size-adjust: 100%;
-			}
-
-			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
-				table[width] {
-					width: 100% !important;
-					height: auto !important;
-				}
-
-				td[width],
-				th[width],
-				td[height],
-				th[height] {
-					width: auto !important;
-					height: auto !important;
-				}
-
-				.section-header h2,
-				.section-header h3 {
-					margin: 0.3em 0;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				hr[width] {
-					width: 100% !important;
-				}
-
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					white-space: pre-wrap;
-					word-wrap: break-word;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"],
-				code[class*="language-"] {
-					white-space: pre-wrap !important;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
-				}
-
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
+			.section-sidebar {
+				align-self: stretch;
 			}
 		</style>
 		<script src="../components/copyright-notice.js" defer></script>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -4,159 +4,25 @@
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>The INSPECT verb</title>
+		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<style type="text/css">
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
 			ol.spaced > li + li {
 				margin-top: 0.6em;
 			}
 
-			.course-section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.course-section-label h3,
-			.course-section-label h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-		</style>
-		<style type="text/css">
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			pre {
-				overflow-x: auto;
-				max-width: 100%;
-			}
-
-			body {
-				-webkit-text-size-adjust: 100%;
-			}
-
-			.page-wrapper {
-				border: 1px solid;
-				max-width: 715px;
-				margin: 0 auto;
-				box-sizing: border-box;
-			}
-
-			.course-section {
-				max-width: 710px;
-				margin: 0 auto;
-			}
-
-			.course-section-header {
-				background-color: #993300;
-				padding: 4px;
+			.section-header {
 				text-align: center;
 			}
 
-			.course-section-header h2 {
+			.section-header h2 {
 				margin: 0;
 			}
 
-			.course-section-full {
-				padding: 4px;
-			}
-
-			.course-section-row {
-				display: grid;
-				grid-template-columns: 175px 1fr;
-			}
-
-			.course-section-label {
-				background-color: #FFFFCC;
-				padding: 4px;
+			.section-sidebar {
 				align-self: stretch;
-			}
-
-			.course-section-content {
-				padding: 4px;
-			}
-
-			.page-top-link {
-				max-width: 710px;
-				margin: 0 auto;
-			}
-
-			.page-top-link p {
-				text-align: center;
-			}
-
-			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
-				.course-section-header h2,
-				.course-section-header h3 {
-					margin: 0.3em 0;
-				}
-
-				.course-section-row {
-					grid-template-columns: 1fr;
-				}
-
-				.course-section-label h3,
-				.course-section-label h4,
-				.course-section-label p {
-					margin: 0.2em 0;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					white-space: pre-wrap;
-					word-wrap: break-word;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"],
-				code[class*="language-"] {
-					white-space: pre-wrap !important;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
-				}
 			}
 		</style>
 		<script src="../components/copyright-notice.js" defer></script>
@@ -211,15 +77,15 @@
 					<code class="language-cobol">INSPECT</code>.
 				</li>
 			</ul>
-			<div class="course-section">
-				<div class="course-section-header">
+			<div class="page-section">
+				<div class="section-header">
 					<h2 id="intro">Introduction</h2>
 				</div>
-				<div class="course-section-row">
-					<div class="course-section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Aims</h3>
 					</div>
-					<div class="course-section-content">
+					<div class="section-content">
 						<p>
 							Many programming languages rely on library functions for string handling. COBOL
 							too, uses Intrinsic Functions for some tasks but most string manipulation is
@@ -233,11 +99,11 @@
 						<hr />
 					</div>
 				</div>
-				<div class="course-section-row">
-					<div class="course-section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Objectives</h3>
 					</div>
-					<div class="course-section-content">
+					<div class="section-content">
 						<p>By the end of this unit you should:</p>
 						<ol>
 							<li>Understand how the INSPECT verb works.</li>
@@ -253,11 +119,11 @@
 						<hr />
 					</div>
 				</div>
-				<div class="course-section-row">
-					<div class="course-section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Prerequisites</h3>
 					</div>
-					<div class="course-section-content">
+					<div class="section-content">
 						<p>You should be familiar with the following material;</p>
 						<ul>
 							<li>Data Declaration</li>
@@ -269,11 +135,11 @@
 						<hr />
 					</div>
 				</div>
-				<div class="course-section-row">
-					<div class="course-section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Syntax legend</h3>
 					</div>
-					<div class="course-section-content">
+					<div class="section-content">
 						<p>
 							To simplify the syntax diagrams and reduce the number of rules that must be
 							explained, special operand endings are used in this unit's syntax diagrams.
@@ -314,15 +180,15 @@
 					/></a>
 				</p>
 			</div>
-			<div class="course-section">
-				<div class="course-section-header">
+			<div class="page-section">
+				<div class="section-header">
 					<h2 id="inspect">Using the INSPECT</h2>
 				</div>
-				<div class="course-section-row">
-					<div class="course-section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Introduction</h3>
 					</div>
-					<div class="course-section-content">
+					<div class="section-content">
 						<p>The INSPECT has four formats;</p>
 						<ol class="spaced">
 							<li>The first format is used for counting characters in a string.</li>
@@ -339,11 +205,11 @@
 						<hr />
 					</div>
 				</div>
-				<div class="course-section-row">
-					<div class="course-section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Example program Counting letter occurences using the INSPECT</h3>
 					</div>
-					<div class="course-section-content">
+					<div class="section-content">
 						<p>
 							We'll start by looking at the PROCEDURE DIVISION of an example
 							program that uses the INSPECT verb. This program reads through a
@@ -399,11 +265,11 @@ Begin.
 						<hr />
 					</div>
 				</div>
-				<div class="course-section-row">
-					<div class="course-section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>How the INSPECT works.</h3>
 					</div>
-					<div class="course-section-content">
+					<div class="section-content">
 						<p>
 							The INSPECT scans the source string from left to right counting, replacing or
 							converting characters under the control of the TALLYING, REPLACING or CONVERTING
@@ -420,11 +286,11 @@ Begin.
 						<hr />
 					</div>
 				</div>
-				<div class="course-section-row">
-					<div class="course-section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>The modifying phrases</h3>
 					</div>
-					<div class="course-section-content">
+					<div class="section-content">
 						<p>
 							The <b>LEADING</b> phrase causes counting/replacement of all Compare$il
 							characters from the first valid one encountered to the first invalid one.
@@ -454,11 +320,11 @@ Begin.
 					/></a>
 				</p>
 			</div>
-			<div class="course-section">
-				<div class="course-section-header">
+			<div class="page-section">
+				<div class="section-header">
 					<h2 id="count">The counting INSPECT</h2>
 				</div>
-				<div class="course-section-full">
+				<div class="section-full">
 					<h3>Syntax</h3>
 					<p><img src="Resources/pics/CntInspect.gif" /></p>
 					<p align="left">
@@ -466,11 +332,11 @@ Begin.
 					</p>
 					<hr />
 				</div>
-				<div class="course-section-row">
-					<div class="course-section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Notes</h3>
 					</div>
-					<div class="course-section-content">
+					<div class="section-content">
 						<p>If Compare$il or Delim$il is a figurative constant it is 1 character in size.</p>
 						<p>
 							An ALL, LEADING or CHARACTERS phrase can have not more than one BEFORE and one
@@ -478,11 +344,11 @@ Begin.
 						</p>
 					</div>
 				</div>
-				<div class="course-section-row">
-					<div class="course-section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Examples</h3>
 					</div>
-					<div class="course-section-content">
+					<div class="section-content">
 						<pre
 							class="language-cobol"
 						><code class="language-cobol">INSPECT FullName TALLYING UnstrPtr FOR LEADING SPACES.
@@ -501,11 +367,11 @@ INSPECT SourceLine TALLYING ECount
 					/></a>
 				</p>
 			</div>
-			<div class="course-section">
-				<div class="course-section-header">
+			<div class="page-section">
+				<div class="section-header">
 					<h2 id="replace">The replacing INSPECT</h2>
 				</div>
-				<div class="course-section-full">
+				<div class="section-full">
 					<h3>Syntax</h3>
 					<p><img height="255" src="Resources/pics/RepInspect.gif" width="619" /></p>
 					<p align="left">
@@ -513,11 +379,11 @@ INSPECT SourceLine TALLYING ECount
 					</p>
 					<hr />
 				</div>
-				<div class="course-section-row">
-					<div class="course-section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Rules</h3>
 					</div>
-					<div class="course-section-content">
+					<div class="section-content">
 						<p>The sizes of Compare$il and Replace$il must be equal.</p>
 						<p>When Replace$il is a figurative constant its size equals that of Compare$il.</p>
 						<p>
@@ -531,14 +397,14 @@ INSPECT SourceLine TALLYING ECount
 						<hr />
 					</div>
 				</div>
-				<div class="course-section-row">
-					<div class="course-section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>
 							Example 1<br />
 							with animation
 						</h3>
 					</div>
-					<div class="course-section-content">
+					<div class="section-content">
 						<p>
 							The following examples work on the data in StringData to produce the results
 							shown in the storage schematic below.
@@ -578,11 +444,11 @@ INSPECT SourceLine TALLYING ECount
 						</center>
 					</div>
 				</div>
-				<div class="course-section-row">
-					<div class="course-section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Example 2</h3>
 					</div>
-					<div class="course-section-content">
+					<div class="section-content">
 						<p>
 							This example inspects the string TextLine and checks it for each of the 4 letter
 							swear words in the table. If one is found it is replaced by the text *#@!.
@@ -595,14 +461,14 @@ END-PERFORM</code></pre>
 						<hr />
 					</div>
 				</div>
-				<div class="course-section-row">
-					<div class="course-section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>
 							Example 3<br />
 							with animation
 						</h3>
 					</div>
-					<div class="course-section-content">
+					<div class="section-content">
 						<p>
 							In this example we want to create an edited item with a floating Rouble currency
 							symbol instead of a floating dollar sign.
@@ -638,11 +504,11 @@ END-PERFORM</code></pre>
 					/></a>
 				</p>
 			</div>
-			<div class="course-section">
-				<div class="course-section-header">
+			<div class="page-section">
+				<div class="section-header">
 					<h2 id="combine">The combined INSPECT</h2>
 				</div>
-				<div class="course-section-full">
+				<div class="section-full">
 					<h3>Syntax</h3>
 					<p><img height="338" src="Resources/pics/CombInspect.gif" width="649" /></p>
 					<p>
@@ -660,20 +526,20 @@ END-PERFORM</code></pre>
 				</p>
 			</div>
 			<hr />
-			<div class="course-section">
-				<div class="course-section-header">
+			<div class="page-section">
+				<div class="section-header">
 					<h2 id="convert">The converting INSPECT</h2>
 				</div>
-				<div class="course-section-full">
+				<div class="section-full">
 					<h3>Syntax</h3>
 					<p><img src="Resources/pics/ConvInspect.gif" /></p>
 					<hr />
 				</div>
-				<div class="course-section-row">
-					<div class="course-section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>How this format of the INSPECT works</h3>
 					</div>
-					<div class="course-section-content">
+					<div class="section-content">
 						<p>
 							The INSPECT..CONVERTING works on individual characters. Compare$il is a list of
 							characters that will be replaced with the characters in Convert$il on a one for
@@ -687,11 +553,11 @@ END-PERFORM</code></pre>
 						<hr />
 					</div>
 				</div>
-				<div class="course-section-row">
-					<div class="course-section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Rules</h3>
 					</div>
-					<div class="course-section-content">
+					<div class="section-content">
 						<ol class="spaced">
 							<li>Compare$il and Convert$il must be equal in size.</li>
 							<li>
@@ -705,14 +571,14 @@ END-PERFORM</code></pre>
 						<hr />
 					</div>
 				</div>
-				<div class="course-section-row">
-					<div class="course-section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>
 							Example 1<br />
 							with animation
 						</h3>
 					</div>
-					<div class="course-section-content">
+					<div class="section-content">
 						<p align="left">
 							The following examples work on the data in StringData to produce the results
 							shown in the storage schematic below.
@@ -743,11 +609,11 @@ END-PERFORM</code></pre>
 						<hr />
 					</div>
 				</div>
-				<div class="course-section-row">
-					<div class="course-section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Example 2</h3>
 					</div>
-					<div class="course-section-content">
+					<div class="section-content">
 						<p>
 							This example shows how the INSPECT..CONVERTING can be used to implement a simple
 							encoding mechanism.
@@ -763,11 +629,11 @@ END-PERFORM</code></pre>
 						<hr />
 					</div>
 				</div>
-				<div class="course-section-row">
-					<div class="course-section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Example 3</h3>
 					</div>
-					<div class="course-section-content">
+					<div class="section-content">
 						<p>
 							In this example, the INSPECT..CONVERTING is used to convert upper case letters
 							to lower case and visa versa.

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -4,25 +4,16 @@
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>Introduction to Direct Access Files</title>
+		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<style type="text/css">
-			/* === Page layout === */
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-			}
-
 			.page-content {
 				padding: 0;
 			}
 
-			.page-header {
-				padding: 0 8px;
-			}
-
+			.page-header,
 			.toc-container {
 				padding: 0 8px;
 			}
@@ -32,64 +23,16 @@
 				text-align: center;
 			}
 
-			/* === TOC === */
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
-
-			/* === Section layout === */
-			.section-header {
-				background-color: #993300;
-				padding: 4px;
-			}
-
 			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
 				text-align: center;
 				margin: 0.3em 0;
 			}
 
-			.section-row {
-				display: grid;
-				grid-template-columns: 175px 1fr;
-			}
-
-			.section-label {
-				background-color: #FFFFCC;
-				padding: 4px;
-			}
-
-			.section-label h3,
-			.section-label h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-content {
-				padding: 4px;
-			}
-
-			/* === Section divider === */
 			.section-divider {
 				padding: 0 4px;
 				text-align: center;
 			}
 
-			/* === Two-column layout within content === */
 			.two-col {
 				display: flex;
 				gap: 1em;
@@ -106,7 +49,6 @@
 				justify-content: center;
 			}
 
-			/* === Figure (image + caption) === */
 			.img-figure {
 				display: flex;
 				flex-direction: column;
@@ -119,95 +61,9 @@
 				text-align: center;
 			}
 
-			/* === Shared === */
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			table {
-				max-width: 100%;
-			}
-
-			pre {
-				overflow-x: auto;
-				max-width: 100%;
-			}
-
-			body {
-				-webkit-text-size-adjust: 100%;
-			}
-
-			/* === Mobile === */
 			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
-				.section-row {
-					grid-template-columns: 1fr;
-				}
-
-				.section-label h3,
-				.section-label h4 {
-					margin: 0.2em 0;
-				}
-
-				.section-label p {
-					margin: 0.2em 0;
-				}
-
 				.two-col {
 					flex-direction: column;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					white-space: pre-wrap;
-					word-wrap: break-word;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"],
-				code[class*="language-"] {
-					white-space: pre-wrap !important;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
-				}
-
-				table[width] {
-					width: 100% !important;
-					height: auto !important;
-				}
-
-				td[width],
-				th[width],
-				td[height],
-				th[height] {
-					width: auto !important;
-					height: auto !important;
 				}
 			}
 		</style>
@@ -263,8 +119,8 @@
 				<div class="section-header">
 					<h2 id="intro">Introduction</h2>
 				</div>
-				<div class="section-row">
-					<div class="section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Aims</h3>
 					</div>
 					<div class="section-content">
@@ -276,8 +132,8 @@
 						<hr />
 					</div>
 				</div>
-				<div class="section-row">
-					<div class="section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Objectives</h3>
 					</div>
 					<div class="section-content">
@@ -304,8 +160,8 @@
 						</ol>
 					</div>
 				</div>
-				<div class="section-row">
-					<div class="section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Prerequisites</h3>
 					</div>
 					<div class="section-content">
@@ -329,8 +185,8 @@
 				<div class="section-header">
 					<h2 id="seq">Sequential files</h2>
 				</div>
-				<div class="section-row">
-					<div class="section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Introduction</h3>
 					</div>
 					<div class="section-content">
@@ -352,8 +208,8 @@
 						<hr />
 					</div>
 				</div>
-				<div class="section-row">
-					<div class="section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Problems accessing ordered Sequential files.</h3>
 					</div>
 					<div class="section-content">
@@ -379,8 +235,8 @@
 						<hr />
 					</div>
 				</div>
-				<div class="section-row">
-					<div class="section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Contrast with direct access files</h3>
 					</div>
 					<div class="section-content">
@@ -396,8 +252,8 @@
 						</p>
 					</div>
 				</div>
-				<div class="section-row">
-					<div class="section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Inserting records in an ordered Sequential file</h3>
 					</div>
 					<div class="section-content">
@@ -417,8 +273,8 @@
 						<hr />
 					</div>
 				</div>
-				<div class="section-row">
-					<div class="section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Deleting records from an ordered Sequential file</h3>
 					</div>
 					<div class="section-content">
@@ -439,8 +295,8 @@
 						<hr />
 					</div>
 				</div>
-				<div class="section-row">
-					<div class="section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Amending records in an ordered Sequential file</h3>
 					</div>
 					<div class="section-content">
@@ -461,8 +317,8 @@
 						<hr />
 					</div>
 				</div>
-				<div class="section-row">
-					<div class="section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Sequential files - animation</h3>
 					</div>
 					<div class="section-content">
@@ -481,8 +337,8 @@
 						<hr />
 					</div>
 				</div>
-				<div class="section-row">
-					<div class="section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Summary</h3>
 					</div>
 					<div class="section-content">
@@ -511,8 +367,8 @@
 				<div class="section-header">
 					<h2 id="rel">Relative Files</h2>
 				</div>
-				<div class="section-row">
-					<div class="section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Introduction</h3>
 					</div>
 					<div class="section-content">
@@ -533,8 +389,8 @@
 						<hr />
 					</div>
 				</div>
-				<div class="section-row">
-					<div class="section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Organization of Relative files</h3>
 					</div>
 					<div class="section-content">
@@ -575,8 +431,8 @@
 						<hr />
 					</div>
 				</div>
-				<div class="section-row">
-					<div class="section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Accessing records in a Relative file</h3>
 					</div>
 					<div class="section-content">
@@ -602,8 +458,8 @@
 						<hr />
 					</div>
 				</div>
-				<div class="section-row">
-					<div class="section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Animation - Organization and use of Relative files</h3>
 					</div>
 					<div class="section-content">
@@ -632,8 +488,8 @@
 						<hr />
 					</div>
 				</div>
-				<div class="section-row">
-					<div class="section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Summary</h3>
 					</div>
 					<div class="section-content">
@@ -658,8 +514,8 @@
 				<div class="section-header">
 					<h2 id="idx">Indexed Files</h2>
 				</div>
-				<div class="section-row">
-					<div class="section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Introduction</h3>
 					</div>
 					<div class="section-content">
@@ -678,8 +534,8 @@
 						<hr />
 					</div>
 				</div>
-				<div class="section-row">
-					<div class="section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Organization of Indexed files</h3>
 					</div>
 					<div class="section-content">
@@ -716,8 +572,8 @@
 						<hr />
 					</div>
 				</div>
-				<div class="section-row">
-					<div class="section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Animation - Organization and use of Indexed files</h3>
 					</div>
 					<div class="section-content">
@@ -756,8 +612,8 @@ END-IF</code></pre>
 						<hr />
 					</div>
 				</div>
-				<div class="section-row">
-					<div class="section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Summary</h3>
 					</div>
 					<div class="section-content">
@@ -780,8 +636,8 @@ END-IF</code></pre>
 				<div class="section-header">
 					<h2 id="comp">Comparison of COBOL file organizations</h2>
 				</div>
-				<div class="section-row">
-					<div class="section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Introduction</h3>
 					</div>
 					<div class="section-content">
@@ -792,8 +648,8 @@ END-IF</code></pre>
 						<hr />
 					</div>
 				</div>
-				<div class="section-row">
-					<div class="section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Sequential files</h3>
 					</div>
 					<div class="section-content">
@@ -890,8 +746,8 @@ END-IF</code></pre>
 						<hr />
 					</div>
 				</div>
-				<div class="section-row">
-					<div class="section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Relative files</h3>
 					</div>
 					<div class="section-content">
@@ -1078,8 +934,8 @@ END-IF</code></pre>
 						<hr />
 					</div>
 				</div>
-				<div class="section-row">
-					<div class="section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Indexed files</h3>
 					</div>
 					<div class="section-content">
@@ -1172,8 +1028,8 @@ END-IF</code></pre>
 						<hr />
 					</div>
 				</div>
-				<div class="section-row">
-					<div class="section-label">
+				<div class="section-grid">
+					<div class="section-sidebar">
 						<h3>Summary</h3>
 					</div>
 					<div class="section-content">

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -6,78 +6,34 @@
 		<title>COBOL Interation Constructs</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style type="text/css">
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
+			pre {
+				white-space: pre-wrap;
+				word-wrap: break-word;
+				overflow-wrap: break-word;
 			}
 
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
-
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
+			pre[class*="language-"],
+			code[class*="language-"] {
+				white-space: pre-wrap !important;
+				overflow-wrap: break-word;
 			}
 
 			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-				min-width: 0;
 				border-bottom: 1px solid;
 			}
 
 			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
 				align-self: stretch;
-				min-width: 0;
 				border-right: 1px solid;
 				border-bottom: 1px solid;
 			}
 
 			.section-content {
-				padding: 4px;
 				align-self: start;
-				min-width: 0;
 				border-bottom: 1px solid;
 			}
 
 			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
-				min-width: 0;
 				border-bottom: 1px solid;
 			}
 
@@ -139,84 +95,7 @@
 				vertical-align: top;
 			}
 
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			pre {
-				max-width: 100%;
-				white-space: pre-wrap;
-				word-wrap: break-word;
-				overflow-wrap: break-word;
-			}
-
-			pre[class*="language-"],
-			code[class*="language-"] {
-				white-space: pre-wrap !important;
-				overflow-wrap: break-word;
-			}
-
-			body {
-				-webkit-text-size-adjust: 100%;
-			}
-
 			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
-				.section-header h2,
-				.section-header h3 {
-					margin: 0.3em 0;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					white-space: pre-wrap;
-					word-wrap: break-word;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"],
-				code[class*="language-"] {
-					white-space: pre-wrap !important;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
-				}
-
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
-
 				.saq-row {
 					display: block;
 					border-bottom: 2px solid #999;

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -6,56 +6,8 @@
 		<title>Reference Modification</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style>
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.page-footer {
-				padding: 2px;
-			}
-
 			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
 				align-items: stretch;
-			}
-
-			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-			}
-
-			.section-sidebar {
-				background-color: #ffffcc;
-				padding: 4px;
-			}
-
-			.section-content {
-				padding: 4px;
-				min-width: 0;
-			}
-
-			.section-content table {
-				max-width: 100%;
 			}
 
 			.table-scroll {
@@ -71,11 +23,6 @@
 			.table-scroll table td {
 				width: auto !important;
 				overflow-wrap: break-word;
-			}
-
-			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
 			}
 
 			.results-box {
@@ -97,27 +44,7 @@
 				gap: 1em;
 			}
 
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			pre {
-				overflow-x: auto;
-				max-width: 100%;
-			}
-
 			@media (max-width: 600px) {
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
-
 				.results-two-col {
 					flex-direction: column;
 					gap: 0;

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -6,83 +6,35 @@
 		<title>Relative Files</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style type="text/css">
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
+			pre {
+				white-space: pre-wrap;
+				word-wrap: break-word;
+				overflow-wrap: break-word;
 			}
 
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
-
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.page-footer {
-				padding: 2px;
-			}
-
-			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
+			pre[class*="language-"],
+			code[class*="language-"] {
+				white-space: pre-wrap !important;
+				overflow-wrap: break-word;
 			}
 
 			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-				min-width: 0;
 				border-bottom: 1px solid;
 			}
 
 			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
 				align-self: stretch;
-				min-width: 0;
 				border-right: 1px solid;
 				border-bottom: 1px solid;
 			}
 
 			.section-content {
-				padding: 4px;
 				align-self: start;
-				min-width: 0;
 				overflow: hidden;
 				border-bottom: 1px solid;
 			}
 
 			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
-				min-width: 0;
 				border-bottom: 1px solid;
 			}
 
@@ -106,76 +58,7 @@
 				justify-content: center;
 			}
 
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			pre {
-				overflow-x: auto;
-				max-width: 100%;
-				white-space: pre-wrap;
-				word-wrap: break-word;
-				overflow-wrap: break-word;
-			}
-
-			pre[class*="language-"],
-			code[class*="language-"] {
-				white-space: pre-wrap !important;
-				overflow-wrap: break-word;
-			}
-
-			body {
-				-webkit-text-size-adjust: 100%;
-			}
-
 			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
-				.section-header h2,
-				.section-header h3 {
-					margin: 0.3em 0;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
-				}
-
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
-
 				.declaratives-layout {
 					flex-direction: column;
 				}
@@ -184,7 +67,6 @@
 					justify-content: flex-start;
 					width: 100%;
 				}
-
 			}
 		</style>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -6,83 +6,23 @@
 		<title>COBOL Report Writer</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style type="text/css">
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
-
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.page-footer {
-				padding: 2px;
-			}
-
-			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
-			}
-
 			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-				min-width: 0;
 				border-bottom: 1px solid;
 			}
 
 			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
 				align-self: stretch;
-				min-width: 0;
 				border-right: 1px solid;
 				border-bottom: 1px solid;
 			}
 
 			.section-content {
-				padding: 4px;
 				align-self: start;
-				min-width: 0;
 				overflow: hidden;
 				border-bottom: 1px solid;
 			}
 
 			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
-				min-width: 0;
 				border-bottom: 1px solid;
 			}
 
@@ -93,77 +33,6 @@
 			.iframe-wrapper {
 				text-align: center;
 				border: 1px solid;
-			}
-
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			pre {
-				overflow-x: auto;
-				max-width: 100%;
-			}
-
-			body {
-				-webkit-text-size-adjust: 100%;
-			}
-
-			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
-				.section-header h2,
-				.section-header h3 {
-					margin: 0.3em 0;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					white-space: pre-wrap;
-					word-wrap: break-word;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"],
-				code[class*="language-"] {
-					white-space: pre-wrap !important;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
-				}
-
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
 			}
 		</style>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -6,98 +6,7 @@
 		<title>COBOL Report Writer - Syntax and Semantics</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style type="text/css">
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
-
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.page-footer {
-				padding: 2px;
-			}
-
-			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
-			}
-
-			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-				min-width: 0;
-				border-bottom: 1px solid;
-			}
-
-			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
-				align-self: stretch;
-				min-width: 0;
-				border-right: 1px solid;
-				border-bottom: 1px solid;
-			}
-
-			.section-content {
-				padding: 4px;
-				align-self: start;
-				min-width: 0;
-				overflow: hidden;
-				border-bottom: 1px solid;
-			}
-
-			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
-				min-width: 0;
-				border-bottom: 1px solid;
-			}
-
-			.section-full:last-child {
-				border-bottom: none;
-			}
-
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
 			pre {
-				overflow-x: auto;
-				max-width: 100%;
 				white-space: pre-wrap;
 				word-wrap: break-word;
 				overflow-wrap: break-word;
@@ -109,56 +18,28 @@
 				overflow-wrap: break-word;
 			}
 
-			body {
-				-webkit-text-size-adjust: 100%;
+			.section-header {
+				border-bottom: 1px solid;
 			}
 
-			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
+			.section-sidebar {
+				align-self: stretch;
+				border-right: 1px solid;
+				border-bottom: 1px solid;
+			}
 
-				.section-header h2,
-				.section-header h3 {
-					margin: 0.3em 0;
-				}
+			.section-content {
+				align-self: start;
+				overflow: hidden;
+				border-bottom: 1px solid;
+			}
 
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
+			.section-full {
+				border-bottom: 1px solid;
+			}
 
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
-				}
-
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
+			.section-full:last-child {
+				border-bottom: none;
 			}
 		</style>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/Resources/css/course.css
+++ b/course/Resources/css/course.css
@@ -136,3 +136,74 @@ td[bgcolor="#FFFFCC"] h4 {
 	color: #800000;
 	font-family: Arial, Helvetica, sans-serif;
 }
+
+/* Shared course-page layout */
+
+.page-wrapper {
+	max-width: 715px;
+	margin: 0 auto;
+	border: 1px solid;
+	box-sizing: border-box;
+}
+
+.page-content,
+.page-footer {
+	padding: 2px;
+}
+
+.section-grid {
+	display: grid;
+	grid-template-columns: 175px 1fr;
+}
+
+.section-header {
+	grid-column: 1 / -1;
+	background-color: #993300;
+	padding: 4px;
+	min-width: 0;
+}
+
+.section-header h2 {
+	color: #ffff00;
+	font-family: Arial, Helvetica, sans-serif;
+}
+
+.section-sidebar {
+	background-color: #FFFFCC;
+	padding: 4px;
+	min-width: 0;
+}
+
+.section-sidebar h3,
+.section-sidebar h4 {
+	color: #800000;
+	font-family: Arial, Helvetica, sans-serif;
+}
+
+.section-content {
+	padding: 4px;
+	min-width: 0;
+}
+
+.section-full {
+	grid-column: 1 / -1;
+	padding: 4px;
+	min-width: 0;
+}
+
+@media (max-width: 600px) {
+	.section-grid {
+		display: block;
+	}
+
+	.section-header h2,
+	.section-header h3 {
+		margin: 0.3em 0;
+	}
+
+	.section-sidebar h3,
+	.section-sidebar h4,
+	.section-sidebar p {
+		margin: 0.2em 0;
+	}
+}

--- a/course/Search.html
+++ b/course/Search.html
@@ -6,98 +6,7 @@
 		<title>Searching Tables</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style type="text/css">
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
-
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.page-footer {
-				padding: 2px;
-			}
-
-			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
-			}
-
-			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-				min-width: 0;
-				border-bottom: 1px solid;
-			}
-
-			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
-				align-self: stretch;
-				min-width: 0;
-				border-right: 1px solid;
-				border-bottom: 1px solid;
-			}
-
-			.section-content {
-				padding: 4px;
-				align-self: start;
-				min-width: 0;
-				overflow: hidden;
-				border-bottom: 1px solid;
-			}
-
-			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
-				min-width: 0;
-				border-bottom: 1px solid;
-			}
-
-			.section-full:last-child {
-				border-bottom: none;
-			}
-
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
 			pre {
-				overflow-x: auto;
-				max-width: 100%;
 				white-space: pre-wrap;
 				word-wrap: break-word;
 				overflow-wrap: break-word;
@@ -109,56 +18,28 @@
 				overflow-wrap: break-word;
 			}
 
-			body {
-				-webkit-text-size-adjust: 100%;
+			.section-header {
+				border-bottom: 1px solid;
 			}
 
-			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
+			.section-sidebar {
+				align-self: stretch;
+				border-right: 1px solid;
+				border-bottom: 1px solid;
+			}
 
-				.section-header h2,
-				.section-header h3 {
-					margin: 0.3em 0;
-				}
+			.section-content {
+				align-self: start;
+				overflow: hidden;
+				border-bottom: 1px solid;
+			}
 
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
+			.section-full {
+				border-bottom: 1px solid;
+			}
 
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
-				}
-
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
+			.section-full:last-child {
+				border-bottom: none;
 			}
 		</style>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -6,101 +6,40 @@
 		<title>COBOL Selection Constructs</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style type="text/css">
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
+			pre {
+				white-space: pre-wrap;
+				word-wrap: break-word;
+				overflow-wrap: break-word;
 			}
 
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
-
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.page-footer {
-				padding: 2px;
-			}
-
-			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
+			pre[class*="language-"],
+			code[class*="language-"] {
+				white-space: pre-wrap !important;
+				overflow-wrap: break-word;
 			}
 
 			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-				min-width: 0;
 				border-bottom: 1px solid;
 			}
 
 			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
 				align-self: stretch;
-				min-width: 0;
 				border-right: 1px solid;
 				border-bottom: 1px solid;
 			}
 
 			.section-content {
-				padding: 4px;
 				align-self: start;
-				min-width: 0;
 				overflow: hidden;
 				border-bottom: 1px solid;
 			}
 
 			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
-				min-width: 0;
 				border-bottom: 1px solid;
 			}
 
 			.section-full:last-child {
 				border-bottom: none;
-			}
-
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			pre {
-				overflow-x: auto;
-				max-width: 100%;
-				white-space: pre-wrap;
-				word-wrap: break-word;
-				overflow-wrap: break-word;
 			}
 
 			.eval-row {
@@ -119,16 +58,6 @@
 				grid-template-columns: auto auto auto auto;
 				justify-content: center;
 				column-gap: 1.5em;
-			}
-
-			pre[class*="language-"],
-			code[class*="language-"] {
-				white-space: pre-wrap !important;
-				overflow-wrap: break-word;
-			}
-
-			body {
-				-webkit-text-size-adjust: 100%;
 			}
 
 			.code-compare {
@@ -162,54 +91,6 @@
 			}
 
 			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
-				.section-header h2,
-				.section-header h3 {
-					margin: 0.3em 0;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
-				}
-
-				.section-grid {
-					grid-template-columns: 1fr;
-				}
-
-				.section-header {
-					grid-column: 1;
-				}
-
-				.section-full {
-					grid-column: 1;
-				}
-
 				.section-sidebar {
 					border-right: none;
 				}

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -6,57 +6,8 @@
 		<title>Introduction to Sequential Files</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style>
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.page-footer {
-				padding: 2px;
-			}
-
 			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
 				align-items: stretch;
-			}
-
-			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-			}
-
-			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
-			}
-
-			.section-content {
-				padding: 4px;
-				min-width: 0;
-			}
-
-			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
 			}
 
 			.code-block {
@@ -72,16 +23,6 @@
 			}
 
 			@media (max-width: 600px) {
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
-
 				.code-block {
 					width: 100%;
 				}

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -6,57 +6,8 @@
 		<title>Processing Sequential Files</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style>
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.page-footer {
-				padding: 2px;
-			}
-
 			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
 				align-items: stretch;
-			}
-
-			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-			}
-
-			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
-			}
-
-			.section-content {
-				padding: 4px;
-				min-width: 0;
-			}
-
-			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
 			}
 
 			.qa-form {
@@ -100,16 +51,6 @@
 			}
 
 			@media (max-width: 600px) {
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
-
 				.qa-row {
 					display: block;
 					border-bottom: 2px solid #999;

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -6,69 +6,8 @@
 		<title>Print files and variable-length records</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style>
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.page-footer {
-				padding: 2px;
-			}
-
 			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
 				align-items: stretch;
-			}
-
-			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-			}
-
-			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
-			}
-
-			.section-content {
-				padding: 4px;
-				min-width: 0;
-			}
-
-			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
-			}
-
-			@media (max-width: 600px) {
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
 			}
 		</style>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -6,49 +6,6 @@
 		<title>Sorting and Merging files</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style>
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
-			}
-
-			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-			}
-
-			.section-sidebar {
-				background-color: #ffffcc;
-				padding: 4px;
-			}
-
-			.section-content {
-				padding: 4px;
-				min-width: 0;
-			}
-
 			.spec-block {
 				background-color: #e1ffe1;
 				border: 1px solid;

--- a/course/String.html
+++ b/course/String.html
@@ -3,183 +3,32 @@
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>The STRING verb</title>
+		<meta content="width=device-width, initial-scale=1" name="viewport" />
+		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<style type="text/css">
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
-
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				border: 1px solid;
-				max-width: 715px;
-				margin-left: auto;
-				margin-right: auto;
-			}
-
-			.page-header {
+			.page-header,
+			.page-nav {
 				max-width: 710px;
 				margin: 0 auto;
 			}
 
 			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
 				max-width: 710px;
 				margin: 0 auto;
 			}
 
-			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-				text-align: left;
-			}
-
+			.section-header,
 			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
 				text-align: left;
-			}
-
-			.section-content {
-				padding: 4px;
-				min-width: 0;
-			}
-
-			.page-nav {
-				max-width: 710px;
-				margin: 0 auto;
-			}
-		</style>
-		<meta content="width=device-width, initial-scale=1" name="viewport" />
-		<style type="text/css">
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			table {
-				max-width: 100%;
-			}
-
-			pre {
-				overflow-x: auto;
-				max-width: 100%;
-			}
-
-			body {
-				-webkit-text-size-adjust: 100%;
 			}
 
 			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
-				table[width],
-				table[width] > tbody,
-				table[width] > tbody > tr,
-				table[width] > tbody > tr > td {
-					width: auto !important;
-					height: auto !important;
-				}
-
-				td[width],
-				th[width],
-				td[height],
-				th[height] {
-					width: auto !important;
-					height: auto !important;
-				}
-
-				.section-header h2,
-				.section-header h3 {
-					margin: 0.3em 0;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				hr[width] {
-					width: 100% !important;
-				}
-
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					white-space: pre-wrap;
-					word-wrap: break-word;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"],
-				code[class*="language-"] {
-					white-space: pre-wrap !important;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
-				}
-
-				.section-grid {
-					grid-template-columns: 1fr;
-				}
-
-				.section-header {
-					grid-column: 1;
-				}
-
 				.section-sidebar > h4:not(:first-child):not(:has(img)),
 				h4:has(> img[src*="PanelLine"]) {
 					display: none;
-				}
-
-				.section-sidebar > h3,
-				.section-sidebar > h4,
-				.section-sidebar > p {
-					margin: 0.2em 0;
 				}
 			}
 		</style>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -6,51 +6,6 @@
 		<title>Contained and external sub-programs</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style>
-			img { max-width: 100%; height: auto; }
-			pre { overflow-x: auto; max-width: 100%; }
-			body { -webkit-text-size-adjust: 100%; }
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content { padding: 2px; }
-			.page-footer { padding: 2px; }
-
-			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
-			}
-
-			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-			}
-
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-content {
-				padding: 4px;
-			}
-
 			.code-run-pair {
 				display: flex;
 				border: 1px solid;
@@ -69,57 +24,6 @@
 			}
 
 			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
-				.section-header h2,
-				.section-header h3 {
-					margin: 0.3em 0;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				hr[width] { width: 100% !important; }
-
-				img, iframe, video, embed, object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					white-space: pre-wrap;
-					word-wrap: break-word;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"],
-				code[class*="language-"] {
-					white-space: pre-wrap !important;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
-				}
-
-				.section-grid { display: block; }
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
-
 				.code-run-pair { flex-direction: column; }
 				.code-run-pair .run-part { border-left: none; border-top: 1px solid; }
 			}

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -6,83 +6,8 @@
 		<title>Using Tables</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style>
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.page-footer {
-				padding: 2px;
-			}
-
 			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
 				align-items: stretch;
-			}
-
-			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-			}
-
-			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
-			}
-
-			.section-content {
-				padding: 4px;
-				min-width: 0;
-			}
-
-			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
-			}
-
-			table {
-				max-width: 100%;
-			}
-
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			pre {
-				overflow-x: auto;
-				max-width: 100%;
-			}
-
-			@media (max-width: 600px) {
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
 			}
 		</style>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -6,52 +6,8 @@
 		<title>Creating tables - syntax and semantics</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style>
-			table { max-width: 100%; }
-			img { max-width: 100%; height: auto; }
-
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
 			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
 				align-items: stretch;
-			}
-
-			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-			}
-
-			.section-sidebar {
-				background-color: #FFFFCC;
-				padding: 4px;
-			}
-
-			.section-content {
-				padding: 4px;
-				min-width: 0;
-			}
-
-			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
 			}
 
 			form select {
@@ -60,16 +16,6 @@
 			}
 
 			@media (max-width: 600px) {
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
-
 				form select {
 					max-width: 100%;
 					width: 100%;

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -3,168 +3,18 @@
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>The UNSTRING verb</title>
+		<meta content="width=device-width, initial-scale=1" name="viewport" />
+		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<style type="text/css">
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
-
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-content {
-				padding: 2px;
-			}
-
-			.page-footer {
-				padding: 2px;
-			}
-
-			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
-			}
-
-			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-			}
-
 			.section-sidebar {
-				background-color: #ffffcc;
-				padding: 4px;
 				align-self: stretch;
 			}
 
 			.section-content {
-				padding: 4px;
 				align-self: start;
-			}
-
-		</style>
-		<meta content="width=device-width, initial-scale=1" name="viewport" />
-		<style type="text/css">
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			table {
-				max-width: 100%;
-			}
-
-			pre {
-				overflow-x: auto;
-				max-width: 100%;
-			}
-
-			body {
-				-webkit-text-size-adjust: 100%;
-			}
-
-			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
-				table[width] {
-					width: 100% !important;
-					height: auto !important;
-				}
-
-				td[width],
-				th[width],
-				td[height],
-				th[height] {
-					width: auto !important;
-					height: auto !important;
-				}
-
-				.section-header h2,
-				.section-header h3 {
-					margin: 0.3em 0;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				hr[width] {
-					width: 100% !important;
-				}
-
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					white-space: pre-wrap;
-					word-wrap: break-word;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"],
-				code[class*="language-"] {
-					white-space: pre-wrap !important;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
-				}
-
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
 			}
 		</style>
 		<script src="../components/copyright-notice.js" defer></script>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -4,158 +4,23 @@
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>The USAGE clause</title>
+		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<style type="text/css">
-			img {
-				max-width: 100%;
-				height: auto;
-			}
-
-			table {
-				max-width: 100%;
-			}
-
-			pre {
-				overflow-x: auto;
-				max-width: 100%;
-			}
-
-			body {
-				-webkit-text-size-adjust: 100%;
-			}
-
-			ul.toc {
-				list-style-image: url(Resources/pics/BallGreenG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
-				font-size: smaller;
-			}
-
-			ul.toc a {
-				font-weight: bold;
-				font-size: larger;
-			}
-
-			.section-header h2 {
-				color: #ffff00;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.section-sidebar h3,
-			.section-sidebar h4 {
-				color: #800000;
-				font-family: Arial, Helvetica, sans-serif;
-			}
-
-			.page-wrapper {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid;
-				box-sizing: border-box;
-			}
-
-			.page-footer {
-				padding: 4px;
-			}
-
 			.section-grid {
-				display: grid;
-				grid-template-columns: 175px 1fr;
-				padding: 4px;
-			}
-
-			.section-header {
-				grid-column: 1 / -1;
-				background-color: #993300;
-				padding: 4px;
-			}
-
-			.section-sidebar {
-				background-color: #FFFFCC;
 				padding: 4px;
 			}
 
 			.section-content {
-				padding: 4px;
 				align-self: start;
 			}
 
-			.section-full {
-				grid-column: 1 / -1;
-				padding: 4px;
-			}
-
-
 			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					overflow-wrap: break-word;
-					word-wrap: break-word;
-				}
-
-				blockquote {
-					margin-left: 12px;
-					margin-right: 12px;
-				}
-
-				hr[width] {
-					width: 100% !important;
-				}
-
-				img,
-				iframe,
-				video,
-				embed,
-				object {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					height: auto;
-				}
-
-				pre {
-					max-width: min(100%, calc(100vw - 16px)) !important;
-					white-space: pre-wrap;
-					word-wrap: break-word;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"],
-				code[class*="language-"] {
-					white-space: pre-wrap !important;
-					overflow-wrap: break-word;
-				}
-
-				pre[class*="language-"] {
-					font-size: 0.8em;
-					line-height: 1.35;
-					padding: 0.6em;
-					overflow-x: auto;
-				}
-
-				.section-grid {
-					display: block;
-				}
-
-				.section-header h2,
-				.section-header h3 {
-					margin: 0.3em 0;
-				}
-
 				.section-sidebar h4:not(:first-child):not(:has(img)),
 				h4:has(> img[src*="PanelLine"]) {
 					display: none;
-				}
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
 				}
 			}
 		</style>


### PR DESCRIPTION
## Summary

- Promotes the shared course-page layout rules (`.page-wrapper`, `.section-grid`, `.section-header`, `.section-sidebar`, `.section-content`, `.section-full`, plus their mobile breakpoint) into `course/Resources/css/course.css` so every course page can rely on them.
- Migrates the five pages that were still using older class vocabularies onto the dominant `.section-*` naming, with no intended visual change:
  - `COBOLIntro.html`: `#page-layout` / `.full-width` / `.sidebar-cell` / `.content-cell` → `.section-grid` / `.section-full` / `.section-sidebar` / `.section-content`
  - `DataDeclaration.html`: `.page-layout` / `.sidebar` / bare `<div>` content cells → standard names (kept the cell-grid border treatment)
  - `Inspect.html`: `.course-section-row/header/label/content/full` → `.section-grid/header/sidebar/content/full`
  - `Copy.html`: `.page-frame` / `.layout-grid` / `.layout-full` / `.sidebar` → standard names
  - `Intro2DirectAccess.html`: `.section-row` / `.section-label` → `.section-grid` / `.section-sidebar`
- Strips the duplicated layout CSS from every page's inline `<style>`, leaving only page-specific overrides (border treatments, page-specific widgets like `.eval-row`, `.code-compare`, `.qa-grid`, `.processing-template`, `.saq-table`, `.code-run-pair`, `.declaratives-layout`, `.results-box`, `.spec-block`, etc., and per-page media-query tweaks).
- Net effect: 26 files changed, **+405 / −2918** lines.

## Why

Every course page was carrying its own ~80–200 line copy of the same `ul.toc`, `.page-wrapper`, `.section-*` rules, with subtle drift (different class names, slight border/padding variations) between pages. This made structural changes painful and obscured what was actually page-specific. Consolidating gives a single canonical vocabulary and shrinks the diff for any future layout tweak to one file.

## Notes for reviewers

- All pages were spot-checked at desktop (1024px) and mobile (375px) widths and render unchanged from the baseline.
- Pages that intentionally render with internal cell borders (COBOLIntro, DataDeclaration, COBOLcommands, EditedPics, Iteration, RelativeFiles, ReportWriter, ReportWriterSS, Search, Selection) keep their border overrides locally; the shared rules in `course.css` are only the cross-cutting ones.
- One incidental coherence fix: EditedPics' TOC was rendering with disc bullets due to a local `list-style-type: disc` override; removed so it now uses the same green-ball image bullets as every other page.
- `index.html` is intentionally untouched — its layout (homepage grid of topics) is structurally distinct and out of scope.

## Test plan

- [ ] Spot-check 3–4 pages at desktop width (e.g., COBOLIntro, Selection, Copy, ReportWriterSS).
- [ ] Spot-check the same pages at mobile width to confirm the grid collapses cleanly.
- [ ] Confirm TOC bullets render as green balls on every course page (including EditedPics).
- [ ] Skim the `course.css` diff to verify the new shared rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)