### PR TITLE
Make Selection, EditedPics, SequentialFiles2, Tables2 pa11y-clean

### DIFF
--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -52,25 +52,21 @@
 					<h4>Aims</h4>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<p align="left">
-							In a business-programming environment, the ability to print reports is an important property
-							for a programming language. COBOL allows programmers to write to the printer, either
-							directly or through an intermediate print file.
-						</p>
-						<p align="left">
-							But there would be little point in being able to write to the printer, if the output could
-							not be formatted properly. COBOL allows sophisticated formatting of output through its
-							Edited Picture clauses.
-						</p>
-						<p align="left">
-							This tutorial introduces the additional symbols required for edited pictures and shows how
-							they may be used to format data for output to screen or printer.
-						</p>
-					</div>
-					<div align="center">
-						<hr width="50%" />
-					</div>
+					<p>
+						In a business-programming environment, the ability to print reports is an important property
+						for a programming language. COBOL allows programmers to write to the printer, either
+						directly or through an intermediate print file.
+					</p>
+					<p>
+						But there would be little point in being able to write to the printer, if the output could
+						not be formatted properly. COBOL allows sophisticated formatting of output through its
+						Edited Picture clauses.
+					</p>
+					<p>
+						This tutorial introduces the additional symbols required for edited pictures and shows how
+						they may be used to format data for output to screen or printer.
+					</p>
+					<hr width="50%" />
 				</div>
 
 				<div class="section-sidebar">
@@ -101,7 +97,7 @@
 				</div>
 
 				<div class="section-full">
-					<div align="center">
+					<div>
 						<hr />
 						<back-to-top></back-to-top>
 					</div>
@@ -117,48 +113,48 @@
 					<h4>Introduction</h4>
 				</div>
 				<div class="section-content">
-					<p align="left">
+					<p>
 						Most users of the data produced by COBOL programs are not content with the simple raw data. They
 						often want it presented in a particular way. Some people like to have the thousands, in numeric
 						values, separated by commas, others may want leading zeros suppressed while still others may
 						require that the currency symbol "floats" up against the first non-zero digit. In COBOL these
 						things can be achieved using Edited Pictures.
 					</p>
-					<table align="center" bgcolor="#E1FFE1" border="1" cellpadding="10" width="72%">
+					<table style="margin:0 auto" bgcolor="#E1FFE1" border="1" cellpadding="10" width="72%">
 						<tr>
 							<td bgcolor="#FFFFCC" width="60%">Original value</td>
 							<td width="40%">
-								<div align="center">00023456.78</div>
+								<div class="center-block">00023456.78</div>
 							</td>
 						</tr>
 						<tr>
 							<td bgcolor="#FFFFCC" width="60%">
-								<div align="left">With commas inserted</div>
+								With commas inserted
 							</td>
 							<td width="40%">
-								<div align="center">00,023,456.78</div>
+								<div class="center-block">00,023,456.78</div>
 							</td>
 						</tr>
 						<tr>
 							<td bgcolor="#FFFFCC" width="60%">
-								<div align="left">Plus zero suppression</div>
+								Plus zero suppression
 							</td>
 							<td width="40%">
-								<div align="center">23,456.78</div>
+								<div class="center-block">23,456.78</div>
 							</td>
 						</tr>
 						<tr>
 							<td bgcolor="#FFFFCC" height="4" width="60%">Plus floating currency symbol</td>
 							<td height="4" width="40%">
-								<div align="center">$23,456.78</div>
+								<div class="center-block">$23,456.78</div>
 							</td>
 						</tr>
 						<tr>
 							<td bgcolor="#FFFFCC" height="4" width="60%">
-								<div align="left">With anti-fraud printing</div>
+								With anti-fraud printing
 							</td>
 							<td height="4" width="40%">
-								<div align="center">$***23,456.78</div>
+								<div class="center-block">$***23,456.78</div>
 							</td>
 						</tr>
 					</table>
@@ -169,34 +165,30 @@
 					<h4>Edit Symbols</h4>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<p align="left">
-							Edited Pictures, are <code class="language-cobol">PICTURE</code> clauses that format data
-							intended for output to screen or printer. To enable the data items to be formatted, COBOL
-							provides additional picture symbols to supplement the basic 9, X, A, V and S.
-						</p>
-						<p align="left">
-							The additional symbols are referred to as "Edit Symbols," and
-							<code class="language-cobol">PICTURE</code> clauses that include edit symbols are called
-							"Edited Pictures".
-						</p>
-						<p align="left">
-							The term edit is used, because the edit symbols have the effect of changing, or editing, the
-							data inserted into the edited item.
-						</p>
-						<p align="left">
-							Edited items cannot be used as operands in a computation, but they may be used as the result
-							or destination of a computation (they can be used in items placed to the right of the word
-							<code class="language-cobol">GIVING</code>).
-						</p>
-					</div>
-					<div align="left">
-						<hr width="50%" />
-					</div>
+					<p>
+						Edited Pictures, are <code class="language-cobol">PICTURE</code> clauses that format data
+						intended for output to screen or printer. To enable the data items to be formatted, COBOL
+						provides additional picture symbols to supplement the basic 9, X, A, V and S.
+					</p>
+					<p>
+						The additional symbols are referred to as "Edit Symbols," and
+						<code class="language-cobol">PICTURE</code> clauses that include edit symbols are called
+						"Edited Pictures".
+					</p>
+					<p>
+						The term edit is used, because the edit symbols have the effect of changing, or editing, the
+						data inserted into the edited item.
+					</p>
+					<p>
+						Edited items cannot be used as operands in a computation, but they may be used as the result
+						or destination of a computation (they can be used in items placed to the right of the word
+						<code class="language-cobol">GIVING</code>).
+					</p>
+					<hr width="50%" />
 				</div>
 
 				<div class="section-sidebar">
-					<h4 align="left">Types of editing picture</h4>
+					<h4>Types of editing picture</h4>
 				</div>
 				<div class="section-content">
 					<p>COBOL permits two basic types of editing picture:</p>
@@ -226,22 +218,22 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4 align="left">Editing symbols</h4>
+					<h4>Editing symbols</h4>
 				</div>
 				<div class="section-content">
 					<p>COBOL permits two basic types of editing picture:&gt;</p>
-					<table align="center" bgcolor="#E1FFE1" border cellpadding="7" cellspacing="1" width="338">
+					<table style="margin:0 auto" bgcolor="#E1FFE1" border cellpadding="7" cellspacing="1" width="338">
 						<tr bgcolor="#FFFFCC">
 							<td valign="top" width="32%">
-								<p align="center"><b>Edit Symbol</b></p>
+								<p class="center-block"><b>Edit Symbol</b></p>
 							</td>
 							<td valign="top" width="68%">
-								<p align="center"><b>Editing Type</b></p>
+								<p class="center-block"><b>Editing Type</b></p>
 							</td>
 						</tr>
 						<tr>
 							<td valign="top" width="32%">
-								<p align="center"><b>, B 0 /</b></p>
+								<p class="center-block"><b>, B 0 /</b></p>
 							</td>
 							<td valign="top" width="68%">
 								<p>Simple Insertion</p>
@@ -249,7 +241,7 @@
 						</tr>
 						<tr>
 							<td valign="top" width="32%">
-								<p align="center"><b>.</b></p>
+								<p class="center-block"><b>.</b></p>
 							</td>
 							<td valign="top" width="68%">
 								<p>Special Insertion</p>
@@ -257,7 +249,7 @@
 						</tr>
 						<tr>
 							<td valign="top" width="32%">
-								<p align="center"><b>+ - CR DB $</b></p>
+								<p class="center-block"><b>+ - CR DB $</b></p>
 							</td>
 							<td valign="top" width="68%">
 								<p>Fixed Insertion</p>
@@ -265,7 +257,7 @@
 						</tr>
 						<tr>
 							<td valign="top" width="32%">
-								<p align="center"><b>+ - $</b></p>
+								<p class="center-block"><b>+ - $</b></p>
 							</td>
 							<td valign="top" width="68%">
 								<p>Floating Insertion</p>
@@ -273,7 +265,7 @@
 						</tr>
 						<tr>
 							<td valign="top" width="32%">
-								<p align="center"><b>Z *</b></p>
+								<p class="center-block"><b>Z *</b></p>
 							</td>
 							<td valign="top" width="68%">
 								<p>Suppression and Replacement</p>
@@ -284,7 +276,7 @@
 				</div>
 
 				<div class="section-full">
-					<div align="center">
+					<div>
 						<hr />
 						<back-to-top></back-to-top>
 					</div>
@@ -297,7 +289,7 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4 align="left">Introduction</h4>
+					<h4>Introduction</h4>
 				</div>
 				<div class="section-content">
 					<p>There are four types of Insertion Editing:-</p>
@@ -315,7 +307,7 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4 align="left">Simple Insertion editing</h4>
+					<h4>Simple Insertion editing</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -352,8 +344,8 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4 align="left">Simple Insertion examples</h4>
-					<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
+					<h4>Simple Insertion examples</h4>
+					<p class="center-block"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
 				</div>
 				<div class="section-content">
 					<p>
@@ -362,188 +354,186 @@
 						of the Sending item is shown in the Picture column and its current value is shown in the Data
 						column.
 					</p>
-					<form action="" method="post">
-						<table align="center" bgcolor="#FFFFCC" border="1" cellpadding="0" cellspacing="0" width="94%">
-							<tr bgcolor="#FFFFCC">
-								<th colspan="2" scope="colgroup">Sending item</th>
-								<th colspan="2" scope="colgroup">Receiving item</th>
-							</tr>
-							<tr bgcolor="#FFFFCC">
-								<th scope="col" width="20%">Picture</th>
-								<th scope="col" width="15%">Data</th>
-								<th scope="col" width="24%">Picture</th>
-								<th scope="col" width="41%">Result</th>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td width="20%">
-									<div align="left">PIC 999999</div>
-								</td>
-								<td width="15%">
-									<div align="center">123456</div>
-								</td>
-								<td width="24%">
-									<div align="left">PIC 999,999</div>
-								</td>
-								<td width="41%">
-									<div align="center">
-										<select name="select">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 123,456</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td width="20%">
-									<div align="left">PIC 9(6)</div>
-								</td>
-								<td width="15%">
-									<div align="center">000078</div>
-								</td>
-								<td width="24%">
-									<div align="left">PIC 9(3),9(3)</div>
-								</td>
-								<td width="41%">
-									<div align="center">
-										<select name="select2">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 000,078</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td width="20%">PIC 9(6)</td>
-								<td width="15%">
-									<div align="center">000078</div>
-								</td>
-								<td width="24%">PIC ZZZ,ZZZ</td>
-								<td width="41%">
-									<div align="center">
-										<select name="select3">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = sssss78</option>
-											<option>s - indicates a space.</option>
-											<option>The Z suppresses</option>
-											<option>leading zeros, replacing</option>
-											<option>them with spaces. Since</option>
-											<option>there are only zeros to</option>
-											<option>the left of the comma, it</option>
-											<option>is replaced by a space.</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td width="20%">PIC 9(6)</td>
-								<td width="15%">
-									<div align="center">000178</div>
-								</td>
-								<td width="24%">PIC ***,***</td>
-								<td width="41%">
-									<div align="center">
-										<select name="select4">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = ****178</option>
-											<option>Since only zeros are</option>
-											<option>to the left of the comma</option>
-											<option>it is replaced by the</option>
-											<option>replacement symbol *.</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td width="20%">PIC 9(6)</td>
-								<td width="15%">
-									<div align="center">002178</div>
-								</td>
-								<td width="24%">PIC ***,***</td>
-								<td width="41%">
-									<div align="center">
-										<select name="select8">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = **2,178</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td width="20%">
-									<div align="left">PIC 9(6)</div>
-								</td>
-								<td width="15%">
-									<div align="center">120183</div>
-								</td>
-								<td width="24%">
-									<div align="left">PIC 99B99B99</div>
-								</td>
-								<td width="41%">
-									<div align="center">
-										<select name="select9">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 12s01s83</option>
-											<option>s - indicates a space</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td width="20%">
-									<div align="left">PIC 9(6)</div>
-								</td>
-								<td width="15%">
-									<div align="center">120183</div>
-								</td>
-								<td width="24%">
-									<div align="left">PIC 99/99/99</div>
-								</td>
-								<td width="41%">
-									<div align="center">
-										<select name="select10">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 12/01/83</option>
-											<option>As in this case,</option>
-											<option>the slash is often</option>
-											<option>used to edit dates.</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="2" width="20%">
-									<div align="left">PIC 9(6)</div>
-								</td>
-								<td height="2" width="15%">
-									<div align="center">031245</div>
-								</td>
-								<td height="2" width="24%">
-									<div align="left">PIC 990099</div>
-								</td>
-								<td height="2" width="41%">
-									<div align="center">
-										<select name="select11">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 120045</option>
-											<option>Decimal point alignment</option>
-											<option>means that 45 will be</option>
-											<option>placed in the rightmost</option>
-											<option>two digits, then the zeros</option>
-											<option>will be inserted and then</option>
-											<option>the 12 will be placed in</option>
-											<option>the last two positions.</option>
-											<option>The 3 will be truncated.</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-						</table>
-					</form>
+					<table style="margin:0 auto" bgcolor="#FFFFCC" border="1" cellpadding="0" cellspacing="0" width="94%">
+						<tr bgcolor="#FFFFCC">
+							<th colspan="2" scope="colgroup">Sending item</th>
+							<th colspan="2" scope="colgroup">Receiving item</th>
+						</tr>
+						<tr bgcolor="#FFFFCC">
+							<th scope="col" width="20%">Picture</th>
+							<th scope="col" width="15%">Data</th>
+							<th scope="col" width="24%">Picture</th>
+							<th scope="col" width="41%">Result</th>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td width="20%">
+								PIC 999999
+							</td>
+							<td width="15%">
+								<div class="center-block">123456</div>
+							</td>
+							<td width="24%">
+								PIC 999,999
+							</td>
+							<td width="41%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = 123,456</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td width="20%">
+								PIC 9(6)
+							</td>
+							<td width="15%">
+								<div class="center-block">000078</div>
+							</td>
+							<td width="24%">
+								PIC 9(3),9(3)
+							</td>
+							<td width="41%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select2">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = 000,078</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td width="20%">PIC 9(6)</td>
+							<td width="15%">
+								<div class="center-block">000078</div>
+							</td>
+							<td width="24%">PIC ZZZ,ZZZ</td>
+							<td width="41%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select3">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = sssss78</option>
+										<option>s - indicates a space.</option>
+										<option>The Z suppresses</option>
+										<option>leading zeros, replacing</option>
+										<option>them with spaces. Since</option>
+										<option>there are only zeros to</option>
+										<option>the left of the comma, it</option>
+										<option>is replaced by a space.</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td width="20%">PIC 9(6)</td>
+							<td width="15%">
+								<div class="center-block">000178</div>
+							</td>
+							<td width="24%">PIC ***,***</td>
+							<td width="41%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select4">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = ****178</option>
+										<option>Since only zeros are</option>
+										<option>to the left of the comma</option>
+										<option>it is replaced by the</option>
+										<option>replacement symbol *.</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td width="20%">PIC 9(6)</td>
+							<td width="15%">
+								<div class="center-block">002178</div>
+							</td>
+							<td width="24%">PIC ***,***</td>
+							<td width="41%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select8">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = **2,178</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td width="20%">
+								PIC 9(6)
+							</td>
+							<td width="15%">
+								<div class="center-block">120183</div>
+							</td>
+							<td width="24%">
+								PIC 99B99B99
+							</td>
+							<td width="41%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select9">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = 12s01s83</option>
+										<option>s - indicates a space</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td width="20%">
+								PIC 9(6)
+							</td>
+							<td width="15%">
+								<div class="center-block">120183</div>
+							</td>
+							<td width="24%">
+								PIC 99/99/99
+							</td>
+							<td width="41%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select10">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = 12/01/83</option>
+										<option>As in this case,</option>
+										<option>the slash is often</option>
+										<option>used to edit dates.</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="2" width="20%">
+								PIC 9(6)
+							</td>
+							<td height="2" width="15%">
+								<div class="center-block">031245</div>
+							</td>
+							<td height="2" width="24%">
+								PIC 990099
+							</td>
+							<td height="2" width="41%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select11">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = 120045</option>
+										<option>Decimal point alignment</option>
+										<option>means that 45 will be</option>
+										<option>placed in the rightmost</option>
+										<option>two digits, then the zeros</option>
+										<option>will be inserted and then</option>
+										<option>the 12 will be placed in</option>
+										<option>the last two positions.</option>
+										<option>The 3 will be truncated.</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+					</table>
 					<hr width="50%" />
 				</div>
 
 				<div class="section-sidebar">
-					<h4 align="left">Special Insertion</h4>
+					<h4>Special Insertion</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -565,140 +555,134 @@
 
 				<div class="section-sidebar">
 					<h4>Special Insertion examples</h4>
-					<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
+					<p class="center-block"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<p align="left">
-							In the examples/questions below, see if you can figure out what result will be produced when
-							the value in the Sending item is moved to the editied picture in the Receiving item. The
-							description of the Sending item is shown in the Picture column and its current value is
-							shown in the Data column.
-						</p>
-					</div>
-					<form action="" method="post">
-						<table
-							align="center"
-							bgcolor="#FFFFCC"
-							border="1"
-							bordercolorlight="#FFFFFF"
-							cellpadding="0"
-							cellspacing="0"
-							width="88%"
-						>
-							<tr bgcolor="#FFFFCC">
-								<th colspan="2" scope="colgroup">Sending item</th>
-								<th colspan="2" scope="colgroup">Receiving item</th>
-							</tr>
-							<tr bgcolor="#FFFFCC">
-								<th scope="col" width="23%">Picture</th>
-								<th scope="col" width="11%">Data</th>
-								<th scope="col" width="22%">Picture</th>
-								<th scope="col" width="44%">Result</th>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="13" width="23%">
-									<div align="left">PIC 999V99</div>
-								</td>
-								<td height="13" width="11%">
-									<div align="center">12345</div>
-								</td>
-								<td height="13" width="22%">
-									<div align="left">PIC 999.99</div>
-								</td>
-								<td height="13" width="44%">
-									<div align="center">
-										<select name="select12" size="1">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 123.45</option>
-											<option>The assumed decimal</option>
-											<option>point (V) aligns with the</option>
-											<option>actual decimal point (.)</option>
-											<option>so 45 goes after the</option>
-											<option>decimal point and 123</option>
-											<option>before it.</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="16" width="23%">
-									<div align="left">PIC 999V99</div>
-								</td>
-								<td height="16" width="11%">
-									<div align="center">02345</div>
-								</td>
-								<td height="16" width="22%">
-									<div align="left">PIC 999.9</div>
-								</td>
-								<td height="16" width="44%">
-									<div align="center">
-										<select name="select12" size="1">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 023.4</option>
-											<option>The receiving field only</option>
-											<option>allows one digit after the</option>
-											<option>decimal point so after</option>
-											<option>decimal point alignment</option>
-											<option>the 5 will be lost.</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="16" width="23%">PIC 999V99</td>
-								<td height="16" width="11%">
-									<div align="center">71234</div>
-								</td>
-								<td height="16" width="22%">PIC 99.99</td>
-								<td height="16" width="44%">
-									<div align="center">
-										<select name="select12" size="1">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 12.34</option>
-											<option>In this case decimal</option>
-											<option>point alignment causes</option>
-											<option>most significant digit (7) to</option>
-											<option>be lost.</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td width="23%">PIC 9(4)</td>
-								<td width="11%">
-									<div align="center">2456</div>
-								</td>
-								<td width="22%">PIC 999.99</td>
-								<td width="44%">
-									<div align="center">
-										<select name="select12" size="1">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 456.00</option>
-											<option>Decimal point alignment</option>
-											<option>means that, the most</option>
-											<option>significant digit (2) will be</option>
-											<option>lost, and the positions</option>
-											<option>after the decimal point</option>
-											<option>will be filled with zeros</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-						</table>
-					</form>
-					<div align="center">
-						<hr width="50%" />
-					</div>
+					<p>
+						In the examples/questions below, see if you can figure out what result will be produced when
+						the value in the Sending item is moved to the editied picture in the Receiving item. The
+						description of the Sending item is shown in the Picture column and its current value is
+						shown in the Data column.
+					</p>
+					<table
+						style="margin:0 auto"
+						bgcolor="#FFFFCC"
+						border="1"
+						bordercolorlight="#FFFFFF"
+						cellpadding="0"
+						cellspacing="0"
+						width="88%"
+					>
+						<tr bgcolor="#FFFFCC">
+							<th colspan="2" scope="colgroup">Sending item</th>
+							<th colspan="2" scope="colgroup">Receiving item</th>
+						</tr>
+						<tr bgcolor="#FFFFCC">
+							<th scope="col" width="23%">Picture</th>
+							<th scope="col" width="11%">Data</th>
+							<th scope="col" width="22%">Picture</th>
+							<th scope="col" width="44%">Result</th>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="13" width="23%">
+								PIC 999V99
+							</td>
+							<td height="13" width="11%">
+								<div class="center-block">12345</div>
+							</td>
+							<td height="13" width="22%">
+								PIC 999.99
+							</td>
+							<td height="13" width="44%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select12" size="1">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = 123.45</option>
+										<option>The assumed decimal</option>
+										<option>point (V) aligns with the</option>
+										<option>actual decimal point (.)</option>
+										<option>so 45 goes after the</option>
+										<option>decimal point and 123</option>
+										<option>before it.</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="16" width="23%">
+								PIC 999V99
+							</td>
+							<td height="16" width="11%">
+								<div class="center-block">02345</div>
+							</td>
+							<td height="16" width="22%">
+								PIC 999.9
+							</td>
+							<td height="16" width="44%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select12b" size="1">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = 023.4</option>
+										<option>The receiving field only</option>
+										<option>allows one digit after the</option>
+										<option>decimal point so after</option>
+										<option>decimal point alignment</option>
+										<option>the 5 will be lost.</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="16" width="23%">PIC 999V99</td>
+							<td height="16" width="11%">
+								<div class="center-block">71234</div>
+							</td>
+							<td height="16" width="22%">PIC 99.99</td>
+							<td height="16" width="44%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select12c" size="1">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = 12.34</option>
+										<option>In this case decimal</option>
+										<option>point alignment causes</option>
+										<option>most significant digit (7) to</option>
+										<option>be lost.</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td width="23%">PIC 9(4)</td>
+							<td width="11%">
+								<div class="center-block">2456</div>
+							</td>
+							<td width="22%">PIC 999.99</td>
+							<td width="44%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select12d" size="1">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = 456.00</option>
+										<option>Decimal point alignment</option>
+										<option>means that, the most</option>
+										<option>significant digit (2) will be</option>
+										<option>lost, and the positions</option>
+										<option>after the decimal point</option>
+										<option>will be filled with zeros</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+					</table>
+					<hr width="50%" />
 				</div>
 
 				<div class="section-sidebar">
-					<h4 align="left">Fixed Insertion</h4>
+					<h4>Fixed Insertion</h4>
 					<aside>
-						<p align="center">
+						<p class="center-block">
 							<span class="i-detail" aria-hidden="true">🔍</span>
 						</p>
-						<p align="left">
+						<p>
 							The default currency symbol is the dollar sign ($) but it may be changed to a different
 							symbol by the <code class="language-cobol">CURRENCY SIGN IS</code> clause, in the
 							<code class="language-cobol">SPECIAL-NAMES</code> paragraph, of the
@@ -747,8 +731,8 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4 align="left">Fixed Insertion examples</h4>
-					<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
+					<h4>Fixed Insertion examples</h4>
+					<p class="center-block"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
 				</div>
 				<div class="section-content">
 					<p>
@@ -756,231 +740,229 @@
 						produced when the value in the Sending item is moved to the editied picture in the Receiving
 						item.
 					</p>
-					<form action="" method="post">
-						<table align="center" bgcolor="#FFFFCC" border="1" cellpadding="0" cellspacing="0" width="87%">
-							<tr bgcolor="#FFFFCC">
-								<th colspan="2" scope="colgroup">Sending item</th>
-								<th colspan="2" scope="colgroup">Receiving item</th>
-							</tr>
-							<tr bgcolor="#FFFFCC">
-								<th scope="col" width="18%">Picture</th>
-								<th scope="col" width="16%">Data</th>
-								<th scope="col" width="20%">Picture</th>
-								<th scope="col" width="46%">Result</th>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="15" width="18%">
-									<div align="left">PIC S999</div>
-								</td>
-								<td height="15" width="16%">
-									<div align="center">-123</div>
-								</td>
-								<td height="15" width="20%">
-									<div align="left">PIC -999</div>
-								</td>
-								<td height="15" width="46%">
-									<div align="center">
-										<select name="select13">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = -123</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="16" width="18%">
-									<div align="left">PIC S999</div>
-								</td>
-								<td height="16" width="16%">
-									<div align="center">-123</div>
-								</td>
-								<td height="16" width="20%">
-									<div align="left">PIC 999-</div>
-								</td>
-								<td height="16" width="46%">
-									<div align="center">
-										<select name="select13">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 123-</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="16" width="18%">PIC S999</td>
-								<td height="16" width="16%">
-									<div align="center">+123</div>
-								</td>
-								<td height="16" width="20%">PIC -999</td>
-								<td height="16" width="46%">
-									<div align="center">
-										<select name="select14">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = s123</option>
-											<option>s - indicates a space</option>
-											<option>The - symbol only</option>
-											<option>highlights negative</option>
-											<option>values. If the value is</option>
-											<option>positive, a space is</option>
-											<option>printed instead of the</option>
-											<option>sign.</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="16" width="18%">PIC S9(5)</td>
-								<td height="16" width="16%">
-									<div align="center">+12345</div>
-								</td>
-								<td height="16" width="20%">PIC +9(5)</td>
-								<td height="16" width="46%">
-									<div align="center">
-										<select name="select15">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = +12345</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="16" width="18%">PIC S9(3)</td>
-								<td height="16" width="16%">
-									<div align="center">-123</div>
-								</td>
-								<td height="16" width="20%">PIC +9(3)</td>
-								<td height="16" width="46%">
-									<div align="center">
-										<select name="select16">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = -123</option>
-											<option>If a + symbol is used, a +</option>
-											<option>is printed if the value is</option>
-											<option>positive and a - is printed</option>
-											<option>if the value is negative.</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="16" width="18%">PIC S9(3)</td>
-								<td height="16" width="16%">
-									<div align="center">-123</div>
-								</td>
-								<td height="16" width="20%">PIC 999+</td>
-								<td height="16" width="46%">
-									<div align="center">
-										<select name="select13">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 123-</option>
-											<option>In this case decimal</option>
-											<option>point alignment causes</option>
-											<option>most significant digit (7)</option>
-											<option>to be lost.</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="16" width="18%">PIC S9(4)</td>
-								<td height="16" width="16%">
-									<div align="center">+1234</div>
-								</td>
-								<td height="16" width="20%">PIC 9(4)CR</td>
-								<td height="16" width="46%">
-									<div align="center">
-										<select name="select17">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 1234ss</option>
-											<option>s- indicates a space</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="16" width="18%">PIC S9(4)</td>
-								<td height="16" width="16%">
-									<div align="center">-1234</div>
-								</td>
-								<td height="16" width="20%">PIC 9(4)CR</td>
-								<td height="16" width="46%">
-									<div align="center">
-										<select name="select18">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 1234CR</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="16" width="18%">PIC S9(4)</td>
-								<td height="16" width="16%">
-									<div align="center">+1234</div>
-								</td>
-								<td height="16" width="20%">PIC 9(4)DB</td>
-								<td height="16" width="46%">
-									<div align="center">
-										<select name="select19">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 1223ss</option>
-											<option>s - indicates a space</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="16" width="18%">PIC S9(4)</td>
-								<td height="16" width="16%">
-									<div align="center">-1234</div>
-								</td>
-								<td height="16" width="20%">PIC 9(4)DB</td>
-								<td height="16" width="46%">
-									<div align="center">
-										<select name="select20">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 1234DB</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="16" width="18%">PIC 9(4)</td>
-								<td height="16" width="16%">
-									<div align="center">1234</div>
-								</td>
-								<td height="16" width="20%">PIC $99999</td>
-								<td height="16" width="46%">
-									<div align="center">
-										<select name="select21">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = $01234</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="16" width="18%">PIC 9(4)</td>
-								<td height="16" width="16%">
-									<div align="center">0000</div>
-								</td>
-								<td height="16" width="20%">PIC $ZZZZZ</td>
-								<td height="16" width="46%">
-									<div align="center">
-										<select name="select22">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = $sssss</option>
-											<option>s - indicates a space</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-						</table>
-					</form>
+					<table style="margin:0 auto" bgcolor="#FFFFCC" border="1" cellpadding="0" cellspacing="0" width="87%">
+						<tr bgcolor="#FFFFCC">
+							<th colspan="2" scope="colgroup">Sending item</th>
+							<th colspan="2" scope="colgroup">Receiving item</th>
+						</tr>
+						<tr bgcolor="#FFFFCC">
+							<th scope="col" width="18%">Picture</th>
+							<th scope="col" width="16%">Data</th>
+							<th scope="col" width="20%">Picture</th>
+							<th scope="col" width="46%">Result</th>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="15" width="18%">
+								PIC S999
+							</td>
+							<td height="15" width="16%">
+								<div class="center-block">-123</div>
+							</td>
+							<td height="15" width="20%">
+								PIC -999
+							</td>
+							<td height="15" width="46%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select13">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = -123</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="16" width="18%">
+								PIC S999
+							</td>
+							<td height="16" width="16%">
+								<div class="center-block">-123</div>
+							</td>
+							<td height="16" width="20%">
+								PIC 999-
+							</td>
+							<td height="16" width="46%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select13b">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = 123-</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="16" width="18%">PIC S999</td>
+							<td height="16" width="16%">
+								<div class="center-block">+123</div>
+							</td>
+							<td height="16" width="20%">PIC -999</td>
+							<td height="16" width="46%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select14">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = s123</option>
+										<option>s - indicates a space</option>
+										<option>The - symbol only</option>
+										<option>highlights negative</option>
+										<option>values. If the value is</option>
+										<option>positive, a space is</option>
+										<option>printed instead of the</option>
+										<option>sign.</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="16" width="18%">PIC S9(5)</td>
+							<td height="16" width="16%">
+								<div class="center-block">+12345</div>
+							</td>
+							<td height="16" width="20%">PIC +9(5)</td>
+							<td height="16" width="46%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select15">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = +12345</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="16" width="18%">PIC S9(3)</td>
+							<td height="16" width="16%">
+								<div class="center-block">-123</div>
+							</td>
+							<td height="16" width="20%">PIC +9(3)</td>
+							<td height="16" width="46%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select16">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = -123</option>
+										<option>If a + symbol is used, a +</option>
+										<option>is printed if the value is</option>
+										<option>positive and a - is printed</option>
+										<option>if the value is negative.</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="16" width="18%">PIC S9(3)</td>
+							<td height="16" width="16%">
+								<div class="center-block">-123</div>
+							</td>
+							<td height="16" width="20%">PIC 999+</td>
+							<td height="16" width="46%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select13c">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = 123-</option>
+										<option>In this case decimal</option>
+										<option>point alignment causes</option>
+										<option>most significant digit (7)</option>
+										<option>to be lost.</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="16" width="18%">PIC S9(4)</td>
+							<td height="16" width="16%">
+								<div class="center-block">+1234</div>
+							</td>
+							<td height="16" width="20%">PIC 9(4)CR</td>
+							<td height="16" width="46%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select17">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = 1234ss</option>
+										<option>s- indicates a space</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="16" width="18%">PIC S9(4)</td>
+							<td height="16" width="16%">
+								<div class="center-block">-1234</div>
+							</td>
+							<td height="16" width="20%">PIC 9(4)CR</td>
+							<td height="16" width="46%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select18">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = 1234CR</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="16" width="18%">PIC S9(4)</td>
+							<td height="16" width="16%">
+								<div class="center-block">+1234</div>
+							</td>
+							<td height="16" width="20%">PIC 9(4)DB</td>
+							<td height="16" width="46%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select19">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = 1223ss</option>
+										<option>s - indicates a space</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="16" width="18%">PIC S9(4)</td>
+							<td height="16" width="16%">
+								<div class="center-block">-1234</div>
+							</td>
+							<td height="16" width="20%">PIC 9(4)DB</td>
+							<td height="16" width="46%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select20">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = 1234DB</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="16" width="18%">PIC 9(4)</td>
+							<td height="16" width="16%">
+								<div class="center-block">1234</div>
+							</td>
+							<td height="16" width="20%">PIC $99999</td>
+							<td height="16" width="46%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select21">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = $01234</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="16" width="18%">PIC 9(4)</td>
+							<td height="16" width="16%">
+								<div class="center-block">0000</div>
+							</td>
+							<td height="16" width="20%">PIC $ZZZZZ</td>
+							<td height="16" width="46%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select22">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = $sssss</option>
+										<option>s - indicates a space</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+					</table>
 					<hr width="50%" />
 				</div>
 
 				<div class="section-sidebar">
-					<h4 align="left">Floating Insertion</h4>
+					<h4>Floating Insertion</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1011,7 +993,7 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4 align="left">Floating Insertion examples</h4>
+					<h4>Floating Insertion examples</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1019,176 +1001,174 @@
 						produced when the value in the Sending item is moved to the editied picture in the Receiving
 						item.
 					</p>
-					<form action="" method="post">
-						<table align="center" bgcolor="#FFFFCC" border="1" cellpadding="0" cellspacing="0" width="83%">
-							<tr bgcolor="#FFFFCC">
-								<th colspan="2" scope="colgroup">Sending item</th>
-								<th colspan="2" scope="colgroup">Receiving item</th>
-							</tr>
-							<tr bgcolor="#FFFFCC">
-								<th scope="col" width="18%">Picture</th>
-								<th scope="col" width="16%">Data</th>
-								<th scope="col" width="23%">Picture</th>
-								<th scope="col" width="43%">Result</th>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="15" width="18%">
-									<div align="left">PIC 9(4)</div>
-								</td>
-								<td height="15" width="16%">
-									<div align="center">0000</div>
-								</td>
-								<td height="15" width="23%">
-									<div align="left">PIC $$,$$9.99</div>
-								</td>
-								<td height="15" width="43%">
-									<div align="center">
-										<select name="select5">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = ssss$0.00</option>
-											<option>s - indicates a space</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="16" width="18%">
-									<div align="left">PIC 9(4)</div>
-								</td>
-								<td height="16" width="16%">
-									<div align="center">0080</div>
-								</td>
-								<td height="16" width="23%">
-									<div align="left">PIC $$,$$9.00</div>
-								</td>
-								<td height="16" width="43%">
-									<div align="center">
-										<select name="select5">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = sss$80.00</option>
-											<option>s - indicates a space</option>
-											<option>The fixed insertion zeros</option>
-											<option>are added to the end.</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="16" width="18%">PIC 9(4)</td>
-								<td height="16" width="16%">
-									<div align="center">0128</div>
-								</td>
-								<td height="16" width="23%">PIC $$,$$9.99</td>
-								<td height="16" width="43%">
-									<div align="center">
-										<select name="select5">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = ss$128.00</option>
-											<option>s - indicates a space</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="16" width="18%">PIC 9(5)</td>
-								<td height="16" width="16%">
-									<div align="center"><b>5</b>7397</div>
-								</td>
-								<td height="16" width="23%">PIC $$,$$9</td>
-								<td height="16" width="43%">
-									<div align="center">
-										<select name="select5">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = $7,397</option>
-											<option>Although the receiving</option>
-											<option>field appears to have</option>
-											<option>enough room for the</option>
-											<option>value, the programmer</option>
-											<option>forgot that the left-most</option>
-											<option>floating symbol cannot</option>
-											<option>be replaced by a digit.</option>
-											<option>This causes the digit (5)</option>
-											<option>to be lost.</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="16" width="18%">PIC S9(4)</td>
-								<td height="16" width="16%">
-									<div align="center">-0005</div>
-								</td>
-								<td height="16" width="23%">PIC ++++9</td>
-								<td height="16" width="43%">
-									<div align="center">
-										<select name="select5">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = sss-5</option>
-											<option>s - indicates a space</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="16" width="18%">PIC S9(4)</td>
-								<td height="16" width="16%">
-									<div align="center">+0080</div>
-								</td>
-								<td height="16" width="23%">PIC ++++9</td>
-								<td height="16" width="43%">
-									<div align="center">
-										<select name="select5">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = sss+80</option>
-											<option>s - indicates a space</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="20" width="18%">
-									<p>PIC S9(4)</p>
-								</td>
-								<td height="20" width="16%">
-									<div align="center">-0080</div>
-								</td>
-								<td height="20" width="23%">PIC - - - - 9</td>
-								<td height="20" valign="top" width="43%">
-									<div align="center">
-										<select name="select5">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = sss-80</option>
-											<option>s- indicates a space</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="16" width="18%">PIC S9(5)</td>
-								<td height="16" width="16%">
-									<div align="center">+<b>7</b>1234</div>
-								</td>
-								<td height="16" width="23%">PIC - - - - 9</td>
-								<td height="16" width="43%">
-									<div align="center">
-										<select name="select5">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = s1234</option>
-											<option>s- indicates a space</option>
-											<option>The left-most sign cannot</option>
-											<option>be replaced by a digit,</option>
-											<option>so the most significant</option>
-											<option>digit (7) is truncated.</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-						</table>
-					</form>
+					<table style="margin:0 auto" bgcolor="#FFFFCC" border="1" cellpadding="0" cellspacing="0" width="83%">
+						<tr bgcolor="#FFFFCC">
+							<th colspan="2" scope="colgroup">Sending item</th>
+							<th colspan="2" scope="colgroup">Receiving item</th>
+						</tr>
+						<tr bgcolor="#FFFFCC">
+							<th scope="col" width="18%">Picture</th>
+							<th scope="col" width="16%">Data</th>
+							<th scope="col" width="23%">Picture</th>
+							<th scope="col" width="43%">Result</th>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="15" width="18%">
+								PIC 9(4)
+							</td>
+							<td height="15" width="16%">
+								<div class="center-block">0000</div>
+							</td>
+							<td height="15" width="23%">
+								PIC $$,$$9.99
+							</td>
+							<td height="15" width="43%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select5">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = ssss$0.00</option>
+										<option>s - indicates a space</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="16" width="18%">
+								PIC 9(4)
+							</td>
+							<td height="16" width="16%">
+								<div class="center-block">0080</div>
+							</td>
+							<td height="16" width="23%">
+								PIC $$,$$9.00
+							</td>
+							<td height="16" width="43%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select5b">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = sss$80.00</option>
+										<option>s - indicates a space</option>
+										<option>The fixed insertion zeros</option>
+										<option>are added to the end.</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="16" width="18%">PIC 9(4)</td>
+							<td height="16" width="16%">
+								<div class="center-block">0128</div>
+							</td>
+							<td height="16" width="23%">PIC $$,$$9.99</td>
+							<td height="16" width="43%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select5c">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = ss$128.00</option>
+										<option>s - indicates a space</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="16" width="18%">PIC 9(5)</td>
+							<td height="16" width="16%">
+								<div class="center-block"><b>5</b>7397</div>
+							</td>
+							<td height="16" width="23%">PIC $$,$$9</td>
+							<td height="16" width="43%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select5d">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = $7,397</option>
+										<option>Although the receiving</option>
+										<option>field appears to have</option>
+										<option>enough room for the</option>
+										<option>value, the programmer</option>
+										<option>forgot that the left-most</option>
+										<option>floating symbol cannot</option>
+										<option>be replaced by a digit.</option>
+										<option>This causes the digit (5)</option>
+										<option>to be lost.</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="16" width="18%">PIC S9(4)</td>
+							<td height="16" width="16%">
+								<div class="center-block">-0005</div>
+							</td>
+							<td height="16" width="23%">PIC ++++9</td>
+							<td height="16" width="43%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select5e">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = sss-5</option>
+										<option>s - indicates a space</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="16" width="18%">PIC S9(4)</td>
+							<td height="16" width="16%">
+								<div class="center-block">+0080</div>
+							</td>
+							<td height="16" width="23%">PIC ++++9</td>
+							<td height="16" width="43%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select5f">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = sss+80</option>
+										<option>s - indicates a space</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="20" width="18%">
+								<p>PIC S9(4)</p>
+							</td>
+							<td height="20" width="16%">
+								<div class="center-block">-0080</div>
+							</td>
+							<td height="20" width="23%">PIC - - - - 9</td>
+							<td height="20" valign="top" width="43%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select5g">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = sss-80</option>
+										<option>s- indicates a space</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="16" width="18%">PIC S9(5)</td>
+							<td height="16" width="16%">
+								<div class="center-block">+<b>7</b>1234</div>
+							</td>
+							<td height="16" width="23%">PIC - - - - 9</td>
+							<td height="16" width="43%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select5h">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = s1234</option>
+										<option>s- indicates a space</option>
+										<option>The left-most sign cannot</option>
+										<option>be replaced by a digit,</option>
+										<option>so the most significant</option>
+										<option>digit (7) is truncated.</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+					</table>
 				</div>
 
 				<div class="section-full">
-					<div align="center">
+					<div>
 						<hr />
 						<back-to-top></back-to-top>
 					</div>
@@ -1201,7 +1181,7 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4 align="left">Introduction</h4>
+					<h4>Introduction</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1231,184 +1211,182 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4 align="left">Suppression and Replacement editing examples</h4>
-					<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
+					<h4>Suppression and Replacement editing examples</h4>
+					<p class="center-block"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
 				</div>
 				<div class="section-content">
-					<form>
-						<table align="center" bgcolor="#FFFFCC" border="1" cellpadding="0" cellspacing="0" width="93%">
-							<tr bgcolor="#FFFFCC">
-								<th colspan="2" scope="colgroup">Sending item</th>
-								<th colspan="2" scope="colgroup">Receiving item</th>
-							</tr>
-							<tr bgcolor="#FFFFCC">
-								<th scope="col" width="21%">Picture</th>
-								<th scope="col" width="13%">Data</th>
-								<th scope="col" width="25%">Picture</th>
-								<th scope="col" width="41%">Result</th>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="15" width="21%">
-									<div align="left">PIC 9(5)</div>
-								</td>
-								<td height="15" width="13%">
-									<div align="center">12345</div>
-								</td>
-								<td height="15" width="25%">
-									<div align="left">PIC ZZ,999</div>
-								</td>
-								<td height="15" width="41%">
-									<div align="center">
-										<select name="select27">
-											<option selected value="none">Click arrow for the answer</option>
-											<option value="none">Ans = 12,345</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="16" width="21%">
-									<div align="left">PIC 9(5)</div>
-								</td>
-								<td height="16" width="13%">
-									<div align="center">01234</div>
-								</td>
-								<td height="16" width="25%">
-									<div align="left">PIC ZZ,999</div>
-								</td>
-								<td height="16" width="41%">
-									<div align="center">
-										<select name="select23" size="1">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = s1,234</option>
-											<option>s - indicates a space</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="16" width="21%">PIC 9(5)</td>
-								<td height="16" width="13%">
-									<div align="center">00123</div>
-								</td>
-								<td height="16" width="25%">PIC ZZ,999</td>
-								<td height="16" width="41%">
-									<div align="center">
-										<select name="select23">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = sss123</option>
-											<option>s - indicates a space</option>
-											<option>Because there are only</option>
-											<option>zeros to the left of the</option>
-											<option>comma, it is replaced by</option>
-											<option>the replacement symbol</option>
-											<option>space.</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="16" width="21%">PIC 9(5)</td>
-								<td height="16" width="13%">
-									<div align="center">00012</div>
-								</td>
-								<td height="16" width="25%">PIC ZZ,999</td>
-								<td height="16" width="41%">
-									<div align="center">
-										<select name="select23">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = sss012</option>
-											<option>s - indicates a space</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="16" width="21%">PIC 9(5)</td>
-								<td height="16" width="13%">
-									<div align="center">05678</div>
-								</td>
-								<td height="16" width="25%">PIC **,**9</td>
-								<td height="16" width="41%">
-									<div align="center">
-										<select name="select23">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = *5,678</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="16" width="21%">PIC 9(5)</td>
-								<td height="16" width="13%">
-									<div align="center">00567</div>
-								</td>
-								<td height="16" width="25%">PIC **,**9</td>
-								<td height="16" width="41%">
-									<div align="center">
-										<select name="select23">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = ***567</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="20" width="21%">PIC 9(5)</td>
-								<td height="20" width="13%">
-									<div align="center">00000</div>
-								</td>
-								<td height="20" width="25%">PIC **,***</td>
-								<td height="20" valign="top" width="41%">
-									<div align="center">
-										<select name="select25">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = ******</option>
-											<option>s- indicates a space</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td height="20" width="21%">
-									<p>PIC 9(5)V99</p>
-								</td>
-								<td height="20" width="13%">
-									<div align="center">00043.45</div>
-								</td>
-								<td height="20" width="25%">PIC $**,**9.99</td>
-								<td bgcolor="#E1FFE1" height="20" valign="top" width="41%">
-									<div align="center">
-										<select name="select26">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = $****43.45</option>
-											<option>Helps to prevent fraud</option>
-											<option>when printing cheques.</option>
-										</select>
-									</div>
-								</td>
-							</tr>
-						</table>
-					</form>
+					<table style="margin:0 auto" bgcolor="#FFFFCC" border="1" cellpadding="0" cellspacing="0" width="93%">
+						<tr bgcolor="#FFFFCC">
+							<th colspan="2" scope="colgroup">Sending item</th>
+							<th colspan="2" scope="colgroup">Receiving item</th>
+						</tr>
+						<tr bgcolor="#FFFFCC">
+							<th scope="col" width="21%">Picture</th>
+							<th scope="col" width="13%">Data</th>
+							<th scope="col" width="25%">Picture</th>
+							<th scope="col" width="41%">Result</th>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="15" width="21%">
+								PIC 9(5)
+							</td>
+							<td height="15" width="13%">
+								<div class="center-block">12345</div>
+							</td>
+							<td height="15" width="25%">
+								PIC ZZ,999
+							</td>
+							<td height="15" width="41%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select27">
+										<option selected value="none">Click arrow for the answer</option>
+										<option value="none">Ans = 12,345</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="16" width="21%">
+								PIC 9(5)
+							</td>
+							<td height="16" width="13%">
+								<div class="center-block">01234</div>
+							</td>
+							<td height="16" width="25%">
+								PIC ZZ,999
+							</td>
+							<td height="16" width="41%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select23" size="1">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = s1,234</option>
+										<option>s - indicates a space</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="16" width="21%">PIC 9(5)</td>
+							<td height="16" width="13%">
+								<div class="center-block">00123</div>
+							</td>
+							<td height="16" width="25%">PIC ZZ,999</td>
+							<td height="16" width="41%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select23b">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = sss123</option>
+										<option>s - indicates a space</option>
+										<option>Because there are only</option>
+										<option>zeros to the left of the</option>
+										<option>comma, it is replaced by</option>
+										<option>the replacement symbol</option>
+										<option>space.</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="16" width="21%">PIC 9(5)</td>
+							<td height="16" width="13%">
+								<div class="center-block">00012</div>
+							</td>
+							<td height="16" width="25%">PIC ZZ,999</td>
+							<td height="16" width="41%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select23c">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = sss012</option>
+										<option>s - indicates a space</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="16" width="21%">PIC 9(5)</td>
+							<td height="16" width="13%">
+								<div class="center-block">05678</div>
+							</td>
+							<td height="16" width="25%">PIC **,**9</td>
+							<td height="16" width="41%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select23d">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = *5,678</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="16" width="21%">PIC 9(5)</td>
+							<td height="16" width="13%">
+								<div class="center-block">00567</div>
+							</td>
+							<td height="16" width="25%">PIC **,**9</td>
+							<td height="16" width="41%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select23e">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = ***567</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="20" width="21%">PIC 9(5)</td>
+							<td height="20" width="13%">
+								<div class="center-block">00000</div>
+							</td>
+							<td height="20" width="25%">PIC **,***</td>
+							<td height="20" valign="top" width="41%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select25">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = ******</option>
+										<option>s- indicates a space</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+						<tr bgcolor="#E1FFE1">
+							<td height="20" width="21%">
+								<p>PIC 9(5)V99</p>
+							</td>
+							<td height="20" width="13%">
+								<div class="center-block">00043.45</div>
+							</td>
+							<td height="20" width="25%">PIC $**,**9.99</td>
+							<td bgcolor="#E1FFE1" height="20" valign="top" width="41%">
+								<div class="center-block">
+									<select aria-label="Click for answer" name="select26">
+										<option selected>Click arrow for the answer</option>
+										<option>Ans = $****43.45</option>
+										<option>Helps to prevent fraud</option>
+										<option>when printing cheques.</option>
+									</select>
+								</div>
+							</td>
+						</tr>
+					</table>
 					<hr width="50%" />
 				</div>
 
 				<div class="section-sidebar">
-					<h4 align="left">Picture string restrictions</h4>
+					<h4>Picture string restrictions</h4>
 				</div>
 				<div class="section-content">
 					<p>
 						Some combinations of picture symbols are not permitted. The table below shows the combination of
 						symbols that is allowed.
 					</p>
-					<table align="center" bgcolor="#E1FFE1" border="1" cellpadding="5" height="69" width="47%">
+					<table style="margin:0 auto" bgcolor="#E1FFE1" border="1" cellpadding="5" height="69" width="47%">
 						<tr bgcolor="#FFFFCC">
 							<th scope="col" width="15%">Character</th>
 							<th scope="col" width="85%">May be followed by</th>
 						</tr>
 						<tr>
 							<td bgcolor="#FFFFCC" height="192" valign="top" width="15%">
-								<div align="center">
+								<div class="center-block">
 									<pre class="language-cobol"><code class="language-cobol">P
 B
 0

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -53,21 +53,17 @@
 					<h4>Aims</h4>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<p align="left">
-							The records in a Sequential file are organized serially, one after another, but the records
-							in the file may be ordered or unordered. The serial organization of the file and whether the
-							file is ordered or unordered has a significant baring on how we process the records in the
-							file and what kind of processing we can do.
-						</p>
-						<p align="left">
-							This tutorial examines the consequences of ordering and organization and reviews some
-							techniques for processing Sequential files.
-						</p>
-					</div>
-					<div align="center">
-						<hr width="50%" />
-					</div>
+					<p>
+						The records in a Sequential file are organized serially, one after another, but the records
+						in the file may be ordered or unordered. The serial organization of the file and whether the
+						file is ordered or unordered has a significant baring on how we process the records in the
+						file and what kind of processing we can do.
+					</p>
+					<p>
+						This tutorial examines the consequences of ordering and organization and reviews some
+						techniques for processing Sequential files.
+					</p>
+					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
 					<h4>Objectives</h4>
@@ -95,7 +91,7 @@
 					</ul>
 				</div>
 				<div class="section-full">
-					<div align="center">
+					<div>
 						<hr />
 						<back-to-top></back-to-top>
 					</div>
@@ -110,107 +106,87 @@
 					<h4>Introduction</h4>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<p align="left">
-							Two important characteristics of files are <i>Data Organization</i> and
-							<i>Method of Access</i><b>.</b>
-						</p>
-						<p align="left">
-							<i>Data organization</i>, refers to the way the records of the file are organized on the
-							backing storage device. COBOL recognizes three main file organizations;
-						</p>
-					</div>
+					<p>
+						Two important characteristics of files are <i>Data Organization</i> and
+						<i>Method of Access</i><b>.</b>
+					</p>
+					<p>
+						<i>Data organization</i>, refers to the way the records of the file are organized on the
+						backing storage device. COBOL recognizes three main file organizations;
+					</p>
 					<ul>
-						<li>
-							<div align="left">Sequential - Records organized serially.</div>
-						</li>
-						<li>
-							<div align="left">Relative - Relative record number based organization.</div>
-						</li>
-						<li>
-							<div align="left">Indexed - Index based organization.</div>
-						</li>
+						<li>Sequential - Records organized serially.</li>
+						<li>Relative - Relative record number based organization.</li>
+						<li>Indexed - Index based organization.</li>
 					</ul>
-					<div align="center">
-						<p align="left">
-							<i>Method of access</i>, refers to the way in which records are accessed. Some organizations
-							are more versatile than others. A file with an organization of Indexed or Relative may still
-							have its records accessed sequentially; but records in a file with an organization of
-							Sequential, cannot be accessed directly.
-						</p>
-					</div>
-					<div align="center">
-						<hr width="50%" />
-					</div>
+					<p>
+						<i>Method of access</i>, refers to the way in which records are accessed. Some organizations
+						are more versatile than others. A file with an organization of Indexed or Relative may still
+						have its records accessed sequentially; but records in a file with an organization of
+						Sequential, cannot be accessed directly.
+					</p>
+					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
 					<h4>Sequential Organization</h4>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<p align="left">Sequential organization is simplest file organization in COBOL.</p>
-						<p align="left">
-							In a Sequential file the records are arranged serially, one after another, like cards in a
-							dealing shoe. The only way to access records in a Sequential file, is serially. A program
-							must start at the first record and read all the succeeding records until the required record
-							is found or until the end of the file is reached.
-						</p>
-						<p align="left">
-							Sequential files may be <i>Ordered</i> or <i>Unordered</i> (these should be called Serial
-							files). The ordering of the records in a file has a significant impact on the way in which
-							it is processed and the processing that can be done on it.
-						</p>
-					</div>
-					<div align="left">
-						<hr width="50%" />
-					</div>
+					<p>Sequential organization is simplest file organization in COBOL.</p>
+					<p>
+						In a Sequential file the records are arranged serially, one after another, like cards in a
+						dealing shoe. The only way to access records in a Sequential file, is serially. A program
+						must start at the first record and read all the succeeding records until the required record
+						is found or until the end of the file is reached.
+					</p>
+					<p>
+						Sequential files may be <i>Ordered</i> or <i>Unordered</i> (these should be called Serial
+						files). The ordering of the records in a file has a significant impact on the way in which
+						it is processed and the processing that can be done on it.
+					</p>
+					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
 					<h4>Ordered and Unordered files</h4>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<div align="center">
-							<p align="left">
-								In an ordered file, the records are sequenced on some field in the record (like
-								StudentId or StudentName etc). In an unordered file, the records are not in any
-								particular order.
-							</p>
-						</div>
-						<table bgcolor="#E1FFE1" border="1" width="53%">
-							<tr bgcolor="#FFFFCC">
-								<th scope="col" width="39%">Ordered File</th>
-								<th scope="col" width="40%">Unordered File</th>
-							</tr>
-							<tr>
-								<td width="39%">
-									<p align="center">
-										RecordA<br />
-										RecordB<br />
-										RecordG<br />
-										RecordH<br />
-										RecordK<br />
-										RecordM<br />
-										RecordN
-									</p>
-								</td>
-								<td width="40%">
-									<p align="center">
-										RecordM<br />
-										RecordH<br />
-										RecordB<br />
-										RecordN<br />
-										RecordA<br />
-										RecordK<br />
-										RecordG
-									</p>
-								</td>
-							</tr>
-						</table>
-					</div>
+					<p>
+						In an ordered file, the records are sequenced on some field in the record (like
+						StudentId or StudentName etc). In an unordered file, the records are not in any
+						particular order.
+					</p>
+					<table bgcolor="#E1FFE1" border="1" width="53%">
+						<tr bgcolor="#FFFFCC">
+							<th scope="col" width="39%">Ordered File</th>
+							<th scope="col" width="40%">Unordered File</th>
+						</tr>
+						<tr>
+							<td width="39%">
+								<p class="center-block">
+									RecordA<br />
+									RecordB<br />
+									RecordG<br />
+									RecordH<br />
+									RecordK<br />
+									RecordM<br />
+									RecordN
+								</p>
+							</td>
+							<td width="40%">
+								<p class="center-block">
+									RecordM<br />
+									RecordH<br />
+									RecordB<br />
+									RecordN<br />
+									RecordA<br />
+									RecordK<br />
+									RecordG
+								</p>
+							</td>
+						</tr>
+					</table>
 				</div>
 				<div class="section-full">
-					<div align="center">
+					<div>
 						<hr />
 						<back-to-top></back-to-top>
 					</div>
@@ -222,7 +198,7 @@
 					<h2 id="part2">Processing unordered Sequential Files</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">Introduction</h4>
+					<h4>Introduction</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -236,7 +212,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">Adding records to an unordered Sequential File</h4>
+					<h4>Adding records to an unordered Sequential File</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -251,7 +227,7 @@
 						transaction file records are <i>applied</i> to the unordered file and the result is an unordered
 						file that has all the transaction file records appended to the end of it.
 					</p>
-					<p align="center">
+					<p class="center-block">
 						<a href="Resources/ppz/TC-SeqFile2a.html"
 							><img height="62" src="Resources/pics/i-Animation.gif" width="62" alt=""
 						/></a>
@@ -259,9 +235,9 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">Problems with unordered Sequential files</h4>
+					<h4>Problems with unordered Sequential files</h4>
 					<aside>
-						<p align="center">
+						<p class="center-block">
 							<span class="i-detail" aria-hidden="true">🔍</span><br />
 							Although it is true that in standard COBOL, Sequential files cannot be deleted or updated
 							"in situ", many vendors, including Microfocus, allow this for disk based files.
@@ -283,7 +259,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">Record matching</h4>
+					<h4>Record matching</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -317,29 +293,25 @@
 					<h4>Attempting to batch delete records in an unordered file.</h4>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<p align="left">
-							Suppose we have an unordered transaction file and an unordered master file. The transaction
-							file contains records which indicate which records in the master file we want to delete. To
-							delete the records we need to create a new master file which does not contain the deleted
-							records.
-						</p>
-						<p align="left">
-							The animation below demonstrates what happens when we attempt to batch-delete records from
-							an unordered Sequential file.
-						</p>
-						<p align="center">
-							<a href="Resources/ppz/TC-SeqFile2b.html"
-								><img height="62" src="Resources/pics/i-Animation.gif" width="62" alt=""
-							/></a>
-						</p>
-					</div>
-					<div align="center">
-						<hr width="50%" />
-					</div>
+					<p>
+						Suppose we have an unordered transaction file and an unordered master file. The transaction
+						file contains records which indicate which records in the master file we want to delete. To
+						delete the records we need to create a new master file which does not contain the deleted
+						records.
+					</p>
+					<p>
+						The animation below demonstrates what happens when we attempt to batch-delete records from
+						an unordered Sequential file.
+					</p>
+					<p class="center-block">
+						<a href="Resources/ppz/TC-SeqFile2b.html"
+							><img height="62" src="Resources/pics/i-Animation.gif" width="62" alt=""
+						/></a>
+					</p>
+					<hr width="50%" />
 				</div>
 				<div class="section-full">
-					<div align="center">
+					<div>
 						<hr />
 						<back-to-top></back-to-top>
 					</div>
@@ -351,7 +323,7 @@
 					<h2 id="part3">Processing Ordered Sequential Files</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">Introduction</h4>
+					<h4>Introduction</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -363,23 +335,23 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">Inserting records into an ordered Sequential file.</h4>
+					<h4>Inserting records into an ordered Sequential file.</h4>
 				</div>
 				<div class="section-content">
-					<p align="left">
+					<p>
 						To add records to an ordered file a major consideration is to preserve the ordering. This means
 						that the record must be inserted into the file in the correct position. It can't just be added
 						to the end of the file as it can with unordered files.
 					</p>
-					<p align="left">
+					<p>
 						As with all changes to ordered Sequential files we can't just insert the records into the
 						existing file. To insert records into the file we have to create a new file that contains the
 						inserted records.
 					</p>
-					<p align="left">
+					<p>
 						The animation below demonstrates how records are inserted into an ordered Sequential file.
 					</p>
-					<p align="center">
+					<p class="center-block">
 						<a href="Resources/ppz/TC-SeqFile2c.html"
 							><img height="62" src="Resources/pics/i-Animation.gif" width="62" alt=""
 						/></a>
@@ -387,9 +359,9 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">Self Assessment questions</h4>
-					<p align="center"><img height="44" src="Resources/pics/program-fragment.svg" width="48" alt="Program fragment" /></p>
-					<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
+					<h4>Self Assessment questions</h4>
+					<p class="center-block"><img height="44" src="Resources/pics/program-fragment.svg" width="48" alt="Program fragment" /></p>
+					<p class="center-block"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
 				</div>
 				<div class="section-content">
 					<p>
@@ -410,7 +382,7 @@
   END-IF
 END-PERFORM
 </code></pre>
-					<form action="SequentialFiles2.html" method="post" class="qa-form">
+					<div class="qa-form">
 						<div class="qa-row">
 							<div class="qa-label">Q1</div>
 							<div class="qa-question">
@@ -418,7 +390,7 @@ END-PERFORM
 								it mean if the keys were equal?
 							</div>
 							<div class="qa-answer">
-								<select name="select" size="1">
+								<select aria-label="Click for answer" name="select" size="1">
 									<option selected>Click the arrow for the answer</option>
 									<option>---------------------------------------------------------------</option>
 									<option>Since the key field is supposed to</option>
@@ -439,7 +411,7 @@ END-PERFORM
 								terminate the loop?
 							</div>
 							<div class="qa-answer">
-								<select name="select" size="1">
+								<select aria-label="Click for answer" name="select" size="1">
 									<option selected>Click the arrow for the answer</option>
 									<option>---------------------------------------------------------------</option>
 									<option>Since we don't know which file is going</option>
@@ -456,7 +428,7 @@ END-PERFORM
 								file ends before the other. Can the code above be correct?
 							</div>
 							<div class="qa-answer">
-								<select name="select" size="1">
+								<select aria-label="Click for answer" name="select" size="1">
 									<option selected>Click the arrow for the answer</option>
 									<option>---------------------------------------------------------------</option>
 									<option>Yes the code is correct!!!</option>
@@ -475,15 +447,15 @@ END-PERFORM
 								</select>
 							</div>
 						</div>
-					</form>
+					</div>
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">Deleting records from an ordered Sequential file.</h4>
+					<h4>Deleting records from an ordered Sequential file.</h4>
 				</div>
 				<div class="section-content">
 					<p>The animation below demonstrates how to delete records from an ordered Sequential file.</p>
-					<p align="center">
+					<p class="center-block">
 						<a href="Resources/ppz/TC-SeqFile2d.html"
 							><img height="62" src="Resources/pics/i-Animation.gif" width="62" alt=""
 						/></a>
@@ -491,7 +463,7 @@ END-PERFORM
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">Updating records in an ordered Sequential file.</h4>
+					<h4>Updating records in an ordered Sequential file.</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -501,14 +473,14 @@ END-PERFORM
 						have to create a new file that contains the updated records.
 					</p>
 					<p>The animation below demonstrates how to batch-update records in an ordered Sequential files.</p>
-					<p align="center">
+					<p class="center-block">
 						<a href="Resources/ppz/TC-SeqFile2e.html"
 							><img height="62" src="Resources/pics/i-Animation.gif" width="62" alt=""
 						/></a>
 					</p>
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">Multiple record type transaction files</h4>
+					<h4>Multiple record type transaction files</h4>
 				</div>
 				<div class="section-content">
 					<p>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -94,17 +94,15 @@
 					<h4>Aims</h4>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<p align="left">
-							In the "Using Tables" tutorial we examined why we might want to use tables as part of the
-							solution to a programming problem.
-						</p>
-						<p align="left">
-							In this tutorial we examine the syntax and semantics of table declaration. We demonstrate
-							how to create single and multi-dimension tables, how to create variable length tables and
-							how to set up a table pre-filled with data..
-						</p>
-					</div>
+					<p>
+						In the "Using Tables" tutorial we examined why we might want to use tables as part of the
+						solution to a programming problem.
+					</p>
+					<p>
+						In this tutorial we examine the syntax and semantics of table declaration. We demonstrate
+						how to create single and multi-dimension tables, how to create variable length tables and
+						how to set up a table pre-filled with data..
+					</p>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
@@ -152,7 +150,7 @@
 					</ul>
 				</div>
 				<div class="section-full">
-					<div align="center">
+					<div>
 						<hr />
 						<back-to-top></back-to-top>
 					</div>
@@ -165,11 +163,11 @@
 					<h4>Introduction</h4>
 				</div>
 				<div class="section-content">
-					<p align="left">
+					<p>
 						In the "Using Tables" tutorial we saw how would could use a table to hold county tax totals. We
 						even had a brief look at how that table might be created.
 					</p>
-					<p align="left">
+					<p>
 						In this section we will examine, in more detail, how a single dimension table, like the
 						CountyTaxTable, may be created.
 					</p>
@@ -179,7 +177,7 @@
 					<h4>Tables - general notes</h4>
 				</div>
 				<div class="section-content">
-					<p align="left">
+					<p>
 						Most programming languages use the term "array" to describe repeated, or multiple- occurrence,
 						data-items. COBOL uses the term "table".
 					</p>
@@ -205,7 +203,7 @@
 							in brackets (see examples below).
 						</li>
 					</ul>
-					<p align="left">A table is stored in memory as a contiguous block of bytes.</p>
+					<p>A table is stored in memory as a contiguous block of bytes.</p>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
@@ -233,29 +231,27 @@
 					</blockquote>
 					<pre class="language-cobol"><code class="language-cobol">01 CountyTax   OCCURS 26 TIMES PIC 9(8)V99.
 </code></pre>
-					<div align="left">
-						<p>We can represent the county tax table diagrammatically as follows;</p>
-						<p align="center">
-							<a href="Resources/ppz/TC-Tables1.html"
-								><img height="71" src="Resources/pics/Tables1.gif" width="456"
-							/></a>
-						</p>
-						<p align="left">
-							In the example above, we can only refer to the individual elements of the table (see rule 2
-							for subscripts below). We can refer to CountyTax(1) or CountyTax(12) but we have no name for
-							the whole table. It is often very useful to be able to refer to the whole table and so it is
-							usual to define a table as subordinate to a group item which is named to indicate the whole
-							table. For example the CountyTax table would probably be described as -
-						</p>
-						<pre class="language-cobol" align="left"><code class="language-cobol">01 CountyTaxTable.
+					<p>We can represent the county tax table diagrammatically as follows;</p>
+					<p class="center-block">
+						<a href="Resources/ppz/TC-Tables1.html"
+							><img height="71" src="Resources/pics/Tables1.gif" width="456" alt="Diagram of a single-dimension CountyTax table with 26 elements"
+						/></a>
+					</p>
+					<p>
+						In the example above, we can only refer to the individual elements of the table (see rule 2
+						for subscripts below). We can refer to CountyTax(1) or CountyTax(12) but we have no name for
+						the whole table. It is often very useful to be able to refer to the whole table and so it is
+						usual to define a table as subordinate to a group item which is named to indicate the whole
+						table. For example the CountyTax table would probably be described as -
+					</p>
+					<pre class="language-cobol"><code class="language-cobol">01 CountyTaxTable.
 
    02 CountyTax  PIC 9(8)V99  OCCURS 26 TIMES.</code></pre>
-						<p>
-							When declared like this we can refer to <i>CountyTax(sub)</i> when we want to access an
-							element of the table and <i>CountyTaxTable</i> when we want to refer to the whole table.
-						</p>
-						<hr size="1" />
-					</div>
+					<p>
+						When declared like this we can refer to <i>CountyTax(sub)</i> when we want to access an
+						element of the table and <i>CountyTaxTable</i> when we want to refer to the whole table.
+					</p>
+					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
 					<h4>OCCURS clause syntax and rules</h4>
@@ -317,7 +313,7 @@
 				</div>
 				<div class="section-sidebar">
 					<h4>Table examples and some SAQ's</h4>
-					<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
+					<p class="center-block"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
 				</div>
 				<div class="section-content">
 					<p>
@@ -336,80 +332,78 @@
    02 ExchangeRate OCCURS 50 TIMES PIC 9(5)V99.
 
 01 MonthName   PIC X(3)OCCURS 12 TIMES. </code></pre>
-					<form action="Tables2.html" method="post">
-						<div align="center">
-							<table bgcolor="#E1FFE1" border="1" width="96%">
-								<tr>
-									<td bgcolor="#FFFFCC" width="8%">Q1</td>
-									<td width="62%">
-										What happens to the elements of the DeptTotalsTable when the statement
-										<code class="language-cobol">MOVE ZEROS TO</code> <i>DeptTotalsTable</i> is
-										executed?
-									</td>
-									<td valign="top" width="30%">
-										<select name="select5" size="1">
-											<option selected>Click the arrow for the answer</option>
-											<option>
-												-----------------------------------------------------------------
-											</option>
-											<option>Every element of the table is filled with</option>
-											<option>zeros.</option>
-										</select>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" width="8%">Q2</td>
-									<td width="62%">
-										What happens when the statement <code class="language-cobol">MOVE</code>
-										<i>456</i> <code class="language-cobol">TO</code> <i>DeptTotal(5)</i> is
-										executed?
-									</td>
-									<td valign="top" width="30%">
-										<select name="select6" size="1">
-											<option selected>Click the arrow for the answer</option>
-											<option>
-												-----------------------------------------------------------------
-											</option>
-											<option>The value 456 is moved into the fifth</option>
-											<option>element of the DeptTotalsTable</option>
-										</select>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" width="8%">Q3</td>
-									<td width="62%">
-										What statement would we have to write to display the second VAT rate in the
-										VATRateTable?
-									</td>
-									<td valign="top" width="30%">
-										<select name="select7" size="1">
-											<option selected>Click the arrow for the answer</option>
-											<option>
-												-----------------------------------------------------------------
-											</option>
-											<option>DISPLAY VATRate(2)</option>
-										</select>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" width="8%">Q4</td>
-									<td width="62%">What is the purpose of the level 88 attached to the RatesTable?</td>
-									<td valign="top" width="30%">
-										<select name="select8" size="1">
-											<option selected>Click the arrow for the answer</option>
-											<option>
-												-----------------------------------------------------------------
-											</option>
-											<option>The TableNotPrimed condition name is</option>
-											<option>true is the whole table contains zeros i.e.</option>
-											<option>has not yet been filled with the exchange</option>
-											<option>rates.</option>
-										</select>
-									</td>
-								</tr>
-							</table>
-						</div>
-					</form>
+					<div class="center-block">
+						<table bgcolor="#E1FFE1" border="1" width="96%">
+							<tr>
+								<td bgcolor="#FFFFCC" width="8%">Q1</td>
+								<td width="62%">
+									What happens to the elements of the DeptTotalsTable when the statement
+									<code class="language-cobol">MOVE ZEROS TO</code> <i>DeptTotalsTable</i> is
+									executed?
+								</td>
+								<td valign="top" width="30%">
+									<select aria-label="Click for answer" name="select5" size="1">
+										<option selected>Click the arrow for the answer</option>
+										<option>
+											-----------------------------------------------------------------
+										</option>
+										<option>Every element of the table is filled with</option>
+										<option>zeros.</option>
+									</select>
+								</td>
+							</tr>
+							<tr>
+								<td bgcolor="#FFFFCC" width="8%">Q2</td>
+								<td width="62%">
+									What happens when the statement <code class="language-cobol">MOVE</code>
+									<i>456</i> <code class="language-cobol">TO</code> <i>DeptTotal(5)</i> is
+									executed?
+								</td>
+								<td valign="top" width="30%">
+									<select aria-label="Click for answer" name="select6" size="1">
+										<option selected>Click the arrow for the answer</option>
+										<option>
+											-----------------------------------------------------------------
+										</option>
+										<option>The value 456 is moved into the fifth</option>
+										<option>element of the DeptTotalsTable</option>
+									</select>
+								</td>
+							</tr>
+							<tr>
+								<td bgcolor="#FFFFCC" width="8%">Q3</td>
+								<td width="62%">
+									What statement would we have to write to display the second VAT rate in the
+									VATRateTable?
+								</td>
+								<td valign="top" width="30%">
+									<select aria-label="Click for answer" name="select7" size="1">
+										<option selected>Click the arrow for the answer</option>
+										<option>
+											-----------------------------------------------------------------
+										</option>
+										<option>DISPLAY VATRate(2)</option>
+									</select>
+								</td>
+							</tr>
+							<tr>
+								<td bgcolor="#FFFFCC" width="8%">Q4</td>
+								<td width="62%">What is the purpose of the level 88 attached to the RatesTable?</td>
+								<td valign="top" width="30%">
+									<select aria-label="Click for answer" name="select8" size="1">
+										<option selected>Click the arrow for the answer</option>
+										<option>
+											-----------------------------------------------------------------
+										</option>
+										<option>The TableNotPrimed condition name is</option>
+										<option>true is the whole table contains zeros i.e.</option>
+										<option>has not yet been filled with the exchange</option>
+										<option>rates.</option>
+									</select>
+								</td>
+							</tr>
+						</table>
+					</div>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
@@ -446,7 +440,7 @@
                       DEPENDING ON NumOfReservations. </code></pre>
 				</div>
 				<div class="section-full">
-					<div align="center">
+					<div>
 						<hr />
 						<back-to-top></back-to-top>
 					</div>
@@ -498,7 +492,7 @@
 						<i>CountyTax</i> and <i>PayerCount</i>.
 					</p>
 					<p>We can represent this table diagrammatically as follows;</p>
-					<p align="center"><img height="149" src="Resources/pics/Tables3.gif" width="466" /></p>
+					<p class="center-block"><img height="149" src="Resources/pics/Tables3.gif" width="466" alt="Diagram of CountyTaxTable where each element is a group item subdivided into CountyTax and PayerCount" /></p>
 					<p>
 						To refer to an item that is subordinate to table element, the same number of subscripts must be
 						used as when referring to the element itself. So, to refer to
@@ -509,7 +503,7 @@
 				</div>
 				<div class="section-sidebar">
 					<h4>Self Assessment Questions and animated example</h4>
-					<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
+					<p class="center-block"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
 				</div>
 				<div class="section-content">
 					<p>
@@ -523,7 +517,7 @@ MOVE ZEROS TO CountyTaxDetails(4)
 MOVE ZEROS TO CountyTaxTable</code></pre>
 					What effect on the table will each of these statements have? Copy the table diagram above, fill in
 					your answer and then click on the animation icon below to see the animated solution.
-					<p align="center">
+					<p class="center-block">
 						<a href="Resources/ppz/TC-Tables3.html"
 							><img height="62" src="Resources/pics/i-Animation.gif" width="62" alt=""
 						/></a>
@@ -539,26 +533,24 @@ MOVE ZEROS TO CountyTaxTable</code></pre>
       03 CountyTax   PIC 9(8)V99 OCCURS 26 TIMES.
       03 PayerCount  PIC 9(7)OCCURS 26 TIMES.
 </code></pre>
-					<form action="Tables2.html" method="post">
-						<div align="center">
-							<select name="select" size="1">
-								<option selected>Click the arrow for the answer</option>
-								<option>
-									------------------------------------------------------------------------------------------------------------------------
-								</option>
-								<option>CountyTaxTable1 is a table where each element is a group item that is</option>
-								<option>divided into the items CountyTax and PayerCount.</option>
-								<option>In CountyTaxTable2, CountyTax and PayerCount are two separate tables.</option>
-								<option>CountyTaxDetails and CountTaxTable2 are group items that contain</option>
-								<option>these two tables.</option>
-							</select>
-						</div>
-					</form>
+					<div class="center-block">
+						<select aria-label="Click for answer" name="select" size="1">
+							<option selected>Click the arrow for the answer</option>
+							<option>
+								------------------------------------------------------------------------------------------------------------------------
+							</option>
+							<option>CountyTaxTable1 is a table where each element is a group item that is</option>
+							<option>divided into the items CountyTax and PayerCount.</option>
+							<option>In CountyTaxTable2, CountyTax and PayerCount are two separate tables.</option>
+							<option>CountyTaxDetails and CountTaxTable2 are group items that contain</option>
+							<option>these two tables.</option>
+						</select>
+					</div>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
 					<h4>Example program</h4>
-					<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
+					<p class="center-block"><img height="44" src="Resources/pics/program.gif" width="42" alt="" /></p>
 				</div>
 				<div class="section-content">
 					<p>
@@ -645,7 +637,7 @@ DisplayCountyTaxes.
    END-IF.</code></pre>
 				</div>
 				<div class="section-full">
-					<div align="center">
+					<div>
 						<hr />
 						<back-to-top></back-to-top>
 					</div>
@@ -658,12 +650,12 @@ DisplayCountyTaxes.
 					<h4>Introduction</h4>
 				</div>
 				<div class="section-content">
-					<p align="left">
+					<p>
 						The Census Office has provided us with a file containing the AgeCategory, Gender, CountyCode and
 						car ownership information of every person in the country. The CensusFile is an unordered
 						sequential file and its records have the following description-
 					</p>
-					<div align="center">
+					<div class="center-block">
 						<table bgcolor="#E1FFE1" border="1" cellpadding="5" width="56%">
 							<tr bgcolor="#FFFFCC">
 								<th scope="col" width="32%">Name</th>
@@ -673,19 +665,19 @@ DisplayCountyTaxes.
 							<tr>
 								<td width="32%">CountyCode</td>
 								<td width="26%">
-									<div align="center">PIC 99</div>
+									<div class="center-block">PIC 99</div>
 								</td>
 								<td width="42%">
-									<div align="center">1-26</div>
+									<div class="center-block">1-26</div>
 								</td>
 							</tr>
 							<tr>
 								<td width="32%">AgeCategory</td>
 								<td width="26%">
-									<div align="center">PIC 9</div>
+									<div class="center-block">PIC 9</div>
 								</td>
 								<td width="42%">
-									<p align="left">
+									<p>
 										1 = Child<br />
 										2 = Teen<br />
 										3 = Adult
@@ -695,7 +687,7 @@ DisplayCountyTaxes.
 							<tr>
 								<td width="32%">Gender</td>
 								<td width="26%">
-									<div align="center">PIC 9</div>
+									<div class="center-block">PIC 9</div>
 								</td>
 								<td width="42%">
 									<p>
@@ -707,15 +699,15 @@ DisplayCountyTaxes.
 							<tr>
 								<td width="32%">CarOwner</td>
 								<td width="26%">
-									<div align="center">PIC X</div>
+									<div class="center-block">PIC X</div>
 								</td>
 								<td width="42%">
-									<p align="center">Y/N</p>
+									<p class="center-block">Y/N</p>
 								</td>
 							</tr>
 						</table>
 					</div>
-					<p align="left">
+					<p>
 						Suppose we were asked to write a program to produce a report displaying the number of males, and
 						the number of females, in each AgeCategory - Child, Teen and Adult. How would we go about it?
 					</p>
@@ -724,22 +716,22 @@ DisplayCountyTaxes.
 					<h4>Problem discussion</h4>
 				</div>
 				<div class="section-content">
-					<p align="left">
+					<p>
 						One way to solve this problem, would be to sort the file on AgeCategory and Gender, and then
 						treat it as a control break problem.
 					</p>
-					<p align="left">
+					<p>
 						Another way to solve the problem, would be to set up a number of total variables and then, when
 						a record is read, use the AgeCategory and Gender information to tell us which total to
 						increment.
 					</p>
-					<p align="left">
+					<p>
 						In this particular problem there are only six totals required - CFTotal, CMTotal, TFTotal,
 						TMTotal, AFTotal, AMTotal - so a solution which involves creating these totals and using an
 						<code class="language-cobol">EVALUATE</code> to decide which total to increment, would not be
 						entirely out of the question.
 					</p>
-					<p align="left">
+					<p>
 						But instead of an <code class="language-cobol">EVALUATE-</code>based solution let's consider
 						using a table to hold the totals. What kind of a table might we require? We can see that six
 						totals are needed, so we might think that the six element, single-dimension, table shown below
@@ -747,7 +739,7 @@ DisplayCountyTaxes.
 					</p>
 					<pre class="language-cobol"><code class="language-cobol">01 PopulationTable.
    02 PopTotal PIC 9(6) OCCURS 6 TIMES.</code></pre>
-					<p align="left">
+					<p>
 						The problem with this is - what can we use as an index into the table? No single item in the
 						record will do. The index must be a combination of the
 						<i>AgeCategory</i> and the <i>Gender</i>. Of course, we could use an
@@ -756,7 +748,6 @@ DisplayCountyTaxes.
 					</p>
 					<pre
 						class="language-cobol"
-						align="left"
 					><code class="language-cobol">EVALUATE AgeCategory ALSO Gender
   WHEN        1      ALSO    1      MOVE 1 TO Idx
   WHEN        1      ALSO    2      MOVE 2 TO Idx
@@ -764,15 +755,15 @@ DisplayCountyTaxes.
           etc...
 END-EVALUATE.
 </code></pre>
-					<p align="left">
+					<p>
 						Or we could manipulate the values arithmetically to map them to the index value. For instance
 						<i>COMPUTE Idx = ((AgeCategory -1) * 2) + Gender</i>
 					</p>
-					<p align="left">
+					<p>
 						But both these methods lack something in elegance and will be difficult to extend when, as I'm
 						sure you have anticipated, we ask for the population information to be provided for each county.
 					</p>
-					<p align="left">
+					<p>
 						The best, and most extensible, solution to the problem is to set up a two dimension table to
 						hold the totals. Since the elements of a two dimension table require two subscripts, we can use
 						the AgeCategory and the Gender to identify the particular element we need to access.
@@ -782,30 +773,30 @@ END-EVALUATE.
 					<h4>A two dimension table</h4>
 				</div>
 				<div class="section-content">
-					<p align="left">
+					<p>
 						A multi-dimension table is declared by nesting
 						<code class="language-cobol">OCCURS</code> clauses. So we can define the two dimension
 						<i>PopulationTable</i> as follows -
 					</p>
-					<pre class="language-cobol" align="left"><code class="language-cobol">01 PopulationTable.
+					<pre class="language-cobol"><code class="language-cobol">01 PopulationTable.
    02 Age OCCURS 3 TIMES.
       03 PopTotal   PIC 9(6)OCCURS 2 TIMES.</code></pre>
-					<p align="left">
+					<p>
 						While the table description shown above is correct; it is not, perhaps, as understandable as it
 						might be. You might prefer to define the table as shown below.
 					</p>
-					<pre class="language-cobol" align="left"><code class="language-cobol">01 PopulationTable.
+					<pre class="language-cobol"><code class="language-cobol">01 PopulationTable.
    02 Age OCCURS 3 TIMES.
       03 Gender OCCURS 2 TIMES.
          04 PopTotal   PIC 9(6).
 </code></pre>
-					<p align="left">We can represent this table diagrammatically as -</p>
-					<p align="center"><img height="170" src="Resources/pics/Tables4.gif" width="470" /></p>
-					<p align="left">
+					<p>We can represent this table diagrammatically as -</p>
+					<p class="center-block"><img height="170" src="Resources/pics/Tables4.gif" width="470" alt="Diagram of a two-dimension PopulationTable with Age (3 elements) and nested Gender (2 elements) containing PopTotal" /></p>
+					<p>
 						Two dimension tables are sometimes represented as a row and column grid, but that representation
 						has the flaw that it does not accurately reflect the data hierarchy.
 					</p>
-					<p align="left">
+					<p>
 						The diagram above uses the correct representation for a two dimension table because it expresses
 						the data hierarchy inherent in the table description where one
 						<code class="language-cobol">OCCURS</code> clause is subordinate to the another.
@@ -814,7 +805,7 @@ END-EVALUATE.
 				</div>
 				<div class="section-sidebar">
 					<h4>Self Assessment Questions and examples</h4>
-					<p align="center"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
+					<p class="center-block"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
 				</div>
 				<div class="section-content">
 					<p>
@@ -827,7 +818,7 @@ MOVE 456 TO Gender(3,2)
 ADD 1255 TO PopTotal(2,2)
 MOVE ZEROS TO Age(3)</code></pre>
 					<p>Click on the animation icon below to see an animated answer.</p>
-					<p align="center">
+					<p class="center-block">
 						<a href="Resources/ppz/TC-Tables4.html"
 							><img height="62" src="Resources/pics/i-Animation.gif" width="62" alt=""
 						/></a>
@@ -885,7 +876,7 @@ MOVE ZEROS TO Age(3)</code></pre>
             05 PopTotal   PIC 9(6).
 </code></pre>
 					<p>This table may be represented diagrammatically as follows -</p>
-					<p align="center"><img height="145" src="Resources/pics/Tables5.gif" width="480" /></p>
+					<p class="center-block"><img height="145" src="Resources/pics/Tables5.gif" width="480" alt="Diagram of a three-dimension PopulationTable with County (26), Age (3), and Gender (2) containing PopTotal" /></p>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
@@ -903,7 +894,7 @@ MOVE 56 TO PopTotal(1,3,2)
 MOVE 12 TO PopTotal(2,1,1)
 MOVE ZEROS TO PopulationTable</code></pre>
 					<p>Click on the animation icon below to see an animated answer.</p>
-					<p align="center">
+					<p class="center-block">
 						<a href="Resources/ppz/TC-Tables5.html"
 							><img height="62" src="Resources/pics/i-Animation.gif" width="62" alt=""
 						/></a>
@@ -959,7 +950,7 @@ MOVE ZEROS TO PopulationTable</code></pre>
          04 Gender OCCURS 2 TIMES.
             05 PopTotal   PIC 9(6).  </code></pre>
 					<p>We can represent the declaration above diagrammatically as follows -</p>
-					<p align="center"><img height="156" src="Resources/pics/Tables6.gif" width="481" /></p>
+					<p class="center-block"><img height="156" src="Resources/pics/Tables6.gif" width="481" alt="Diagram of PopulationTable extended with CarOwnersTotal at the County level alongside the Age/Gender sub-table" /></p>
 					<p>
 						One question we might have with this arrangement is - how many subscripts are required when we
 						refer to <i>CarOwnersTotal</i>? To answer this we can frame a general rule -
@@ -988,7 +979,7 @@ MOVE ZEROS TO Gender(18,3,2)
 ADD 56 TO PopTotal(12,3,2)</code></pre>
 				</div>
 				<div class="section-full">
-					<div align="center">
+					<div>
 						<hr />
 						<back-to-top></back-to-top>
 					</div>
@@ -998,7 +989,7 @@ ADD 56 TO PopTotal(12,3,2)</code></pre>
 					<h2 id="part4">Creating pre-filled tables with the REDEFINES clause</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">Introduction</h4>
+					<h4>Introduction</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1027,55 +1018,55 @@ ADD 56 TO PopTotal(12,3,2)</code></pre>
 					<h4>Non-tables uses for the REDEFINES clause - some examples</h4>
 				</div>
 				<div class="section-content">
-					<p align="left">
+					<p>
 						<b>Example 1<br /></b> Some COBOL statements, like the UNSTRING, require their receiving fields
 						to be alphanumeric (PIC X) data-items. This is inconvenient if the value of the data-item is
 						actually numeric because then a <code class="language-cobol">MOVE</code> is required to place
 						the value into a numeric item. If the value contains a decimal point then this creates even more
 						difficulties.
 					</p>
-					<p align="left">
+					<p>
 						For example, suppose an <code class="language-cobol">UNSTRING</code> statement has just
 						extracted the text value "1234567" from a string and we want to move this value to a numeric
 						item described as PIC 9(5)V99. An ordinary <code class="language-cobol">MOVE</code> is not going
 						to work because the computer will not know that we actually want the item treated as if it were
 						the value 12345.67.
 					</p>
-					<p align="left">
+					<p>
 						The <code class="language-cobol">REDEFINES</code> clause allows us to solve this problem neatly
 						because we can <code class="language-cobol">UNSTRING</code> the number into <i>TextValue</i> and
 						then treat <i>TextValue</i> as if it were described as PIC 9(5)V99. For instance -
 					</p>
-					<pre class="language-cobol" align="left"><code class="language-cobol">01  TextValue    PIC X(7).
+					<pre class="language-cobol"><code class="language-cobol">01  TextValue    PIC X(7).
 01  NumericValue REDEFINES TextValue PIC 9(5)V99.</code></pre>
-					<p align="left">
+					<p>
 						<b>Example 2<br /></b> The <code class="language-cobol">REDEFINES</code> clause is not just used
 						to create pre-filled tables. It is used whenever a programmer needs to give different data
 						descriptions to the same area of storage.
 					</p>
-					<p align="left">
+					<p>
 						For instance, suppose we accept a date from the user and that sometimes the date has the format
 						yyyymmdd, sometimes it is a European date with the format ddmmyyyy, and somtimes it is a US date
 						with the format mmddyyyy. A code accepted with the date allows us to detect the type of date
 						entered.
 					</p>
-					<p align="left">
+					<p>
 						How can we arrange matters so that no matter which type of date is entered we can retrieve the
 						year, month and day part of the date correctly?
 					</p>
-					<p align="left">
+					<p>
 						If you think about this for a moment you should see that the programming is going to be messy.
 						We'll have to set up three separate date variables and, when we accept the date, we will have to
 						extract the day, month and year parts and put them into the appropriate elementary items of the
 						target date.
 					</p>
-					<p align="left">
+					<p>
 						On the other hand, we could use the <code class="language-cobol">REDEFINES</code> clause to give
 						different names and descriptions to the area of storage holding the date so that we can access
 						the correct day, month and year fields without recourse to special programming. For instance, if
 						define the <i>InputDate</i> as -
 					</p>
-					<pre class="language-cobol" align="left"><code class="language-cobol">01 InputDate.
+					<pre class="language-cobol"><code class="language-cobol">01 InputDate.
    02 DateType         PIC 9.
       88 DateIsSort    VALUE 1.
       88 DateIsEuro    VALUE 2.
@@ -1094,7 +1085,7 @@ ADD 56 TO PopTotal(12,3,2)</code></pre>
       03 USYear        PIC 9(4).
 </code></pre>
 					<p>we can use statements like -</p>
-					<pre class="language-cobol" align="left"><code class="language-cobol">EVALUATE TRUE
+					<pre class="language-cobol"><code class="language-cobol">EVALUATE TRUE
     WHEN DateIsSort
            DISPLAY "SortDate format is yyyy-mm-dd "
            DISPLAY  SortYear "-" SortMonth "-" SortDay
@@ -1106,18 +1097,18 @@ ADD 56 TO PopTotal(12,3,2)</code></pre>
            DISPLAY  USMonth "-" USDay "-" USYear
 END-EVALUATE </code></pre>
 					<p>- and still get the correct values displayed.</p>
-					<p align="left">
+					<p>
 						<b>Example 3<br /></b> The <code class="language-cobol">REDEFINES</code> clause is also useful
 						when we need to treat a numeric item as if it had its decimal point in different places. For
 						instance the value 12345 is treated as if it were 12.345 if we refer to <i>10Rate</i>, 123.45 if
 						we refer to <i>100Rate</i>, and 1234.5 if we refer to <i>1000Rate</i>.
 					</p>
-					<pre class="language-cobol" align="left"><code class="language-cobol">01 Rates.
+					<pre class="language-cobol"><code class="language-cobol">01 Rates.
    02 10Rate                    PIC 99V999.
    02 100Rate  REDEFINES 10Rate PIC 999V99.
    02 1000Rate REDEFINES 10Rate PIC 9999V9.</code></pre>
-					<p align="left"><b>Animated versions of the examples above</b></p>
-					<p align="center">
+					<p><b>Animated versions of the examples above</b></p>
+					<p class="center-block">
 						<a href="Resources/ppz/TC-Tables7.html"
 							><img height="62" src="Resources/pics/i-Animation.gif" width="62" alt=""
 						/></a>
@@ -1128,7 +1119,7 @@ END-EVALUATE </code></pre>
 					<h4>REDEFINES syntax and rules</h4>
 				</div>
 				<div class="section-content">
-					<p><img height="48" src="Resources/pics/Redefines.gif" width="358" /></p>
+					<p><img height="48" src="Resources/pics/Redefines.gif" width="358" alt="REDEFINES clause syntax diagram" /></p>
 					<p><b>REDEFINES</b> <b>rules</b></p>
 					<ol>
 						<li>
@@ -1197,7 +1188,7 @@ END-EVALUATE </code></pre>
 					<pre class="language-cobol"><code class="language-cobol">   02 FILLER REDEFINES MonthValues.
       03 Month OCCURS 12 TIMES PIC X(9).</code></pre>
 					<p>Examine the animation below to view this and other examples.</p>
-					<p align="center">
+					<p class="center-block">
 						<a href="Resources/ppz/TC-Tables8.html"
 							><img height="62" src="Resources/pics/i-Animation.gif" width="62" alt=""
 						/></a>
@@ -1206,7 +1197,7 @@ END-EVALUATE </code></pre>
 				</div>
 				<div class="section-sidebar">
 					<h4>Example program</h4>
-					<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
+					<p class="center-block"><img height="44" src="Resources/pics/program.gif" width="42" alt="" /></p>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1335,7 +1326,7 @@ DisplayCountyTaxes.
 					</p>
 					<pre class="language-cobol"><code class="language-cobol">01 DayTable VALUE "MonTueWedThrFriSatSun".
    02 Day OCCURS 7 TIMES PIC X(3).</code></pre>
-					<div align="center">
+					<div class="center-block">
 						<img
 							alt="Diagram showing DayTable filling a 7-entry table with the values Mon, Tue, Wed, Thr, Fri, Sat, and Sun"
 							height="84"
@@ -1348,10 +1339,10 @@ DisplayCountyTaxes.
 					<h4>COBOL'85 table initialisation changes</h4>
 				</div>
 				<div class="section-content">
-					<p align="left">
+					<p>
 						The 1985 COBOL standard also introduced some changes to the way tables are initialised.
 					</p>
-					<p align="left">
+					<p>
 						In the previous versions of COBOL initialising a table was never a problem if the elements of
 						the table were elementary items. All that was required was to move the initialising value to the
 						table's group name. For instance, the statement


### PR DESCRIPTION
## Summary
- Deep-cleaned 4 SAQ-heavy course pages to 0 pa11y violations (WCAG 2.1 AA)
- `Selection.html`, `EditedPics.html`, `SequentialFiles2.html`, `Tables2.html`

## Changes per file
- Added descriptive `alt` text to content figures (syntax diagrams)
- Added `aria-label="Click for answer"` to all unlabeled `<select>` elements
- Removed vestigial `<form action="..." method="post">` wrappers (Word export artifacts, caused H32.2 violations)
- Stripped `align="left"` attributes (LTR default)
- Replaced `align="center"` on block elements with `class="center-block"`
- Replaced `align="center"` on `<td>`/`<th>` with `style="text-align:center"`
- Replaced `align="center"` on `<table>` with `style="margin:0 auto"`
- Unwrapped `<center>` and `<div align="center">` elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)