### PR TITLE
Normalize page-wrapper, page-footer, and link colors across course pages

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -9,24 +9,6 @@
 		<script src="Resources/vendor/prism/prism.min.js" charset="utf-8" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" charset="utf-8" defer></script>
 		<style type="text/css">
-			body > hr {
-				margin-left: auto;
-				margin-right: auto;
-			}
-
-			.section-grid {
-				max-width: 715px;
-				margin-left: auto;
-				margin-right: auto;
-				border-top: 1px solid;
-				border-left: 1px solid;
-			}
-
-			.section-grid > * {
-				border-right: 1px solid;
-				border-bottom: 1px solid;
-			}
-
 			.section-sidebar h4 {
 				font-weight: bold;
 				font-size: 1.17em;
@@ -99,8 +81,9 @@
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
-	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
-		<div class="section-grid">
+	<body>
+		<div class="page-wrapper">
+		<div class="section-grid section-grid--bordered" id="top">
 			<div class="section-full">
 				<center>
 					<p><img src="Resources/pics/t-CobolTut.gif" width="173" height="59" /></p>
@@ -1267,13 +1250,14 @@ DisplayGreeting.
    DISPLAY "Hello world".
    STOP RUN.</code></pre>
 			</div>
-			<div class="section-full">
+			<div class="section-full page-footer">
 				<hr />
 				<div align="center">
 					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
 				</div>
 				<copyright-notice></copyright-notice>
 			</div>
+		</div>
 		</div>
 	</body>
 </html>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -11,7 +11,7 @@
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
-	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
 				<center>
@@ -990,7 +990,7 @@ The time is 14:41
 						/></a>
 					</p>
 				</div>
-				<div class="section-full">
+				<div class="section-full page-footer">
 					<hr />
 					<div align="center">
 						<a href="#top"

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -35,7 +35,7 @@
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
-	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+	<body>
 		<div class="page-wrapper">
 			<div class="section-grid">
 				<!-- Header -->

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -9,26 +9,6 @@
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<style type="text/css">
-			.section-grid {
-				max-width: 715px;
-				margin: 0 auto;
-				border: 1px solid black;
-				border-right: none;
-				border-bottom: none;
-			}
-
-			.section-grid > div {
-				padding: 4px;
-				border-right: 1px solid black;
-				border-bottom: 1px solid black;
-				min-width: 0;
-				box-sizing: border-box;
-			}
-
-			.section-sidebar {
-				align-self: stretch;
-			}
-
 			.code-record {
 				background-color: #E1FFE1;
 				border: 1px solid black;
@@ -65,10 +45,6 @@
 			}
 
 			@media (max-width: 600px) {
-				.section-grid {
-					border-right: 1px solid black;
-				}
-
 				.code-record {
 					width: 100%;
 					max-width: 100%;
@@ -81,9 +57,10 @@
 		</style>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
-	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
-		<div class="section-grid">
-			<div class="section-full">
+	<body>
+		<div class="page-wrapper">
+			<div class="section-grid section-grid--bordered" id="top">
+				<div class="section-full">
 				<center>
 					<p><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
 					<h1>Declaring Data in COBOL</h1>
@@ -117,7 +94,7 @@
 			<div class="section-sidebar">
 				<h4>Aims</h4>
 			</div>
-			<div>
+			<div class="section-content">
 				<p>
 					The aim of this unit is to give you an understanding of the different categories of data used in
 					a COBOL program and to demonstrate how items of each category may be created and used.
@@ -127,7 +104,7 @@
 			<div class="section-sidebar">
 				<h4>Objectives</h4>
 			</div>
-			<div>
+			<div class="section-content">
 				<p>By the end of this unit you should -</p>
 				<ol>
 					<li>Know how to use and create literals, variables and Figurative Constants.</li>
@@ -144,7 +121,7 @@
 			<div class="section-sidebar">
 				<h4>Prerequisites</h4>
 			</div>
-			<div>
+			<div class="section-content">
 				<p>Introduction to COBOL.</p>
 				<p>but more information on declaring data items in COBOL can be found in the units covering</p>
 				<ul>
@@ -156,7 +133,7 @@
 			<div class="section-sidebar">
 				<h4>Further reading</h4>
 			</div>
-			<div>
+			<div class="section-content">
 				<p>More information on declaring data items in COBOL can be found in the units covering -</p>
 				<ul>
 					<li>Edited Pictures</li>
@@ -180,7 +157,7 @@
 			<div class="section-sidebar">
 				<h4 align="left">Introduction</h4>
 			</div>
-			<div>
+			<div class="section-content">
 				<p>There are three categories of data item used in COBOL programs:</p>
 				<ul>
 					<li>Variables.</li>
@@ -192,7 +169,7 @@
 			<div class="section-sidebar">
 				<h4 align="left">Variables</h4>
 			</div>
-			<div>
+			<div class="section-content">
 				<p>
 					A data-name or identifier is the name used to identify the area of memory reserved for a
 					variable. A variable is a named location in memory into which a program can put data, and from
@@ -217,7 +194,7 @@
 					</p>
 				</aside>
 			</div>
-			<div>
+			<div class="section-content">
 				<p>
 					Some languages like Modula-2,Pascal or Ada are described as being
 					<i>strongly typed</i>. In these languages there are a large number of different data types and
@@ -251,7 +228,7 @@
 			<div class="section-sidebar">
 				<h4 align="left">Literals</h4>
 			</div>
-			<div>
+			<div class="section-content">
 				<p>
 					A literal is a data-item that consists only of the data-item value itself. It cannot be referred
 					to by a name. By definition, literals are constant data-items.
@@ -265,14 +242,14 @@
 			<div class="section-sidebar">
 				<h4 align="left">String Literals</h4>
 			</div>
-			<div>
+			<div class="section-content">
 				<p>String/Alphanumeric literals are enclosed in quotes and consist of alphanumeric characters.</p>
 				<p>For example: "Michael Ryan", "-123", "123.45"</p>
 			</div>
 			<div class="section-sidebar">
 				<h4 align="left">Numeric Literals</h4>
 			</div>
-			<div>
+			<div class="section-content">
 				<p>
 					Numeric literals may consist of numerals, the decimal point, and the plus or minus sign. Numeric
 					literals are not enclosed in quotes.
@@ -302,7 +279,7 @@
 					</p>
 				</aside>
 			</div>
-			<div>
+			<div class="section-content">
 				<p>
 					Unlike most other programming languages COBOL does not provide a mechanism for creating
 					user-defined constants but it does provide a set of special constants called Figurative
@@ -377,7 +354,7 @@
 			<div class="section-sidebar">
 				<h4 align="left">Using COBOL data — examples</h4>
 			</div>
-			<div>
+			<div class="section-content">
 				<p id="data1">
 					The animated program fragments below demonstrate how variables, literals and Figurative
 					Constants may be created and used.
@@ -409,7 +386,7 @@
 			<div class="section-sidebar">
 				<h4>Introduction</h4>
 			</div>
-			<div>
+			<div class="section-content">
 				<p>
 					Because COBOL is not a typed language like Modula-2 or C it employs a different mechanism for
 					describing the characteristics of the data-items in a program.
@@ -440,7 +417,7 @@
 					</p>
 				</aside>
 			</div>
-			<div>
+			<div class="section-content">
 				<p>
 					To create the required 'picture' the programmer uses a set of symbols. The most common symbols
 					used in standard picture clauses are:
@@ -519,7 +496,7 @@
 			<div class="section-sidebar">
 				<h4 align="left">Picture clause notes</h4>
 			</div>
-			<div>
+			<div class="section-content">
 				<p>
 					Although the word <code class="language-cobol">PICTURE</code> can be used when defining a
 					picture clause it is normal to use the abbreviation <code class="language-cobol">PIC</code>.
@@ -551,7 +528,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 			<div class="section-sidebar">
 				<h4>Introduction</h4>
 			</div>
-			<div>
+			<div class="section-content">
 				<div align="center">
 					<p align="left">
 						Although we stated above that each variable declaration consists of a level number, an
@@ -575,7 +552,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 					</p>
 				</aside>
 			</div>
-			<div>
+			<div class="section-content">
 				<p>
 					An "elementary item" is the name we use in COBOL to describe a data-item that has not been
 					further subdivided. Other languages might describe these as ordinary variables.
@@ -608,7 +585,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 			<div class="section-sidebar">
 				<h4>Group items</h4>
 			</div>
-			<div>
+			<div class="section-content">
 				<p align="left">
 					Sometimes when we are manipulating data it is convenient to treat a collection of elementary
 					items as a single group. For instance, we may want to group the data-items YearofBirth,
@@ -661,7 +638,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 					</p>
 				</aside>
 			</div>
-			<div>
+			<div class="section-content">
 				<div align="center">
 					<p align="left">
 						Level numbers are used to express data hierarchy. The higher the level number, the lower the
@@ -707,7 +684,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 			<div class="section-sidebar">
 				<h4 align="left">Some observations on Record-A</h4>
 			</div>
-			<div>
+			<div class="section-content">
 				<p>It is useful to examine Record-A above and to answer the following questions:</p>
 				<div class="qa-grid">
 					<div class="qa-label">Q1.</div>
@@ -742,7 +719,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 			<div class="section-sidebar">
 				<h4 align="left">Level number notes</h4>
 			</div>
-			<div>
+			<div class="section-content">
 				<div align="center">
 					<p align="left">
 						The level numbers 01 through 49 are general level numbers but there are also special level
@@ -769,7 +746,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 			<div class="section-sidebar">
 				<h4>Building a record structure</h4>
 			</div>
-			<div>
+			<div class="section-content">
 				<p>
 					In the animation below we show how level numbers can be used to define a record structure as a
 					hierarchy of data-items.
@@ -787,13 +764,14 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 					</p>
 				</div>
 			</div>
-			<div class="section-full">
+			<div class="section-full page-footer">
 				<hr />
 				<div align="center">
 					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
 				</div>
 				<copyright-notice></copyright-notice>
 			</div>
+		</div>
 		</div>
 	</body>
 </html>

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -17,7 +17,7 @@
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
-	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
 				<center>

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -16,7 +16,7 @@
 		</style>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
-	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
 				<div>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -19,7 +19,7 @@
 		</style>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
-	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+	<body>
 		<div class="page-wrapper">
 			<div>
 				<center>
@@ -656,13 +656,15 @@ END-PERFORM</code></pre>
 					</div>
 				</div>
 			</div>
-			<hr />
-			<div style="text-align: center;">
-				<a href="#top"
-					><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-				/></a>
+			<div class="page-footer">
+				<hr />
+				<div align="center">
+					<a href="#top"
+						><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
+					/></a>
+				</div>
+				<copyright-notice></copyright-notice>
 			</div>
-			<copyright-notice></copyright-notice>
 		</div>
 	</body>
 </html>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -69,7 +69,7 @@
 		</style>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
-	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
 				<div class="page-header">

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -104,7 +104,7 @@
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
-	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
 				<center>
@@ -1305,7 +1305,7 @@ CountMileage.
 					</form>
 					<hr width="50%" />
 				</div>
-				<div class="section-full">
+				<div class="section-full page-footer">
 					<hr />
 					<div align="center">
 						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -52,7 +52,7 @@
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
-	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
 				<center>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -50,7 +50,7 @@
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
-	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
 				<div>

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -16,7 +16,7 @@
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
-	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
 				<div>
@@ -1011,7 +1011,7 @@ Programmer - Michael Coughlan               Page :  1 </code></pre>
 						<hr />
 					</div>
 
-					<div class="section-full">
+					<div class="section-full page-footer">
 						<hr />
 						<div align="center">
 							<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -23,7 +23,7 @@
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
-	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
 				<div>

--- a/course/Resources/css/course.css
+++ b/course/Resources/css/course.css
@@ -1,3 +1,15 @@
+a:link {
+	color: #0000ff;
+}
+
+a:visited {
+	color: #ff0000;
+}
+
+a:active {
+	color: #009b00;
+}
+
 img {
 	max-width: 100%;
 	height: auto;

--- a/course/Search.html
+++ b/course/Search.html
@@ -24,7 +24,7 @@
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
-	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
 				<div>

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -90,7 +90,7 @@
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
-	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+	<body>
 		<div class="page-wrapper">
 			<!-- Header / TOC -->
 			<div class="page-content">
@@ -1411,7 +1411,7 @@ END-EVALUATE
 					</p>
 				</div>
 
-				<div class="section-full">
+				<div class="section-full page-footer">
 					<hr />
 					<div align="center">
 						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -30,7 +30,7 @@
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
-	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
 				<center>

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -80,7 +80,7 @@
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
-	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+	<body>
 		<div class="page-wrapper">
 			<div class="page-content" id="top">
 				<center>

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -11,7 +11,7 @@
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
-	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
 				<center>
@@ -966,7 +966,7 @@ DisplayTransactions.
 
 </code></pre>
 				</div>
-				<div class="section-full">
+				<div class="section-full page-footer">
 					<hr />
 					<div align="center">
 						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -27,7 +27,7 @@
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
-	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
 				<div>
@@ -1567,7 +1567,7 @@ Begin.
 </code></pre>
 					</div>
 				</div>
-				<div>
+				<div class="section-full page-footer">
 					<hr />
 					<div align="center">
 						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>

--- a/course/String.html
+++ b/course/String.html
@@ -27,7 +27,7 @@
 		</style>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
-	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+	<body>
 		<div class="page-wrapper">
 			<div class="page-header">
 				<center>
@@ -458,13 +458,15 @@ END-STRING.</code></pre>
 					</p>
 				</div>
 			</div>
-			<hr />
-			<div align="center">
-				<a href="#top"
-					><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-				/></a>
+			<div class="page-footer">
+				<hr />
+				<div align="center">
+					<a href="#top"
+						><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
+					/></a>
+				</div>
+				<copyright-notice></copyright-notice>
 			</div>
-			<copyright-notice></copyright-notice>
 		</div>
 	</body>
 </html>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -34,7 +34,7 @@
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
-	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
 				<center>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -11,7 +11,7 @@
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
-	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+	<body>
 		<div class="page-wrapper">
 			<div class="page-content" id="top">
 				<center>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -51,7 +51,7 @@
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
-	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+	<body>
 		<div class="page-wrapper">
 			<div class="section-grid">
 				<div class="section-full">
@@ -1412,7 +1412,7 @@ DisplayCountyTaxes.
       03 CountyTax  PIC 9(5) VALUE ZEROS.
       03 CountyName PIC X(12) VALUE SPACES.</code></pre>
 				</div>
-				<div class="section-full">
+				<div class="section-full page-footer">
 					<hr />
 					<div align="center">
 						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -15,7 +15,7 @@
 		</style>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
-	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
 				<div style="text-align: center;">

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -20,7 +20,7 @@
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
-	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
+	<body>
 		<div class="page-wrapper">
 			<div class="section-grid">
 				<div class="section-full">


### PR DESCRIPTION
## Summary

- **Apply canonical `.page-wrapper` + `.section-grid--bordered` to the two outlier pages.** [COBOLIntro.html](course/COBOLIntro.html) and [DataDeclaration.html](course/DataDeclaration.html) were the only pages that bypassed `.page-wrapper` and re-implemented the bordered-grid styling in their own `<style>` blocks. They now match the structure used by the other 23 course pages, and the duplicate per-page CSS is gone.
- **Add `.page-footer` everywhere.** 11 pages were missing the class on their footer block (the bottom `<hr>` + back-to-top arrow + `<copyright-notice>`). Where the footer sat inside a section-grid as `.section-full`, it now also has `.page-footer` (no visual change). The two pages with loose, unwrapped footer markup ([Inspect.html](course/Inspect.html), [String.html](course/String.html)) now wrap that block in `<div class=\"page-footer\">`.
- **Centralize the legacy `<body>` presentational attributes.** Every page repeated the identical `<body alink=\"#009B00\" bgcolor=\"#FFFFFF\" link=\"#0000FF\" text=\"#000000\" vlink=\"#FF0000\">`. Moved the meaningful link colors into `a:link / a:visited / a:active` rules in [course.css](course/Resources/css/course.css) and removed the attributes from all 25 pages.

## Why

These changes improve coherence across the course pages without altering visual output. The audit at the start of the session found these as the highest-impact, lowest-risk normalization opportunities — every page now uses the same wrapper, footer marker, and link-color source.

Net diff: 26 files, +91 / −113 lines. No changes to `course/index.html`.

## Test plan
- [ ] Spot-check several pages render unchanged at the top: COBOLIntro, DataDeclaration, Iteration, Selection, RelativeFiles, Tables1, Inspect, String, SortMerge.
- [ ] Confirm link colors still match (blue unvisited, red visited, green active) — same as before, but now driven from CSS.
- [ ] Confirm every page has `.page-wrapper` and `.page-footer` in the DOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)