### PR TITLE
Course pages: <back-to-top> Web Component (Phase 3 of cleanup)

### DIFF
--- a/components/back-to-top.js
+++ b/components/back-to-top.js
@@ -1,0 +1,22 @@
+// Light-DOM custom element. Replaces the legacy back-to-top block:
+//   <p align="center">
+//     <a href="#top"><img border="0" height="38" src=".../i-pagetop.gif" width="132" /></a>
+//   </p>
+// (and the equivalent <div align="center"> form used in .page-footer).
+//
+// Light DOM (mandatory) so the global a:link/a:visited rules in course.css
+// keep applying — shadow DOM would isolate the anchor from those colors and
+// break the visited-state contract the surrounding pages rely on. The
+// .back-to-top class hooks the centering and 1em vertical-rhythm rules
+// already defined in course-components.css (Phase 1).
+class BackToTop extends HTMLElement {
+	connectedCallback() {
+		this.innerHTML = `
+			<div class="back-to-top">
+				<p><a href="#top"><img src="Resources/pics/i-pagetop.gif" width="132" height="38" alt="Back to top" /></a></p>
+			</div>
+		`;
+	}
+}
+
+customElements.define("back-to-top", BackToTop);

--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -75,6 +75,7 @@
 			}
 		</style>
 		<script src="../components/page-hero.js" defer></script>
+		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -160,11 +161,7 @@
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img src="Resources/pics/i-pagetop.gif" width="132" height="38" border="0"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 				<div class="section-header">
@@ -496,11 +493,7 @@
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img src="Resources/pics/i-pagetop.gif" width="132" height="38" border="0"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 				<div class="section-header">
@@ -727,11 +720,7 @@
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img src="Resources/pics/i-pagetop.gif" width="132" height="38" border="0"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 				<div class="section-header">
@@ -1030,11 +1019,7 @@ PROGRAM-ID.</code></pre>
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img src="Resources/pics/i-pagetop.gif" width="132" height="38" border="0"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 				<div class="section-header">
@@ -1240,9 +1225,7 @@ DisplayGreeting.
 				</div>
 				<div class="page-footer">
 					<hr />
-					<div align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</div>
+					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>
 				</div>
 			</div>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -10,6 +10,7 @@
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
+		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -89,9 +90,7 @@
 			<div class="page-content">
 				<div align="center">
 					<hr />
-					<p>
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</p>
+					<back-to-top></back-to-top>
 				</div>
 			</div>
 
@@ -373,9 +372,7 @@ The time is 14:41
 			<div class="page-content">
 				<div align="center">
 					<hr />
-					<p>
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</p>
+					<back-to-top></back-to-top>
 				</div>
 			</div>
 
@@ -485,9 +482,7 @@ The time is 14:41
 			<div class="page-content">
 				<div align="center">
 					<hr />
-					<p>
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</p>
+					<back-to-top></back-to-top>
 				</div>
 			</div>
 
@@ -988,9 +983,7 @@ The time is 14:41
 				</div>
 				<div class="page-footer">
 					<hr />
-					<div align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</div>
+					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>
 				</div>
 			</div>

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -34,6 +34,7 @@
 			}
 		</style>
 		<script src="../components/page-hero.js" defer></script>
+		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -155,11 +156,7 @@
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 				<!-- Section: Using the COPY verb -->
@@ -247,11 +244,7 @@
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 				<!-- Section: COPY Syntax and Semantics -->
@@ -455,11 +448,7 @@ COPY CopyFile4 IN EGLIB.</code></pre>
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 				<!-- Section: COPY examples -->
@@ -1034,9 +1023,7 @@ COPY CopyFile7 REPLACING N1 BY Num1
 			<!-- Footer -->
 			<div class="page-footer">
 				<hr />
-				<div align="center">
-					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-				</div>
+				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -57,6 +57,7 @@
 			}
 		</style>
 		<script src="../components/page-hero.js" defer></script>
+		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
@@ -143,11 +144,7 @@
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 				<div class="section-header">
@@ -372,11 +369,7 @@
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 				<div class="section-header">
@@ -514,11 +507,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 				<div class="section-header">
@@ -763,9 +752,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 				</div>
 				<div class="page-footer">
 					<hr />
-					<div align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</div>
+					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>
 				</div>
 			</div>

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -10,6 +10,7 @@
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
+		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -102,11 +103,7 @@
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 			</div>
@@ -289,11 +286,7 @@
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 			</div>
@@ -1197,11 +1190,7 @@
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 			</div>
@@ -1455,9 +1444,7 @@ B 0 / , + - CR DB 9</code></pre>
 
 			<div class="page-footer">
 				<hr />
-				<div align="center">
-					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-				</div>
+				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -16,6 +16,7 @@
 			}
 		</style>
 		<script src="../components/page-hero.js" defer></script>
+		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
@@ -115,9 +116,7 @@
 				</div>
 				<div>
 					<hr />
-					<p align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</p>
+					<back-to-top></back-to-top>
 				</div>
 				<!-- Programs -->
 				<div class="section-grid">
@@ -294,9 +293,7 @@ VIDEO STATUS :- 23</code></pre>
 				</div>
 				<div>
 					<hr />
-					<p align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</p>
+					<back-to-top></back-to-top>
 				</div>
 				<!-- Organization -->
 				<div class="section-grid">
@@ -408,9 +405,7 @@ END-IF</code></pre>
 				</div>
 				<div>
 					<hr />
-					<p align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</p>
+					<back-to-top></back-to-top>
 				</div>
 				<!-- Declarations -->
 				<div class="section-grid">
@@ -473,9 +468,7 @@ END-IF</code></pre>
 				</div>
 				<div>
 					<hr />
-					<p align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</p>
+					<back-to-top></back-to-top>
 				</div>
 				<hr />
 				<!-- File processing verbs -->
@@ -696,9 +689,7 @@ END-IF</code></pre>
 				</div>
 				<div>
 					<hr />
-					<p align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</p>
+					<back-to-top></back-to-top>
 				</div>
 				<!-- Comprehensive Example -->
 				<div class="section-grid">
@@ -1074,9 +1065,7 @@ ProcessOneBook.
 			</div>
 			<div class="page-footer">
 				<hr />
-				<div align="center">
-					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-				</div>
+				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -15,6 +15,7 @@
 			}
 		</style>
 		<script src="../components/page-hero.js" defer></script>
+		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
@@ -145,9 +146,7 @@
 			</div>
 			<div class="section-full">
 				<hr />
-				<p align="center">
-					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-				</p>
+				<back-to-top></back-to-top>
 			</div>
 			<div class="section-header">
 				<h2 id="inspect">Using the INSPECT</h2>
@@ -264,9 +263,7 @@ Begin.
 			</div>
 			<div class="section-full">
 				<hr />
-				<p align="center">
-					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-				</p>
+				<back-to-top></back-to-top>
 			</div>
 			<div class="section-header">
 				<h2 id="count">The counting INSPECT</h2>
@@ -305,9 +302,7 @@ INSPECT SourceLine TALLYING ECount
 			</div>
 			<div class="section-full">
 				<hr />
-				<p align="center">
-					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-				</p>
+				<back-to-top></back-to-top>
 			</div>
 			<div class="section-header">
 				<h2 id="replace">The replacing INSPECT</h2>
@@ -432,9 +427,7 @@ END-PERFORM</code></pre>
 			</div>
 			<div class="section-full">
 				<hr />
-				<p align="center">
-					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-				</p>
+				<back-to-top></back-to-top>
 			</div>
 			<div class="section-header">
 				<h2 id="combine">The combined INSPECT</h2>
@@ -449,9 +442,7 @@ END-PERFORM</code></pre>
 			</div>
 			<div class="section-full">
 				<hr />
-				<p align="center">
-					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-				</p>
+				<back-to-top></back-to-top>
 			</div>
 			<hr />
 			<div class="section-header">
@@ -581,9 +572,7 @@ END-PERFORM</code></pre>
 			</div>
 			<div class="page-footer">
 				<hr />
-				<div align="center">
-					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-				</div>
+				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -49,6 +49,7 @@
 			}
 		</style>
 		<script src="../components/page-hero.js" defer></script>
+		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
@@ -141,9 +142,7 @@
 
 				<div class="section-full">
 					<hr />
-					<p align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</p>
+					<back-to-top></back-to-top>
 				</div>
 
 				<!-- Section: Sequential files -->
@@ -318,9 +317,7 @@
 
 				<div class="section-full">
 					<hr />
-					<p align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</p>
+					<back-to-top></back-to-top>
 				</div>
 
 				<!-- Section: Relative Files -->
@@ -447,9 +444,7 @@
 
 				<div class="section-full">
 					<hr />
-					<p align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</p>
+					<back-to-top></back-to-top>
 				</div>
 
 				<!-- Section: Indexed Files -->
@@ -552,9 +547,7 @@ END-IF</code></pre>
 
 				<div class="section-full">
 					<hr />
-					<p align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</p>
+					<back-to-top></back-to-top>
 				</div>
 
 				<!-- Section: Comparison -->
@@ -943,7 +936,7 @@ END-IF</code></pre>
 
 			<div class="page-footer">
 				<hr />
-				<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
+				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -91,6 +91,7 @@
 			}
 		</style>
 		<script src="../components/page-hero.js" defer></script>
+		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -253,11 +254,7 @@
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 				<div class="section-header">
@@ -615,11 +612,7 @@ ThreeLevelsDown.
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 				<div class="section-header">
@@ -750,11 +743,7 @@ SumSalesExit.
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 				<div class="section-header">
@@ -887,11 +876,7 @@ OutOfLineEG.
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 				<div class="section-header">
@@ -1051,11 +1036,7 @@ END-PERFORM</code></pre>
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 				<div class="section-header">
@@ -1279,9 +1260,7 @@ CountMileage.
 				</div>
 				<div class="page-footer">
 					<hr />
-					<div align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</div>
+					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>
 				</div>
 			</div>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -52,6 +52,7 @@
 			}
 		</style>
 		<script src="../components/page-hero.js" defer></script>
+		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
@@ -141,13 +142,7 @@
 				</div>
 				<div class="section-full">
 					<hr />
-					<div align="center">
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
-					</div>
+					<back-to-top></back-to-top>
 				</div>
 			</div>
 			<!-- Reference Modification -->
@@ -1219,9 +1214,7 @@ Begin.
 			</div>
 			<div class="page-footer">
 				<hr />
-				<div align="center">
-					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-				</div>
+				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -38,6 +38,7 @@
 			}
 		</style>
 		<script src="../components/page-hero.js" defer></script>
+		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
@@ -126,9 +127,7 @@
 			</div>
 			<div class="section-full">
 				<hr />
-				<p align="center">
-					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-				</p>
+				<back-to-top></back-to-top>
 			</div>
 			<div class="section-header">
 				<h2 id="progs">A look at some programs that use Relative files</h2>
@@ -209,9 +208,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-full">
 				<hr />
-				<p align="center">
-					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-				</p>
+				<back-to-top></back-to-top>
 			</div>
 			<div class="section-header">
 				<h2 id="declar">Relative file - Declarations</h2>
@@ -303,9 +300,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-full">
 				<hr />
-				<p align="center">
-					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-				</p>
+				<back-to-top></back-to-top>
 			</div>
 			<div class="section-header">
 				<h2 id="verbs">Relative file - file processing verbs</h2>
@@ -594,9 +589,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-full">
 				<hr />
-				<p align="center">
-					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-				</p>
+				<back-to-top></back-to-top>
 			</div>
 			<div class="section-header">
 				<h2 id="declaratives">Introduction to Declaratives</h2>
@@ -716,9 +709,7 @@ Begin.</code></pre>
 			</div>
 			<div class="page-footer">
 				<hr />
-				<div align="center">
-					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-				</div>
+				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -16,6 +16,7 @@
 			}
 		</style>
 		<script src="../components/page-hero.js" defer></script>
+		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -137,11 +138,7 @@
 					<div class="section-full">
 						<div align="center">
 							<hr />
-							<p>
-								<a href="#top"
-									><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-								/></a>
-							</p>
+							<back-to-top></back-to-top>
 						</div>
 					</div>
 
@@ -996,11 +993,7 @@ Programmer - Michael Coughlan               Page :  1 </code></pre>
 
 					<div class="page-footer">
 						<hr />
-						<div align="center">
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</div>
+						<back-to-top></back-to-top>
 						<copyright-notice></copyright-notice>
 					</div>
 				</div>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -10,6 +10,7 @@
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
+		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -128,11 +129,7 @@
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 				<div class="section-header">
@@ -1172,9 +1169,7 @@ END DECLARATIVES.</code></pre>
 			</div>
 			<div class="page-footer">
 				<hr />
-				<div align="center">
-					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-				</div>
+				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>

--- a/course/Search.html
+++ b/course/Search.html
@@ -10,6 +10,7 @@
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
+		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -142,11 +143,7 @@
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 				<div class="section-header">
@@ -246,11 +243,7 @@
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 				<div class="section-header">
@@ -560,11 +553,7 @@ DisplayCountyTaxes.
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 				<div class="section-header">
@@ -823,11 +812,7 @@ END-SEARCH</code></pre>
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 				<div class="section-header">
@@ -1122,9 +1107,7 @@ DisplayCountyTaxes.
 			</div>
 			<div class="page-footer">
 				<hr />
-				<div align="center">
-					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-				</div>
+				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -77,6 +77,7 @@
 			}
 		</style>
 		<script src="../components/page-hero.js" defer></script>
+		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -178,11 +179,7 @@
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 			</div>
@@ -778,11 +775,7 @@ END-IF
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 			</div>
@@ -965,11 +958,7 @@ END-IF
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 			</div>
@@ -1106,11 +1095,7 @@ Begin.
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 			</div>
@@ -1431,9 +1416,7 @@ END-EVALUATE
 
 				<div class="page-footer">
 					<hr />
-					<div align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</div>
+					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>
 				</div>
 			</div>

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -29,6 +29,7 @@
 			}
 		</style>
 		<script src="../components/page-hero.js" defer></script>
+		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -140,11 +141,7 @@
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 			</div>
@@ -281,11 +278,7 @@
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 			</div>
@@ -533,11 +526,7 @@ SELECT StudentFile
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 			</div>
@@ -814,9 +803,7 @@ GetStudentRecord.
 			</div>
 			<div class="page-footer">
 				<hr />
-				<div align="center">
-					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-				</div>
+				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -79,6 +79,7 @@
 			}
 		</style>
 		<script src="../components/page-hero.js" defer></script>
+		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -165,11 +166,7 @@
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 			</div>
@@ -284,11 +281,7 @@
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 			</div>
@@ -417,11 +410,7 @@
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 			</div>
@@ -612,9 +601,7 @@ END-PERFORM
 			</div>
 			<div class="page-footer">
 				<hr />
-				<div align="center">
-					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-				</div>
+				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -10,6 +10,7 @@
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
+		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -107,11 +108,7 @@
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 			</div>
@@ -435,11 +432,7 @@ FD TransFile.
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 			</div>
@@ -731,11 +724,7 @@ PrintPageHeadings.
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 			</div>
@@ -956,9 +945,7 @@ DisplayTransactions.
 				</div>
 				<div class="page-footer">
 					<hr />
-					<div align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</div>
+					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>
 				</div>
 			</div>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -26,6 +26,7 @@
 			}
 		</style>
 		<script src="../components/page-hero.js" defer></script>
+		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -154,9 +155,7 @@
 				</div>
 				<div class="section-full">
 					<hr />
-					<p align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</p>
+					<back-to-top></back-to-top>
 				</div>
 			</div>
 			<!-- Simple Sorting -->
@@ -628,9 +627,7 @@ etc.</code></pre>
 				</div>
 				<div class="section-full">
 					<hr />
-					<p align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</p>
+					<back-to-top></back-to-top>
 				</div>
 			</div>
 			<!-- SORTing with an INPUT PROCEDURE -->
@@ -1040,9 +1037,7 @@ GetStudentDetails.
 				</div>
 				<div class="section-full">
 					<hr />
-					<p align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</p>
+					<back-to-top></back-to-top>
 				</div>
 			</div>
 			<!-- Sorting with an OUTPUT PROCEDURE -->
@@ -1400,9 +1395,7 @@ PrintReportBody.
 				</div>
 				<div class="section-full">
 					<hr />
-					<p align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</p>
+					<back-to-top></back-to-top>
 				</div>
 			</div>
 			<!-- MERGEing files -->
@@ -1552,9 +1545,7 @@ Begin.
 			</div>
 			<div class="page-footer">
 				<hr />
-				<div align="center">
-					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-				</div>
+				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>

--- a/course/String.html
+++ b/course/String.html
@@ -10,6 +10,7 @@
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
+		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
@@ -73,9 +74,7 @@
 				</div>
 				<div class="section-full">
 					<hr />
-					<p align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</p>
+					<back-to-top></back-to-top>
 				</div>
 			</div>
 			<div class="section-grid">
@@ -252,9 +251,7 @@ END-STRING.</code></pre>
 				</div>
 				<div class="section-full">
 					<hr />
-					<p align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</p>
+					<back-to-top></back-to-top>
 				</div>
 			</div>
 			<div class="section-grid">
@@ -411,9 +408,7 @@ END-STRING.</code></pre>
 			</div>
 			<div class="page-footer">
 				<hr />
-				<div align="center">
-					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-				</div>
+				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -38,6 +38,7 @@
 			}
 		</style>
 		<script src="../components/page-hero.js" defer></script>
+		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -165,9 +166,7 @@
 				</div>
 				<div class="section-full">
 					<hr />
-					<p align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</p>
+					<back-to-top></back-to-top>
 				</div>
 			</div>
 			<!-- The CALL verb -->
@@ -699,9 +698,7 @@ CALL "Fickle" USING BY CONTENT IncValue.</code></pre>
 				</div>
 				<div class="section-full">
 					<hr />
-					<p align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</p>
+					<back-to-top></back-to-top>
 				</div>
 			</div>
 			<!-- Contained Subprograms -->
@@ -1191,9 +1188,7 @@ Value - 0</code></pre>
 			</div>
 			<div class="page-footer">
 				<hr />
-				<div align="center">
-					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-				</div>
+				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -10,6 +10,7 @@
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
+		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -103,11 +104,7 @@
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 			</div>
@@ -250,11 +247,7 @@ DISPLAY "County 3 total is ", County3TaxTotal
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 			</div>
@@ -371,11 +364,7 @@ Begin.
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 			</div>
@@ -472,11 +461,7 @@ Begin.
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 			</div>
@@ -598,9 +583,7 @@ Begin.
 
 			<div class="page-footer">
 				<hr />
-				<div align="center">
-					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-				</div>
+				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -46,6 +46,7 @@
 			}
 		</style>
 		<script src="../components/page-hero.js" defer></script>
+		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -153,11 +154,7 @@
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 
@@ -451,11 +448,7 @@
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 
@@ -654,11 +647,7 @@ DisplayCountyTaxes.
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 
@@ -1001,11 +990,7 @@ ADD 56 TO PopTotal(12,3,2)</code></pre>
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 
@@ -1399,9 +1384,7 @@ DisplayCountyTaxes.
 				</div>
 				<div class="page-footer">
 					<hr />
-					<div align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</div>
+					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>
 				</div>
 			</div>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -10,6 +10,7 @@
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
+		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
@@ -82,9 +83,7 @@
 				</div>
 				<div class="section-full">
 					<hr />
-					<p align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</p>
+					<back-to-top></back-to-top>
 				</div>
 			</div>
 			<div class="section-grid">
@@ -330,9 +329,7 @@ END-UNSTRING.</code></pre>
 				</div>
 				<div class="section-full">
 					<hr />
-					<p align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</p>
+					<back-to-top></back-to-top>
 				</div>
 			</div>
 			<div class="section-grid">
@@ -489,9 +486,7 @@ Begin.
 				</div>
 				<div class="section-full">
 					<hr />
-					<p align="center">
-						<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-					</p>
+					<back-to-top></back-to-top>
 				</div>
 			</div>
 			<div class="section-grid">
@@ -547,9 +542,7 @@ Begin.
 			</div>
 			<div class="page-footer">
 				<hr />
-				<div align="center">
-					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-				</div>
+				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -10,6 +10,7 @@
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
+		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -109,11 +110,7 @@
 				<div class="section-full">
 					<div align="center">
 						<hr />
-						<p>
-							<a href="#top"
-								><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132"
-							/></a>
-						</p>
+						<back-to-top></back-to-top>
 					</div>
 				</div>
 				<div class="section-header">
@@ -2331,9 +2328,7 @@ Begin.
 			</div>
 			<div class="page-footer">
 				<hr />
-				<div align="center">
-					<a href="#top"><img border="0" height="38" src="Resources/pics/i-pagetop.gif" width="132" /></a>
-				</div>
+				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>


### PR DESCRIPTION
## Summary

Phase 3 of the course-page modernization. Builds on the `<page-hero>` component from #176.

- New light-DOM custom element `<back-to-top>` in `components/back-to-top.js`.
- Replaces **103 inline back-to-top blocks** across all 25 course pages with `<back-to-top></back-to-top>`.
- 26 files changed, 151 insertions / 408 deletions (-257 net lines of HTML).

## Why light DOM is mandatory here

`a:visited` is the visual contract of the back-to-top button — it turns red after first use, signaling navigation history. Shadow DOM would isolate the anchor from the global `a:link` / `a:visited` rules in `course.css` and break that contract. Light DOM keeps `course.css` selectors applying.

The `.back-to-top` class on the rendered wrapper hooks rules from `course-components.css` (Phase 1):

- `.back-to-top { text-align: center; margin: 1em 0 }` — matches the legacy `<p align="center">` rendering.
- `.page-footer .back-to-top { margin: 0 }` — matches the legacy `<div align="center">` rendering inside `.page-footer`.

## Markup variants handled

The replacement covered four observed variants via two regexes (`<p>`-form, `<div>`-form) plus one targeted Edit:

1. `<p align="center"><a href="#top"><img.../></a></p>` (most common).
2. Multi-line `<p>` with no `align` (RefMod, Iteration, DataDeclaration).
3. `<div align="center">...</div>` inside `.page-footer`.
4. Bare `<a>...</a>` in `Intro2DirectAccess.html` footer (handled directly).

In `RefMod.html`, one block had a redundant outer `<div align="center">` wrapping the inner `<p>`. That outer wrapper is now stripped since `<back-to-top>` self-centers — no visual change, just removes empty centering nesting.

## Why this is safe

Verified on http://localhost:8000/course/ with `python -m http.server 8000`:

- Component upgrades to light DOM with `.back-to-top > p > a > img` structure.
- Computed link color: `rgb(0, 0, 255)` — proves `a:link` from `course.css` reaches the upgraded anchor (light-DOM proof).
- **Pixel-identical to legacy `<p align="center">`**: synthesized a sibling and compared `getBoundingClientRect()` for the image — center-x and size match to sub-pixel precision.
- Section-context margins: 16px top/bottom (matches `<p>` default).
- Footer-context margins: 0px (matches `<div>` default).
- Mobile @ 375×667: image centered within `page-wrapper`, no overflow.
- Zero `i-pagetop.gif` references remain in `course/*.html`.
- No console errors on COBOLIntro / RefMod.

## Test plan

- [x] DevTools: every `<back-to-top>` upgrades; computed `a:link` color is blue.
- [x] Pixel parity vs synthesized legacy `<p align="center">` sibling.
- [x] Footer-context margin override fires (`.page-footer .back-to-top { margin: 0 }`).
- [x] Mobile @ 375px viewport.
- [x] No console errors.

## Follow-ups (not in this PR)

4. `.data-table` rollout for legacy `<table border cellspacing cellpadding>`.
5. Migrate per-page `<style>` blocks into the shared sheet.
6. Mechanical attribute sweep (`border="0"` on imgs, `align/size/width` on `<hr>`, residual `<div align="center">` wrappers, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)