### PR TITLE
Tighten course-page consistency: fix content bugs, drop stale overrides and vestigial markup

### DIFF
--- a/course/Copy.html
+++ b/course/Copy.html
@@ -78,7 +78,6 @@
 				</div>
 				<div class="section-sidebar">
 					<h4>Aims</h4>
-					<h4><img height="1" src="Resources/pics/PanelLine.gif" width="175" /></h4>
 				</div>
 				<div>
 					<div align="center">
@@ -170,7 +169,6 @@
 				</div>
 				<div class="section-sidebar">
 					<h4>Introduction</h4>
-					<h4><img height="1" src="Resources/pics/PanelLine.gif" width="175" /></h4>
 				</div>
 				<div>
 					<div align="center">
@@ -276,7 +274,6 @@
 							identify all the replaceable objects.
 						</p>
 					</aside>
-					<h4><img height="1" src="Resources/pics/PanelLine.gif" width="175" /></h4>
 				</div>
 				<div>
 					<div align="center">
@@ -640,7 +637,6 @@ BeginProg.
 							full stop after the PIC 9(8) in the TextWord2 replacement text.
 						</p>
 					</aside>
-					<p align="left"><img height="1" src="Resources/pics/PanelLine.gif" width="175" /></p>
 				</div>
 				<div>
 					<div class="code-section">

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -8,12 +8,6 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
-		<style type="text/css">
-			.page-content,
-			.page-footer {
-				padding: 4px;
-			}
-		</style>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -43,7 +43,7 @@
 							program that produced the report.
 						</li>
 						<li>
-							<a href="#part2">Let's write a Report Writer p</a><a href="#part2">rogram</a><br />
+							<a href="#part2">Let's write a Report Writer program</a><br />
 							This section uses learning by doing as its mode of instruction. We learn how to write a
 							simple version of the report program shown in the previous section.
 						</li>

--- a/course/Resources/css/course.css
+++ b/course/Resources/css/course.css
@@ -109,20 +109,6 @@ body {
 		width: auto !important;
 	}
 
-	td[width="175"] > h4:not(:first-child):not(:has(img)),
-	td[width="160"] > h4:not(:first-child):not(:has(img)),
-	h4:has(> img[src*="PanelLine"]) {
-		display: none;
-	}
-
-	td[width="175"] > h3,
-	td[width="175"] > h4,
-	td[width="175"] > p,
-	td[width="160"] > h3,
-	td[width="160"] > h4,
-	td[width="160"] > p {
-		margin: 0.2em 0;
-	}
 }
 
 ul.toc {
@@ -226,11 +212,5 @@ td[bgcolor="#FFFFCC"] h4 {
 	.section-sidebar h4,
 	.section-sidebar p {
 		margin: 0.2em 0;
-	}
-
-	/* Hide decorative PanelLine spacer h4s on narrow screens */
-	.section-sidebar h4:not(:first-child):not(:has(img)),
-	h4:has(> img[src*="PanelLine"]) {
-		display: none;
 	}
 }

--- a/course/Resources/css/course.css
+++ b/course/Resources/css/course.css
@@ -108,7 +108,6 @@ body {
 		display: block;
 		width: auto !important;
 	}
-
 }
 
 ul.toc {

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -33,11 +33,9 @@
 				<div>
 					<center>
 						<p id="top"><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
-					</center>
-					<center>
 						<h1>Sorting and Merging files</h1>
-						<hr />
 					</center>
+					<hr />
 					<ul class="toc">
 						<li>
 							<a href="#intro">Introduction</a><br />

--- a/course/String.html
+++ b/course/String.html
@@ -8,12 +8,6 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
-		<style type="text/css">
-			.section-header,
-			.section-sidebar {
-				text-align: left;
-			}
-		</style>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
@@ -59,7 +53,7 @@
 					<h4>Objectives</h4>
 				</div>
 				<div class="section-content">
-					<p>By the end of this unit you should:By the end of this unit you should:</p>
+					<p>By the end of this unit you should:</p>
 					<ol>
 						<li>Understand how the STRING verb works.</li>
 						<li>Be able to use the STRING to concatenate text strings in your programs</li>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -72,7 +72,6 @@
 				</div>
 				<div class="section-sidebar">
 					<h4>Aims</h4>
-					<h4><img height="1" src="Resources/pics/PanelLine.gif" width="175" /></h4>
 				</div>
 				<div class="section-content">
 					<div align="center">

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -16,11 +16,9 @@
 			<div class="page-content">
 				<center>
 					<p id="top"><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
-				</center>
-				<center>
 					<h1>Using Tables</h1>
-					<hr />
 				</center>
+				<hr />
 				<ul class="toc">
 					<li>
 						<a href="#intro">Introduction</a><br />

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -53,11 +53,9 @@
 				<div class="section-full">
 					<center>
 						<p id="top"><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
-					</center>
-					<center>
 						<h1>Creating Tables - syntax and semantics</h1>
-						<hr />
 					</center>
+					<hr />
 					<ul class="toc">
 						<li>
 							<a href="#intro">Introduction</a><br />

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -60,7 +60,7 @@
 						<h4>Objectives</h4>
 					</div>
 					<div class="section-content">
-						<p>By the end of this unit you should:By the end of this unit you should:</p>
+						<p>By the end of this unit you should:</p>
 						<ol>
 							<li>Understand how the UNSTRING works</li>
 							<li>Be able to use the UNSTRING to divide a string into sub-strings</li>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -42,7 +42,6 @@
 				</div>
 				<div class="section-sidebar">
 					<h4>Aims</h4>
-					<h4><img height="1" src="Resources/pics/PanelLine.gif" width="175" /></h4>
 				</div>
 				<div class="section-content">
 					<div align="center">


### PR DESCRIPTION
## Summary

Consistency pass over the 25 course HTML pages (excluding `index.html`). All changes are aimed at structural/content coherence with no intended visual changes on standard pages.

## What changed

**Content fixes**
- [String.html](course/String.html), [Unstring.html](course/Unstring.html): drop duplicated `"By the end of this unit you should:"` sentence in Objectives.
- [ReportWriter.html](course/ReportWriter.html): join split TOC anchor `Let's write a Report Writer p</a><a>rogram` into a single link.

**Stale page-local CSS overrides removed**
- [String.html](course/String.html): drop `<style>` forcing `.section-header` / `.section-sidebar` to `text-align: left` — the dark-red banner now centers like every other page.
- [EditedPics.html](course/EditedPics.html): drop `<style>` forcing 4px `page-content`/`page-footer` padding — now matches the shared 2px.

**Vestigial PanelLine spacer markup removed**
- 1px decorative `<img>` spacers left over from the table layout: [Copy.html](course/Copy.html) ×4, [Subprograms.html](course/Subprograms.html) ×1, [Usage.html](course/Usage.html) ×1. They were already hidden on mobile and were visually negligible on desktop.

**course.css cleanup**
- Remove now-unused `h4:has(> img[src*="PanelLine"])` selectors and legacy `td[width=\"175\"]` / `td[width=\"160\"]` sidebar margin/display rules. No course HTML targets these.

**Structural normalization**
- [Tables1.html](course/Tables1.html), [SortMerge.html](course/SortMerge.html), [Tables2.html](course/Tables2.html): collapse two adjacent `<center>` wrappers (one for the banner image, one for `<h1>`) into the single-wrapper pattern used by every other page.

## Deliberately not touched

- **Pattern C section-header outside grid** (8 files): `grid-column: 1/-1` is just ignored on non-grid items, so it renders identically to Pattern A. Restructuring would be invasive without payoff.
- **Copy.html bare `<div>` content cells** with the local `.section-grid > * { padding: 4px }` rule: promoting them to `.section-content` would add `align-self: start` and could subtly shift vertical layout.
- **Larger CSS consolidations** (`.code-box` / `.two-col` / `.qa-row`+`.saq-row` unification): high-touch, best left to a separate dedicated pass.

## Test plan

- [x] String.html: section-header now `text-align: center` (verified via `getComputedStyle`); duplicated sentence gone (verified via DOM text)
- [x] Unstring.html: duplicated sentence gone
- [x] ReportWriter.html: TOC entry "Let's write a Report Writer program" is a single anchor
- [x] Subprograms.html, Usage.html, Copy.html: zero `img[src*="PanelLine"]` in DOM, sidebars still render with maroon Arial h4s
- [x] EditedPics.html: `.page-content` padding is 2px (was 4px)
- [x] Tables1.html, SortMerge.html, Tables2.html: single wrapping `<center>`, `<h1>` still horizontally centered
- [x] COBOLIntro.html, Inspect.html, SortMerge.html spot checks: section headers render yellow Arial on red, centered
- [x] No new console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)