### PR TITLE
Make course/Selection.html pa11y-clean (207 → 0 violations)

### DIFF
--- a/course/Resources/css/course.css
+++ b/course/Resources/css/course.css
@@ -194,7 +194,9 @@ table[bgcolor="#ffffcc"],
 tr[bgcolor="#FFFFCC"],
 tr[bgcolor="#ffffcc"],
 td[bgcolor="#FFFFCC"],
-td[bgcolor="#ffffcc"] {
+td[bgcolor="#ffffcc"],
+th[bgcolor="#FFFFCC"],
+th[bgcolor="#ffffcc"] {
 	background-color: var(--color-panel-bg);
 }
 

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -122,7 +122,7 @@
 				</div>
 
 				<div class="section-full">
-					<div align="center">
+					<div class="center-block">
 						<hr />
 						<back-to-top></back-to-top>
 					</div>
@@ -159,7 +159,7 @@
 				</div>
 				<div class="section-content">
 					<p>
-						<img height="102" src="Resources/pics/Select1.gif" width="379" />
+						<img height="102" src="Resources/pics/Select1.gif" width="379" alt="IF statement syntax diagram" />
 					</p>
 					<p>
 						When an <code class="language-cobol">IF</code> statement is encountered in a program, the
@@ -262,32 +262,31 @@ Statement6.</code></pre>
 					<h4>Relation Conditions</h4>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<div align="center">
-							<p align="left">
-								<img height="245" src="Resources/pics/Select2.gif" width="484" />
+					<div>
+						<div>
+							<p>
+								<img height="245" src="Resources/pics/Select2.gif" width="484" alt="Relation Condition syntax diagram showing comparison operators (less than, equal to, greater than)" />
 							</p>
-							<p align="left">
+							<p>
 								The syntax of a Relation Condition is shown above. As you can see from the diagram a
 								Relation Condition may be used to test whether a value is less than, equal to, or
 								greater than, another value.
 							</p>
-							<p align="left">
+							<p>
 								In the comparison we can use the full words or the symbols shown. Note however, that
 								there is no symbol for <code class="language-cobol">NOT</code>; you must use the word if
 								you want to express this condition.
 							</p>
-							<p align="left">
+							<p>
 								When a condition is evaluated, it evaluates to either True or False. It does not
 								evaluate to 1 or 0.
 							</p>
-							<p align="left">
+							<p>
 								Note that the values of the compared items must be type compatible. For instance, it is
 								not valid to have a statement that says
 							</p>
 							<pre
 								class="language-cobol"
-								align="left"
 							><code class="language-cobol">IF "mike" IS EQUAL TO 123 THEN etc</code></pre>
 						</div>
 					</div>
@@ -296,14 +295,14 @@ Statement6.</code></pre>
 				<div class="section-sidebar">
 					<h4>Class Conditions</h4>
 					<aside>
-						<p align="center">
+						<p class="center-block">
 							<img height="44" src="Resources/pics/i-LightBulbTip.gif" width="42" alt="" />
 						</p>
-						<p align="left">
+						<p>
 							Although this course will not cover the SPECIAL-NAMES paragraph in detail it is useful to
 							acquaint yourself with its clauses.
 						</p>
-						<p align="left">
+						<p>
 							As well as setting up a class name, the SPECIAL-NAMES paragraph allows you to do such things
 							as;<br />
 							Specify the collating sequence - e.g. ASCII or EBCDIC<br />
@@ -313,7 +312,7 @@ Statement6.</code></pre>
 					</aside>
 				</div>
 				<div class="section-content">
-					<p><img height="125" src="Resources/pics/Select3.gif" width="312" /></p>
+					<p><img height="125" src="Resources/pics/Select3.gif" width="312" alt="Class Condition syntax diagram" /></p>
 					<p>
 						Although COBOL data-items are not "strongly typed", they do fall into some broad categories or
 						classes, such as numeric or alphanumeric. A Class Condition may be used to determine whether the
@@ -353,10 +352,10 @@ END-IF</code></pre>
 				</div>
 
 				<div class="section-sidebar">
-					<h4 align="left">Sign Condition</h4>
+					<h4>Sign Condition</h4>
 				</div>
 				<div class="section-content">
-					<p><img height="76" src="Resources/pics/Select4.gif" width="313" /></p>
+					<p><img height="76" src="Resources/pics/Select4.gif" width="313" alt="Sign Condition syntax diagram" /></p>
 					<p>
 						The Sign Condition determines whether or not the value of an arithmetic expression is less than,
 						greater than, or equal to zero. Sign Conditions are shorter way of writing certain Relational
@@ -365,12 +364,12 @@ END-IF</code></pre>
 				</div>
 
 				<div class="section-sidebar">
-					<h4 align="left">Complex Conditions</h4>
+					<h4>Complex Conditions</h4>
 					<aside>
-						<p align="center">
+						<p class="center-block">
 							<img height="44" src="Resources/pics/i-LightBulbTip.gif" width="42" alt="" />
 						</p>
-						<p align="left">
+						<p>
 							You can see from the <code class="language-cobol">IF Amnt1</code> example, that figuring out
 							how a complex condition will be evaluated is not straightfoward.<br />
 							Always use brackets to make the order of evaluation explicit.
@@ -379,7 +378,7 @@ END-IF</code></pre>
 				</div>
 				<div class="section-content">
 					<p>
-						<img height="52" src="Resources/pics/Select5.gif" width="228" />
+						<img height="52" src="Resources/pics/Select5.gif" width="228" alt="Complex Condition syntax diagram showing the AND and OR conjunction operators" />
 					</p>
 					<p>
 						Complex Conditions are formed by combining two or more simple conditions using the conjunction
@@ -405,30 +404,30 @@ END-IF</code></pre>
 							<col style="width: 42%" />
 						</colgroup>
 						<tr bgcolor="#FFFFCC">
-							<th align="center">
+							<th style="text-align:center">
 								<span style="color: #ff0000"><b>Precedence</b></span>
 							</th>
-							<th align="center">
+							<th style="text-align:center">
 								<span style="color: #ff0000"><b>Condition Value</b></span>
 							</th>
-							<th align="center">
+							<th style="text-align:center">
 								<span style="color: #ff0000"><b>Arithmetic Equivalent</b></span>
 							</th>
 						</tr>
 						<tr>
-							<td align="center"><b>1.</b></td>
-							<td align="center"><code class="language-cobol">NOT</code></td>
-							<td align="center"><b>**</b></td>
+							<td style="text-align:center"><b>1.</b></td>
+							<td style="text-align:center"><code class="language-cobol">NOT</code></td>
+							<td style="text-align:center"><b>**</b></td>
 						</tr>
 						<tr>
-							<td align="center"><b>2.</b></td>
-							<td align="center"><code class="language-cobol">AND</code></td>
-							<td align="center"><b>*</b> or <b>/</b></td>
+							<td style="text-align:center"><b>2.</b></td>
+							<td style="text-align:center"><code class="language-cobol">AND</code></td>
+							<td style="text-align:center"><b>*</b> or <b>/</b></td>
 						</tr>
 						<tr>
-							<td align="center"><b>3.</b></td>
-							<td align="center"><code class="language-cobol">OR</code></td>
-							<td align="center"><b>+</b> or <b>-</b></td>
+							<td style="text-align:center"><b>3.</b></td>
+							<td style="text-align:center"><code class="language-cobol">OR</code></td>
+							<td style="text-align:center"><b>+</b> or <b>-</b></td>
 						</tr>
 					</table>
 					<p><b>Example</b></p>
@@ -463,9 +462,9 @@ END-IF
 						</p>
 					</blockquote>
 					<p>If all the simple conditions are true; will the Complex Condition be true? Let's check.</p>
-					<table align="center" border="1" width="94%" style="display: table">
+					<table border="1" width="94%" style="display: table;margin-inline:auto">
 						<tr>
-							<th scope="row" bgcolor="#FFFFCC" width="16%" align="center">Condition</th>
+							<th scope="row" bgcolor="#FFFFCC" width="16%" style="text-align:center">Condition</th>
 							<td bgcolor="#E1FFE1" width="84%">
 								<p style="text-align: center; margin: 0.3em 0">
 									&nbsp;(<code class="language-cobol">NOT</code> (Amnt1 &lt; 10))
@@ -475,7 +474,7 @@ END-IF
 							</td>
 						</tr>
 						<tr>
-							<th scope="row" bgcolor="#FFFFCC" width="16%" align="center">Expressed as</th>
+							<th scope="row" bgcolor="#FFFFCC" width="16%" style="text-align:center">Expressed as</th>
 							<td bgcolor="#E1FFE1" width="84%">
 								<div class="eval-row eval-row-3col">
 									<span>(<code class="language-cobol">NOT</code>&nbsp;(T))</span>
@@ -485,7 +484,7 @@ END-IF
 							</td>
 						</tr>
 						<tr>
-							<th scope="row" bgcolor="#FFFFCC" height="17" width="16%" align="center">Evaluates to</th>
+							<th scope="row" bgcolor="#FFFFCC" height="17" width="16%" style="text-align:center">Evaluates to</th>
 							<td bgcolor="#E1FFE1" height="17" width="84%">
 								<div class="eval-row eval-row-3col">
 									<span>(F)</span>
@@ -495,7 +494,7 @@ END-IF
 							</td>
 						</tr>
 						<tr>
-							<th scope="row" bgcolor="#FFFFCC" width="16%" align="center">Evaluates to</th>
+							<th scope="row" bgcolor="#FFFFCC" width="16%" style="text-align:center">Evaluates to</th>
 							<td bgcolor="#E1FFE1" width="84%">
 								<p style="text-align: center; margin: 0.3em 0">
 									<code class="language-cobol">True</code>
@@ -507,9 +506,9 @@ END-IF
 						Consider the condition in the table below and ask the same question. Is the Complex Condition
 						true if all the Simple Conditions are true? &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 					</p>
-					<table align="center" border="1" width="93%" style="display: table">
+					<table border="1" width="93%" style="display: table;margin-inline:auto">
 						<tr>
-							<th scope="row" bgcolor="#FFFFCC" width="16%" align="center">Condition</th>
+							<th scope="row" bgcolor="#FFFFCC" width="16%" style="text-align:center">Condition</th>
 							<td bgcolor="#E1FFE1" width="84%">
 								<p style="text-align: center; margin: 0.3em 0">
 									<code class="language-cobol">NOT</code> ((Amnt1 &lt; 10)
@@ -519,7 +518,7 @@ END-IF
 							</td>
 						</tr>
 						<tr>
-							<th scope="row" bgcolor="#FFFFCC" width="16%" align="center">Expressed as</th>
+							<th scope="row" bgcolor="#FFFFCC" width="16%" style="text-align:center">Expressed as</th>
 							<td bgcolor="#E1FFE1" width="84%">
 								<div class="eval-row eval-row-4col">
 									<code class="language-cobol">NOT</code>
@@ -530,7 +529,7 @@ END-IF
 							</td>
 						</tr>
 						<tr>
-							<th scope="row" bgcolor="#FFFFCC" height="17" width="16%" align="center">Evaluates to</th>
+							<th scope="row" bgcolor="#FFFFCC" height="17" width="16%" style="text-align:center">Evaluates to</th>
 							<td bgcolor="#E1FFE1" height="17" width="84%">
 								<div class="eval-row eval-row-4col">
 									<code class="language-cobol">NOT</code>
@@ -541,7 +540,7 @@ END-IF
 							</td>
 						</tr>
 						<tr>
-							<th scope="row" bgcolor="#FFFFCC" width="16%" align="center">Evaluates to</th>
+							<th scope="row" bgcolor="#FFFFCC" width="16%" style="text-align:center">Evaluates to</th>
 							<td bgcolor="#E1FFE1" width="84%">
 								<div class="eval-row eval-row-4col">
 									<span style="grid-column: 1 / 3">(F)</span>
@@ -551,7 +550,7 @@ END-IF
 							</td>
 						</tr>
 						<tr>
-							<th scope="row" bgcolor="#FFFFCC" width="16%" align="center">Evaluates to</th>
+							<th scope="row" bgcolor="#FFFFCC" width="16%" style="text-align:center">Evaluates to</th>
 							<td bgcolor="#E1FFE1" width="84%">
 								<p style="text-align: center; margin: 0.3em 0">
 									<code class="language-cobol">False</code>
@@ -563,7 +562,7 @@ END-IF
 						Now, consider the condition below and create a table similar to the ones above. Is this Complex
 						Condition true if all the Simple Conditions are true?
 					</p>
-					<p align="center">
+					<p class="center-block">
 						<code class="language-cobol">IF NOT</code> (((Amnt1 &lt; 10)
 						<code class="language-cobol">OR</code>
 						(Amnt2 = 50))
@@ -574,7 +573,7 @@ END-IF
 				</div>
 
 				<div class="section-sidebar">
-					<h4 align="left">Implied Subjects</h4>
+					<h4>Implied Subjects</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -620,8 +619,8 @@ END-IF
 				</div>
 
 				<div class="section-sidebar">
-					<h4 align="left">Nested Ifs</h4>
-					<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
+					<h4>Nested Ifs</h4>
+					<p class="center-block"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
 				</div>
 				<div class="section-content">
 					<p>COBOL allows nested <code class="language-cobol">IF</code> statements.</p>
@@ -642,22 +641,21 @@ END-IF
 						instance, see if you can figure out which of the messages will be displayed. To see the answer,
 						move your cursor over the text "Answer" and the correct answer should be shown.
 					</p>
-					<form action="Selection.html" method="post">
-						<table align="center" bgcolor="#E1FFE1" border="1" width="50%" style="display: table">
+						<table bgcolor="#E1FFE1" border="1" width="50%" style="display: table;margin-inline:auto">
 							<tr bgcolor="#FFFFCC">
-								<th width="13%" align="center">
+								<th width="13%" style="text-align:center">
 									<span style="color: #ff0000"><b>VarA</b></span>
 								</th>
-								<th width="13%" align="center">
+								<th width="13%" style="text-align:center">
 									<span style="color: #ff0000"><b>VarB</b></span>
 								</th>
-								<th width="13%" align="center">
+								<th width="13%" style="text-align:center">
 									<span style="color: #ff0000"><b>VarC</b></span>
 								</th>
-								<th width="12%" align="center">
+								<th width="12%" style="text-align:center">
 									<span style="color: #ff0000"><b>VarG</b></span>
 								</th>
-								<th bgcolor="#FFFFCC" width="49%" align="center">
+								<th bgcolor="#FFFFCC" width="49%" style="text-align:center">
 									<span style="color: #ff0000"
 										><b>
 											<code class="language-cobol">DISPLAY</code>
@@ -666,59 +664,58 @@ END-IF
 								</th>
 							</tr>
 							<tr>
-								<td width="13%" align="center">3</td>
-								<td width="13%" align="center">4</td>
-								<td width="13%" align="center">15</td>
-								<td width="12%" align="center">14</td>
-								<td bgcolor="#E1FFE1" width="49%" align="center">
-									<select name="select">
+								<td width="13%" style="text-align:center">3</td>
+								<td width="13%" style="text-align:center">4</td>
+								<td width="13%" style="text-align:center">15</td>
+								<td width="12%" style="text-align:center">14</td>
+								<td bgcolor="#E1FFE1" width="49%" style="text-align:center">
+									<select aria-label="Click for answer" name="select">
 										<option selected>Click arrow for answer</option>
 										<option>First is displayed</option>
 									</select>
 								</td>
 							</tr>
 							<tr>
-								<td width="13%" align="center">3</td>
-								<td width="13%" align="center">4</td>
-								<td width="13%" align="center">15</td>
-								<td width="12%" align="center">15</td>
-								<td bgcolor="#E1FFE1" width="49%" align="center">
-									<select name="select2">
+								<td width="13%" style="text-align:center">3</td>
+								<td width="13%" style="text-align:center">4</td>
+								<td width="13%" style="text-align:center">15</td>
+								<td width="12%" style="text-align:center">15</td>
+								<td bgcolor="#E1FFE1" width="49%" style="text-align:center">
+									<select aria-label="Click for answer" name="select2">
 										<option selected>Click arrow for answer</option>
 										<option>Second is displayed</option>
 									</select>
 								</td>
 							</tr>
 							<tr>
-								<td width="13%" align="center">3</td>
-								<td width="13%" align="center">4</td>
-								<td width="13%" align="center">3</td>
-								<td width="12%" align="center">14</td>
-								<td bgcolor="#E1FFE1" width="49%" align="center">
-									<select name="select3">
+								<td width="13%" style="text-align:center">3</td>
+								<td width="13%" style="text-align:center">4</td>
+								<td width="13%" style="text-align:center">3</td>
+								<td width="12%" style="text-align:center">14</td>
+								<td bgcolor="#E1FFE1" width="49%" style="text-align:center">
+									<select aria-label="Click for answer" name="select3">
 										<option selected>Click arrow for answer</option>
 										<option>Third is displayed</option>
 									</select>
 								</td>
 							</tr>
 							<tr>
-								<td width="13%" align="center">13</td>
-								<td width="13%" align="center">4</td>
-								<td width="13%" align="center">15</td>
-								<td width="12%" align="center">14</td>
-								<td bgcolor="#E1FFE1" width="49%" align="center">
-									<select name="select4">
+								<td width="13%" style="text-align:center">13</td>
+								<td width="13%" style="text-align:center">4</td>
+								<td width="13%" style="text-align:center">15</td>
+								<td width="12%" style="text-align:center">14</td>
+								<td bgcolor="#E1FFE1" width="49%" style="text-align:center">
+									<select aria-label="Click for answer" name="select4">
 										<option selected>Click arrow for answer</option>
 										<option>Third is displayed</option>
 									</select>
 								</td>
 							</tr>
 						</table>
-					</form>
 				</div>
 
 				<div class="section-full">
-					<div align="center">
+					<div class="center-block">
 						<hr />
 						<back-to-top></back-to-top>
 					</div>
@@ -732,7 +729,7 @@ END-IF
 				</div>
 
 				<div class="section-sidebar">
-					<h4 align="left">Introduction</h4>
+					<h4>Introduction</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -754,64 +751,62 @@ END-IF
 				</div>
 
 				<div class="section-sidebar">
-					<h4 align="left">Condition Name Syntax</h4>
+					<h4>Condition Name Syntax</h4>
 				</div>
 				<div class="section-content">
-					<p align="left"><img height="76" src="Resources/pics/Select6.gif" width="501" /></p>
-					<p align="left">
+					<p><img height="76" src="Resources/pics/Select6.gif" width="501" alt="Condition Name syntax diagram" /></p>
+					<p>
 						When used with Condition Names, the <code class="language-cobol">VALUE</code> clause does not
 						assign a value. It merely identifies the value(s) in the data-item which make the Condition Name
 						True.
 					</p>
-					<p align="left">
+					<p>
 						When identifying the condition values, you can specify a single value, a list of values, a range
 						of values, or any combination of these.
 					</p>
-					<p align="left">
+					<p>
 						To specify a list of values, simply list the values after the keyword
 						<code class="language-cobol">VALUE</code>. The list entries may be separated by commas or spaces
 						but must terminate with a full-stop.
 					</p>
 					<blockquote>
-						<div align="left">
+						<div>
 							<pre
 								class="language-cobol"
-								align="left"
 							><code class="language-cobol">e.g. 02 DeptCode          PIC X.
         88 ProductionDept VALUE "I","L","T". </code></pre>
 						</div>
 					</blockquote>
-					<p align="left">
+					<p>
 						To specify a range, use the keyword <code class="language-cobol">THRU</code>, or
 						<code class="language-cobol">THROUGH</code>, to separate the low and high values.
 					</p>
 					<blockquote>
-						<div align="left">
+						<div>
 							<pre
 								class="language-cobol"
-								align="left"
 							><code class="language-cobol">E.g. 02 AgeInYears  PIC 9(3).
         88 Teenager VALUE 13 THRU 19. </code></pre>
 						</div>
 					</blockquote>
-					<p align="left">Several Condition Names may be associated with a single data item,</p>
-					<pre class="language-cobol" align="left"><code class="language-cobol">e.g. 02 AgeInYears  PIC 9(3).
+					<p>Several Condition Names may be associated with a single data item,</p>
+					<pre class="language-cobol"><code class="language-cobol">e.g. 02 AgeInYears  PIC 9(3).
         88 Child    VALUE 0  THRU 12.
         88 Teenager VALUE 13 THRU 19.
         88 Adult    VALUE 21 THRU 999.
 </code></pre>
 					<blockquote></blockquote>
-					<p align="left">
+					<p>
 						More than one Condition Names may be true at the same time. For instance, if AgeInYears contains
 						the value 20 both Teenager and Voter will be true.
 					</p>
-					<pre class="language-cobol" align="left"><code class="language-cobol">E.g. 02 AgeInYears  PIC 9(3).
+					<pre class="language-cobol"><code class="language-cobol">E.g. 02 AgeInYears  PIC 9(3).
         88 Child    VALUE 0  THRU 12.
         88 Teenager VALUE 13 THRU 19.
         88 Adult    VALUE 21 THRU 999.
         88 Voter    VALUE 18 THRU 999.
 </code></pre>
-					<p align="left"><b>Condition Name notes</b></p>
+					<p><b>Condition Name notes</b></p>
 					<ul>
 						<li>
 							A Condition Name evaluates to True or False depending on the value of its associated
@@ -830,14 +825,14 @@ END-IF
 				</div>
 
 				<div class="section-sidebar">
-					<h4 align="left">Condition Names examples</h4>
+					<h4>Condition Names examples</h4>
 				</div>
 				<div class="section-content">
 					<p>
 						Examine the examples in the animation below. Make sure you understand how Condition Names are
 						created, how they work and how they are used.
 					</p>
-					<p align="center">
+					<p class="center-block">
 						<a href="Resources/ppz/TC-Condition1.html"
 							><img
 								alt="Click to view the animation"
@@ -850,7 +845,7 @@ END-IF
 				</div>
 
 				<div class="section-sidebar">
-					<h4 align="left">Using Condition Names correctly</h4>
+					<h4>Using Condition Names correctly</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -900,7 +895,7 @@ END-IF
 				</div>
 
 				<div class="section-full">
-					<div align="center">
+					<div class="center-block">
 						<hr />
 						<back-to-top></back-to-top>
 					</div>
@@ -914,7 +909,7 @@ END-IF
 				</div>
 
 				<div class="section-sidebar">
-					<h4 align="left">Introduction</h4>
+					<h4>Introduction</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -930,7 +925,7 @@ END-IF
 				</div>
 
 				<div class="section-sidebar">
-					<h4 align="left">SET syntax</h4>
+					<h4>SET syntax</h4>
 				</div>
 				<div class="section-content">
 					<p>SET {ConditionName} ... TO TRUE</p>
@@ -955,7 +950,7 @@ END-IF
 				</div>
 
 				<div class="section-sidebar">
-					<h4 align="left">SET verb example</h4>
+					<h4>SET verb example</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -963,7 +958,7 @@ END-IF
 						Condition Name when reading Sequential Files. The animation below demonstrates how to set up and
 						use an end of file Condition Name.
 					</p>
-					<p align="center">
+					<p class="center-block">
 						<a href="Resources/ppz/TC-Condition2.html"
 							><img
 								alt="Click to view the animation"
@@ -976,8 +971,8 @@ END-IF
 				</div>
 
 				<div class="section-sidebar">
-					<h4 align="left">Using the SET verb with Sequential Files</h4>
-					<p align="center"><img height="44" src="Resources/pics/program-fragment.svg" width="48" alt="Program fragment" /></p>
+					<h4>Using the SET verb with Sequential Files</h4>
+					<p class="center-block"><img height="44" src="Resources/pics/program-fragment.svg" width="48" alt="Program fragment" /></p>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1036,7 +1031,7 @@ Begin.
 				</div>
 
 				<div class="section-full">
-					<div align="center">
+					<div class="center-block">
 						<hr />
 						<back-to-top></back-to-top>
 					</div>
@@ -1050,7 +1045,7 @@ Begin.
 				</div>
 
 				<div class="section-sidebar">
-					<h4 align="left">Introduction</h4>
+					<h4>Introduction</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1067,10 +1062,10 @@ Begin.
 				</div>
 
 				<div class="section-sidebar">
-					<h4 align="left">Evaluate syntax</h4>
+					<h4>Evaluate syntax</h4>
 				</div>
 				<div class="section-content">
-					<p><img height="453" src="Resources/pics/Select7.gif" width="523" /></p>
+					<p><img height="453" src="Resources/pics/Select7.gif" width="523" alt="EVALUATE statement syntax diagram" /></p>
 					<p>
 						<b>EVALUATE notes</b><br />
 						The items immediately after the word <code class="language-cobol">EVALUATE</code> and before the
@@ -1107,7 +1102,7 @@ Begin.
 				</div>
 
 				<div class="section-sidebar">
-					<h4 align="left">EVALUATE example1</h4>
+					<h4>EVALUATE example1</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1115,8 +1110,8 @@ Begin.
 						allow them to be edited. The edit field will be implemented as a ten character array as shown
 						below.
 					</p>
-					<p align="center">
-						<img align="absmiddle" height="100" src="Resources/pics/eval1.gif" width="450" />
+					<p class="center-block">
+						<img height="100" src="Resources/pics/eval1.gif" width="450" alt="Ten-character edit-field array used by the EVALUATE example" />
 					</p>
 					<p>What sort of functionality do we want to implement?</p>
 					<ul>
@@ -1177,7 +1172,7 @@ END-EVALUATE
 				</div>
 
 				<div class="section-sidebar">
-					<h4 align="left">EVALUATE example2</h4>
+					<h4>EVALUATE example2</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1195,120 +1190,120 @@ END-EVALUATE
 						Jupiter Books uses a decision table to decide what discount to apply. The decision table and the
 						<code class="language-cobol">EVALUATE</code> which implements it are shown below.
 					</p>
-					<table align="center" bgcolor="#E1FFE1" border="1" width="83%">
+					<table bgcolor="#E1FFE1" border="1" width="83%" style="margin-inline:auto">
 						<tr bgcolor="#FFFFCC" valign="top">
-							<th height="10" width="20%" align="center">QtyOfBooks</th>
-							<th bgcolor="#FFFFCC" height="10" width="43%" align="center">ValueOfPurchases (VOP)</th>
-							<th height="10" width="14%" align="center">ClubMember</th>
-							<th height="10" width="23%" align="center">% Discount</th>
+							<th height="10" width="20%" style="text-align:center">QtyOfBooks</th>
+							<th bgcolor="#FFFFCC" height="10" width="43%" style="text-align:center">ValueOfPurchases (VOP)</th>
+							<th height="10" width="14%" style="text-align:center">ClubMember</th>
+							<th height="10" width="23%" style="text-align:center">% Discount</th>
 						</tr>
 						<tr>
-							<td width="20%" align="center">1-5</td>
-							<td width="43%" align="center">$0-500</td>
-							<td width="14%" align="center">Y</td>
-							<td width="23%" align="center">2%</td>
+							<td width="20%" style="text-align:center">1-5</td>
+							<td width="43%" style="text-align:center">$0-500</td>
+							<td width="14%" style="text-align:center">Y</td>
+							<td width="23%" style="text-align:center">2%</td>
 						</tr>
 						<tr>
-							<td width="20%" align="center">6-16</td>
-							<td width="43%" align="center">$0-500</td>
-							<td width="14%" align="center">Y</td>
-							<td width="23%" align="center">3%</td>
+							<td width="20%" style="text-align:center">6-16</td>
+							<td width="43%" style="text-align:center">$0-500</td>
+							<td width="14%" style="text-align:center">Y</td>
+							<td width="23%" style="text-align:center">3%</td>
 						</tr>
 						<tr>
-							<td width="20%" align="center">&gt;16</td>
-							<td width="43%" align="center">$0-500</td>
-							<td width="14%" align="center">Y</td>
-							<td width="23%" align="center">5%</td>
+							<td width="20%" style="text-align:center">&gt;16</td>
+							<td width="43%" style="text-align:center">$0-500</td>
+							<td width="14%" style="text-align:center">Y</td>
+							<td width="23%" style="text-align:center">5%</td>
 						</tr>
 						<tr>
-							<td width="20%" align="center">1-5</td>
-							<td width="43%" align="center">$501-2000</td>
-							<td width="14%" align="center">Y</td>
-							<td width="23%" align="center">7%</td>
+							<td width="20%" style="text-align:center">1-5</td>
+							<td width="43%" style="text-align:center">$501-2000</td>
+							<td width="14%" style="text-align:center">Y</td>
+							<td width="23%" style="text-align:center">7%</td>
 						</tr>
 						<tr>
-							<td width="20%" align="center">6-16</td>
-							<td width="43%" align="center">$501-2000</td>
-							<td width="14%" align="center">Y</td>
-							<td width="23%" align="center">12%</td>
+							<td width="20%" style="text-align:center">6-16</td>
+							<td width="43%" style="text-align:center">$501-2000</td>
+							<td width="14%" style="text-align:center">Y</td>
+							<td width="23%" style="text-align:center">12%</td>
 						</tr>
 						<tr>
-							<td width="20%" align="center">&gt;16</td>
-							<td width="43%" align="center">$501-2000</td>
-							<td width="14%" align="center">Y</td>
-							<td width="23%" align="center">18%</td>
+							<td width="20%" style="text-align:center">&gt;16</td>
+							<td width="43%" style="text-align:center">$501-2000</td>
+							<td width="14%" style="text-align:center">Y</td>
+							<td width="23%" style="text-align:center">18%</td>
 						</tr>
 						<tr>
-							<td width="20%" align="center">1-5</td>
-							<td width="43%" align="center">&gt; $2000</td>
-							<td width="14%" align="center">Y</td>
-							<td width="23%" align="center">10%</td>
+							<td width="20%" style="text-align:center">1-5</td>
+							<td width="43%" style="text-align:center">&gt; $2000</td>
+							<td width="14%" style="text-align:center">Y</td>
+							<td width="23%" style="text-align:center">10%</td>
 						</tr>
 						<tr>
-							<td width="20%" align="center">6-16</td>
-							<td width="43%" align="center">&gt; $2000</td>
-							<td width="14%" align="center">Y</td>
-							<td width="23%" align="center">23%</td>
+							<td width="20%" style="text-align:center">6-16</td>
+							<td width="43%" style="text-align:center">&gt; $2000</td>
+							<td width="14%" style="text-align:center">Y</td>
+							<td width="23%" style="text-align:center">23%</td>
 						</tr>
 						<tr>
-							<td width="20%" align="center">&gt;16</td>
-							<td width="43%" align="center">&gt; $2000</td>
-							<td width="14%" align="center">Y</td>
-							<td width="23%" align="center">35%</td>
+							<td width="20%" style="text-align:center">&gt;16</td>
+							<td width="43%" style="text-align:center">&gt; $2000</td>
+							<td width="14%" style="text-align:center">Y</td>
+							<td width="23%" style="text-align:center">35%</td>
 						</tr>
 						<tr>
-							<td width="20%" align="center">1-5</td>
-							<td width="43%" align="center">$0-500</td>
-							<td width="14%" align="center">N</td>
-							<td width="23%" align="center">1%</td>
+							<td width="20%" style="text-align:center">1-5</td>
+							<td width="43%" style="text-align:center">$0-500</td>
+							<td width="14%" style="text-align:center">N</td>
+							<td width="23%" style="text-align:center">1%</td>
 						</tr>
 						<tr>
-							<td width="20%" align="center">6-16</td>
-							<td width="43%" align="center">$0-500</td>
-							<td width="14%" align="center">N</td>
-							<td width="23%" align="center">2%</td>
+							<td width="20%" style="text-align:center">6-16</td>
+							<td width="43%" style="text-align:center">$0-500</td>
+							<td width="14%" style="text-align:center">N</td>
+							<td width="23%" style="text-align:center">2%</td>
 						</tr>
 						<tr>
-							<td width="20%" align="center">&gt;16</td>
-							<td width="43%" align="center">$0-500</td>
-							<td width="14%" align="center">N</td>
-							<td width="23%" align="center">3%</td>
+							<td width="20%" style="text-align:center">&gt;16</td>
+							<td width="43%" style="text-align:center">$0-500</td>
+							<td width="14%" style="text-align:center">N</td>
+							<td width="23%" style="text-align:center">3%</td>
 						</tr>
 						<tr>
-							<td width="20%" align="center">1-5</td>
-							<td width="43%" align="center">$501-2000</td>
-							<td width="14%" align="center">N</td>
-							<td width="23%" align="center">5%</td>
+							<td width="20%" style="text-align:center">1-5</td>
+							<td width="43%" style="text-align:center">$501-2000</td>
+							<td width="14%" style="text-align:center">N</td>
+							<td width="23%" style="text-align:center">5%</td>
 						</tr>
 						<tr>
-							<td width="20%" align="center">6-16</td>
-							<td width="43%" align="center">$501-2000</td>
-							<td width="14%" align="center">N</td>
-							<td width="23%" align="center">10%</td>
+							<td width="20%" style="text-align:center">6-16</td>
+							<td width="43%" style="text-align:center">$501-2000</td>
+							<td width="14%" style="text-align:center">N</td>
+							<td width="23%" style="text-align:center">10%</td>
 						</tr>
 						<tr>
-							<td width="20%" align="center">&gt;16</td>
-							<td width="43%" align="center">$501-2000</td>
-							<td width="14%" align="center">N</td>
-							<td width="23%" align="center">15%</td>
+							<td width="20%" style="text-align:center">&gt;16</td>
+							<td width="43%" style="text-align:center">$501-2000</td>
+							<td width="14%" style="text-align:center">N</td>
+							<td width="23%" style="text-align:center">15%</td>
 						</tr>
 						<tr>
-							<td width="20%" align="center">1-5</td>
-							<td width="43%" align="center">&gt; $2000</td>
-							<td width="14%" align="center">N</td>
-							<td width="23%" align="center">8%</td>
+							<td width="20%" style="text-align:center">1-5</td>
+							<td width="43%" style="text-align:center">&gt; $2000</td>
+							<td width="14%" style="text-align:center">N</td>
+							<td width="23%" style="text-align:center">8%</td>
 						</tr>
 						<tr>
-							<td width="20%" align="center">6-16</td>
-							<td width="43%" align="center">&gt; $2000</td>
-							<td width="14%" align="center">N</td>
-							<td width="23%" align="center">23%</td>
+							<td width="20%" style="text-align:center">6-16</td>
+							<td width="43%" style="text-align:center">&gt; $2000</td>
+							<td width="14%" style="text-align:center">N</td>
+							<td width="23%" style="text-align:center">23%</td>
 						</tr>
 						<tr>
-							<td width="20%" align="center">&gt;16</td>
-							<td width="43%" align="center">&gt; $2000</td>
-							<td width="14%" align="center">N</td>
-							<td width="23%" align="center">28%</td>
+							<td width="20%" style="text-align:center">&gt;16</td>
+							<td width="43%" style="text-align:center">&gt; $2000</td>
+							<td width="14%" style="text-align:center">N</td>
+							<td width="23%" style="text-align:center">28%</td>
 						</tr>
 					</table>
 					<pre


### PR DESCRIPTION
## Summary

Second per-chapter modernisation pass, paired with [#192](https://github.com/bushidocodes/limerick-cobol/pull/192)'s Iteration chapter. Same pattern, applied to the IF/EVALUATE control-structures chapter. `course/Selection.html` is now pa11y-clean at WCAG 2.1 AA (0 violations from 207).

The page has more tables than Iteration did — the bulk of the diff is `align="center"` on `<td>`/`<th>` cells getting replaced with inline `text-align:center` style.

## Changes

### Descriptive alt for 8 syntax diagrams

| Image | Alt |
| --- | --- |
| `Select1.gif` | IF statement syntax diagram |
| `Select2.gif` | Relation Condition syntax diagram (with operators) |
| `Select3.gif` | Class Condition syntax diagram |
| `Select4.gif` | Sign Condition syntax diagram |
| `Select5.gif` | Complex Condition syntax diagram (AND/OR) |
| `Select6.gif` | Condition Name syntax diagram |
| `Select7.gif` | EVALUATE statement syntax diagram |
| `eval1.gif`   | Ten-character edit-field array used by the EVALUATE example |

The `<img align="absmiddle">` on `eval1.gif` is removed — that was an HTML 4 vertical-alignment hack with no modern equivalent needed.

### `course.css` dark-mode fix for `<th bgcolor="#FFFFCC">`

This is a real bug in the existing dark-mode handling that was masked by no chapter previously running through pa11y. The `#FFFFCC` rule covered `table`, `tr`, `td` with `bgcolor="#FFFFCC"` — but **not** `<th>`. So in dark mode, `<th>` cells kept the hardcoded light yellow background while text inherited dark-mode's light-on-dark colour, giving a **1.21:1 contrast ratio**.

The fix is two new selectors (uppercase + lowercase) added to the existing rule. **Affects every page with `<th bgcolor>`, not just Selection.html.**

### Legacy attribute cleanup (~180 violations)

- 122 × `align="center"` on `<td>`/`<th>` → inline `style="text-align:center"` (merged into existing style attr where present)
- 4 × `align="center"` on `<table>` → inline `style="margin-inline:auto"` (preserves the "table centered as block" semantics)
- 8 × `<p align="center">` → `<p class="center-block">`
- 4 × `<div align="center">` (back-to-top footers) → `<div class="center-block">`
- 2 × `<div align="center">` (vestigial Word-export wrappers around `<p align="left">` body text where master rendering was already all-left) → plain `<div>`
- 39 × `align="left"` defaults on `<p>`, `<h4>`, `<pre>`, `<div>` → removed
- 1 × `<img align="absmiddle">` → removed

### Form modernisation

- 4 SAQ `<select>` elements get `aria-label="Click for answer"`
- 1 vestigial `<form action="Selection.html" method="post">` wrapper removed

## pa11y delta

| Code | Before | After |
| --- | --: | --: |
| H49.AlignAttr | 180 | 0 |
| G18.Fail (contrast) | 10 | 0 |
| H37 (img alt) | 8 | 0 |
| H91.Select.Name | 4 | 0 |
| F68 | 4 | 0 |
| H32.2 | 1 | 0 |
| **Total** | **207** | **0** |

## Test plan

- [x] `npm run validate` clean
- [x] `npm run links` clean (586 links)
- [x] `pa11y` reports 0 violations
- [x] Spot-checked in browser preview: IF syntax diagram, body text alignment, Complex Condition evaluation table (`<th>` headers now render with proper dark-mode contrast), SAQ selects render with their dropdowns
- [x] Verified `getComputedStyle` on `<th[bgcolor="#FFFFCC"]>` returns the dark-mode panel-bg (`rgb(58, 53, 32)`) instead of the hardcoded light yellow
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)