### PR TITLE
Drop bordered grid variant, force-wrap Prism code, dedupe per-page CSS

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -61,10 +61,6 @@
 					margin: 0;
 				}
 
-				pre[class*="language-"] {
-					max-width: min(100%, calc(100vw - 16px));
-				}
-
 				blockquote font[face*="Courier"] {
 					font-size: 0.8em;
 				}
@@ -83,7 +79,7 @@
 
 	<body>
 		<div class="page-wrapper">
-		<div class="section-grid section-grid--bordered">
+		<div class="section-grid">
 			<div class="section-full">
 				<center>
 					<p id="top"><img src="Resources/pics/t-CobolTut.gif" width="173" height="59" /></p>
@@ -1250,7 +1246,7 @@ DisplayGreeting.
    DISPLAY "Hello world".
    STOP RUN.</code></pre>
 			</div>
-			<div class="section-full page-footer">
+			<div class="page-footer">
 				<hr />
 				<div align="center">
 					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -42,7 +42,7 @@
 			</div>
 
 			<!-- Introduction -->
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-header">
 					<h2 align="center" id="intro">Introduction</h2>
 				</div>
@@ -99,7 +99,7 @@
 			</div>
 
 			<!-- Part 1: Basic User Input and Output -->
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-header">
 					<h2 align="center" id="part1">Basic User Input and Output</h2>
 				</div>
@@ -385,7 +385,7 @@ The time is 14:41
 			</div>
 
 			<!-- Part 2: Assignment using the MOVE verb -->
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-header">
 					<h2 align="center" id="part2">Assignment using the MOVE verb</h2>
 				</div>
@@ -496,7 +496,7 @@ The time is 14:41
 			</div>
 
 			<!-- Part 3: Arithmetic in COBOL -->
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-header">
 					<h2 align="center" id="part3">Arithmetic in COBOL</h2>
 				</div>
@@ -990,7 +990,7 @@ The time is 14:41
 						/></a>
 					</p>
 				</div>
-				<div class="section-full page-footer">
+				<div class="page-footer">
 					<hr />
 					<div align="center">
 						<a href="#top"

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -59,7 +59,7 @@
 	</head>
 	<body>
 		<div class="page-wrapper">
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-full">
 				<center>
 					<p id="top"><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
@@ -764,7 +764,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 					</p>
 				</div>
 			</div>
-			<div class="section-full page-footer">
+			<div class="page-footer">
 				<hr />
 				<div align="center">
 					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -5,15 +5,15 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>Edited Pictures</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
+		<script src="Resources/vendor/prism/prism.min.js" defer></script>
+		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<style type="text/css">
 			.page-content,
 			.page-footer {
 				padding: 4px;
 			}
 		</style>
-		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
-		<script src="Resources/vendor/prism/prism.min.js" defer></script>
-		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -49,7 +49,7 @@
 				<hr />
 			</div>
 
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-header">
 					<h2 id="intro">Introduction</h2>
 				</div>
@@ -118,7 +118,7 @@
 				</div>
 			</div>
 
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-header">
 					<h2 id="part1">What is an Edited Picture?</h2>
 				</div>
@@ -305,7 +305,7 @@
 				</div>
 			</div>
 
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-header">
 					<h2 id="part2">Insertion Editing</h2>
 				</div>
@@ -1213,7 +1213,7 @@
 				</div>
 			</div>
 
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-header">
 					<h2 id="part3">Suppression and Replacement Editing</h2>
 				</div>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -5,19 +5,10 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>COBOL Interation Constructs</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
+		<script src="Resources/vendor/prism/prism.min.js" defer></script>
+		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<style type="text/css">
-			pre {
-				white-space: pre-wrap;
-				word-wrap: break-word;
-				overflow-wrap: break-word;
-			}
-
-			pre[class*="language-"],
-			code[class*="language-"] {
-				white-space: pre-wrap !important;
-				overflow-wrap: break-word;
-			}
-
 			.processing-template {
 				border: 1px solid;
 				padding: 0;
@@ -98,9 +89,6 @@
 				}
 			}
 		</style>
-		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
-		<script src="Resources/vendor/prism/prism.min.js" defer></script>
-		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -147,7 +135,7 @@
 				</ul>
 				<hr />
 			</div>
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-header">
 					<h2 align="center" id="intro">Introduction</h2>
 				</div>
@@ -1305,7 +1293,7 @@ CountMileage.
 					</form>
 					<hr width="50%" />
 				</div>
-				<div class="section-full page-footer">
+				<div class="page-footer">
 					<hr />
 					<div align="center">
 						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -5,7 +5,10 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>Reference Modification</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
-		<style>
+		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
+		<script src="Resources/vendor/prism/prism.min.js" defer></script>
+		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<style type="text/css">
 			.table-scroll {
 				overflow-x: auto;
 			}
@@ -47,9 +50,6 @@
 				}
 			}
 		</style>
-		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
-		<script src="Resources/vendor/prism/prism.min.js" defer></script>
-		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -5,19 +5,10 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>Relative Files</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
+		<script src="Resources/vendor/prism/prism.min.js" defer></script>
+		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<style type="text/css">
-			pre {
-				white-space: pre-wrap;
-				word-wrap: break-word;
-				overflow-wrap: break-word;
-			}
-
-			pre[class*="language-"],
-			code[class*="language-"] {
-				white-space: pre-wrap !important;
-				overflow-wrap: break-word;
-			}
-
 			.declaratives-layout {
 				display: flex;
 				gap: 1em;
@@ -45,9 +36,6 @@
 				}
 			}
 		</style>
-		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
-		<script src="Resources/vendor/prism/prism.min.js" defer></script>
-		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
@@ -89,7 +77,7 @@
 			<div class="section-header">
 				<h2 align="center" id="intro">Introduction</h2>
 			</div>
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-sidebar">
 					<h4>Aims</h4>
 				</div>
@@ -106,7 +94,7 @@
 					<hr />
 				</div>
 			</div>
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-sidebar">
 					<h4>Objectives</h4>
 				</div>
@@ -131,7 +119,7 @@
 					</ol>
 				</div>
 			</div>
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-sidebar">
 					<h4>Prerequisites</h4>
 				</div>
@@ -153,7 +141,7 @@
 			<div class="section-header">
 				<h2 align="center" id="progs">A look at some programs that use Relative files</h2>
 			</div>
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-sidebar">
 					<h4 align="left">Example program - Creating a Relative file</h4>
 				</div>
@@ -195,7 +183,7 @@
 					<hr />
 				</div>
 			</div>
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-sidebar">
 					<h4>Example program - Reading a Relative file</h4>
 				</div>
@@ -259,7 +247,7 @@ Enter supplier key (2 digits)-&gt; 05
 			<div class="section-header">
 				<h2 align="center" id="declar">Relative file - Declarations</h2>
 			</div>
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-sidebar">
 					<h4>Introduction</h4>
 				</div>
@@ -272,7 +260,7 @@ Enter supplier key (2 digits)-&gt; 05
 					<hr />
 				</div>
 			</div>
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-sidebar">
 					<h4>Select and Assign clause syntax</h4>
 				</div>
@@ -280,7 +268,7 @@ Enter supplier key (2 digits)-&gt; 05
 					<p><img height="189" src="Resources/pics/I-DFrel1.gif" width="507" /></p>
 				</div>
 			</div>
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-sidebar">
 					<h4>The Optional phrase</h4>
 				</div>
@@ -291,7 +279,7 @@ Enter supplier key (2 digits)-&gt; 05
 					</p>
 				</div>
 			</div>
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-sidebar">
 					<h4>The Access Mode</h4>
 				</div>
@@ -305,7 +293,7 @@ Enter supplier key (2 digits)-&gt; 05
 					</p>
 				</div>
 			</div>
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-sidebar">
 					<h4>The Record Key phrase</h4>
 				</div>
@@ -320,7 +308,7 @@ Enter supplier key (2 digits)-&gt; 05
 					</p>
 				</div>
 			</div>
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-sidebar">
 					<h4>The File Status</h4>
 				</div>
@@ -363,7 +351,7 @@ Enter supplier key (2 digits)-&gt; 05
 			<div class="section-header">
 				<h2 align="center" id="verbs">Relative file - file processing verbs</h2>
 			</div>
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-sidebar">
 					<h4>Introduction</h4>
 				</div>
@@ -381,7 +369,7 @@ Enter supplier key (2 digits)-&gt; 05
 					<hr />
 				</div>
 			</div>
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-sidebar">
 					<h4>The Invalid Key clause</h4>
 				</div>
@@ -398,7 +386,7 @@ Enter supplier key (2 digits)-&gt; 05
 					<hr />
 				</div>
 			</div>
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-sidebar">
 					<h4>OPEN/CLOSE verbs</h4>
 				</div>
@@ -434,7 +422,7 @@ Enter supplier key (2 digits)-&gt; 05
 					<hr />
 				</div>
 			</div>
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-sidebar">
 					<h4>The READ verb</h4>
 				</div>
@@ -446,7 +434,7 @@ Enter supplier key (2 digits)-&gt; 05
 					</p>
 				</div>
 			</div>
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-sidebar">
 					<h4>Reading using a key</h4>
 				</div>
@@ -483,7 +471,7 @@ Enter supplier key (2 digits)-&gt; 05
 					<p>The file must be opened for I-O or INPUT.&nbsp;</p>
 				</div>
 			</div>
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-sidebar">
 					<h4>Reading Sequentially</h4>
 				</div>
@@ -513,7 +501,7 @@ Enter supplier key (2 digits)-&gt; 05
 					<hr />
 				</div>
 			</div>
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-sidebar">
 					<h4 align="left">The WRITE verb</h4>
 				</div>
@@ -546,7 +534,7 @@ Enter supplier key (2 digits)-&gt; 05
 					<hr />
 				</div>
 			</div>
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-sidebar">
 					<h4 align="left">The REWRITE verb</h4>
 				</div>
@@ -580,7 +568,7 @@ Enter supplier key (2 digits)-&gt; 05
 					<hr />
 				</div>
 			</div>
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-sidebar">
 					<h4 align="left">The DELETE verb</h4>
 				</div>
@@ -619,7 +607,7 @@ Enter supplier key (2 digits)-&gt; 05
 					<hr />
 				</div>
 			</div>
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-sidebar">
 					<h4>The START verb</h4>
 				</div>
@@ -678,7 +666,7 @@ Enter supplier key (2 digits)-&gt; 05
 			<div class="section-header">
 				<h2 align="center" id="declaratives">Introduction to Declaratives</h2>
 			</div>
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-sidebar">
 					<h4 align="left">Introduction</h4>
 				</div>
@@ -690,7 +678,7 @@ Enter supplier key (2 digits)-&gt; 05
 					<hr />
 				</div>
 			</div>
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-sidebar">
 					<h4 align="left">The Declaratives template</h4>
 				</div>
@@ -748,7 +736,7 @@ Begin.</code></pre>
 					<hr />
 				</div>
 			</div>
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-sidebar">
 					<h4 align="left">The Use phrase</h4>
 				</div>
@@ -779,7 +767,7 @@ Begin.</code></pre>
 					<hr />
 				</div>
 			</div>
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-sidebar">
 					<h4 align="center">Example program - fragment</h4>
 				</div>

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -5,15 +5,15 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>COBOL Report Writer</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
+		<script src="Resources/vendor/prism/prism.min.js" defer></script>
+		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<style type="text/css">
 			.iframe-wrapper {
 				text-align: center;
 				border: 1px solid;
 			}
 		</style>
-		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
-		<script src="Resources/vendor/prism/prism.min.js" defer></script>
-		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
@@ -58,7 +58,7 @@
 					</ul>
 				</div>
 
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-header">
 						<h2 align="center" id="intro">Introduction</h2>
 					</div>
@@ -1011,7 +1011,7 @@ Programmer - Michael Coughlan               Page :  1 </code></pre>
 						<hr />
 					</div>
 
-					<div class="section-full page-footer">
+					<div class="page-footer">
 						<hr />
 						<div align="center">
 							<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -5,19 +5,6 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>COBOL Report Writer - Syntax and Semantics</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
-		<style type="text/css">
-			pre {
-				white-space: pre-wrap;
-				word-wrap: break-word;
-				overflow-wrap: break-word;
-			}
-
-			pre[class*="language-"],
-			code[class*="language-"] {
-				white-space: pre-wrap !important;
-				overflow-wrap: break-word;
-			}
-		</style>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
@@ -86,7 +73,7 @@
 				<div class="section-header">
 					<h2 align="center" id="intro">Introduction</h2>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>Aims</h4>
 					</div>
@@ -98,7 +85,7 @@
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>Objectives</h4>
 					</div>
@@ -121,7 +108,7 @@
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>Prerequisites</h4>
 					</div>
@@ -147,7 +134,7 @@
 				<div class="section-header">
 					<h2 align="center" id="part1">Defining the Report - Report File entries</h2>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4><code class="language-cobol">ENVIRONMENT DIVISION</code> entries</h4>
 					</div>
@@ -201,7 +188,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4 align="left">File Section entries</h4>
 					</div>
@@ -235,7 +222,7 @@ RD  SalesReport
 				<div class="section-header">
 					<h2 align="center" id="part2">Defining the Report - Report Description (RD) Entries</h2>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>Introduction</h4>
 					</div>
@@ -259,7 +246,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4 align="left">The Report Description (RD) entries - Syntax</h4>
 					</div>
@@ -269,7 +256,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4 align="left">The Report Description (RD) entries - Semantics</h4>
 					</div>
@@ -338,7 +325,7 @@ RD  SalesReport
 				<div class="section-header">
 					<h2 align="center" id="part3">Defining the Report - Report Group entries</h2>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>Introduction</h4>
 					</div>
@@ -355,7 +342,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4 align="left">Defining a Report Group Record - Syntax</h4>
 					</div>
@@ -367,7 +354,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4 align="left"><i>ReportGroupName</i> Rules</h4>
 					</div>
@@ -388,7 +375,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4 align="left">The LINE NUMBER clause</h4>
 					</div>
@@ -435,7 +422,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4 align="left">The NEXT GROUP clause</h4>
 					</div>
@@ -471,7 +458,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4 align="left">The TYPE clause</h4>
 					</div>
@@ -520,7 +507,7 @@ RD  SalesReport
 				<div class="section-header">
 					<h2 align="center" id="part4">Defining the Report - Lines and Columns</h2>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4 align="left">Introduction</h4>
 					</div>
@@ -534,7 +521,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4 align="left">Defining Report Lines</h4>
 					</div>
@@ -550,7 +537,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4 align="center">Defining Elementary print items in a report group</h4>
 					</div>
@@ -575,7 +562,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4 align="left">The COLUMN NUMBER clause</h4>
 					</div>
@@ -593,7 +580,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>The GROUP INDICATE clause</h4>
 					</div>
@@ -621,7 +608,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>The SOURCE clause</h4>
 					</div>
@@ -635,7 +622,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>The SUM clause</h4>
 					</div>
@@ -725,7 +712,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>The RESET ON clause</h4>
 					</div>
@@ -747,7 +734,7 @@ RD  SalesReport
 				<div class="section-header">
 					<h2 align="center" id="part5">Special Report Writer registers</h2>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>Introduction</h4>
 					</div>
@@ -765,7 +752,7 @@ RD  SalesReport
 						</p>
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>The LINE-COUNTER register</h4>
 					</div>
@@ -792,7 +779,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>The PAGE-COUNTER register</h4>
 					</div>
@@ -825,7 +812,7 @@ RD  SalesReport
 				<div class="section-header">
 					<h2 align="center" id="part6">Procedure Division verbs</h2>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>Introduction</h4>
 					</div>
@@ -855,7 +842,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>Syntax</h4>
 					</div>
@@ -864,7 +851,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>INITIATE</h4>
 					</div>
@@ -891,7 +878,7 @@ RD  SalesReport
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>GENERATE</h4>
 					</div>
@@ -988,7 +975,7 @@ Programmer - Michael Coughlan               Page :  1
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>TERMINATE</h4>
 					</div>
@@ -1010,7 +997,7 @@ Programmer - Michael Coughlan               Page :  1
 				<div class="section-header">
 					<h2 align="center" id="part7">Report Writer Declaratives</h2>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>Introduction</h4>
 					</div>
@@ -1035,7 +1022,7 @@ Programmer - Michael Coughlan               Page :  1
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>Using Declaratives with the Report Writer</h4>
 					</div>
@@ -1059,7 +1046,7 @@ Programmer - Michael Coughlan               Page :  1
 						<p align="left">Statements in the Declaratives must not reference non-declarative procedures.</p>
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>Declaratives Example</h4>
 					</div>
@@ -1086,7 +1073,7 @@ Begin.
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>The SUPPRESS PRINTING statement</h4>
 					</div>
@@ -1119,7 +1106,7 @@ END DECLARATIVES.</code></pre>
 						<hr />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>Control Break Registers</h4>
 					</div>

--- a/course/Resources/css/course.css
+++ b/course/Resources/css/course.css
@@ -28,6 +28,19 @@ body > hr {
 pre {
 	overflow-x: auto;
 	max-width: 100%;
+	white-space: pre-wrap;
+	word-wrap: break-word;
+	overflow-wrap: break-word;
+}
+
+/* Force Prism-highlighted code to wrap by default rather than scroll. The
+   `body` prefix bumps specificity to (0,1,2) so this rule wins against
+   prism.min.css's `pre[class*="language-"]` (specificity 0,1,1), regardless
+   of stylesheet load order. */
+body pre[class*="language-"],
+body code[class*="language-"] {
+	white-space: pre-wrap;
+	overflow-wrap: break-word;
 }
 
 body {
@@ -79,15 +92,6 @@ body {
 
 	pre {
 		max-width: min(100%, calc(100vw - 16px)) !important;
-		white-space: pre-wrap;
-		word-wrap: break-word;
-		overflow-wrap: break-word;
-	}
-
-	pre[class*="language-"],
-	code[class*="language-"] {
-		white-space: pre-wrap !important;
-		overflow-wrap: break-word;
 	}
 
 	pre[class*="language-"] {
@@ -163,6 +167,12 @@ td[bgcolor="#FFFFCC"] h4 {
 	padding: 2px;
 }
 
+/* When the footer sits inside a section-grid (rather than as a sibling of it),
+   span all columns so it occupies a full row. */
+.section-grid > .page-footer {
+	grid-column: 1 / -1;
+}
+
 .section-grid {
 	display: grid;
 	grid-template-columns: 175px 1fr;
@@ -196,6 +206,7 @@ td[bgcolor="#FFFFCC"] h4 {
 .section-content {
 	padding: 4px;
 	min-width: 0;
+	align-self: start;
 }
 
 .section-full {
@@ -225,44 +236,4 @@ td[bgcolor="#FFFFCC"] h4 {
 	h4:has(> img[src*="PanelLine"]) {
 		display: none;
 	}
-}
-
-/* Bordered grid variant — opt-in via `section-grid section-grid--bordered`.
-   Draws horizontal dividers between sections and a vertical divider between
-   sidebar and content cells. Applied where the page is laid out as a
-   table-like sequence of sidebar/content rows. */
-.section-grid--bordered .section-header {
-	border-bottom: 1px solid;
-}
-
-.section-grid--bordered .section-sidebar {
-	border-right: 1px solid;
-	border-bottom: 1px solid;
-}
-
-.section-grid--bordered .section-content {
-	align-self: start;
-	overflow: hidden;
-	border-bottom: 1px solid;
-}
-
-.section-grid--bordered .section-full {
-	border-bottom: 1px solid;
-}
-
-.section-grid--bordered > .section-full:last-child {
-	border-bottom: none;
-}
-
-@media (max-width: 600px) {
-	.section-grid--bordered .section-sidebar {
-		border-right: none;
-	}
-}
-
-/* Wrap long Prism-highlighted code so it doesn't overflow narrow columns. */
-.section-grid--bordered .section-content pre[class*="language-"],
-.section-grid--bordered .section-content code[class*="language-"] {
-	white-space: pre-wrap;
-	overflow-wrap: break-word;
 }

--- a/course/Search.html
+++ b/course/Search.html
@@ -5,19 +5,6 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>Searching Tables</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
-		<style type="text/css">
-			pre {
-				white-space: pre-wrap;
-				word-wrap: break-word;
-				overflow-wrap: break-word;
-			}
-
-			pre[class*="language-"],
-			code[class*="language-"] {
-				white-space: pre-wrap !important;
-				overflow-wrap: break-word;
-			}
-		</style>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
@@ -71,7 +58,7 @@
 				<div class="section-header">
 					<h2 align="center" id="intro">Introduction</h2>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>Aims</h4>
 					</div>
@@ -105,7 +92,7 @@
 						<hr align="center" size="1" width="100%" />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>Objectives</h4>
 					</div>
@@ -132,7 +119,7 @@
 						<hr align="center" size="1" width="100%" />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>Prerequisites</h4>
 					</div>
@@ -165,7 +152,7 @@
 				<div class="section-header">
 					<h2 align="center" id="part1">Occurs clause extensions</h2>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>Introduction</h4>
 					</div>
@@ -186,7 +173,7 @@
 						<hr size="1" width="100%" />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>Full OCCURS clause syntax</h4>
 					</div>
@@ -194,7 +181,7 @@
 						<p align="left"><img height="122" src="Resources/pics/Search1.gif" width="331" /></p>
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>INDEXED BY phrase - notes</h4>
 					</div>
@@ -236,7 +223,7 @@
 						</p>
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>KEY IS phrase - notes</h4>
 					</div>
@@ -269,7 +256,7 @@
 				<div class="section-header">
 					<h2 align="center" id="part2">The SEARCH verb</h2>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>Introduction</h4>
 					</div>
@@ -281,7 +268,7 @@
 						</p>
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>SEARCH syntax</h4>
 					</div>
@@ -347,7 +334,7 @@
 						<hr size="1" width="100%" />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>The SET verb syntax</h4>
 					</div>
@@ -375,7 +362,7 @@
 						<p><img height="148" src="Resources/pics/Search4.gif" width="326" /></p>
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>SEARCH example 1</h4>
 						<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
@@ -448,7 +435,7 @@ Begin.
 						<hr size="1" width="100%" />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>Example program 2</h4>
 						<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
@@ -585,7 +572,7 @@ DisplayCountyTaxes.
 				<div class="section-header">
 					<h2 align="center" id="part3">Searching multi-dimension tables</h2>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>Introduction</h4>
 					</div>
@@ -638,7 +625,7 @@ DisplayCountyTaxes.
 						</p>
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
 					</div>
@@ -712,7 +699,7 @@ LoadTable.
 						<hr size="1" width="100%" />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>The Race Results Example program</h4>
 					</div>
@@ -742,7 +729,7 @@ LoadTable.
 						</p>
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
 					</div>
@@ -852,7 +839,7 @@ END-SEARCH</code></pre>
 				<div class="section-header">
 					<h2 align="center" id="part4">The SEARCH ALL verb</h2>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4 align="left">Introduction</h4>
 					</div>
@@ -868,7 +855,7 @@ END-SEARCH</code></pre>
 						<hr size="1" />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>SEARCH ALL syntax</h4>
 					</div>
@@ -917,7 +904,7 @@ END-SEARCH</code></pre>
 						<hr size="1" width="100%" />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>How a binary search works</h4>
 					</div>
@@ -976,7 +963,7 @@ END-SEARCH.</code></pre>
 						<p align="left">The full program for searching the letter table is given below.</p>
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
 					</div>
@@ -1024,7 +1011,7 @@ Begin.
 						<hr size="1" width="100%" />
 					</div>
 				</div>
-				<div class="section-grid section-grid--bordered">
+				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>Example program</h4>
 						<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -5,19 +5,10 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>COBOL Selection Constructs</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
+		<script src="Resources/vendor/prism/prism.min.js" defer></script>
+		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<style type="text/css">
-			pre {
-				white-space: pre-wrap;
-				word-wrap: break-word;
-				overflow-wrap: break-word;
-			}
-
-			pre[class*="language-"],
-			code[class*="language-"] {
-				white-space: pre-wrap !important;
-				overflow-wrap: break-word;
-			}
-
 			.eval-row {
 				display: grid;
 				font-family: monospace;
@@ -84,9 +75,6 @@
 				}
 			}
 		</style>
-		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
-		<script src="Resources/vendor/prism/prism.min.js" defer></script>
-		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -128,7 +116,7 @@
 			</div>
 
 			<!-- Introduction section -->
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-header">
 					<h2 align="center" id="intro">Introduction</h2>
 				</div>
@@ -201,7 +189,7 @@
 			</div>
 
 			<!-- Selection using IF section -->
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-header">
 					<h2 align="center" id="part1">Selection using IF</h2>
 				</div>
@@ -767,7 +755,7 @@ END-IF
 			</div>
 
 			<!-- Condition Names section -->
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-header">
 					<h2 align="center" id="part2">Condition Names</h2>
 				</div>
@@ -955,7 +943,7 @@ END-IF
 			</div>
 
 			<!-- Using the SET verb section -->
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-header">
 					<h2 align="center" id="part3">Using the SET verb with Condition Names</h2>
 				</div>
@@ -1098,7 +1086,7 @@ Begin.
 			</div>
 
 			<!-- The EVALUATE verb section -->
-			<div class="section-grid section-grid--bordered">
+			<div class="section-grid">
 				<div class="section-header">
 					<h2 align="center" id="part4">The EVALUATE verb</h2>
 				</div>
@@ -1411,7 +1399,7 @@ END-EVALUATE
 					</p>
 				</div>
 
-				<div class="section-full page-footer">
+				<div class="page-footer">
 					<hr />
 					<div align="center">
 						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -5,7 +5,10 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>Introduction to Sequential Files</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
-		<style>
+		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
+		<script src="Resources/vendor/prism/prism.min.js" defer></script>
+		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<style type="text/css">
 			.code-block {
 				border: 1px solid;
 				padding: 5px;
@@ -24,9 +27,6 @@
 				}
 			}
 		</style>
-		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
-		<script src="Resources/vendor/prism/prism.min.js" defer></script>
-		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -5,7 +5,10 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>Processing Sequential Files</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
-		<style>
+		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
+		<script src="Resources/vendor/prism/prism.min.js" defer></script>
+		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<style type="text/css">
 			.qa-form {
 				border: 1px solid;
 				width: 96%;
@@ -74,9 +77,6 @@
 				}
 			}
 		</style>
-		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
-		<script src="Resources/vendor/prism/prism.min.js" defer></script>
-		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -966,7 +966,7 @@ DisplayTransactions.
 
 </code></pre>
 				</div>
-				<div class="section-full page-footer">
+				<div class="page-footer">
 					<hr />
 					<div align="center">
 						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -5,7 +5,10 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>Sorting and Merging files</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
-		<style>
+		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
+		<script src="Resources/vendor/prism/prism.min.js" defer></script>
+		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<style type="text/css">
 			.spec-block {
 				background-color: #e1ffe1;
 				border: 1px solid;
@@ -21,9 +24,6 @@
 				}
 			}
 		</style>
-		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
-		<script src="Resources/vendor/prism/prism.min.js" defer></script>
-		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -1567,7 +1567,7 @@ Begin.
 </code></pre>
 					</div>
 				</div>
-				<div class="section-full page-footer">
+				<div class="page-footer">
 					<hr />
 					<div align="center">
 						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -5,7 +5,10 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>Contained and external sub-programs</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
-		<style>
+		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
+		<script src="Resources/vendor/prism/prism.min.js" defer></script>
+		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<style type="text/css">
 			.code-run-pair {
 				display: flex;
 				border: 1px solid;
@@ -28,9 +31,6 @@
 				.code-run-pair .run-part { border-left: none; border-top: 1px solid; }
 			}
 		</style>
-		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
-		<script src="Resources/vendor/prism/prism.min.js" defer></script>
-		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -8,17 +8,10 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
-		<style>
+		<style type="text/css">
 			form select {
 				max-width: 100%;
 				box-sizing: border-box;
-			}
-
-			pre[class*="language-"],
-			code[class*="language-"] {
-				white-space: pre-wrap;
-				overflow: visible;
-				overflow-wrap: break-word;
 			}
 
 			@media (max-width: 600px) {
@@ -1415,7 +1408,7 @@ DisplayCountyTaxes.
       03 CountyTax  PIC 9(5) VALUE ZEROS.
       03 CountyName PIC X(12) VALUE SPACES.</code></pre>
 				</div>
-				<div class="section-full page-footer">
+				<div class="page-footer">
 					<hr />
 					<div align="center">
 						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -8,11 +8,6 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
-		<style type="text/css">
-			.section-content {
-				align-self: start;
-			}
-		</style>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -12,10 +12,6 @@
 			.section-grid {
 				padding: 4px;
 			}
-
-			.section-content {
-				align-self: start;
-			}
 		</style>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>


### PR DESCRIPTION
## Summary

Several small consistency improvements across the 25 course pages, building on the recent normalization work.

## What changed

- **Remove the `section-grid--bordered` variant entirely.** All grids now use the simple non-bordered look (continuous yellow sidebar, no internal horizontal dividers between rows, no vertical divider between sidebar and content) on every page. The variant was previously opted into by 10 pages (98 class-name occurrences); the supporting rules in `course.css` are gone too. The non-bordered look is now the canonical course-page style.
- **Make Prism-highlighted code wrap by default rather than scroll horizontally.** The rule lives in `course.css` with a `body pre[class*="language-"]` selector that wins against `prism.min.css`'s same-element rule by specificity (0,1,2 vs 0,1,1) — no `!important` needed. Removes inline duplicates from 5 pages (Iteration, RelativeFiles, ReportWriterSS, Search, Selection) and the redundant Tables2 variant.
- **Lift `.section-content { align-self: start }` to `course.css`** so the sidebar `<h4>` labels align with the start of their content row on every page. Removes the inline overrides from Usage and Unstring.
- **Footer wrapper standardization.** Move from `class=\"section-full page-footer\"` to plain `class=\"page-footer\"` on 9 pages, with a new `.section-grid > .page-footer { grid-column: 1 / -1 }` rule so it still spans the full grid row when nested.
- **Normalize `<style>` block placement.** All 25 pages now load resources in the same order at lines 7-11: `course.css` → `prism.css` → prism JS → page `<style>` → copyright-notice JS. Also fixes 6 pages that used `<style>` without `type=\"text/css\"`.

## Why

The recent commits have been normalizing one cross-cutting concern at a time (meta tags, hero markup, page-wrapper, etc.). This continues that pattern by tackling the bordered/non-bordered split (per request, the bordered variant was a mistake and shouldn't have existed), the Prism wrap inconsistency (some pages opted in inline, others let code overflow), and the inline-rule duplication that comes with both. The cascade specificity trick lets the wrap rule live in one place without needing `!important`.

## Net effect

- **20 files**, +163/-274 lines (net **-111 lines** — more deduped than added).
- Same simple grid look on every page, prism code wraps everywhere, single source of truth for shared styles.

## Test plan

- [x] Visually verified on DataDeclaration, Selection, Tables2, ReportWriterSS, COBOLIntro, Subprograms, RelativeFiles, EditedPics at desktop (1280px), 800px, and mobile (375px).
- [x] Confirmed via computed styles: 0 borders on any `.section-content`/`.section-sidebar`, prism `<pre>` shows `whiteSpace: pre-wrap` with 0 horizontally-overflowing blocks across all sampled pages, `.section-content` has `align-self: start`.
- [x] Stylesheet load order verified consistent across all 25 pages (`course.css → prism.css → inline`).
- [x] Page-specific custom classes still work (`.eval-row` is grid, `.code-run-pair` is flex with border, etc.).
- [x] No browser console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)