### PR TITLE
Fix invisible #E8E8E8 label cells in dark mode

### DIFF
--- a/course/Resources/css/course.css
+++ b/course/Resources/css/course.css
@@ -14,6 +14,7 @@
 	--color-panel-text: #800000;
 	--color-code-bg: #e1ffe1;
 	--color-results-bg: #ddffff;
+	--color-cell-label-bg: #e8e8e8;
 	--color-emphasis: #000099;
 
 	--color-border: currentColor;
@@ -36,6 +37,7 @@
 		--color-panel-text: #ffb3b3;
 		--color-code-bg: #1f2e1f;
 		--color-results-bg: #1a2e2e;
+		--color-cell-label-bg: #2d2d2d;
 		--color-emphasis: #8aa8ff;
 
 		--color-border-soft: #444444;
@@ -202,6 +204,11 @@ td[bgcolor="#e1ffe1"] {
 td[bgcolor="#DDFFFF"],
 td[bgcolor="#ddffff"] {
 	background-color: var(--color-results-bg);
+}
+
+td[bgcolor="#E8E8E8"],
+td[bgcolor="#e8e8e8"] {
+	background-color: var(--color-cell-label-bg);
 }
 
 td[bgcolor="#993300"] h2 {


### PR DESCRIPTION
## Summary

- Adds a `--color-cell-label-bg` token (light: `#e8e8e8`, dark: `#2d2d2d`) and a `td[bgcolor="#E8E8E8"]` attribute selector in `course/Resources/css/course.css`, mirroring the existing legacy-`bgcolor` re-skin pattern (lines 183–205).
- Fixes 19 label cells in `course/Intro2DirectAccess.html` (Advantages/Disadvantages tables for Sequential, Relative, and Indexed files) that were rendering as light gray with light body text in dark mode — visually invisible.

## Why

The dark-mode stylesheet introduced in #180 mapped `#993300`, `#FFFFCC`, `#FFFFFF`, `#E1FFE1`, and `#DDFFFF` to theme tokens, but missed `#E8E8E8`. Light gray background + dark-mode light text (`#e6e6e6`) = unreadable labels. `#E8E8E8` only appears in `Intro2DirectAccess.html`, so one CSS rule fixes all 19 occurrences.

Light mode is byte-identical (the token resolves to `#e8e8e8`, matching the original `bgcolor` value).

## Test plan

- [x] Dark mode: label cells render with `rgb(45, 45, 45)` background and light text — confirmed via DOM inspection and screenshot of the Sequential-files Disadvantages table.
- [x] Light mode: token resolves to `#e8e8e8`, same as the legacy attribute value (no visual change).
- [x] No regression on adjacent themed surfaces — `.section-header` (`#6b2400`) and `.section-sidebar` (`#3a3520`) still render correctly in dark mode.
- [ ] Reviewer: load `course/Intro2DirectAccess.html` and toggle OS dark mode; spot-check the six Advantages/Disadvantages tables (Sequential, Relative, Indexed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)