### PR TITLE
Generalize legacy bgcolor dark-mode coverage to <table>/<tr>, plus more colors

### DIFF
--- a/course/Resources/css/course.css
+++ b/course/Resources/css/course.css
@@ -237,6 +237,10 @@ td[bgcolor="#ddffff"] {
 	background-color: var(--color-results-bg);
 }
 
+table[bgcolor="#E8E8E8"],
+table[bgcolor="#e8e8e8"],
+tr[bgcolor="#E8E8E8"],
+tr[bgcolor="#e8e8e8"],
 td[bgcolor="#E8E8E8"],
 td[bgcolor="#e8e8e8"] {
 	background-color: var(--color-cell-label-bg);
@@ -462,21 +466,15 @@ td[bgcolor="#ffffcc"] h4 {
 		color: #888888 !important;
 	}
 
-	/* Gray label/spacer bgcolors don't have matching light-mode tokens, so
-	   they're remapped only here in dark mode and render as authored in
-	   light mode. */
-	table[bgcolor="#E8E8E8"],
-	table[bgcolor="#e8e8e8"],
+	/* #CCCCCC has no matching light-mode token (only used as decorative
+	   spacer cells), so it's remapped only in dark mode. Uses the same
+	   --color-cell-label-bg as #E8E8E8 since both are gray. */
 	table[bgcolor="#CCCCCC"],
 	table[bgcolor="#cccccc"],
-	tr[bgcolor="#E8E8E8"],
-	tr[bgcolor="#e8e8e8"],
 	tr[bgcolor="#CCCCCC"],
 	tr[bgcolor="#cccccc"],
-	td[bgcolor="#E8E8E8"],
-	td[bgcolor="#e8e8e8"],
 	td[bgcolor="#CCCCCC"],
 	td[bgcolor="#cccccc"] {
-		background-color: var(--color-panel-bg);
+		background-color: var(--color-cell-label-bg);
 	}
 }

--- a/course/Resources/css/course.css
+++ b/course/Resources/css/course.css
@@ -179,28 +179,59 @@ ul.toc a {
 	font-size: larger;
 }
 
-/* Recolor legacy <td bgcolor="..."> attribute markup via CSS background-color,
-   which wins over the deprecated HTML attribute. Lets the theme tokens drive
-   colors on pages that haven't been migrated to component classes. */
+/* Recolor legacy <table>/<tr>/<td> bgcolor="..." attribute markup via CSS
+   background-color, which wins over the deprecated HTML attribute. Lets the
+   theme tokens drive colors on pages that haven't been migrated to component
+   classes. */
+table[bgcolor="#993300"],
+tr[bgcolor="#993300"],
 td[bgcolor="#993300"] {
 	background-color: var(--color-header-bg);
 }
 
+table[bgcolor="#FFFFCC"],
+table[bgcolor="#ffffcc"],
+tr[bgcolor="#FFFFCC"],
+tr[bgcolor="#ffffcc"],
 td[bgcolor="#FFFFCC"],
 td[bgcolor="#ffffcc"] {
 	background-color: var(--color-panel-bg);
 }
 
+table[bgcolor="#FFFFFF"],
+table[bgcolor="#ffffff"],
+tr[bgcolor="#FFFFFF"],
+tr[bgcolor="#ffffff"],
 td[bgcolor="#FFFFFF"],
 td[bgcolor="#ffffff"] {
 	background-color: var(--color-bg);
 }
 
+table[bgcolor="#E1FFE1"],
+table[bgcolor="#e1ffe1"],
+table[bgcolor="#D2FFD2"],
+table[bgcolor="#d2ffd2"],
+table[bgcolor="#DDFFDD"],
+table[bgcolor="#ddffdd"],
+tr[bgcolor="#E1FFE1"],
+tr[bgcolor="#e1ffe1"],
+tr[bgcolor="#D2FFD2"],
+tr[bgcolor="#d2ffd2"],
+tr[bgcolor="#DDFFDD"],
+tr[bgcolor="#ddffdd"],
 td[bgcolor="#E1FFE1"],
-td[bgcolor="#e1ffe1"] {
+td[bgcolor="#e1ffe1"],
+td[bgcolor="#D2FFD2"],
+td[bgcolor="#d2ffd2"],
+td[bgcolor="#DDFFDD"],
+td[bgcolor="#ddffdd"] {
 	background-color: var(--color-code-bg);
 }
 
+table[bgcolor="#DDFFFF"],
+table[bgcolor="#ddffff"],
+tr[bgcolor="#DDFFFF"],
+tr[bgcolor="#ddffff"],
 td[bgcolor="#DDFFFF"],
 td[bgcolor="#ddffff"] {
 	background-color: var(--color-results-bg);
@@ -410,5 +441,42 @@ td[bgcolor="#ffffcc"] h4 {
 	[style*="color:#800000"],
 	[style*="color: #800000"] {
 		color: var(--color-panel-text) !important;
+	}
+
+	[style*="color:#ff0000"],
+	[style*="color: #ff0000"],
+	[style*="color:#FF0000"],
+	[style*="color: #FF0000"] {
+		color: #ff8a8a !important;
+	}
+
+	[style*="color:#006600"],
+	[style*="color: #006600"] {
+		color: #7ec47e !important;
+	}
+
+	[style*="color:#cccccc"],
+	[style*="color: #cccccc"],
+	[style*="color:#CCCCCC"],
+	[style*="color: #CCCCCC"] {
+		color: #888888 !important;
+	}
+
+	/* Gray label/spacer bgcolors don't have matching light-mode tokens, so
+	   they're remapped only here in dark mode and render as authored in
+	   light mode. */
+	table[bgcolor="#E8E8E8"],
+	table[bgcolor="#e8e8e8"],
+	table[bgcolor="#CCCCCC"],
+	table[bgcolor="#cccccc"],
+	tr[bgcolor="#E8E8E8"],
+	tr[bgcolor="#e8e8e8"],
+	tr[bgcolor="#CCCCCC"],
+	tr[bgcolor="#cccccc"],
+	td[bgcolor="#E8E8E8"],
+	td[bgcolor="#e8e8e8"],
+	td[bgcolor="#CCCCCC"],
+	td[bgcolor="#cccccc"] {
+		background-color: var(--color-panel-bg);
 	}
 }


### PR DESCRIPTION
## Summary

- Extend the legacy `bgcolor` dark-mode remapping in `course/Resources/css/course.css` from `<td>` only to `<table>`/`<tr>`/`<td>`, fixing tables that were unreadable in dark mode (light pastel backgrounds bleeding through with light gray body text). Affected pages include `SequentialFiles2.html`, `DataDeclaration.html`, `COBOLcommands.html`, `Selection.html`, `Tables2.html`, `EditedPics.html`, `Inspect.html`, `Iteration.html`, `RefMod.html`, `SortMerge.html`, `String.html`, `Unstring.html`, and `Intro2DirectAccess.html`.
- Add three previously-unmapped `bgcolor` values: `#D2FFD2` and `#DDFFDD` join the `--color-code-bg` group; `#CCCCCC` (3× spacer cells in `SortMerge.html`) gets a dark-only override to `--color-cell-label-bg` (matches master's existing gray token for `#E8E8E8`).
- Add three inline text-color overrides in the dark-mode `@media` block to soften code-sample callouts that were authored for white backgrounds: `#ff0000` → `#ff8a8a`, `#006600` → `#7ec47e`, `#cccccc` → `#888888`. Mirrors the existing pattern for `#0000ff`, `#993300`, `#000099`, `#800000`.

## Why

Recent dark-mode work targeted `<td bgcolor>` but missed `<table bgcolor>` and `<tr bgcolor>`, which are widespread in the COBOL course pages (a survey found 153 `bgcolor` attributes across 6 distinct hex values). Tables like the Ordered/Unordered File table, Figurative Constants, ROUNDED examples, and Truth tables rendered as light pastel blocks with washed-out text. Several inline color highlights in code samples had the same issue.

Approach is purely additive CSS in one file. Light mode is unchanged: existing token defaults equal the original hex values, and the dark-only overrides live inside `@media (prefers-color-scheme: dark)`.

## Test plan

- [x] Verified in browser preview (dark mode emulated): `td[bgcolor="#E8E8E8"]` → `#2d2d2d`, `td[bgcolor="#CCCCCC"]` → `#2d2d2d`, `table[bgcolor="#D2FFD2"]` → `#1f2e1f`, `table[bgcolor="#E1FFE1"]` → `#1f2e1f`, `tr[bgcolor="#FFFFCC"]` → `#3a3520`, `style="color:#ff0000"` → `#ff8a8a`, `style="color:#006600"` → `#7ec47e`, `style="color:#cccccc"` → `#888888`.
- [x] Verified light mode unchanged: `td[bgcolor="#E8E8E8"]` → `#e8e8e8`, `td[bgcolor="#CCCCCC"]` → `#cccccc` (no rule applies in light mode), `table[bgcolor="#E1FFE1"]` → `#e1ffe1`, `tr[bgcolor="#FFFFCC"]` → `#ffffcc`.
- [ ] Spot-check the affected course pages in your own browser for any regressions, especially `Intro2DirectAccess.html` (most `#E8E8E8` cells) and `EditedPics.html` (heaviest `<tr bgcolor>` use).

🤖 Generated with [Claude Code](https://claude.com/claude-code)