### PR TITLE
Course pages: <page-hero> Web Component (Phase 2 of cleanup)

### DIFF
--- a/components/page-hero.js
+++ b/components/page-hero.js
@@ -1,0 +1,21 @@
+// Light-DOM custom element. Replaces the legacy hero block:
+//   <center>
+//     <p id="top"><img src=".../t-CobolTut.gif" width="173" height="59" /></p>
+//     <h1>{TITLE}</h1>
+//   </center>
+// Light DOM (not shadow DOM) so course.css link colors, image sizing,
+// and the .hero centering rule from course-components.css all apply.
+class PageHero extends HTMLElement {
+	connectedCallback() {
+		const title = this.getAttribute("title") || "";
+		this.innerHTML = `
+			<div class="hero">
+				<p id="top"><img src="Resources/pics/t-CobolTut.gif" width="173" height="59" alt="" /></p>
+				<h1></h1>
+			</div>
+		`;
+		this.querySelector("h1").textContent = title;
+	}
+}
+
+customElements.define("page-hero", PageHero);

--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -74,6 +74,7 @@
 				}
 			}
 		</style>
+		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -81,10 +82,7 @@
 		<div class="page-wrapper">
 			<div class="section-grid">
 				<div class="section-full">
-					<center>
-						<p id="top"><img src="Resources/pics/t-CobolTut.gif" width="173" height="59" /></p>
-						<h1>Introduction to COBOL</h1>
-					</center>
+					<page-hero title="Introduction to COBOL"></page-hero>
 					<hr />
 					<ul class="toc">
 						<li>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -9,16 +9,14 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
 	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
-				<center>
-					<p id="top"><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
-					<h1>Basic Procedure Division Commands</h1>
-				</center>
+				<page-hero title="Basic Procedure Division Commands"></page-hero>
 				<hr />
 				<ul class="toc">
 					<li>

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -33,6 +33,7 @@
 				}
 			}
 		</style>
+		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -41,10 +42,7 @@
 			<div class="section-grid">
 				<!-- Header -->
 				<div class="section-full">
-					<center>
-						<p id="top"><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
-						<h1>The COPY verb</h1>
-					</center>
+					<page-hero title="The COPY verb"></page-hero>
 					<hr />
 					<ul class="toc">
 						<li>

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -56,16 +56,14 @@
 				}
 			}
 		</style>
+		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
 		<div class="page-wrapper">
 			<div class="section-grid">
 				<div class="section-full">
-					<center>
-						<p id="top"><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
-						<h1>Declaring Data in COBOL</h1>
-					</center>
+					<page-hero title="Declaring Data in COBOL"></page-hero>
 					<hr />
 					<ul class="toc">
 						<li>

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -9,16 +9,14 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
 	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
-				<center>
-					<p id="top"><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
-					<h1>Edited Pictures</h1>
-				</center>
+				<page-hero title="Edited Pictures"></page-hero>
 				<hr />
 				<ul class="toc">
 					<li>

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -15,17 +15,13 @@
 				box-sizing: border-box;
 			}
 		</style>
+		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
-				<center>
-					<p id="top">
-						<img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173" />
-					</p>
-					<h1>Indexed Files</h1>
-				</center>
+				<page-hero title="Indexed Files"></page-hero>
 				<hr />
 				<ul class="toc">
 					<li>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -14,17 +14,13 @@
 				margin-top: 0.6em;
 			}
 		</style>
+		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
-				<center>
-					<p id="top">
-						<img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173" />
-					</p>
-					<h1>The INSPECT verb</h1>
-				</center>
+				<page-hero title="The INSPECT verb"></page-hero>
 				<hr />
 				<ul class="toc">
 					<li>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -48,17 +48,13 @@
 				}
 			}
 		</style>
+		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
-				<center>
-					<p id="top">
-						<img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173" />
-					</p>
-					<h1>Introduction to Direct Access Files</h1>
-				</center>
+				<page-hero title="Introduction to Direct Access Files"></page-hero>
 				<hr />
 				<ul class="toc">
 					<li>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -90,16 +90,14 @@
 				}
 			}
 		</style>
+		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
 	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
-				<center>
-					<p id="top"><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
-					<h1>COBOL Iteration Constructs</h1>
-				</center>
+				<page-hero title="COBOL Iteration Constructs"></page-hero>
 				<hr />
 				<ul class="toc">
 					<li>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -51,15 +51,13 @@
 				}
 			}
 		</style>
+		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
-				<center>
-					<p id="top"><img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
-					<h1>Reference Modification and Intrinsic Functions</h1>
-				</center>
+				<page-hero title="Reference Modification and Intrinsic Functions"></page-hero>
 				<hr />
 				<ul class="toc">
 					<li>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -37,17 +37,13 @@
 				}
 			}
 		</style>
+		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
-				<center>
-					<p id="top">
-						<img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173" />
-					</p>
-					<h1>Relative Files</h1>
-				</center>
+				<page-hero title="Relative Files"></page-hero>
 				<hr />
 				<ul class="toc">
 					<li>

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -15,6 +15,7 @@
 				border: 1px solid;
 			}
 		</style>
+		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -22,10 +23,7 @@
 		<div class="page-wrapper">
 			<div class="page-content">
 				<div>
-					<center>
-						<p id="top"><img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
-						<h1>The COBOL Report Writer</h1>
-					</center>
+					<page-hero title="The COBOL Report Writer"></page-hero>
 					<hr />
 					<ul class="toc">
 						<li>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -9,6 +9,7 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -16,10 +17,7 @@
 		<div class="page-wrapper">
 			<div class="page-content">
 				<div>
-					<center>
-						<p id="top"><img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
-						<h1>The COBOL Report Writer - Syntax and Semantics</h1>
-					</center>
+					<page-hero title="The COBOL Report Writer - Syntax and Semantics"></page-hero>
 					<hr />
 					<ul class="toc">
 						<li>

--- a/course/Search.html
+++ b/course/Search.html
@@ -9,6 +9,7 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -16,10 +17,7 @@
 		<div class="page-wrapper">
 			<div class="page-content">
 				<div>
-					<center>
-						<p id="top"><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
-						<h1>Searching Tables</h1>
-					</center>
+					<page-hero title="Searching Tables"></page-hero>
 					<hr />
 					<ul class="toc">
 						<li>

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -76,6 +76,7 @@
 				}
 			}
 		</style>
+		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -83,10 +84,7 @@
 		<div class="page-wrapper">
 			<!-- Header / TOC -->
 			<div class="page-content">
-				<center>
-					<p id="top"><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
-					<h1>COBOL Selection Constructs</h1>
-				</center>
+				<page-hero title="COBOL Selection Constructs"></page-hero>
 				<hr />
 				<ul class="toc">
 					<li>

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -28,16 +28,14 @@
 				}
 			}
 		</style>
+		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
 	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
-				<center>
-					<p id="top"><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
-					<h1>Introduction to Sequential Files</h1>
-				</center>
+				<page-hero title="Introduction to Sequential Files"></page-hero>
 				<hr />
 				<ul class="toc">
 					<li>

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -78,16 +78,14 @@
 				}
 			}
 		</style>
+		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
 	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
-				<center>
-					<p id="top"><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
-					<h1>Processing Sequential Files</h1>
-				</center>
+				<page-hero title="Processing Sequential Files"></page-hero>
 				<hr />
 				<ul class="toc">
 					<li>

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -9,16 +9,14 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
 	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
-				<center>
-					<p id="top"><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
-					<h1>Print files and variable-length records</h1>
-				</center>
+				<page-hero title="Print files and variable-length records"></page-hero>
 				<hr />
 				<ul class="toc">
 					<li>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -25,6 +25,7 @@
 				}
 			}
 		</style>
+		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -32,10 +33,7 @@
 		<div class="page-wrapper">
 			<div class="page-content">
 				<div>
-					<center>
-						<p id="top"><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
-						<h1>Sorting and Merging files</h1>
-					</center>
+					<page-hero title="Sorting and Merging files"></page-hero>
 					<hr />
 					<ul class="toc">
 						<li>

--- a/course/String.html
+++ b/course/String.html
@@ -9,17 +9,13 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
-				<center>
-					<p id="top">
-						<img alt="Cobol Tutorial" height="59" src="Resources/pics/t-CobolTut.gif" width="173" />
-					</p>
-					<h1>The STRING verb</h1>
-				</center>
+				<page-hero title="The STRING verb"></page-hero>
 				<hr />
 				<ul class="toc">
 					<li>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -37,16 +37,14 @@
 				}
 			}
 		</style>
+		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
 	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
-				<center>
-					<p id="top"><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
-					<h1>Subprograms</h1>
-				</center>
+				<page-hero title="Subprograms"></page-hero>
 				<hr />
 				<ul class="toc">
 					<li>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -9,16 +9,14 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
 	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
-				<center>
-					<p id="top"><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
-					<h1>Using Tables</h1>
-				</center>
+				<page-hero title="Using Tables"></page-hero>
 				<hr />
 				<ul class="toc">
 					<li>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -45,6 +45,7 @@
 				}
 			}
 		</style>
+		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -52,10 +53,7 @@
 		<div class="page-wrapper">
 			<div class="section-grid">
 				<div class="section-full">
-					<center>
-						<p id="top"><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
-						<h1>Creating Tables - syntax and semantics</h1>
-					</center>
+					<page-hero title="Creating Tables - syntax and semantics"></page-hero>
 					<hr />
 					<ul class="toc">
 						<li>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -9,17 +9,13 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
 		<div class="page-wrapper">
 			<div class="page-content">
-				<center>
-					<p id="top">
-						<img alt="" height="59" src="Resources/pics/t-CobolTut.gif" width="173" />
-					</p>
-					<h1>The UNSTRING verb</h1>
-				</center>
+				<page-hero title="The UNSTRING verb"></page-hero>
 				<hr />
 				<ul class="toc">
 					<li>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -9,6 +9,7 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -16,13 +17,8 @@
 		<div class="page-wrapper">
 			<div class="section-grid">
 				<div class="section-full">
-					<center>
-						<p id="top"><img height="59" src="Resources/pics/t-CobolTut.gif" width="173" /></p>
-					</center>
-					<center>
-						<h1>The USAGE clause</h1>
-						<hr />
-					</center>
+					<page-hero title="The USAGE clause"></page-hero>
+					<hr />
 					<ul class="toc">
 						<li>
 							<a href="#intro">Introduction</a><br />


### PR DESCRIPTION
## Summary

Phase 2 of the course-page modernization. Builds on the `course-components.css` scaffold from #175.

- New light-DOM custom element `<page-hero>` in `components/page-hero.js`.
- Adopted across **all 25 course pages** in place of the legacy hero block:
  ```html
  <center>
    <p id="top"><img src=".../t-CobolTut.gif" width="173" height="59" /></p>
    <h1>{TITLE}</h1>
  </center>
  ```
  becomes
  ```html
  <page-hero title="{TITLE}"></page-hero>
  ```
- Drops 25 deprecated `<center>` tags. 25 HTML files, 51 insertions / 115 deletions (-64 net lines of HTML).

## Why light DOM, not shadow DOM

`<copyright-notice>` uses shadow DOM because its content is fully self-contained boilerplate. `<page-hero>` contains the `<h1>` page title, the masthead image, and the `id="top"` anchor target — all of which need the existing `course.css` rules (link colors, `img { max-width: 100% }`, font inheritance) and the `.hero { text-align: center }` rule from `course-components.css`. Light DOM keeps those selectors applying.

## Why this is safe

Verified on http://localhost:8000/course/ with `python -m http.server 8000`:

- **Pixel-identical to legacy:** injected a synthesized `<center>...<h1>...</center>` sibling next to the upgraded `<page-hero>` and captured `getBoundingClientRect()` for both. H1 width, H1 center-x, IMG center-x, IMG size all matched to sub-pixel precision.
- Three known markup variants all transformed correctly:
  - Standard inline `<p>` (most pages, e.g. `COBOLIntro.html`, `Selection.html`).
  - Multi-line `<p>` (e.g. `RelativeFiles.html`, `IndexedFiles.html`, `String.html`).
  - **Special**: `Usage.html` had a split two-`<center>` form with `<hr/>` inside the second block — handled via a dedicated regex; the `<hr/>` is preserved as a sibling.
- Back-to-top anchor navigation tested: clicking `<a href="#top">` after scrolling to y=1500 jumps back to y≈27 — the `id="top"` anchor inside the upgraded element resolves correctly.
- Mobile @ 375×667: hero image and h1 still center within `body { margin: 4px }`.
- No console errors on COBOLIntro / Selection / Usage / RelativeFiles.

## Test plan

- [x] DevTools: `<page-hero>` upgrades to light DOM with the expected children (`.hero > p#top > img`, `.hero > h1`).
- [x] Pixel parity vs synthesized legacy `<center>` sibling (sub-pixel rect match).
- [x] Back-to-top anchor navigation lands on hero `#top`.
- [x] Mobile @ 375px viewport: hero centered, no overflow.
- [x] No console errors across COBOLIntro / Selection / Usage / RelativeFiles.

## Follow-ups (not in this PR)

3. `<back-to-top>` Web Component (~80–100 inline blocks).
4. `.data-table` rollout for legacy `<table border cellspacing cellpadding>`.
5. Migrate per-page `<style>` blocks into the shared sheet.
6. Mechanical attribute sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)