### PR TITLE
Add preliminary dark mode to course/index.html

### DIFF
--- a/course/index.html
+++ b/course/index.html
@@ -23,6 +23,9 @@
 		<meta name="robots" content="All" />
 		<meta name="rating" content="General" />
 		<style type="text/css">
+			:root {
+				color-scheme: light dark;
+			}
 			body {
 				color: #000000;
 				background-color: #ffffff;
@@ -149,6 +152,43 @@
 				/* Topic sections stack vertically on mobile */
 				.course-topics {
 					grid-template-columns: 1fr;
+				}
+			}
+
+			/* Preliminary dark mode. Token values mirror course.css so this page
+			   feels consistent with the rest of the dark-themed lessons. */
+			@media (prefers-color-scheme: dark) {
+				body {
+					color: #e6e6e6;
+					background-color: #1a1a1a;
+				}
+				a:link {
+					color: #6ea8ff;
+				}
+				a:visited {
+					color: #ff8a8a;
+				}
+				a:active {
+					color: #6ee06e;
+				}
+				.topic-label {
+					background-color: #3a3520;
+				}
+				.topic-links {
+					background-color: #1a1a1a;
+				}
+				.topic-divider {
+					background-color: #b3334d;
+				}
+				img {
+					filter: invert(0.92) hue-rotate(180deg);
+				}
+				img.no-invert,
+				img[src$=".jpg"],
+				img[src$=".jpeg"],
+				img[src$=".JPG"],
+				img[src$=".JPEG"] {
+					filter: none;
 				}
 			}
 		</style>


### PR DESCRIPTION
## Summary

The course landing page (`course/index.html`) keeps all its styling in an inline `<style>` block and doesn't link `course.css`, so the OS-preference dark mode added in #180 didn't reach it. This PR appends a self-contained `@media (prefers-color-scheme: dark)` block to that same inline style.

The token values mirror those used in `course.css`, so the landing page reads coherently with the lesson pages it links to:

- `body` → `#1a1a1a` bg / `#e6e6e6` text
- Links → `#6ea8ff` link / `#ff8a8a` visited / `#6ee06e` active
- `.topic-label` (the per-section yellow band) → `#3a3520`
- `.topic-links` (the white panel) → `#1a1a1a`
- `.topic-divider` (the maroon hairline between sections) → `#b3334d`
- Light-background icons (`i-Tut.gif`, `i-exercise.gif`, `BallRedG.gif`, `T-Dept.gif`) inverted with `filter: invert(0.92) hue-rotate(180deg)`
- `color-scheme: light dark;` declared at `:root` so native form controls, scrollbars, and the canvas backdrop render in matching colors

This is deliberately minimal — no refactor of the existing inline rules, no new dependencies, nothing new in light mode.

## Verification

Tested locally with `prefers-color-scheme` emulation:

- [x] Dark mode: body, `.topic-label`, `.topic-links`, `.topic-divider`, and `a:link` all resolve to the dark token values listed above.
- [x] Light mode: every same selector resolves to its original hex value (`#ffffff`, `#ffffcc`, `#ffffff`, `#990033`, `#0000ff`) — unchanged from `master`.
- [x] Image inversion handles the tutorial / exercise / SAQ icons; JPEG photos opt out by extension.

## Test plan

- [ ] Toggle the OS dark-mode setting and reload `course/index.html`. Confirm the page is fully legible on dark and visually consistent with the linked-to lesson pages (e.g., click through to `course/COBOLIntro.html` — the maroon-yellow theme should feel continuous).
- [ ] Toggle back to light. Confirm pixel-for-pixel match with the previous appearance.
- [ ] Run a contrast check on the dark variant — particularly the `.topic-label` text on `#3a3520` and the link colors on `#1a1a1a`.

## Follow-ups (out of scope)

- Adopting `course.css` across the ~115 other pages that still link nothing shared (lectures, examples, exercises, FAQ, root `index.html`).
- A manual `<theme-toggle>` web component if OS-preference-only proves limiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)