### PR TITLE
Normalize hero/title markup, sidebar headings, and id="top" anchors

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -83,10 +83,10 @@
 
 	<body>
 		<div class="page-wrapper">
-		<div class="section-grid section-grid--bordered" id="top">
+		<div class="section-grid section-grid--bordered">
 			<div class="section-full">
 				<center>
-					<p><img src="Resources/pics/t-CobolTut.gif" width="173" height="59" /></p>
+					<p id="top"><img src="Resources/pics/t-CobolTut.gif" width="173" height="59" /></p>
 					<h1>Introduction to COBOL</h1>
 				</center>
 				<hr />

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -59,10 +59,10 @@
 	</head>
 	<body>
 		<div class="page-wrapper">
-			<div class="section-grid section-grid--bordered" id="top">
+			<div class="section-grid section-grid--bordered">
 				<div class="section-full">
 				<center>
-					<p><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
+					<p id="top"><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
 					<h1>Declaring Data in COBOL</h1>
 				</center>
 				<hr />

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -19,22 +19,18 @@
 	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
-				<div>
-					<center>
-						<p id="top">
-							<img
-								alt=""
-								height="59"
-								src="Resources/pics/t-CobolTut.gif"
-								width="173"
-							/>
-						</p>
-					</center>
-					<center>
-						<h1>Indexed Files</h1>
-						<hr align="left" />
-					</center>
-				</div>
+				<center>
+					<p id="top">
+						<img
+							alt=""
+							height="59"
+							src="Resources/pics/t-CobolTut.gif"
+							width="173"
+						/>
+					</p>
+					<h1>Indexed Files</h1>
+				</center>
+				<hr />
 				<ul class="toc">
 					<li>
 						<a href="#intro">Introduction</a><br />
@@ -77,7 +73,7 @@
 						<h2 align="center" id="intro">Introduction</h2>
 					</div>
 					<div class="section-sidebar">
-						<h3>Aims</h3>
+						<h4>Aims</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -88,7 +84,7 @@
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h3>Objectives</h3>
+						<h4>Objectives</h4>
 					</div>
 					<div class="section-content">
 						<p>By the end of this unit you should:</p>
@@ -119,7 +115,7 @@
 						</ol>
 					</div>
 					<div class="section-sidebar">
-						<h3>Prerequisites</h3>
+						<h4>Prerequisites</h4>
 					</div>
 					<div class="section-content">
 						<p>You should be familiar with the material covered in the unit;</p>
@@ -142,7 +138,7 @@
 						<h2 align="center" id="progs">A look at some programs that use Indexed files</h2>
 					</div>
 					<div class="section-sidebar">
-						<h3 align="left">Example program - Creating an Indexed file</h3>
+						<h4 align="left">Example program - Creating an Indexed file</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -182,7 +178,7 @@
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h3>Example program - Reading an Indexed file sequentially</h3>
+						<h4>Example program - Reading an Indexed file sequentially</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -279,7 +275,7 @@ Enter key : 1=VideoCode, 2=VideoTitle -&gt;2
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h3>Example program - Reading an Indexed file directly</h3>
+						<h4>Example program - Reading an Indexed file directly</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -355,7 +351,7 @@ VIDEO STATUS :- 23</code></pre>
 						<h2 align="center" id="org">Indexed file organization</h2>
 					</div>
 					<div class="section-sidebar">
-						<h3>Introduction</h3>
+						<h4>Introduction</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -391,7 +387,7 @@ VIDEO STATUS :- 23</code></pre>
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h3>Primary Key Index</h3>
+						<h4>Primary Key Index</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -409,7 +405,7 @@ VIDEO STATUS :- 23</code></pre>
 						</p>
 					</div>
 					<div class="section-sidebar">
-						<h3>Alternate Key Index</h3>
+						<h4>Alternate Key Index</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -434,7 +430,7 @@ VIDEO STATUS :- 23</code></pre>
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h3 align="left">Animation of the primary and alternate key indexes</h3>
+						<h4 align="left">Animation of the primary and alternate key indexes</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -482,7 +478,7 @@ END-IF</code></pre>
 						<h2 align="center" id="declar">Indexed file - Declarations</h2>
 					</div>
 					<div class="section-sidebar">
-						<h3>Introduction</h3>
+						<h4>Introduction</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -493,13 +489,13 @@ END-IF</code></pre>
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h3>Select and Assign clause syntax</h3>
+						<h4>Select and Assign clause syntax</h4>
 					</div>
 					<div class="section-content">
 						<p><img height="245" src="Resources/pics/I-DFidx1.gif" width="474" /></p>
 					</div>
 					<div class="section-sidebar">
-						<h3>The Record Key phrase</h3>
+						<h4>The Record Key phrase</h4>
 					</div>
 					<div class="section-content">
 						<p>The RECORD KEY phrase defines the Indexed file's primary key.</p>
@@ -514,7 +510,7 @@ END-IF</code></pre>
 						<p>The key field must be a numeric or alphanumeric data item.</p>
 					</div>
 					<div class="section-sidebar">
-						<h3>The Alternate Record Key phrase</h3>
+						<h4>The Alternate Record Key phrase</h4>
 					</div>
 					<div class="section-content">
 						<div align="center">
@@ -550,7 +546,7 @@ END-IF</code></pre>
 						<h2 align="center" id="verbs">Indexed file - file processing verbs</h2>
 					</div>
 					<div class="section-sidebar">
-						<h3>Introduction</h3>
+						<h4>Introduction</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -569,7 +565,7 @@ END-IF</code></pre>
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h3>The READ verb</h3>
+						<h4>The READ verb</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -581,7 +577,7 @@ END-IF</code></pre>
 						</p>
 					</div>
 					<div class="section-sidebar">
-						<h3>Key Of Reference</h3>
+						<h4>Key Of Reference</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -608,7 +604,7 @@ END-IF</code></pre>
 						<p>When the file is opened the primary key is, by default, the Key Of Reference.</p>
 					</div>
 					<div class="section-sidebar">
-						<h3>Reading Sequentially</h3>
+						<h4>Reading Sequentially</h4>
 					</div>
 					<div class="section-content">
 						<p><img src="Resources/pics/I-DFrel4.gif" /></p>
@@ -639,7 +635,7 @@ END-IF</code></pre>
 						</ol>
 					</div>
 					<div class="section-sidebar">
-						<h3>Reading using a key</h3>
+						<h4>Reading using a key</h4>
 					</div>
 					<div class="section-content">
 						<p><img src="Resources/pics/I-DFrel3.gif" /></p>
@@ -696,7 +692,7 @@ END-IF</code></pre>
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h3 align="left">The WRITE, REWRITE and DELETE verbs.</h3>
+						<h4 align="left">The WRITE, REWRITE and DELETE verbs.</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -716,7 +712,7 @@ END-IF</code></pre>
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h3>The START verb</h3>
+						<h4>The START verb</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -785,7 +781,7 @@ END-IF</code></pre>
 						<h2 align="center" id="example">An Comprehensive Example Program</h2>
 					</div>
 					<div class="section-sidebar">
-						<h3 align="left">Program Specification</h3>
+						<h4 align="left">Program Specification</h4>
 					</div>
 					<div class="section-content">
 						<p align="center">ROYALTY PAYMENT REPORT PROGRAM.</p>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -22,22 +22,18 @@
 	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
-				<div>
-					<center>
-						<p id="top">
-							<img
-								alt=""
-								height="59"
-								src="Resources/pics/t-CobolTut.gif"
-								width="173"
-							/>
-						</p>
-					</center>
-					<center>
-						<h1>The INSPECT verb</h1>
-						<hr align="left" />
-					</center>
-				</div>
+				<center>
+					<p id="top">
+						<img
+							alt=""
+							height="59"
+							src="Resources/pics/t-CobolTut.gif"
+							width="173"
+						/>
+					</p>
+					<h1>The INSPECT verb</h1>
+				</center>
+				<hr />
 				<ul class="toc">
 					<li>
 						<a href="#intro">Introduction</a><br />
@@ -76,7 +72,7 @@
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h3>Aims</h3>
+					<h4>Aims</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -94,7 +90,7 @@
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h3>Objectives</h3>
+					<h4>Objectives</h4>
 				</div>
 				<div class="section-content">
 					<p>By the end of this unit you should:</p>
@@ -114,7 +110,7 @@
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h3>Prerequisites</h3>
+					<h4>Prerequisites</h4>
 				</div>
 				<div class="section-content">
 					<p>You should be familiar with the following material;</p>
@@ -130,7 +126,7 @@
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h3>Syntax legend</h3>
+					<h4>Syntax legend</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -177,7 +173,7 @@
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h3>Introduction</h3>
+					<h4>Introduction</h4>
 				</div>
 				<div class="section-content">
 					<p>The INSPECT has four formats;</p>
@@ -198,7 +194,7 @@
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h3>Example program Counting letter occurences using the INSPECT</h3>
+					<h4>Example program Counting letter occurences using the INSPECT</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -258,7 +254,7 @@ Begin.
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h3>How the INSPECT works.</h3>
+					<h4>How the INSPECT works.</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -279,7 +275,7 @@ Begin.
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h3>The modifying phrases</h3>
+					<h4>The modifying phrases</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -314,7 +310,7 @@ Begin.
 				<h2 id="count">The counting INSPECT</h2>
 			</div>
 			<div class="section-full">
-				<h3>Syntax</h3>
+				<h4>Syntax</h4>
 				<p><img src="Resources/pics/CntInspect.gif" /></p>
 				<p align="left">
 					This format of the Inspect is used to count characters in a string.
@@ -323,7 +319,7 @@ Begin.
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h3>Notes</h3>
+					<h4>Notes</h4>
 				</div>
 				<div class="section-content">
 					<p>If Compare$il or Delim$il is a figurative constant it is 1 character in size.</p>
@@ -335,7 +331,7 @@ Begin.
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h3>Examples</h3>
+					<h4>Examples</h4>
 				</div>
 				<div class="section-content">
 					<pre
@@ -359,7 +355,7 @@ INSPECT SourceLine TALLYING ECount
 				<h2 id="replace">The replacing INSPECT</h2>
 			</div>
 			<div class="section-full">
-				<h3>Syntax</h3>
+				<h4>Syntax</h4>
 				<p><img height="255" src="Resources/pics/RepInspect.gif" width="619" /></p>
 				<p align="left">
 					This format of the INSPECT is used to count characters in a string.
@@ -368,7 +364,7 @@ INSPECT SourceLine TALLYING ECount
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h3>Rules</h3>
+					<h4>Rules</h4>
 				</div>
 				<div class="section-content">
 					<p>The sizes of Compare$il and Replace$il must be equal.</p>
@@ -386,10 +382,10 @@ INSPECT SourceLine TALLYING ECount
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h3>
+					<h4>
 						Example 1<br />
 						with animation
-					</h3>
+					</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -433,7 +429,7 @@ INSPECT SourceLine TALLYING ECount
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h3>Example 2</h3>
+					<h4>Example 2</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -450,10 +446,10 @@ END-PERFORM</code></pre>
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h3>
+					<h4>
 						Example 3<br />
 						with animation
-					</h3>
+					</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -494,7 +490,7 @@ END-PERFORM</code></pre>
 				<h2 id="combine">The combined INSPECT</h2>
 			</div>
 			<div class="section-full">
-				<h3>Syntax</h3>
+				<h4>Syntax</h4>
 				<p><img height="338" src="Resources/pics/CombInspect.gif" width="649" /></p>
 				<p>
 					This format of the INSPECT combines the syntactic elements of the previous two
@@ -514,13 +510,13 @@ END-PERFORM</code></pre>
 				<h2 id="convert">The converting INSPECT</h2>
 			</div>
 			<div class="section-full">
-				<h3>Syntax</h3>
+				<h4>Syntax</h4>
 				<p><img src="Resources/pics/ConvInspect.gif" /></p>
 				<hr />
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h3>How this format of the INSPECT works</h3>
+					<h4>How this format of the INSPECT works</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -538,7 +534,7 @@ END-PERFORM</code></pre>
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h3>Rules</h3>
+					<h4>Rules</h4>
 				</div>
 				<div class="section-content">
 					<ol class="spaced">
@@ -556,10 +552,10 @@ END-PERFORM</code></pre>
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h3>
+					<h4>
 						Example 1<br />
 						with animation
-					</h3>
+					</h4>
 				</div>
 				<div class="section-content">
 					<p align="left">
@@ -594,7 +590,7 @@ END-PERFORM</code></pre>
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h3>Example 2</h3>
+					<h4>Example 2</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -614,7 +610,7 @@ END-PERFORM</code></pre>
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h3>Example 3</h3>
+					<h4>Example 3</h4>
 				</div>
 				<div class="section-content">
 					<p>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -67,8 +67,8 @@
 						/>
 					</p>
 					<h1>Introduction to Direct Access Files</h1>
-					<hr />
 				</center>
+				<hr />
 				<ul class="toc">
 					<li>
 						<a href="#intro">Introduction</a><br />
@@ -102,7 +102,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h3>Aims</h3>
+						<h4>Aims</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -115,7 +115,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h3>Objectives</h3>
+						<h4>Objectives</h4>
 					</div>
 					<div class="section-content">
 						<p>By the end of this unit you should:</p>
@@ -143,7 +143,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h3>Prerequisites</h3>
+						<h4>Prerequisites</h4>
 					</div>
 					<div class="section-content">
 						<p>You should be familiar with the material covered in the unit;</p>
@@ -168,7 +168,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h3>Introduction</h3>
+						<h4>Introduction</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -191,7 +191,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h3>Problems accessing ordered Sequential files.</h3>
+						<h4>Problems accessing ordered Sequential files.</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -218,7 +218,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h3>Contrast with direct access files</h3>
+						<h4>Contrast with direct access files</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -235,7 +235,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h3>Inserting records in an ordered Sequential file</h3>
+						<h4>Inserting records in an ordered Sequential file</h4>
 					</div>
 					<div class="section-content">
 						<p>To insert a record in an ordered Sequential file:</p>
@@ -256,7 +256,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h3>Deleting records from an ordered Sequential file</h3>
+						<h4>Deleting records from an ordered Sequential file</h4>
 					</div>
 					<div class="section-content">
 						<p>To delete a record in an ordered Sequential file:</p>
@@ -278,7 +278,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h3>Amending records in an ordered Sequential file</h3>
+						<h4>Amending records in an ordered Sequential file</h4>
 					</div>
 					<div class="section-content">
 						<p>To amend a record in an ordered Sequential file:</p>
@@ -300,7 +300,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h3>Sequential files - animation</h3>
+						<h4>Sequential files - animation</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -320,7 +320,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h3>Summary</h3>
+						<h4>Summary</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -350,7 +350,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h3>Introduction</h3>
+						<h4>Introduction</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -372,7 +372,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h3>Organization of Relative files</h3>
+						<h4>Organization of Relative files</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -414,7 +414,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h3>Accessing records in a Relative file</h3>
+						<h4>Accessing records in a Relative file</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -441,7 +441,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h3>Animation - Organization and use of Relative files</h3>
+						<h4>Animation - Organization and use of Relative files</h4>
 					</div>
 					<div class="section-content">
 						<div class="two-col">
@@ -471,7 +471,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h3>Summary</h3>
+						<h4>Summary</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -497,7 +497,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h3>Introduction</h3>
+						<h4>Introduction</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -517,7 +517,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h3>Organization of Indexed files</h3>
+						<h4>Organization of Indexed files</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -555,7 +555,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h3>Animation - Organization and use of Indexed files</h3>
+						<h4>Animation - Organization and use of Indexed files</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -595,7 +595,7 @@ END-IF</code></pre>
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h3>Summary</h3>
+						<h4>Summary</h4>
 					</div>
 					<div class="section-content">
 						<p>An Indexed file may have multiple, alphanumeric, keys.</p>
@@ -619,7 +619,7 @@ END-IF</code></pre>
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h3>Introduction</h3>
+						<h4>Introduction</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -631,10 +631,10 @@ END-IF</code></pre>
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h3>Sequential files</h3>
+						<h4>Sequential files</h4>
 					</div>
 					<div class="section-content">
-						<h3 align="center">Disadvantages</h3>
+						<h4 align="center">Disadvantages</h4>
 						<table border="3" cellpadding="4" width="100%">
 							<tr>
 								<td bgcolor="#E8E8E8" width="150">
@@ -675,7 +675,7 @@ END-IF</code></pre>
 								</td>
 							</tr>
 						</table>
-						<h3 align="center">Advantages</h3>
+						<h4 align="center">Advantages</h4>
 						<table border="1" cellpadding="4" width="101%">
 							<tr>
 								<td bgcolor="#E8E8E8" valign="middle" width="150">
@@ -729,10 +729,10 @@ END-IF</code></pre>
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h3>Relative files</h3>
+						<h4>Relative files</h4>
 					</div>
 					<div class="section-content">
-						<h3 align="center">Disadvantages</h3>
+						<h4 align="center">Disadvantages</h4>
 						<table border="3" cellpadding="4" width="100%">
 							<tr>
 								<td bgcolor="#E8E8E8" width="150">
@@ -876,7 +876,7 @@ END-IF</code></pre>
 								</td>
 							</tr>
 						</table>
-						<h3 align="center">Advantages</h3>
+						<h4 align="center">Advantages</h4>
 						<table border="1" cellpadding="4" width="101%">
 							<tr>
 								<td bgcolor="#E8E8E8" width="150">
@@ -917,10 +917,10 @@ END-IF</code></pre>
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h3>Indexed files</h3>
+						<h4>Indexed files</h4>
 					</div>
 					<div class="section-content">
-						<h3 align="center">Disadvantages</h3>
+						<h4 align="center">Disadvantages</h4>
 						<table border="3" cellpadding="4" width="100%">
 							<tr>
 								<td bgcolor="#E8E8E8" width="150">
@@ -981,7 +981,7 @@ END-IF</code></pre>
 								</td>
 							</tr>
 						</table>
-						<h3 align="center">Advantages</h3>
+						<h4 align="center">Advantages</h4>
 						<table border="1" cellpadding="4" width="101%">
 							<tr>
 								<td bgcolor="#E8E8E8" width="27%">
@@ -1011,7 +1011,7 @@ END-IF</code></pre>
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h3>Summary</h3>
+						<h4>Summary</h4>
 					</div>
 					<div class="section-content">
 						<p>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -53,15 +53,14 @@
 	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
-				<div>
-					<center>
-						<p id="top">
-							<img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173" />
-						</p>
-						<h1>Relative Files</h1>
-					</center>
-					<hr />
-					<ul class="toc">
+				<center>
+					<p id="top">
+						<img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173" />
+					</p>
+					<h1>Relative Files</h1>
+				</center>
+				<hr />
+				<ul class="toc">
 						<li>
 							<a href="#intro">Introduction</a><br />
 							Unit aims, objectives and prerequisites.
@@ -85,15 +84,14 @@
 							<a href="#declaratives">Introduction to Declaratives</a><br />
 							Introduces Declaratives, showing when and how to use them.
 						</li>
-					</ul>
-				</div>
+				</ul>
 			</div>
 			<div class="section-header">
 				<h2 align="center" id="intro">Introduction</h2>
 			</div>
 			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
-					<h3>Aims</h3>
+					<h4>Aims</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -110,7 +108,7 @@
 			</div>
 			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
-					<h3>Objectives</h3>
+					<h4>Objectives</h4>
 				</div>
 				<div class="section-content">
 					<p>By the end of this unit you should:</p>
@@ -135,7 +133,7 @@
 			</div>
 			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
-					<h3>Prerequisites</h3>
+					<h4>Prerequisites</h4>
 				</div>
 				<div class="section-content">
 					<p>You should be familiar with the material covered in the unit;</p>
@@ -157,7 +155,7 @@
 			</div>
 			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
-					<h3 align="left">Example program - Creating a Relative file</h3>
+					<h4 align="left">Example program - Creating a Relative file</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -199,7 +197,7 @@
 			</div>
 			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
-					<h3>Example program - Reading a Relative file</h3>
+					<h4>Example program - Reading a Relative file</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -263,7 +261,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
-					<h3>Introduction</h3>
+					<h4>Introduction</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -276,7 +274,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
-					<h3>Select and Assign clause syntax</h3>
+					<h4>Select and Assign clause syntax</h4>
 				</div>
 				<div class="section-content">
 					<p><img height="189" src="Resources/pics/I-DFrel1.gif" width="507" /></p>
@@ -284,7 +282,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
-					<h3>The Optional phrase</h3>
+					<h4>The Optional phrase</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -295,7 +293,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
-					<h3>The Access Mode</h3>
+					<h4>The Access Mode</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -309,7 +307,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
-					<h3>The Record Key phrase</h3>
+					<h4>The Record Key phrase</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -324,7 +322,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
-					<h3>The File Status</h3>
+					<h4>The File Status</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -367,7 +365,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
-					<h3>Introduction</h3>
+					<h4>Introduction</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -385,7 +383,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
-					<h3>The Invalid Key clause</h3>
+					<h4>The Invalid Key clause</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -402,7 +400,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
-					<h3>OPEN/CLOSE verbs</h3>
+					<h4>OPEN/CLOSE verbs</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -438,7 +436,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
-					<h3>The READ verb</h3>
+					<h4>The READ verb</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -450,7 +448,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
-					<h3>Reading using a key</h3>
+					<h4>Reading using a key</h4>
 				</div>
 				<div class="section-content">
 					<p><img src="Resources/pics/I-DFrel3.gif" /></p>
@@ -487,7 +485,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
-					<h3>Reading Sequentially</h3>
+					<h4>Reading Sequentially</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -517,7 +515,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
-					<h3 align="left">The WRITE verb</h3>
+					<h4 align="left">The WRITE verb</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -550,7 +548,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
-					<h3 align="left">The REWRITE verb</h3>
+					<h4 align="left">The REWRITE verb</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -584,7 +582,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
-					<h3 align="left">The DELETE verb</h3>
+					<h4 align="left">The DELETE verb</h4>
 				</div>
 				<div class="section-content">
 					<p><img src="Resources/pics/I-DFrel7.gif" /></p>
@@ -623,7 +621,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
-					<h3>The START verb</h3>
+					<h4>The START verb</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -682,7 +680,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
-					<h3 align="left">Introduction</h3>
+					<h4 align="left">Introduction</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -694,7 +692,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
-					<h3 align="left">The Declaratives template</h3>
+					<h4 align="left">The Declaratives template</h4>
 				</div>
 				<div class="section-content">
 					<div class="declaratives-layout">
@@ -752,7 +750,7 @@ Begin.</code></pre>
 			</div>
 			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
-					<h3 align="left">The Use phrase</h3>
+					<h4 align="left">The Use phrase</h4>
 				</div>
 				<div class="section-content">
 					<p><img src="Resources/pics/I-DFrel9.gif" /></p>
@@ -783,7 +781,7 @@ Begin.</code></pre>
 			</div>
 			<div class="section-grid section-grid--bordered">
 				<div class="section-sidebar">
-					<h3 align="center">Example program - fragment</h3>
+					<h4 align="center">Example program - fragment</h4>
 				</div>
 					<pre class="language-cobol"><code class="language-cobol"> PROCEDURE DIVISION.
  DECLARATIVES.

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -82,9 +82,9 @@
 
 	<body>
 		<div class="page-wrapper">
-			<div class="page-content" id="top">
+			<div class="page-content">
 				<center>
-					<p><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
+					<p id="top"><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
 					<h1>Processing Sequential Files</h1>
 				</center>
 				<hr />

--- a/course/String.html
+++ b/course/String.html
@@ -28,11 +28,9 @@
 							width="173"
 						/>
 					</p>
-				</center>
-				<center>
 					<h1>The STRING verb</h1>
-					<hr align="left" />
 				</center>
+				<hr />
 				<ul class="toc">
 					<li>
 						<a href="#intro">Introduction</a><br />
@@ -54,7 +52,7 @@
 					<h2 align="center" id="intro">Introduction</h2>
 				</div>
 				<div class="section-sidebar">
-					<h3>Aims</h3>
+					<h4>Aims</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -64,7 +62,7 @@
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h3>Objectives</h3>
+					<h4>Objectives</h4>
 				</div>
 				<div class="section-content">
 					<p>By the end of this unit you should:By the end of this unit you should:</p>
@@ -75,7 +73,7 @@
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h3>Prerequisites</h3>
+					<h4>Prerequisites</h4>
 				</div>
 				<div class="section-content">
 					<p>You should be familiar with the material covered in the unit;</p>
@@ -102,7 +100,7 @@
 					<h2 align="center" id="verb">The STRING verb</h2>
 				</div>
 				<div class="section-sidebar">
-					<h3 align="left">Introduction</h3>
+					<h4 align="left">Introduction</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -135,7 +133,7 @@ END-STRING.</code></pre>
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h3>STRING syntax</h3>
+					<h4>STRING syntax</h4>
 				</div>
 				<div class="section-content">
 					<p><img src="Resources/pics/I-String.gif" /></p>
@@ -160,7 +158,7 @@ END-STRING.</code></pre>
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h3>How the STRING works</h3>
+					<h4>How the STRING works</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -195,7 +193,7 @@ END-STRING.</code></pre>
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h3>Data movement termination</h3>
+					<h4>Data movement termination</h4>
 				</div>
 				<div class="section-content">
 					<p>Data movement from a particular source string ends when either;</p>
@@ -207,7 +205,7 @@ END-STRING.</code></pre>
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h3>STRING termination</h3>
+					<h4>STRING termination</h4>
 				</div>
 				<div class="section-content">
 					<p>The STRING statement ends when either;</p>
@@ -219,7 +217,7 @@ END-STRING.</code></pre>
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h3>STRING rules</h3>
+					<h4>STRING rules</h4>
 				</div>
 				<div class="section-content">
 					<ol>
@@ -247,7 +245,7 @@ END-STRING.</code></pre>
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h3>STRING clauses</h3>
+					<h4>STRING clauses</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -290,7 +288,7 @@ END-STRING.</code></pre>
 					<h2 align="center" id="examples">STRING examples</h2>
 				</div>
 				<div class="section-sidebar">
-					<h3>Introduction</h3>
+					<h4>Introduction</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -301,10 +299,10 @@ END-STRING.</code></pre>
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h3>
+					<h4>
 						Example 1<br />
 						(animation)
-					</h3>
+					</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -327,10 +325,10 @@ END-STRING.</code></pre>
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h3>
+					<h4>
 						Example 2<br />
 						(animation)
-					</h3>
+					</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -364,7 +362,7 @@ END-STRING.</code></pre>
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h3 align="left">Self assessment questions/examples</h3>
+					<h4 align="left">Self assessment questions/examples</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -432,7 +430,7 @@ END-STRING.</code></pre>
    DISPLAY Field2. </code></pre>
 				</div>
 				<div class="section-sidebar">
-					<h3>Answers to SAQs</h3>
+					<h4>Answers to SAQs</h4>
 				</div>
 				<div class="section-content">
 					<p align="center">

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -39,11 +39,9 @@
 			<div class="page-content">
 				<center>
 					<p id="top"><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
-				</center>
-				<center>
 					<h1>Subprograms</h1>
-					<hr />
 				</center>
+				<hr />
 				<ul class="toc">
 					<li>
 						<a href="#intro">Introduction</a><br />

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -13,9 +13,9 @@
 
 	<body>
 		<div class="page-wrapper">
-			<div class="page-content" id="top">
+			<div class="page-content">
 				<center>
-					<p><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
+					<p id="top"><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
 				</center>
 				<center>
 					<h1>Using Tables</h1>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -18,13 +18,13 @@
 	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
-				<div style="text-align: center;">
+				<center>
 					<p id="top">
 						<img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173" />
 					</p>
 					<h1>The UNSTRING verb</h1>
-					<hr align="left" />
-				</div>
+				</center>
+				<hr />
 				<ul class="toc">
 					<li>
 						<a href="#intro">Introduction</a><br />
@@ -52,7 +52,7 @@
 						<h2 align="center" id="intro">Introduction</h2>
 					</div>
 					<div class="section-sidebar">
-						<h3>Aims</h3>
+						<h4>Aims</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -62,7 +62,7 @@
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h3>Objectives</h3>
+						<h4>Objectives</h4>
 					</div>
 					<div class="section-content">
 						<p>By the end of this unit you should:By the end of this unit you should:</p>
@@ -73,7 +73,7 @@
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h3>Prerequisites</h3>
+						<h4>Prerequisites</h4>
 					</div>
 					<div class="section-content">
 						<p>You should be familiar with the material covered in the unit;</p>
@@ -101,7 +101,7 @@
 						<h2 align="center" id="verb">The UNSTRING verb</h2>
 					</div>
 					<div class="section-sidebar">
-						<h3 align="left">Introduction</h3>
+						<h4 align="left">Introduction</h4>
 					</div>
 					<div class="section-content">
 						<p>The UNSTRING is used to divide a string into sub-strings.</p>
@@ -134,7 +134,7 @@ END-UNSTRING.</code></pre>
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h3>UNSTRING syntax</h3>
+						<h4>UNSTRING syntax</h4>
 					</div>
 					<div class="section-content">
 						<p><img src="Resources/pics/I-UnString.gif" /></p>
@@ -180,7 +180,7 @@ END-UNSTRING.</code></pre>
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h3>How the UNSTRING works</h3>
+						<h4>How the UNSTRING works</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -199,7 +199,7 @@ END-UNSTRING.</code></pre>
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h3>Data movement termination</h3>
+						<h4>Data movement termination</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -221,7 +221,7 @@ END-UNSTRING.</code></pre>
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h3>UNSTRING termination</h3>
+						<h4>UNSTRING termination</h4>
 					</div>
 					<div class="section-content">
 						<p>The UNSTRING statement terminates when either;</p>
@@ -236,7 +236,7 @@ END-UNSTRING.</code></pre>
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h3>UNSTRING rules</h3>
+						<h4>UNSTRING rules</h4>
 					</div>
 					<div class="section-content">
 						<ol>
@@ -267,7 +267,7 @@ END-UNSTRING.</code></pre>
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h3>UNSTRING clauses</h3>
+						<h4>UNSTRING clauses</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -358,7 +358,7 @@ END-UNSTRING.</code></pre>
 						<h2 align="center" id="examples">UNSTRING examples</h2>
 					</div>
 					<div class="section-sidebar">
-						<h3>Introduction</h3>
+						<h4>Introduction</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -370,10 +370,10 @@ END-UNSTRING.</code></pre>
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h3>
+						<h4>
 							Examples 1 - 6<br />
 							(animation)
-						</h3>
+						</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -402,10 +402,10 @@ END-UNSTRING.</code></pre>
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h3>
+						<h4>
 							Example 7<br />
 							(animation)
-						</h3>
+						</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -430,7 +430,7 @@ END-UNSTRING.</code></pre>
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h3>Example program</h3>
+						<h4>Example program</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -531,7 +531,7 @@ Begin.
 						<h2 align="center" id="combined">Combined example</h2>
 					</div>
 					<div class="section-sidebar">
-						<h3>Introduction</h3>
+						<h4>Introduction</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -542,7 +542,7 @@ Begin.
 						<p>For example "Michael John Tim James Ryan" becomes "M.J.T.J. Ryan".</p>
 					</div>
 					<div class="section-sidebar">
-						<h3>Data items used in the example</h3>
+						<h4>Data items used in the example</h4>
 					</div>
 					<div class="section-content">
 						<pre class="language-cobol"><code class="language-cobol">01 OldName  PIC X(80).
@@ -560,7 +560,7 @@ Begin.
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h3>Animation</h3>
+						<h4>Animation</h4>
 					</div>
 					<div class="section-content">
 						<center>


### PR DESCRIPTION
## Summary

Three targeted consistency improvements across course pages, continuing the recent normalization series:

- **`id=\"top\"` placement** — moved onto the `<p>` holding the hero image (the dominant pattern used by 16+ pages). Updated `COBOLIntro`, `DataDeclaration`, `Tables1`, `SequentialFiles2`. Same scroll target; no visual change.
- **Sidebar headings unified to `<h4>`** — six pages were using `<h3>` for sidebar labels (Aims/Objectives/Prerequisites/...) while 19 others used `<h4>`. Converted `IndexedFiles`, `Inspect`, `Intro2DirectAccess`, `RelativeFiles`, `String`, `Unstring` to match.
- **Hero/title centering markup** — collapsed two-`<center>` splits into a single `<center>` followed by `<hr />`, removed deprecated `<hr align=\"left\" />`, and dropped a redundant wrapper `<div>` in RelativeFiles. Modern browsers ignore `align` on `<hr>`, so no visual change.

## Why

Earlier PRs in this series normalized meta tags, link colors, page-wrapper, page-footer, and bordered grid styles. This pass tackles the remaining structural outliers in the title region and sidebar heading levels — the last places where pages diverged from the shared `course.css` vocabulary in a way visible to a casual reader.

## Visual impact

- Sidebar labels on the six h3 → h4 pages now render slightly smaller, matching the rest of the course. This is the only visible change.
- Everything else is markup-only: same scroll anchors, same rendered geometry.

## Out of scope

- Inline `<style>` block ordering relative to Prism CSS — the current 10/12 split is behaviorally equivalent (page-specific selectors don't overlap with Prism's), so leaving it.
- The two competing top-of-page structural patterns (`page-content` + `section-grid` vs all-in-one bordered grid) — each has page-specific reasons; touching them risks rendering shifts disproportionate to the consistency gain.

## Test plan

- [x] Pages render correctly in a local browser (verified Inspect, String, RelativeFiles, COBOLIntro, Tables1, Subprograms, Intro2DirectAccess)
- [x] Back-to-top anchor still scrolls correctly on pages where `id=\"top\"` was moved (verified Tables1, COBOLIntro)
- [x] Spot-check h4-converted pages render section labels at the unified size

🤖 Generated with [Claude Code](https://claude.com/claude-code)