### PR TITLE
Remove dead .mso link refs from Prj-* exercise pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,6 @@ CI runs two checks on every PR (see [.github/workflows/checks.yml](.github/workf
 
 The starting `html-validate` ruleset is intentionally permissive — it catches parse errors and structural bugs but doesn't flag every legacy-HTML pattern. Tighten over time as modernization progresses.
 
-`linkinator.config.json` skips externals and `*.mso` references — Word "Save as Web Page" debris in the `Prj-*` exercise pages. Remove the `*.mso` skip once those refs are cleaned up.
+`linkinator.config.json` only skips external URLs and `mailto:` links — internal refs are all expected to resolve.
 
 `npm run a11y` is available locally but not in CI yet. Existing pages have many pre-existing WCAG violations; wiring a strict gate now would just memorize current breakage. The a11y job gets added back after the accessibility cleanup pass lands.

--- a/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html
+++ b/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html
@@ -2,8 +2,6 @@
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
-		<link href="CSISEvalForm_files/editdata.mso" rel="Edit-Time-Data" />
-		<link href="CSISEvalForm_files/oledata.mso" rel="OLE-Object-Data" />
 		<title>Aromamora Essential Oils - Sales Report (25 hours)</title>
 
 		<style>

--- a/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html
+++ b/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html
@@ -2,8 +2,6 @@
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
-		<link href="CSISEvalForm_files/editdata.mso" rel="Edit-Time-Data" />
-		<link href="CSISEvalForm_files/oledata.mso" rel="OLE-Object-Data" />
 		<title>Aromamora Essential Oils - Sales Report (25 hours)</title>
 
 		<style>

--- a/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html
+++ b/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html
@@ -2,8 +2,6 @@
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
-		<link href="CSISEvalForm_files/editdata.mso" rel="Edit-Time-Data" />
-		<link href="CSISEvalForm_files/oledata.mso" rel="OLE-Object-Data" />
 		<title>UL CAO points calculator and Report</title>
 
 		<style>

--- a/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html
+++ b/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html
@@ -2,8 +2,6 @@
 <html>
 	<head>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
-		<link href="CSISEvalForm_files/editdata.mso" rel="Edit-Time-Data" />
-		<link href="CSISEvalForm_files/oledata.mso" rel="OLE-Object-Data" />
 		<title>Munster Surnames Frequency Report</title>
 
 		<style>

--- a/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html
+++ b/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html
@@ -3,8 +3,6 @@
 	<head>
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
-		<link href="CSISEvalForm_files/editdata.mso" rel="Edit-Time-Data" />
-		<link href="CSISEvalForm_files/oledata.mso" rel="OLE-Object-Data" />
 		<title>Aromamora Essential Oils - Sales Report (25 hours)</title>
 
 		<style>

--- a/linkinator.config.json
+++ b/linkinator.config.json
@@ -1,8 +1,4 @@
 {
 	"recurse": true,
-	"skip": [
-		"^https?://(?!localhost)",
-		"^mailto:",
-		"\\.mso(?:$|\\?)"
-	]
+	"skip": ["^https?://(?!localhost)", "^mailto:"]
 }


### PR DESCRIPTION
## Summary

Cleans up the last set of legacy dead refs the link checker was skipping. Five exercise pages had two MS Word "Save as Web Page" leftover `<link>` tags in `<head>` referencing `CSISEvalForm_files/editdata.mso` and `CSISEvalForm_files/oledata.mso`. Those directories don't exist in the tree, the refs are inert in browsers, and they were the last entries on the linkinator skip list.

This finishes the "ratchet" started by the CI PR — the skip list is now down to just external URLs and `mailto:`.

## Changes

- Removed the two `.mso` `<link>` tags from each of:
  - `exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html`
  - `exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html`
  - `exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html`
  - `exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html`
  - `exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html`
- Dropped the `\.mso(?:$|\?)` skip pattern from `linkinator.config.json`.
- Updated README to reflect the simpler skip list.

## Test plan

- [x] `npm run validate` clean
- [x] `npm run links` clean (586 links)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)