### PR TITLE
Course pages: add course-components.css scaffold (Phase 1 of cleanup)

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -5,6 +5,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>Introduction to COBOL</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -5,6 +5,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>Basic Procedure Division commands</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -5,6 +5,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>The COPY verb</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -5,6 +5,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>Declaring Data in COBOL</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -5,6 +5,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>Edited Pictures</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -5,6 +5,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>Indexed Files</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -5,6 +5,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>The INSPECT verb</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -5,6 +5,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>Introduction to Direct Access Files</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -5,6 +5,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>COBOL Interation Constructs</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -5,6 +5,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>Reference Modification</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -5,6 +5,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>Relative Files</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -5,6 +5,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>COBOL Report Writer</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -5,6 +5,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>COBOL Report Writer - Syntax and Semantics</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>

--- a/course/Resources/css/course-components.css
+++ b/course/Resources/css/course-components.css
@@ -1,0 +1,41 @@
+/* Course-page component utilities. Loaded after course.css so these rules can
+   override layout-level styling when needed. Each class is designed to replace
+   a recurring chunk of legacy presentational HTML (<center>, align="...",
+   <table border cellspacing cellpadding>) without changing the rendered output. */
+
+.hero {
+	text-align: center;
+}
+
+.center-block {
+	text-align: center;
+}
+
+/* Replaces <p align="center"><a href="#top"><img .../></a></p> blocks placed
+   between sections. The 1em vertical margin matches the default <p> margin so
+   the divider/anchor pair retains its rhythm. The .page-footer override drops
+   that margin because the footer variant uses a <div>, which has no default
+   margin. */
+.back-to-top {
+	text-align: center;
+	margin: 1em 0;
+}
+
+.page-footer .back-to-top {
+	margin: 0;
+}
+
+/* Reproduces <table border="1" cellspacing="1" cellpadding="5"> exactly:
+   1px outer border, 1px gap between cells, 1px border on every cell, 5px
+   cell padding. Verified against legacy renderings before the Phase 4 sweep. */
+.data-table {
+	border-collapse: separate;
+	border-spacing: 1px;
+	border: 1px solid;
+}
+
+.data-table > * > tr > th,
+.data-table > * > tr > td {
+	border: 1px solid;
+	padding: 5px;
+}

--- a/course/Search.html
+++ b/course/Search.html
@@ -5,6 +5,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>Searching Tables</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -5,6 +5,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>COBOL Selection Constructs</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -5,6 +5,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>Introduction to Sequential Files</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -5,6 +5,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>Processing Sequential Files</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -5,6 +5,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>Print files and variable-length records</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -5,6 +5,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>Sorting and Merging files</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>

--- a/course/String.html
+++ b/course/String.html
@@ -5,6 +5,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>The STRING verb</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -5,6 +5,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>Contained and external sub-programs</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -5,6 +5,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>Using Tables</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -5,6 +5,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>Creating tables - syntax and semantics</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -5,6 +5,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>The UNSTRING verb</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -5,6 +5,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>The USAGE clause</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>


### PR DESCRIPTION
## Summary

- Phase 1 of a multi-PR course-page modernization. Pure additive — **zero visual delta**.
- New shared stylesheet at `course/Resources/css/course-components.css` linked from every course page right after `course.css`.
- Starter rules for `.hero`, `.center-block`, `.back-to-top`, `.data-table`. None of these selectors match any element today; they sit ready for the follow-up PRs.

## Why this is safe

I ran the site under `python -m http.server 8000` and confirmed on `COBOLIntro.html` and `Selection.html`:

- The new stylesheet is loaded (`document.styleSheets` contains it).
- `document.querySelectorAll('.hero,.center-block,.back-to-top,.data-table').length === 0` — nothing matches yet, so nothing rendered changes.
- No console errors.

## Follow-ups (not in this PR)

1. `<page-hero>` Web Component → drops 25 `<center>` tags around hero blocks.
2. `<back-to-top>` Web Component → replaces ~80–100 inline back-to-top blocks.
3. `.data-table` rollout → replaces legacy `<table border="1" cellspacing="1" cellpadding="5">` presentational attributes.
4. Migrate per-page `<style>` blocks into the shared sheet.
5. Mechanical attribute sweep (`border="0"` on `<img>`, `align/size/width` on `<hr>`, etc.).

`course/index.html` is intentionally out of scope — its layout is structurally different from the per-topic course pages.

## Test plan

- [x] `python -m http.server 8000` from repo root, open `course/COBOLIntro.html` and `course/Selection.html`, confirm visual parity.
- [x] DevTools: confirm `course-components.css` loads with status 200, no rule mismatch.
- [x] No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)