### PR TITLE
Add OS-driven dark mode via CSS custom properties

### DIFF
--- a/course/Resources/css/course-components.css
+++ b/course/Resources/css/course-components.css
@@ -54,7 +54,7 @@ ul.construct-list {
 	list-style-image: url(../pics/BallRedG.gif);
 	font-family: Arial, Helvetica, sans-serif;
 	font-weight: bold;
-	color: #000099;
+	color: var(--color-emphasis);
 	font-size: 1.5em;
 	padding-left: 4em;
 }
@@ -88,14 +88,14 @@ ul.construct-list li {
 }
 
 .code-section.white-bg {
-	background-color: #ffffff;
+	background-color: var(--color-bg);
 }
 
 /* DataDeclaration.html */
 
 .code-record {
-	background-color: #e1ffe1;
-	border: 1px solid black;
+	background-color: var(--color-code-bg);
+	border: 1px solid;
 	width: fit-content;
 	max-width: 90%;
 	margin: 0.5em auto;
@@ -106,7 +106,7 @@ ul.construct-list li {
 	font-weight: bold;
 	text-align: center;
 	padding: 4px;
-	border-bottom: 1px solid black;
+	border-bottom: 1px solid;
 }
 
 .code-record pre {
@@ -175,7 +175,7 @@ ol.spaced > li + li {
 }
 
 .processing-template-header {
-	background-color: #ffffcc;
+	background-color: var(--color-panel-bg);
 	text-align: center;
 	padding: 5px;
 	border-bottom: 1px solid;
@@ -187,7 +187,7 @@ ol.spaced > li + li {
 }
 
 .saq-table {
-	background-color: #e1ffe1;
+	background-color: var(--color-code-bg);
 	border: 1px solid;
 	margin: 0 auto;
 	overflow: hidden;
@@ -204,7 +204,7 @@ ol.spaced > li + li {
 }
 
 .saq-label {
-	background-color: #ffffcc;
+	background-color: var(--color-panel-bg);
 	padding: 4px 8px;
 	font-weight: bold;
 	border-right: 1px solid;
@@ -238,7 +238,7 @@ ol.spaced > li + li {
 }
 
 .results-box {
-	background-color: #ddffff;
+	background-color: var(--color-results-bg);
 	border: 2px solid;
 	padding: 7px;
 	max-width: 366px;
@@ -321,13 +321,13 @@ ol.spaced > li + li {
 }
 
 .condition-types-box .box-header {
-	background-color: #ffffcc;
+	background-color: var(--color-panel-bg);
 	padding: 7px;
 	text-align: center;
 }
 
 .condition-types-box .box-body {
-	background-color: #e1ffe1;
+	background-color: var(--color-code-bg);
 	padding: 7px;
 }
 
@@ -343,7 +343,7 @@ ol.spaced > li + li {
 .qa-form .qa-row {
 	display: grid;
 	grid-template-columns: 8% 62% 30%;
-	border-bottom: 1px solid #ccc;
+	border-bottom: 1px solid var(--color-border-soft);
 }
 
 .qa-form .qa-row:last-child {
@@ -351,19 +351,19 @@ ol.spaced > li + li {
 }
 
 .qa-form .qa-label {
-	background-color: #ffffcc;
+	background-color: var(--color-panel-bg);
 	padding: 4px 8px;
-	border-right: 1px solid #ccc;
+	border-right: 1px solid var(--color-border-soft);
 }
 
 .qa-form .qa-question {
-	background-color: #e1ffe1;
+	background-color: var(--color-code-bg);
 	padding: 4px 8px;
-	border-right: 1px solid #ccc;
+	border-right: 1px solid var(--color-border-soft);
 }
 
 .qa-form .qa-answer {
-	background-color: #e1ffe1;
+	background-color: var(--color-code-bg);
 	padding: 4px 8px;
 	overflow: hidden;
 }
@@ -377,7 +377,7 @@ ol.spaced > li + li {
 /* SortMerge.html */
 
 .spec-block {
-	background-color: #e1ffe1;
+	background-color: var(--color-code-bg);
 	border: 1px solid;
 	padding: 10px;
 	max-width: 500px;
@@ -399,7 +399,7 @@ ol.spaced > li + li {
 }
 
 .code-run-pair .run-part {
-	background-color: #ffffff;
+	background-color: var(--color-bg);
 	padding: 5px;
 	border-left: 1px solid;
 }
@@ -423,7 +423,7 @@ ol.spaced > li + li {
 	/* Iteration.html */
 	.saq-row {
 		display: block;
-		border-bottom: 2px solid #999;
+		border-bottom: 2px solid var(--color-border-mute);
 	}
 
 	.saq-label {
@@ -475,7 +475,7 @@ ol.spaced > li + li {
 	/* SequentialFiles2.html */
 	.qa-form .qa-row {
 		display: block;
-		border-bottom: 2px solid #999;
+		border-bottom: 2px solid var(--color-border-mute);
 		margin-bottom: 0;
 	}
 

--- a/course/Resources/css/course.css
+++ b/course/Resources/css/course.css
@@ -1,13 +1,63 @@
+:root {
+	color-scheme: light dark;
+
+	--color-bg: #ffffff;
+	--color-text: #000000;
+
+	--color-link: #0000ff;
+	--color-link-visited: #ff0000;
+	--color-link-active: #009b00;
+
+	--color-header-bg: #993300;
+	--color-header-text: #ffff00;
+	--color-panel-bg: #ffffcc;
+	--color-panel-text: #800000;
+	--color-code-bg: #e1ffe1;
+	--color-results-bg: #ddffff;
+	--color-emphasis: #000099;
+
+	--color-border: currentColor;
+	--color-border-soft: #cccccc;
+	--color-border-mute: #999999;
+}
+
+@media (prefers-color-scheme: dark) {
+	:root {
+		--color-bg: #1a1a1a;
+		--color-text: #e6e6e6;
+
+		--color-link: #6ea8ff;
+		--color-link-visited: #ff8a8a;
+		--color-link-active: #6ee06e;
+
+		--color-header-bg: #6b2400;
+		--color-header-text: #ffe066;
+		--color-panel-bg: #3a3520;
+		--color-panel-text: #ffb3b3;
+		--color-code-bg: #1f2e1f;
+		--color-results-bg: #1a2e2e;
+		--color-emphasis: #8aa8ff;
+
+		--color-border-soft: #444444;
+		--color-border-mute: #666666;
+	}
+}
+
+body {
+	background-color: var(--color-bg);
+	color: var(--color-text);
+}
+
 a:link {
-	color: #0000ff;
+	color: var(--color-link);
 }
 
 a:visited {
-	color: #ff0000;
+	color: var(--color-link-visited);
 }
 
 a:active {
-	color: #009b00;
+	color: var(--color-link-active);
 }
 
 img {
@@ -127,14 +177,43 @@ ul.toc a {
 	font-size: larger;
 }
 
+/* Recolor legacy <td bgcolor="..."> attribute markup via CSS background-color,
+   which wins over the deprecated HTML attribute. Lets the theme tokens drive
+   colors on pages that haven't been migrated to component classes. */
+td[bgcolor="#993300"] {
+	background-color: var(--color-header-bg);
+}
+
+td[bgcolor="#FFFFCC"],
+td[bgcolor="#ffffcc"] {
+	background-color: var(--color-panel-bg);
+}
+
+td[bgcolor="#FFFFFF"],
+td[bgcolor="#ffffff"] {
+	background-color: var(--color-bg);
+}
+
+td[bgcolor="#E1FFE1"],
+td[bgcolor="#e1ffe1"] {
+	background-color: var(--color-code-bg);
+}
+
+td[bgcolor="#DDFFFF"],
+td[bgcolor="#ddffff"] {
+	background-color: var(--color-results-bg);
+}
+
 td[bgcolor="#993300"] h2 {
-	color: #ffff00;
+	color: var(--color-header-text);
 	font-family: Arial, Helvetica, sans-serif;
 }
 
 td[bgcolor="#FFFFCC"] h3,
-td[bgcolor="#FFFFCC"] h4 {
-	color: #800000;
+td[bgcolor="#FFFFCC"] h4,
+td[bgcolor="#ffffcc"] h3,
+td[bgcolor="#ffffcc"] h4 {
+	color: var(--color-panel-text);
 	font-family: Arial, Helvetica, sans-serif;
 }
 
@@ -165,7 +244,7 @@ td[bgcolor="#FFFFCC"] h4 {
 
 .section-header {
 	grid-column: 1 / -1;
-	background-color: #993300;
+	background-color: var(--color-header-bg);
 	padding: 4px;
 	min-width: 0;
 	text-align: center;
@@ -173,20 +252,20 @@ td[bgcolor="#FFFFCC"] h4 {
 
 .section-header h2,
 .section-header h3 {
-	color: #ffff00;
+	color: var(--color-header-text);
 	font-family: Arial, Helvetica, sans-serif;
 	margin: 0.3em 0;
 }
 
 .section-sidebar {
-	background-color: #ffffcc;
+	background-color: var(--color-panel-bg);
 	padding: 4px;
 	min-width: 0;
 }
 
 .section-sidebar h3,
 .section-sidebar h4 {
-	color: #800000;
+	color: var(--color-panel-text);
 	font-family: Arial, Helvetica, sans-serif;
 }
 
@@ -211,5 +290,118 @@ td[bgcolor="#FFFFCC"] h4 {
 	.section-sidebar h4,
 	.section-sidebar p {
 		margin: 0.2em 0;
+	}
+}
+
+/* ============================================================================
+   Dark-mode overrides
+   The :root token swap above handles backgrounds and text. The rules below
+   handle three things tokens can't reach: Prism's token colors (defined in
+   the vendor stylesheet), light-background images that need inversion, and
+   inline `style="color: #..."` highlights baked into legacy code samples.
+   ============================================================================ */
+@media (prefers-color-scheme: dark) {
+	/* Prism syntax highlighting — re-color the vendor light theme. The `body`
+	   prefix lifts specificity to (0,1,2) so these win against prism.min.css's
+	   (0,1,1) selectors despite the vendor sheet loading after course.css. */
+	body pre[class*="language-"],
+	body code[class*="language-"] {
+		background: #1f1f1f;
+		color: #e6e6e6;
+		text-shadow: none;
+	}
+
+	body :not(pre) > code[class*="language-"] {
+		background: #1f1f1f;
+	}
+
+	body .token.comment,
+	body .token.prolog,
+	body .token.doctype,
+	body .token.cdata {
+		color: #8a8a8a;
+	}
+
+	body .token.punctuation {
+		color: #c8c8c8;
+	}
+
+	body .token.keyword,
+	body .token.tag,
+	body .token.selector,
+	body .token.atrule {
+		color: #ff9d6e;
+	}
+
+	body .token.string,
+	body .token.attr-value,
+	body .token.char,
+	body .token.builtin,
+	body .token.inserted {
+		color: #b5e8a3;
+	}
+
+	body .token.number,
+	body .token.boolean,
+	body .token.constant,
+	body .token.symbol,
+	body .token.deleted {
+		color: #f8d57e;
+	}
+
+	body .token.function,
+	body .token.class-name {
+		color: #90c8ff;
+	}
+
+	body .token.operator,
+	body .token.entity,
+	body .token.url,
+	body .token.variable,
+	body .language-css .token.string,
+	body .style .token.string {
+		color: #d8a0ff;
+		background: transparent;
+	}
+
+	/* Light-background diagrams and decorative GIFs invert to read on dark.
+	   `0.92` keeps blacks just shy of pure white so they merge into the page;
+	   `hue-rotate(180deg)` recovers reds/greens. Photos opt out by extension
+	   or by adding `class="no-invert"` to the <img>. */
+	img {
+		filter: invert(0.92) hue-rotate(180deg);
+	}
+
+	img.no-invert,
+	img[src$=".jpg"],
+	img[src$=".jpeg"],
+	img[src$=".JPG"],
+	img[src$=".JPEG"] {
+		filter: none;
+	}
+
+	/* Override inline `style="color: #..."` spans baked into legacy code
+	   samples. These attribute selectors target the raw inline value, so
+	   `!important` is required to beat the inline declaration. */
+	[style*="color:#0000ff"],
+	[style*="color: #0000ff"],
+	[style*="color:#0000FF"],
+	[style*="color: #0000FF"] {
+		color: var(--color-link) !important;
+	}
+
+	[style*="color:#993300"],
+	[style*="color: #993300"] {
+		color: #ff9966 !important;
+	}
+
+	[style*="color:#000099"],
+	[style*="color: #000099"] {
+		color: var(--color-emphasis) !important;
+	}
+
+	[style*="color:#800000"],
+	[style*="color: #800000"] {
+		color: var(--color-panel-text) !important;
 	}
 }


### PR DESCRIPTION
## Summary

- Adds dark mode that follows the reader's OS preference via `@media (prefers-color-scheme: dark)`. Zero JavaScript, zero new vendor files, zero HTML edits across the ~25 main course pages.
- Refactors `course.css` and `course-components.css` to drive every panel/text/link color from a small set of semantic CSS custom properties (`--color-bg`, `--color-panel-bg`, `--color-header-bg`, `--color-link`, etc.). Light-mode values exactly match the original palette.
- Recolors legacy `<td bgcolor="...">` markup via attribute selectors so the deprecated HTML attribute is overridden by CSS in both modes — no edits to the bulk pages still using `bgcolor=""`.
- Overrides Prism's vendor light theme inside the dark media query (the rules are prefixed with `body` to lift specificity above `prism.min.css`, which loads after `course.css`).
- Inverts light-background diagrams/decorative GIFs in dark mode with `filter: invert(0.92) hue-rotate(180deg)`; photos and `.no-invert` images opt out.
- Targets inline `style="color: #..."` spans baked into legacy code samples with attribute selectors + `!important` for the four colors that fail contrast on dark (`#0000ff`, `#993300`, `#000099`, `#800000`).
- Adds `color-scheme: light dark;` so native form controls, scrollbars, and the embedded PDF.js viewer chrome render in matching colors.

## Scope

In scope: the 25 pages in `course/*.html` that already link `course.css` + `course-components.css`. Out of scope (clean follow-ups): lectures, examples, exercises, and FAQ pages, which don't link the shared stylesheets and remain light-only until a mechanical `<link>` sweep adopts `course.css` across them. A manual `<theme-toggle>` web component with localStorage override is also a deliberate follow-up — the user opted for OS-preference-only.

## Verification

Tested locally with the http-server preview (`npx http-server`) and Chrome DevTools' `prefers-color-scheme` emulation:

- [x] Light mode: body, `.section-header`, `.section-sidebar`, `.processing-template-header`, `.saq-table`, `.code-record`, Prism `pre`, and `a:link` all resolve to their original hex values exactly.
- [x] Dark mode: same elements resolve to dark tokens (`#1a1a1a` bg, `#6b2400` header, `#3a3520` panel, `#1f2e1f` code, `#6ea8ff` links).
- [x] Legacy `<td bgcolor="#FFFFCC">` on `course/COBOLcommands.html` recolors to the dark panel tone via attribute selector.
- [x] Inline `style="color: #0000ff"` on `course/Subprograms.html` is overridden to the dark link blue (`#6ea8ff`).
- [x] Prism keywords / strings / numbers render orange / green / gold on a `#1f1f1f` code background.
- [x] Image-inversion filter applies to GIF diagrams; JPEG photos opt out by extension.
- [x] No console errors.

## Test plan

- [ ] Toggle the OS-level dark mode (Windows: Settings → Personalization → Colors; macOS: System Settings → Appearance) and reload `course/COBOLIntro.html`, `course/Iteration.html`, `course/Selection.html`, `course/SequentialFiles2.html`, `course/DataDeclaration.html`, `course/COBOLcommands.html`, and `course/index.html`.
- [ ] Confirm the maroon header band, yellow sidebars, green code panels, and Prism syntax highlighting all read well on dark.
- [ ] Spot-check a flowchart-heavy page (e.g. `course/Iteration.html` for Perform diagrams, `course/Selection.html` for condition flowcharts) — note any image where `filter: invert(...)` produces a poor result; those become candidates for `class="no-invert"` in a follow-up.
- [ ] Run an axe-devtools / Lighthouse contrast pass on the dark variant of `course/Selection.html` (heaviest inline color usage) to flag any AA failures.
- [ ] Confirm light mode is visually unchanged from `master` on the same set of pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)