### PR TITLE
Centralize bordered grid styles and remove duplicate CSS across course pages

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -99,7 +99,7 @@
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
-	<body text="#000000" bgcolor="#FFFFFF" link="#0000FF" vlink="#FF0000" alink="#009B00">
+	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
 		<div class="section-grid">
 			<div class="section-full">
 				<center>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -5,37 +5,6 @@
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>Basic Procedure Division commands</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
-		<style type="text/css">
-			.section-header {
-				border-bottom: 1px solid;
-			}
-
-			.section-sidebar {
-				align-self: stretch;
-				border-right: 1px solid;
-				border-bottom: 1px solid;
-			}
-
-			.section-content {
-				align-self: start;
-				overflow: hidden;
-				border-bottom: 1px solid;
-			}
-
-			.section-full {
-				border-bottom: 1px solid;
-			}
-
-			.section-full:last-child {
-				border-bottom: none;
-			}
-
-			.section-content pre[class*="language-"],
-			.section-content code[class*="language-"] {
-				white-space: pre-wrap;
-				overflow-wrap: break-word;
-			}
-		</style>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
@@ -73,7 +42,7 @@
 			</div>
 
 			<!-- Introduction -->
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-header">
 					<h2 align="center" id="intro">Introduction</h2>
 				</div>
@@ -130,7 +99,7 @@
 			</div>
 
 			<!-- Part 1: Basic User Input and Output -->
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-header">
 					<h2 align="center" id="part1">Basic User Input and Output</h2>
 				</div>
@@ -416,7 +385,7 @@ The time is 14:41
 			</div>
 
 			<!-- Part 2: Assignment using the MOVE verb -->
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-header">
 					<h2 align="center" id="part2">Assignment using the MOVE verb</h2>
 				</div>
@@ -527,7 +496,7 @@ The time is 14:41
 			</div>
 
 			<!-- Part 3: Arithmetic in COBOL -->
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-header">
 					<h2 align="center" id="part3">Arithmetic in COBOL</h2>
 				</div>

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -30,17 +30,6 @@
 				.page-wrapper {
 					border: none;
 				}
-
-				.section-sidebar > h4:not(:first-child):not(:has(img)),
-				h4:has(> img[src*="PanelLine"]) {
-					display: none;
-				}
-
-				.section-sidebar > h3,
-				.section-sidebar > h4,
-				.section-sidebar > p {
-					margin: 0.2em 0;
-				}
 			}
 		</style>
 		<script src="../components/copyright-notice.js" defer></script>

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -69,10 +69,6 @@
 					border-right: 1px solid black;
 				}
 
-				.section-sidebar h4:not(:first-child):not(:has(img)) {
-					display: none;
-				}
-
 				.code-record {
 					width: 100%;
 					max-width: 100%;

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -10,35 +10,6 @@
 			.page-footer {
 				padding: 4px;
 			}
-
-			.section-header {
-				border-bottom: 1px solid;
-			}
-
-			.section-header h2 {
-				text-align: center;
-				margin: 0.3em 0;
-			}
-
-			.section-sidebar {
-				align-self: stretch;
-				border-right: 1px solid;
-				border-bottom: 1px solid;
-			}
-
-			.section-content {
-				align-self: start;
-				overflow: hidden;
-				border-bottom: 1px solid;
-			}
-
-			.section-full {
-				border-bottom: 1px solid;
-			}
-
-			.section-full:last-child {
-				border-bottom: none;
-			}
 		</style>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
@@ -78,7 +49,7 @@
 				<hr />
 			</div>
 
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-header">
 					<h2 id="intro">Introduction</h2>
 				</div>
@@ -147,7 +118,7 @@
 				</div>
 			</div>
 
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-header">
 					<h2 id="part1">What is an Edited Picture?</h2>
 				</div>
@@ -334,7 +305,7 @@
 				</div>
 			</div>
 
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-header">
 					<h2 id="part2">Insertion Editing</h2>
 				</div>
@@ -1242,7 +1213,7 @@
 				</div>
 			</div>
 
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-header">
 					<h2 id="part3">Suppression and Replacement Editing</h2>
 				</div>

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -13,10 +13,6 @@
 				max-width: 700px;
 				box-sizing: border-box;
 			}
-
-			.section-sidebar {
-				align-self: stretch;
-			}
 		</style>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -13,16 +13,8 @@
 				margin-top: 0.6em;
 			}
 
-			.section-header {
-				text-align: center;
-			}
-
 			.section-header h2 {
 				margin: 0;
-			}
-
-			.section-sidebar {
-				align-self: stretch;
 			}
 		</style>
 		<script src="../components/copyright-notice.js" defer></script>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -18,29 +18,6 @@
 				overflow-wrap: break-word;
 			}
 
-			.section-header {
-				border-bottom: 1px solid;
-			}
-
-			.section-sidebar {
-				align-self: stretch;
-				border-right: 1px solid;
-				border-bottom: 1px solid;
-			}
-
-			.section-content {
-				align-self: start;
-				border-bottom: 1px solid;
-			}
-
-			.section-full {
-				border-bottom: 1px solid;
-			}
-
-			.section-full:last-child {
-				border-bottom: none;
-			}
-
 			.processing-template {
 				border: 1px solid;
 				padding: 0;
@@ -170,7 +147,7 @@
 				</ul>
 				<hr />
 			</div>
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-header">
 					<h2 align="center" id="intro">Introduction</h2>
 				</div>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -6,10 +6,6 @@
 		<title>Reference Modification</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style>
-			.section-grid {
-				align-items: stretch;
-			}
-
 			.table-scroll {
 				overflow-x: auto;
 			}

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -18,30 +18,6 @@
 				overflow-wrap: break-word;
 			}
 
-			.section-header {
-				border-bottom: 1px solid;
-			}
-
-			.section-sidebar {
-				align-self: stretch;
-				border-right: 1px solid;
-				border-bottom: 1px solid;
-			}
-
-			.section-content {
-				align-self: start;
-				overflow: hidden;
-				border-bottom: 1px solid;
-			}
-
-			.section-full {
-				border-bottom: 1px solid;
-			}
-
-			.section-full:last-child {
-				border-bottom: none;
-			}
-
 			.declaratives-layout {
 				display: flex;
 				gap: 1em;
@@ -115,7 +91,7 @@
 			<div class="section-header">
 				<h2 align="center" id="intro">Introduction</h2>
 			</div>
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
 					<h3>Aims</h3>
 				</div>
@@ -132,7 +108,7 @@
 					<hr />
 				</div>
 			</div>
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
 					<h3>Objectives</h3>
 				</div>
@@ -157,7 +133,7 @@
 					</ol>
 				</div>
 			</div>
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
 					<h3>Prerequisites</h3>
 				</div>
@@ -179,7 +155,7 @@
 			<div class="section-header">
 				<h2 align="center" id="progs">A look at some programs that use Relative files</h2>
 			</div>
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
 					<h3 align="left">Example program - Creating a Relative file</h3>
 				</div>
@@ -221,7 +197,7 @@
 					<hr />
 				</div>
 			</div>
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
 					<h3>Example program - Reading a Relative file</h3>
 				</div>
@@ -285,7 +261,7 @@ Enter supplier key (2 digits)-&gt; 05
 			<div class="section-header">
 				<h2 align="center" id="declar">Relative file - Declarations</h2>
 			</div>
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
 					<h3>Introduction</h3>
 				</div>
@@ -298,7 +274,7 @@ Enter supplier key (2 digits)-&gt; 05
 					<hr />
 				</div>
 			</div>
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
 					<h3>Select and Assign clause syntax</h3>
 				</div>
@@ -306,7 +282,7 @@ Enter supplier key (2 digits)-&gt; 05
 					<p><img height="189" src="Resources/pics/I-DFrel1.gif" width="507" /></p>
 				</div>
 			</div>
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
 					<h3>The Optional phrase</h3>
 				</div>
@@ -317,7 +293,7 @@ Enter supplier key (2 digits)-&gt; 05
 					</p>
 				</div>
 			</div>
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
 					<h3>The Access Mode</h3>
 				</div>
@@ -331,7 +307,7 @@ Enter supplier key (2 digits)-&gt; 05
 					</p>
 				</div>
 			</div>
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
 					<h3>The Record Key phrase</h3>
 				</div>
@@ -346,7 +322,7 @@ Enter supplier key (2 digits)-&gt; 05
 					</p>
 				</div>
 			</div>
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
 					<h3>The File Status</h3>
 				</div>
@@ -389,7 +365,7 @@ Enter supplier key (2 digits)-&gt; 05
 			<div class="section-header">
 				<h2 align="center" id="verbs">Relative file - file processing verbs</h2>
 			</div>
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
 					<h3>Introduction</h3>
 				</div>
@@ -407,7 +383,7 @@ Enter supplier key (2 digits)-&gt; 05
 					<hr />
 				</div>
 			</div>
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
 					<h3>The Invalid Key clause</h3>
 				</div>
@@ -424,7 +400,7 @@ Enter supplier key (2 digits)-&gt; 05
 					<hr />
 				</div>
 			</div>
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
 					<h3>OPEN/CLOSE verbs</h3>
 				</div>
@@ -460,7 +436,7 @@ Enter supplier key (2 digits)-&gt; 05
 					<hr />
 				</div>
 			</div>
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
 					<h3>The READ verb</h3>
 				</div>
@@ -472,7 +448,7 @@ Enter supplier key (2 digits)-&gt; 05
 					</p>
 				</div>
 			</div>
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
 					<h3>Reading using a key</h3>
 				</div>
@@ -509,7 +485,7 @@ Enter supplier key (2 digits)-&gt; 05
 					<p>The file must be opened for I-O or INPUT.&nbsp;</p>
 				</div>
 			</div>
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
 					<h3>Reading Sequentially</h3>
 				</div>
@@ -539,7 +515,7 @@ Enter supplier key (2 digits)-&gt; 05
 					<hr />
 				</div>
 			</div>
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
 					<h3 align="left">The WRITE verb</h3>
 				</div>
@@ -572,7 +548,7 @@ Enter supplier key (2 digits)-&gt; 05
 					<hr />
 				</div>
 			</div>
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
 					<h3 align="left">The REWRITE verb</h3>
 				</div>
@@ -606,7 +582,7 @@ Enter supplier key (2 digits)-&gt; 05
 					<hr />
 				</div>
 			</div>
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
 					<h3 align="left">The DELETE verb</h3>
 				</div>
@@ -645,7 +621,7 @@ Enter supplier key (2 digits)-&gt; 05
 					<hr />
 				</div>
 			</div>
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
 					<h3>The START verb</h3>
 				</div>
@@ -704,7 +680,7 @@ Enter supplier key (2 digits)-&gt; 05
 			<div class="section-header">
 				<h2 align="center" id="declaratives">Introduction to Declaratives</h2>
 			</div>
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
 					<h3 align="left">Introduction</h3>
 				</div>
@@ -716,7 +692,7 @@ Enter supplier key (2 digits)-&gt; 05
 					<hr />
 				</div>
 			</div>
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
 					<h3 align="left">The Declaratives template</h3>
 				</div>
@@ -774,7 +750,7 @@ Begin.</code></pre>
 					<hr />
 				</div>
 			</div>
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
 					<h3 align="left">The Use phrase</h3>
 				</div>
@@ -805,7 +781,7 @@ Begin.</code></pre>
 					<hr />
 				</div>
 			</div>
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
 					<h3 align="center">Example program - fragment</h3>
 				</div>

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -6,30 +6,6 @@
 		<title>COBOL Report Writer</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style type="text/css">
-			.section-header {
-				border-bottom: 1px solid;
-			}
-
-			.section-sidebar {
-				align-self: stretch;
-				border-right: 1px solid;
-				border-bottom: 1px solid;
-			}
-
-			.section-content {
-				align-self: start;
-				overflow: hidden;
-				border-bottom: 1px solid;
-			}
-
-			.section-full {
-				border-bottom: 1px solid;
-			}
-
-			.section-full:last-child {
-				border-bottom: none;
-			}
-
 			.iframe-wrapper {
 				text-align: center;
 				border: 1px solid;
@@ -82,7 +58,7 @@
 					</ul>
 				</div>
 
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-header">
 						<h2 align="center" id="intro">Introduction</h2>
 					</div>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -17,30 +17,6 @@
 				white-space: pre-wrap !important;
 				overflow-wrap: break-word;
 			}
-
-			.section-header {
-				border-bottom: 1px solid;
-			}
-
-			.section-sidebar {
-				align-self: stretch;
-				border-right: 1px solid;
-				border-bottom: 1px solid;
-			}
-
-			.section-content {
-				align-self: start;
-				overflow: hidden;
-				border-bottom: 1px solid;
-			}
-
-			.section-full {
-				border-bottom: 1px solid;
-			}
-
-			.section-full:last-child {
-				border-bottom: none;
-			}
 		</style>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
@@ -110,7 +86,7 @@
 				<div class="section-header">
 					<h2 align="center" id="intro">Introduction</h2>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>Aims</h4>
 					</div>
@@ -122,7 +98,7 @@
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>Objectives</h4>
 					</div>
@@ -145,7 +121,7 @@
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>Prerequisites</h4>
 					</div>
@@ -171,7 +147,7 @@
 				<div class="section-header">
 					<h2 align="center" id="part1">Defining the Report - Report File entries</h2>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4><code class="language-cobol">ENVIRONMENT DIVISION</code> entries</h4>
 					</div>
@@ -225,7 +201,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4 align="left">File Section entries</h4>
 					</div>
@@ -259,7 +235,7 @@ RD  SalesReport
 				<div class="section-header">
 					<h2 align="center" id="part2">Defining the Report - Report Description (RD) Entries</h2>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>Introduction</h4>
 					</div>
@@ -283,7 +259,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4 align="left">The Report Description (RD) entries - Syntax</h4>
 					</div>
@@ -293,7 +269,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4 align="left">The Report Description (RD) entries - Semantics</h4>
 					</div>
@@ -362,7 +338,7 @@ RD  SalesReport
 				<div class="section-header">
 					<h2 align="center" id="part3">Defining the Report - Report Group entries</h2>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>Introduction</h4>
 					</div>
@@ -379,7 +355,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4 align="left">Defining a Report Group Record - Syntax</h4>
 					</div>
@@ -391,7 +367,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4 align="left"><i>ReportGroupName</i> Rules</h4>
 					</div>
@@ -412,7 +388,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4 align="left">The LINE NUMBER clause</h4>
 					</div>
@@ -459,7 +435,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4 align="left">The NEXT GROUP clause</h4>
 					</div>
@@ -495,7 +471,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4 align="left">The TYPE clause</h4>
 					</div>
@@ -544,7 +520,7 @@ RD  SalesReport
 				<div class="section-header">
 					<h2 align="center" id="part4">Defining the Report - Lines and Columns</h2>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4 align="left">Introduction</h4>
 					</div>
@@ -558,7 +534,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4 align="left">Defining Report Lines</h4>
 					</div>
@@ -574,7 +550,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4 align="center">Defining Elementary print items in a report group</h4>
 					</div>
@@ -599,7 +575,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4 align="left">The COLUMN NUMBER clause</h4>
 					</div>
@@ -617,7 +593,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>The GROUP INDICATE clause</h4>
 					</div>
@@ -645,7 +621,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>The SOURCE clause</h4>
 					</div>
@@ -659,7 +635,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>The SUM clause</h4>
 					</div>
@@ -749,7 +725,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>The RESET ON clause</h4>
 					</div>
@@ -771,7 +747,7 @@ RD  SalesReport
 				<div class="section-header">
 					<h2 align="center" id="part5">Special Report Writer registers</h2>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>Introduction</h4>
 					</div>
@@ -789,7 +765,7 @@ RD  SalesReport
 						</p>
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>The LINE-COUNTER register</h4>
 					</div>
@@ -816,7 +792,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>The PAGE-COUNTER register</h4>
 					</div>
@@ -849,7 +825,7 @@ RD  SalesReport
 				<div class="section-header">
 					<h2 align="center" id="part6">Procedure Division verbs</h2>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>Introduction</h4>
 					</div>
@@ -879,7 +855,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>Syntax</h4>
 					</div>
@@ -888,7 +864,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>INITIATE</h4>
 					</div>
@@ -915,7 +891,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>GENERATE</h4>
 					</div>
@@ -1012,7 +988,7 @@ Programmer - Michael Coughlan               Page :  1
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>TERMINATE</h4>
 					</div>
@@ -1034,7 +1010,7 @@ Programmer - Michael Coughlan               Page :  1
 				<div class="section-header">
 					<h2 align="center" id="part7">Report Writer Declaratives</h2>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>Introduction</h4>
 					</div>
@@ -1059,7 +1035,7 @@ Programmer - Michael Coughlan               Page :  1
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>Using Declaratives with the Report Writer</h4>
 					</div>
@@ -1083,7 +1059,7 @@ Programmer - Michael Coughlan               Page :  1
 						<p align="left">Statements in the Declaratives must not reference non-declarative procedures.</p>
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>Declaratives Example</h4>
 					</div>
@@ -1110,7 +1086,7 @@ Begin.
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>The SUPPRESS PRINTING statement</h4>
 					</div>
@@ -1143,7 +1119,7 @@ END DECLARATIVES.</code></pre>
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>Control Break Registers</h4>
 					</div>

--- a/course/Resources/css/course.css
+++ b/course/Resources/css/course.css
@@ -161,6 +161,7 @@ td[bgcolor="#FFFFCC"] h4 {
 	background-color: #993300;
 	padding: 4px;
 	min-width: 0;
+	text-align: center;
 }
 
 .section-header h2 {
@@ -206,4 +207,50 @@ td[bgcolor="#FFFFCC"] h4 {
 	.section-sidebar p {
 		margin: 0.2em 0;
 	}
+
+	/* Hide decorative PanelLine spacer h4s on narrow screens */
+	.section-sidebar h4:not(:first-child):not(:has(img)),
+	h4:has(> img[src*="PanelLine"]) {
+		display: none;
+	}
+}
+
+/* Bordered grid variant — opt-in via `section-grid section-grid--bordered`.
+   Draws horizontal dividers between sections and a vertical divider between
+   sidebar and content cells. Applied where the page is laid out as a
+   table-like sequence of sidebar/content rows. */
+.section-grid--bordered .section-header {
+	border-bottom: 1px solid;
+}
+
+.section-grid--bordered .section-sidebar {
+	border-right: 1px solid;
+	border-bottom: 1px solid;
+}
+
+.section-grid--bordered .section-content {
+	align-self: start;
+	overflow: hidden;
+	border-bottom: 1px solid;
+}
+
+.section-grid--bordered .section-full {
+	border-bottom: 1px solid;
+}
+
+.section-grid--bordered > .section-full:last-child {
+	border-bottom: none;
+}
+
+@media (max-width: 600px) {
+	.section-grid--bordered .section-sidebar {
+		border-right: none;
+	}
+}
+
+/* Wrap long Prism-highlighted code so it doesn't overflow narrow columns. */
+.section-grid--bordered .section-content pre[class*="language-"],
+.section-grid--bordered .section-content code[class*="language-"] {
+	white-space: pre-wrap;
+	overflow-wrap: break-word;
 }

--- a/course/Search.html
+++ b/course/Search.html
@@ -17,30 +17,6 @@
 				white-space: pre-wrap !important;
 				overflow-wrap: break-word;
 			}
-
-			.section-header {
-				border-bottom: 1px solid;
-			}
-
-			.section-sidebar {
-				align-self: stretch;
-				border-right: 1px solid;
-				border-bottom: 1px solid;
-			}
-
-			.section-content {
-				align-self: start;
-				overflow: hidden;
-				border-bottom: 1px solid;
-			}
-
-			.section-full {
-				border-bottom: 1px solid;
-			}
-
-			.section-full:last-child {
-				border-bottom: none;
-			}
 		</style>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
@@ -95,7 +71,7 @@
 				<div class="section-header">
 					<h2 align="center" id="intro">Introduction</h2>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>Aims</h4>
 					</div>
@@ -129,7 +105,7 @@
 						<hr align="center" size="1" width="100%" />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>Objectives</h4>
 					</div>
@@ -156,7 +132,7 @@
 						<hr align="center" size="1" width="100%" />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>Prerequisites</h4>
 					</div>
@@ -189,7 +165,7 @@
 				<div class="section-header">
 					<h2 align="center" id="part1">Occurs clause extensions</h2>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>Introduction</h4>
 					</div>
@@ -210,7 +186,7 @@
 						<hr size="1" width="100%" />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>Full OCCURS clause syntax</h4>
 					</div>
@@ -218,7 +194,7 @@
 						<p align="left"><img height="122" src="Resources/pics/Search1.gif" width="331" /></p>
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>INDEXED BY phrase - notes</h4>
 					</div>
@@ -260,7 +236,7 @@
 						</p>
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>KEY IS phrase - notes</h4>
 					</div>
@@ -293,7 +269,7 @@
 				<div class="section-header">
 					<h2 align="center" id="part2">The SEARCH verb</h2>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>Introduction</h4>
 					</div>
@@ -305,7 +281,7 @@
 						</p>
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>SEARCH syntax</h4>
 					</div>
@@ -371,7 +347,7 @@
 						<hr size="1" width="100%" />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>The SET verb syntax</h4>
 					</div>
@@ -399,7 +375,7 @@
 						<p><img height="148" src="Resources/pics/Search4.gif" width="326" /></p>
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>SEARCH example 1</h4>
 						<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
@@ -472,7 +448,7 @@ Begin.
 						<hr size="1" width="100%" />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>Example program 2</h4>
 						<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
@@ -609,7 +585,7 @@ DisplayCountyTaxes.
 				<div class="section-header">
 					<h2 align="center" id="part3">Searching multi-dimension tables</h2>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>Introduction</h4>
 					</div>
@@ -662,7 +638,7 @@ DisplayCountyTaxes.
 						</p>
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
 					</div>
@@ -736,7 +712,7 @@ LoadTable.
 						<hr size="1" width="100%" />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>The Race Results Example program</h4>
 					</div>
@@ -766,7 +742,7 @@ LoadTable.
 						</p>
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
 					</div>
@@ -876,7 +852,7 @@ END-SEARCH</code></pre>
 				<div class="section-header">
 					<h2 align="center" id="part4">The SEARCH ALL verb</h2>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4 align="left">Introduction</h4>
 					</div>
@@ -892,7 +868,7 @@ END-SEARCH</code></pre>
 						<hr size="1" />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>SEARCH ALL syntax</h4>
 					</div>
@@ -941,7 +917,7 @@ END-SEARCH</code></pre>
 						<hr size="1" width="100%" />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>How a binary search works</h4>
 					</div>
@@ -1000,7 +976,7 @@ END-SEARCH.</code></pre>
 						<p align="left">The full program for searching the letter table is given below.</p>
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
 					</div>
@@ -1048,7 +1024,7 @@ Begin.
 						<hr size="1" width="100%" />
 					</div>
 				</div>
-				<div class="section-grid">
+				<div class="section-grid section-grid--bordered">
 					<div class="section-sidebar">
 						<h4>Example program</h4>
 						<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -18,30 +18,6 @@
 				overflow-wrap: break-word;
 			}
 
-			.section-header {
-				border-bottom: 1px solid;
-			}
-
-			.section-sidebar {
-				align-self: stretch;
-				border-right: 1px solid;
-				border-bottom: 1px solid;
-			}
-
-			.section-content {
-				align-self: start;
-				overflow: hidden;
-				border-bottom: 1px solid;
-			}
-
-			.section-full {
-				border-bottom: 1px solid;
-			}
-
-			.section-full:last-child {
-				border-bottom: none;
-			}
-
 			.eval-row {
 				display: grid;
 				font-family: monospace;
@@ -91,10 +67,6 @@
 			}
 
 			@media (max-width: 600px) {
-				.section-sidebar {
-					border-right: none;
-				}
-
 				.code-compare {
 					flex-direction: column;
 					width: 100%;
@@ -156,7 +128,7 @@
 			</div>
 
 			<!-- Introduction section -->
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-header">
 					<h2 align="center" id="intro">Introduction</h2>
 				</div>
@@ -229,7 +201,7 @@
 			</div>
 
 			<!-- Selection using IF section -->
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-header">
 					<h2 align="center" id="part1">Selection using IF</h2>
 				</div>
@@ -795,7 +767,7 @@ END-IF
 			</div>
 
 			<!-- Condition Names section -->
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-header">
 					<h2 align="center" id="part2">Condition Names</h2>
 				</div>
@@ -983,7 +955,7 @@ END-IF
 			</div>
 
 			<!-- Using the SET verb section -->
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-header">
 					<h2 align="center" id="part3">Using the SET verb with Condition Names</h2>
 				</div>
@@ -1126,7 +1098,7 @@ Begin.
 			</div>
 
 			<!-- The EVALUATE verb section -->
-			<div class="section-grid">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-header">
 					<h2 align="center" id="part4">The EVALUATE verb</h2>
 				</div>

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -6,10 +6,6 @@
 		<title>Introduction to Sequential Files</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style>
-			.section-grid {
-				align-items: stretch;
-			}
-
 			.code-block {
 				border: 1px solid;
 				padding: 5px;

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -6,10 +6,6 @@
 		<title>Processing Sequential Files</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style>
-			.section-grid {
-				align-items: stretch;
-			}
-
 			.qa-form {
 				border: 1px solid;
 				width: 96%;

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -5,11 +5,6 @@
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>Print files and variable-length records</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
-		<style>
-			.section-grid {
-				align-items: stretch;
-			}
-		</style>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -15,22 +15,7 @@
 				box-sizing: border-box;
 			}
 
-			@media (max-width: 750px) {
-				.section-header h2,
-				.section-header h3 {
-					margin: 0.3em 0;
-				}
-
-				.section-grid {
-					display: block;
-				}
-
-				.section-sidebar h3,
-				.section-sidebar h4,
-				.section-sidebar p {
-					margin: 0.2em 0;
-				}
-
+			@media (max-width: 600px) {
 				.spec-block {
 					max-width: 100%;
 				}

--- a/course/String.html
+++ b/course/String.html
@@ -1,9 +1,9 @@
 <!doctype html>
 <html>
 	<head>
+		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>The STRING verb</title>
-		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
@@ -23,13 +23,6 @@
 			.section-header,
 			.section-sidebar {
 				text-align: left;
-			}
-
-			@media (max-width: 600px) {
-				.section-sidebar > h4:not(:first-child):not(:has(img)),
-				h4:has(> img[src*="PanelLine"]) {
-					display: none;
-				}
 			}
 		</style>
 		<script src="../components/copyright-notice.js" defer></script>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -5,11 +5,6 @@
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>Using Tables</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
-		<style>
-			.section-grid {
-				align-items: stretch;
-			}
-		</style>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -6,10 +6,6 @@
 		<title>Creating tables - syntax and semantics</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<style>
-			.section-grid {
-				align-items: stretch;
-			}
-
 			form select {
 				max-width: 100%;
 				box-sizing: border-box;

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -1,18 +1,14 @@
 <!doctype html>
 <html>
 	<head>
+		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>The UNSTRING verb</title>
-		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<style type="text/css">
-			.section-sidebar {
-				align-self: stretch;
-			}
-
 			.section-content {
 				align-self: start;
 			}

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -16,13 +16,6 @@
 			.section-content {
 				align-self: start;
 			}
-
-			@media (max-width: 600px) {
-				.section-sidebar h4:not(:first-child):not(:has(img)),
-				h4:has(> img[src*="PanelLine"]) {
-					display: none;
-				}
-			}
 		</style>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>


### PR DESCRIPTION
## Summary

- Extract the bordered-grid CSS pattern (used identically on 8 tutorial pages) into a new `.section-grid--bordered` modifier in `course.css`, removing ~25 lines of duplicate CSS per page
- Promote a few near-duplicate rules (header centering, mobile PanelLine-h4 hiding) to `course.css` so pages don't redefine them
- Strip declarations that just re-assert grid defaults (`align-items: stretch`, `align-self: stretch`) and mobile rules that already exist in the shared sheet
- Fix three small structural inconsistencies: viewport meta order, body attribute order, and a stray 750px breakpoint

Net diff: **24 files, -246 lines** (393 deletions, 147 insertions).

## What changed

### `course.css` additions
- `.section-grid--bordered` modifier holds the row/cell border pattern previously copy-pasted into 8 pages
- `text-align: center` on `.section-header` so headings center consistently — was relying on the deprecated `align="center"` attribute on `<h2>` (EditedPics had no attribute and was relying on a local CSS rule that this PR removes)
- Mobile rule to hide decorative PanelLine spacer `<h4>`s — was duplicated in Copy, DataDeclaration, Usage, String, Selection

### Pages migrated to `.section-grid--bordered`
COBOLcommands, EditedPics, Iteration, RelativeFiles, ReportWriter, ReportWriterSS, Search, Selection.

### Redundant CSS removed
- `align-items: stretch` (grid default) and `align-self: stretch` (also default) stripped from Tables1, Tables2, SequentialFiles1, SequentialFiles2, SequentialFiles3, RefMod, IndexedFiles, Inspect, Unstring
- Mobile rules duplicating `course.css` removed from Copy, Usage, String, DataDeclaration, Selection, SortMerge

### Structural fixes
- `String.html` / `Unstring.html`: viewport meta moved to first position
- `COBOLIntro.html`: body attributes reordered to match the rest
- `SortMerge.html`: mobile breakpoint corrected from `750px` to the standard `600px`

## For the reviewer

The goal here was structural / DRY cleanup with **no visual change**. I diffed renderings at 1280×900 (desktop) and 547×800 (mobile) across 13+ pages spanning both the bordered (Group A) and borderless (Group B) variants — nothing shifted. The one place visuals could plausibly drift is the new global `text-align: center` on `.section-header`: pages that previously relied on `<h2 align="center">` keep that attribute (no change), pages that had local CSS overrides retain them (e.g. String keeps its left-align), and pages with neither (EditedPics) now get centering from the shared rule, which restores what the deleted local CSS was doing.

## Test plan

- [ ] Spot-check a few pages from each group at desktop width: `course/COBOLcommands.html`, `course/EditedPics.html`, `course/Iteration.html`, `course/Selection.html` (Group A); `course/Subprograms.html`, `course/Tables1.html`, `course/SortMerge.html` (Group B)
- [ ] Resize to <600px and confirm sidebar/content stack vertically with proper bottom borders
- [ ] Confirm `course/SortMerge.html` mobile layout now triggers at the standard 600px breakpoint (not 750px)
- [ ] Confirm `course/EditedPics.html` "Introduction" / section h2s are still centered (was the highest-risk page during the migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)