### PR TITLE
A11y pass on five front-door pages: lang, viewport-first, alt

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
@@ -576,6 +576,7 @@
 										width="62"
 										height="62"
 										align="middle"
+										alt="Animation: Attempt 1"
 								/></a>
 							</p>
 						</div>
@@ -588,6 +589,7 @@
 										width="62"
 										height="62"
 										align="middle"
+										alt="Animation: Attempt 2"
 								/></a>
 							</p>
 						</div>
@@ -600,6 +602,7 @@
 										width="62"
 										height="62"
 										align="middle"
+										alt="Animation: Attempt 3"
 								/></a>
 							</p>
 						</div>
@@ -623,7 +626,7 @@
 					<p align="center">
 						Annotated Program<br />
 						<a href="Resources/ppz/TC-CobIntro4.html"
-							><img src="Resources/pics/i-Animation.gif" width="62" height="62" align="middle"
+							><img src="Resources/pics/i-Animation.gif" width="62" height="62" align="middle" alt="Animation: annotated program"
 						/></a>
 					</p>
 					<hr size="1" />
@@ -649,7 +652,7 @@
 					<p align="center">
 						Selection Program<br />
 						<a href="Resources/ppz/TC-CobIntro5.html"
-							><img src="Resources/pics/i-Animation.gif" width="62" height="62" align="middle"
+							><img src="Resources/pics/i-Animation.gif" width="62" height="62" align="middle" alt="Animation: selection program"
 						/></a>
 					</p>
 					<hr size="1" />
@@ -670,7 +673,7 @@
 					<p align="center">
 						Iteration Program<br />
 						<a href="Resources/ppz/TC-CobIntro6.html"
-							><img src="Resources/pics/i-Animation.gif" width="62" height="62" align="middle"
+							><img src="Resources/pics/i-Animation.gif" width="62" height="62" align="middle" alt="Animation: iteration program"
 						/></a>
 					</p>
 				</div>
@@ -812,7 +815,7 @@
 						In COBOL, evaluating an arithmetic expression and assigning the result to a data item is
 						achieved by means of the COMPUTE statement. The syntax diagram for the COMPUTE is shown below.
 					</p>
-					<p align="center"><img src="Resources/pics/Compute.gif" width="509" height="77" /></p>
+					<p align="center"><img src="Resources/pics/Compute.gif" width="509" height="77" alt="Syntax diagram for the COBOL COMPUTE statement" /></p>
 					<p>This syntax diagram may be interpreted as follows;</p>
 					<p>
 						We must start a <code class="language-cobol">COMPUTE</code> statement with the keyword
@@ -882,7 +885,7 @@
 					</p>
 					<p align="center">
 						<b>Ancient COBOL coding form</b
-						><img src="Resources/pics/CodingForm.jpg" width="498" height="415" border="1" />
+						><img src="Resources/pics/CodingForm.jpg" width="498" height="415" border="1" alt="Ancient COBOL coding form" />
 					</p>
 					<hr size="1" />
 				</div>
@@ -923,7 +926,7 @@
 						or more Sentences and a Sentence one or more Statements.
 					</p>
 					<p>We can represent the COBOL hierarchy using the COBOL metalanguage as follows;</p>
-					<p align="center"><img src="Resources/pics/CobolStructure.gif" width="467" height="203" /><br /></p>
+					<p align="center"><img src="Resources/pics/CobolStructure.gif" width="467" height="203" alt="COBOL hierarchy: Divisions contain Sections, Sections contain Paragraphs, Paragraphs contain Sentences, Sentences contain Statements" /><br /></p>
 					<p align="left">
 						<b>Divisions</b><br />
 						A division is a block of code, usually containing one or more sections, that starts where the
@@ -1106,7 +1109,7 @@ AUTHOR. Michael Coughlan.</code></pre>
 						<br />
 						The <code class="language-cobol">DATA DIVISION</code> has the following structure and syntax:
 					</p>
-					<p align="center"><img src="Resources/pics/DataDiv.gif" width="332" height="161" /></p>
+					<p align="center"><img src="Resources/pics/DataDiv.gif" width="332" height="161" alt="Structure and syntax of the COBOL DATA DIVISION" /></p>
 					<p align="left">
 						<br />
 						Below is a sample program fragment -

--- a/course/index.html
+++ b/course/index.html
@@ -1,8 +1,8 @@
 <!doctype html>
-<html>
+<html lang="en">
 	<head>
-		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>COBOL Programming Course</title>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" charset="utf-8" defer></script>
@@ -197,11 +197,11 @@
 		<!-- Header: flex row replaces 3-column layout table -->
 		<div class="course-header">
 			<div class="course-header-icon">
-				<img src="../pics/I-TEACHER.GIF" width="40" height="42" style="margin: 4px" />
+				<img src="../pics/I-TEACHER.GIF" width="40" height="42" style="margin: 4px" alt="" />
 			</div>
 			<div class="course-header-title">
 				<h1>
-					<img src="../pics/T-Dept.gif" width="297" height="36" /><br />
+					<img src="../pics/T-Dept.gif" width="297" height="36" alt="" /><br />
 					&nbsp;COBOL Programming Course
 				</h1>
 				<p align="center">
@@ -216,23 +216,23 @@
 				<table width="100%" border="1" height="100" cellpadding="2" cellspacing="0">
 					<tr>
 						<td colspan="2" height="29">
-							<div align="center"><img src="Resources/pics/aai-Legend.gif" /></div>
+							<div align="center"><img src="Resources/pics/aai-Legend.gif" alt="Legend" /></div>
 						</td>
 					</tr>
 					<tr>
 						<td width="14%" height="15">
-							<img src="Resources/pics/i-Tuts.gif" width="22" height="21" vspace="1" hspace="2" />
+							<img src="Resources/pics/i-Tuts.gif" width="22" height="21" vspace="1" hspace="2" alt="" />
 						</td>
 						<td width="86%" height="15">COBOL tutorial</td>
 					</tr>
 					<tr>
 						<td width="14%">
-							<img src="Resources/pics/i-exercises.gif" width="21" height="21" hspace="2" vspace="1" />
+							<img src="Resources/pics/i-exercises.gif" width="21" height="21" hspace="2" vspace="1" alt="" />
 						</td>
 						<td width="86%">COBOL programming exercise</td>
 					</tr>
 					<tr valign="middle">
-						<td width="14%" height="8"><img src="Resources/pics/i-SAQ.gif" vspace="0" hspace="2" /></td>
+						<td width="14%" height="8"><img src="Resources/pics/i-SAQ.gif" vspace="0" hspace="2" alt="" /></td>
 						<td width="86%" height="8">Self assessement questions</td>
 					</tr>
 				</table>
@@ -245,7 +245,7 @@
 			<div class="course-topics">
 				<!-- Introduction to COBOL -->
 				<div class="topic-label">
-					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" /><b>Introduction to COBOL</b>
+					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" alt="" /><b>Introduction to COBOL</b>
 				</div>
 				<div class="topic-links">
 					<div class="course-link">
@@ -286,13 +286,13 @@
 					</div>
 					<div class="course-link">
 						<span class="course-link-icon"
-							><img src="Resources/pics/i-exercise.gif" width="21" height="21" vspace="4" hspace="5"
+							><img src="Resources/pics/i-exercise.gif" width="21" height="21" vspace="4" hspace="5" alt=""
 						/></span>
 						<a href="../exercises/GettingStarted.html">Getting Started</a>
 					</div>
 					<div class="course-link">
 						<span class="course-link-icon"
-							><img src="Resources/pics/i-SAQ.gif" hspace="5" vspace="4"
+							><img src="Resources/pics/i-SAQ.gif" hspace="5" vspace="4" alt=""
 						/></span>
 						<a href="../exercises/GettingStarted.html">These will be self assessment questions</a>
 					</div>
@@ -301,7 +301,7 @@
 
 				<!-- COBOL Control structures -->
 				<div class="topic-label">
-					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" /><b>COBOL Control structures</b>
+					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" alt="" /><b>COBOL Control structures</b>
 				</div>
 				<div class="topic-links">
 					<div class="course-link">
@@ -330,13 +330,13 @@
 					</div>
 					<div class="course-link">
 						<span class="course-link-icon"
-							><img src="Resources/pics/i-exercise.gif" width="21" height="21" vspace="4" hspace="5"
+							><img src="Resources/pics/i-exercise.gif" width="21" height="21" vspace="4" hspace="5" alt=""
 						/></span>
 						<a href="../exercises/CountDown.html">The Calculator and Countdown exercise</a>
 					</div>
 					<div class="course-link">
 						<span class="course-link-icon"
-							><img src="Resources/pics/i-SAQ.gif" hspace="5" vspace="5"
+							><img src="Resources/pics/i-SAQ.gif" hspace="5" vspace="5" alt=""
 						/></span>
 						<a href="../exercises/GettingStarted.html">These will be self assessment questions</a>
 					</div>
@@ -345,7 +345,7 @@
 
 				<!-- Simple Sequential Files -->
 				<div class="topic-label">
-					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" /><b>Simple Sequential Files</b>
+					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" alt="" /><b>Simple Sequential Files</b>
 				</div>
 				<div class="topic-links">
 					<div class="course-link">
@@ -374,13 +374,13 @@
 					</div>
 					<div class="course-link">
 						<span class="course-link-icon"
-							><img src="Resources/pics/i-exercise.gif" width="21" height="21" vspace="4" hspace="4"
+							><img src="Resources/pics/i-exercise.gif" width="21" height="21" vspace="4" hspace="4" alt=""
 						/></span>
 						<a href="../exercises/SeqRead.html">Reading Sequential Files</a>
 					</div>
 					<div class="course-link">
 						<span class="course-link-icon"
-							><img src="Resources/pics/i-exercise.gif" width="21" height="21" vspace="4" hspace="4"
+							><img src="Resources/pics/i-exercise.gif" width="21" height="21" vspace="4" hspace="4" alt=""
 						/></span>
 						<a href="../exercises/SeqReadIf.html">Counting records in a Sequential File</a>
 					</div>
@@ -389,7 +389,7 @@
 
 				<!-- Advanced data declaration -->
 				<div class="topic-label">
-					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" /><b>Advanced data declaration</b>
+					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" alt="" /><b>Advanced data declaration</b>
 				</div>
 				<div class="topic-links">
 					<div class="course-link">
@@ -418,13 +418,13 @@
 					</div>
 					<div class="course-link">
 						<span class="course-link-icon"
-							><img src="Resources/pics/i-exercise.gif" width="21" height="21" vspace="4" hspace="4"
+							><img src="Resources/pics/i-exercise.gif" width="21" height="21" vspace="4" hspace="4" alt=""
 						/></span>
 						<a href="../exercises/SeqWrite.html">Writing records to a Sequential File</a>
 					</div>
 					<div class="course-link">
 						<span class="course-link-icon"
-							><img src="Resources/pics/i-exercise.gif" width="21" height="21" vspace="4" hspace="4"
+							><img src="Resources/pics/i-exercise.gif" width="21" height="21" vspace="4" hspace="4" alt=""
 						/></span>
 						<a href="../exercises/SeqInsert.html">Inserting records in a Sequential File</a>
 					</div>
@@ -433,7 +433,7 @@
 
 				<!-- Advanced Sequential Files -->
 				<div class="topic-label">
-					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" /><b>Advanced Sequential Files</b>
+					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" alt="" /><b>Advanced Sequential Files</b>
 				</div>
 				<div class="topic-links">
 					<div class="course-link">
@@ -474,13 +474,13 @@
 					</div>
 					<div class="course-link">
 						<span class="course-link-icon"
-							><img src="Resources/pics/i-exercise.gif" width="21" height="21" vspace="4" hspace="4"
+							><img src="Resources/pics/i-exercise.gif" width="21" height="21" vspace="4" hspace="4" alt=""
 						/></span>
 						<a href="../exercises/SeqUpdate.html">Updating a Sequential File</a>
 					</div>
 					<div class="course-link">
 						<span class="course-link-icon"
-							><img src="Resources/pics/i-exercise.gif" width="21" height="21" vspace="4" hspace="4"
+							><img src="Resources/pics/i-exercise.gif" width="21" height="21" vspace="4" hspace="4" alt=""
 						/></span>
 						<a href="../exercises/SortIP.html">Sorting a Sequential File</a>
 					</div>
@@ -489,7 +489,7 @@
 
 				<!-- Direct access files -->
 				<div class="topic-label">
-					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" /><b>Direct access files</b>
+					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" alt="" /><b>Direct access files</b>
 				</div>
 				<div class="topic-links">
 					<div class="course-link">
@@ -533,7 +533,7 @@
 
 				<!-- COBOL tables -->
 				<div class="topic-label">
-					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" /><b>COBOL tables</b>
+					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" alt="" /><b>COBOL tables</b>
 				</div>
 				<div class="topic-links">
 					<div class="course-link">
@@ -574,7 +574,7 @@
 					</div>
 					<div class="course-link">
 						<span class="course-link-icon"
-							><img src="Resources/pics/i-exercise.gif" width="21" height="21" vspace="4" hspace="4"
+							><img src="Resources/pics/i-exercise.gif" width="21" height="21" vspace="4" hspace="4" alt=""
 						/></span>
 						<a href="../exercises/MonthTable.html">Using Tables</a>
 					</div>
@@ -583,7 +583,7 @@
 
 				<!-- Constructing large systems -->
 				<div class="topic-label">
-					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" /><b
+					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" alt="" /><b
 						>Constructing large systems</b
 					>
 				</div>
@@ -617,7 +617,7 @@
 
 				<!-- COBOL string handling -->
 				<div class="topic-label">
-					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" /><b>COBOL string handling</b>
+					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" alt="" /><b>COBOL string handling</b>
 				</div>
 				<div class="topic-links">
 					<div class="course-link">
@@ -673,7 +673,7 @@
 
 				<!-- The COBOL Report Writer -->
 				<div class="topic-label">
-					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" /><b>The COBOL Report Writer</b>
+					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" alt="" /><b>The COBOL Report Writer</b>
 				</div>
 				<div class="topic-links">
 					<div class="course-link">

--- a/examples/default.html
+++ b/examples/default.html
@@ -1,6 +1,7 @@
 <!doctype html>
-<html>
+<html lang="en">
 	<head>
+		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>COBOL example programs</title>
 		<meta content="document" name="resource-type" />
@@ -17,7 +18,6 @@
 		<meta content="Michael Coughlan" name="author" />
 		<meta content="All" name="robots" />
 		<meta content="General" name="rating" />
-		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<style type="text/css">
 			img {
 				max-width: 100%;
@@ -177,8 +177,8 @@
 
 	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
 		<h2>
-			<img height="42" src="../pics/i-program.gif" width="40" />
-			<img height="36" hspace="5" src="../pics/T-Dept.gif" width="297" />&nbsp;<br />
+			<img height="42" src="../pics/i-program.gif" width="40" alt="" />
+			<img height="36" hspace="5" src="../pics/T-Dept.gif" width="297" alt="" />&nbsp;<br />
 			COBOL Example Programs
 		</h2>
 		<hr />

--- a/exercises/index.html
+++ b/exercises/index.html
@@ -1,8 +1,9 @@
 <!doctype html>
-<html>
+<html lang="en">
 	<head>
-		<title>COBOL Programming Exercises</title>
+		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
+		<title>COBOL Programming Exercises</title>
 		<meta content="document" name="resource-type" />
 		<meta
 			content="These pages contain COBOL programming exercises with sample answers. Where required, test data files are also supplied."
@@ -14,7 +15,6 @@
 		<meta content="Michael Coughlan" name="author" />
 		<meta content="All" name="robots" />
 		<meta content="General" name="rating" />
-		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<style type="text/css">
 			img {
 				max-width: 100%;
@@ -173,11 +173,11 @@
 	</head>
 	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
 		<h2>
-			<img align="absbottom" border="1" height="40" src="../pics/i-AtComputer.gif" width="40" /><img
+			<img align="absbottom" border="1" height="40" src="../pics/i-AtComputer.gif" width="40" alt="" /><img
 				height="36"
 				hspace="5"
 				src="../pics/T-Dept.gif"
-				width="297"
+				width="297" alt=""
 			/>&nbsp;<br />
 			COBOL Programming Exercises&nbsp;
 		</h2>
@@ -270,7 +270,7 @@
 			<table border="0" cellpadding="0" cellspacing="0" width="750">
 				<tr>
 					<td height="37" valign="top" width="27%">
-						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" /><a
+						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" alt="" /><a
 							href="Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html"
 						></a
 						><a href="Exm-StudFeesRpt/Exm-StudPay.html">Student Fees Report</a>
@@ -291,7 +291,7 @@
 				</tr>
 				<tr>
 					<td height="47" valign="top" width="27%">
-						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" /><a
+						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" alt="" /><a
 							href="Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html"
 							>Aromamora Summary Sales</a
 						>
@@ -308,7 +308,7 @@
 				</tr>
 				<tr>
 					<td height="62" valign="top" width="27%">
-						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" /><a
+						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" alt="" /><a
 							href="Exm-FlyByNightTravel/Exm-FlyByNight.html"
 							>FlyByNight Summary File</a
 						>
@@ -326,7 +326,7 @@
 				</tr>
 				<tr>
 					<td height="103" valign="top" width="27%">
-						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" /><a
+						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" alt="" /><a
 							href="Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html"
 							>AromamoraMaint&amp;Report</a
 						>
@@ -349,7 +349,7 @@
 				</tr>
 				<tr>
 					<td height="2" valign="top" width="27%">
-						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" /><a
+						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" alt="" /><a
 							href="Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html"
 							>BookshopLecturerReqRpt</a
 						>
@@ -371,7 +371,7 @@
 				</tr>
 				<tr>
 					<td height="93" valign="top" width="27%">
-						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" /><a
+						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" alt="" /><a
 							href="Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html"
 							>ACME Stock Reorder</a
 						>
@@ -395,7 +395,7 @@
 				</tr>
 				<tr>
 					<td height="93" valign="top" width="27%">
-						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" /><a
+						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" alt="" /><a
 							href="Exm-FileConversion/Exm-FileConversion.html"
 							>File Conversion</a
 						>
@@ -415,7 +415,7 @@
 				</tr>
 				<tr>
 					<td height="29" valign="top" width="27%">
-						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" /><a
+						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" alt="" /><a
 							href="Exm-USSRshipRpt/Exm-USSRshipRpt.html"
 							>USSR Ship Report</a
 						>
@@ -432,7 +432,7 @@
 				</tr>
 				<tr>
 					<td height="57" valign="top" width="27%">
-						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" /><a
+						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" alt="" /><a
 							href="Exm-SFbyMail/Exm-SFbyMai.html"
 							>Science Fiction by mail</a
 						>
@@ -449,7 +449,7 @@
 				</tr>
 				<tr>
 					<td height="65" valign="top" width="27%">
-						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" /><a
+						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" alt="" /><a
 							href="Exm-CSISEmailDomain/Exm-CSISEmailDomain.html"
 							>CSISEmailDomain</a
 						>
@@ -467,7 +467,7 @@
 				</tr>
 				<tr>
 					<td height="110" valign="top" width="27%">
-						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" /><a
+						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" alt="" /><a
 							href="Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html"
 							>LibraryRoyaltiesRpt</a
 						>
@@ -489,7 +489,7 @@
 				</tr>
 				<tr>
 					<td height="49" valign="top" width="27%">
-						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" /><a
+						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" alt="" /><a
 							href="Exm-TopSupplierRpt/Exm-TopSupplierRpt.html"
 							>TopSupplierRpt</a
 						>
@@ -508,7 +508,7 @@
 				</tr>
 				<tr>
 					<td height="56" valign="top" width="27%">
-						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" /><a
+						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" alt="" /><a
 							href="Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html"
 							>FolioBestSellersRpt</a
 						>
@@ -523,7 +523,7 @@
 				</tr>
 				<tr>
 					<td height="56" valign="top" width="27%">
-						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" /><a
+						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" alt="" /><a
 							href="Exm-DueSubsRpt/Exm-DueSubsRpt.html"
 							>DueSubsRpt</a
 						>
@@ -549,7 +549,7 @@
 				<tr>
 					<td height="156" valign="top" width="27%">
 						<p>
-							<img height="12" hspace="4" src="../pics/BallOrangeG.gif" width="12" /><a
+							<img height="12" hspace="4" src="../pics/BallOrangeG.gif" width="12" alt="" /><a
 								href="Proj-CSISEvalform/CSISEvalForm.html"
 								>CSIS evaluation form report</a
 							>
@@ -580,7 +580,7 @@
 				<tr>
 					<td height="68" valign="top" width="27%">
 						<p>
-							<img height="12" hspace="4" src="../pics/BallOrangeG.gif" width="12" /><a
+							<img height="12" hspace="4" src="../pics/BallOrangeG.gif" width="12" alt="" /><a
 								href="Prj-AromaSalesRpt/Prj-AromaSalesRpt.html"
 								>Aroma Sales Report</a
 							>
@@ -596,7 +596,7 @@
 				</tr>
 				<tr>
 					<td height="42" valign="top" width="27%">
-						<img height="12" hspace="4" src="../pics/BallOrangeG.gif" width="12" /><a
+						<img height="12" hspace="4" src="../pics/BallOrangeG.gif" width="12" alt="" /><a
 							href="Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html"
 							>Newtronics File Maintenance</a
 						>
@@ -611,7 +611,7 @@
 				</tr>
 				<tr>
 					<td height="42" valign="top" width="27%">
-						<img height="12" hspace="4" src="../pics/BallOrangeG.gif" width="12" /><a
+						<img height="12" hspace="4" src="../pics/BallOrangeG.gif" width="12" alt="" /><a
 							href="Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html"
 							>Aroma Invoices Report</a
 						>
@@ -625,7 +625,7 @@
 				</tr>
 				<tr>
 					<td height="42" valign="top" width="27%">
-						<img height="12" hspace="4" src="../pics/BallOrangeG.gif" width="12" /><a
+						<img height="12" hspace="4" src="../pics/BallOrangeG.gif" width="12" alt="" /><a
 							href="Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html"
 							>MunsterSurnamesFreqRpt</a
 						>
@@ -638,7 +638,7 @@
 				</tr>
 				<tr>
 					<td height="42" valign="top" width="27%">
-						<img height="12" hspace="4" src="../pics/BallOrangeG.gif" width="12" /><a
+						<img height="12" hspace="4" src="../pics/BallOrangeG.gif" width="12" alt="" /><a
 							href="Prj-CAOPointsCalc/Prj-CAOcalculator.html"
 							>CAO points calculator</a
 						>

--- a/index.html
+++ b/index.html
@@ -1,8 +1,8 @@
 <!doctype html>
-<html>
+<html lang="en">
 	<head>
-		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<meta name="google-site-verification" content="g9Kb5_0qV7EdRel40vEW48IAmR1DCIYL7oBqiuPNTr8" />
 		<title>COBOL programming - tutorials, lectures, exercises, examples</title>
 		<meta name="resource-type" content="document" />
@@ -85,11 +85,11 @@
 	<body text="#000000" bgcolor="#FFFFFF" link="#0000FF" vlink="#FF0000" alink="#009B00">
 		<div id="page-header">
 			<div class="header-icon">
-				<img src="pics/i-program.gif" height="42" width="40" />
+				<img src="pics/i-program.gif" height="42" width="40" alt="" />
 			</div>
 			<div>
 				<h1>
-					<img src="pics/T-Dept.gif" width="297" height="36" /><br />
+					<img src="pics/T-Dept.gif" width="297" height="36" alt="" /><br />
 					COBOL programming - tutorials, lectures, exercises, examples
 				</h1>
 			</div>


### PR DESCRIPTION
## Summary

Narrow accessibility pass on the five pages a screen-reader user is most likely to hit first. Sets the pattern for the eventual script-driven sweep across the remaining ~165 pages, but doesn't try to do everything at once.

The five pages:

- `index.html` — site root
- `course/index.html` — course landing
- `course/COBOLIntro.html` — first chapter (and pa11y sample)
- `exercises/index.html` — exercises landing
- `examples/default.html` — examples landing

## Changes per page

- **`<html lang="en">`** added.
- **`<head>` ordering normalised** — viewport meta now comes before any `<link rel="stylesheet">` or `<style>` block, per the established FOUC fix across the course pages. Three of the five files had viewport buried in the meta tail; only `course/COBOLIntro.html` was already correct.
- **`alt` attributes added to all `<img>` tags**:
  - Decorative imgs (header banners, bullet markers, legend icons, icon-next-to-text rows) get `alt=""` — explicit signal to screen readers that these can be skipped.
  - The four **technical figures** in `COBOLIntro.html` get descriptive alt derived from the surrounding caption text:
    - `Compute.gif` → `"Syntax diagram for the COBOL COMPUTE statement"`
    - `CodingForm.jpg` → `"Ancient COBOL coding form"`
    - `CobolStructure.gif` → `"COBOL hierarchy: Divisions contain Sections, Sections contain Paragraphs, Paragraphs contain Sentences, Sentences contain Statements"`
    - `DataDiv.gif` → `"Structure and syntax of the COBOL DATA DIVISION"`
  - The six `i-Animation.gif` play-button icons (each wrapped in an `<a>` to a different animation) get descriptive alt naming the program they animate — `"Animation: Attempt 1"`, `"Animation: annotated program"`, etc. — so screen-reader users navigating links don't hear bare unlabelled links.

## Method

For decorative imgs, used a small Node helper to add `alt=""` to any `<img>` without an existing alt — fast and consistent for the bulk of the work. The 10 imgs in `COBOLIntro.html` (technical figures + animation buttons) were edited by hand because they need real, content-specific alt text.

## pa11y delta (WCAG 2.1 AA)

| Page                       | Before | After |
| -------------------------- | -----: | ----: |
| `index.html`               |      3 | **0** |
| `course/index.html`        |      ~ |     2 |
| `exercises/index.html`     |      ~ |     5 |
| `course/COBOLIntro.html`   |      ~ |    54 |
| `examples/default.html`    |      ~ |   272 |

`index.html` is fully clean. Remaining violations on the others are entirely from legacy presentational attributes (`align="center"`, `bgcolor="..."`, `<font>`, etc.) — a separate, larger modernisation pass. The lang/alt/head violations this PR targets are gone across all five pages.

## Test plan

- [x] `npm run validate` clean
- [x] `npm run links` clean (586 links)
- [x] `npm run a11y` shows the violation deltas above
- [ ] CI green on this PR
- [ ] Spot-check the rendered pages in a browser — header banners, animation links, and figure captions should look unchanged (alt text isn't visually rendered)

## Notes

The displayed UI doesn't change at all — alt text only surfaces in screen readers and when images fail to load. The `<head>` reorder is similarly invisible. So this should be a no-op visually but a real win for accessibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)