### PR TITLE
Make COBOLcommands, Search, SortMerge, Subprograms pa11y-clean

### DIFF
--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -88,10 +88,8 @@
 			</div>
 
 			<div class="page-content">
-				<div align="center">
-					<hr />
-					<back-to-top></back-to-top>
-				</div>
+				<hr />
+				<back-to-top></back-to-top>
 			</div>
 
 			<!-- Part 1: Basic User Input and Output -->
@@ -103,43 +101,41 @@
 					<h4>Introduction</h4>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<p align="left">
-							In COBOL, the <code class="language-cobol">ACCEPT</code> and
-							<code class="language-cobol">DISPLAY</code> verbs are used to read from the keyboard and
-							write to the screen. Input and output using these commands is somewhat primitive because
-							they were originally designed to be used in a batch programming environment to communicate
-							with the computer operator.
-						</p>
-						<p align="left">
-							In recent years many vendors have augmented the
-							<code class="language-cobol">ACCEPT</code> and
-							<code class="language-cobol">DISPLAY</code> syntax to facilitate the creation of on-line
-							systems by allowing such things as: cursor positioning, character attribute control and
-							auto-validation of input.
-						</p>
-						<p align="left">
-							In this tutorial we will examine only the standard
-							<code class="language-cobol">ACCEPT</code> and
-							<code class="language-cobol">DISPLAY</code> syntax.
-						</p>
-						<hr width="50%" />
-					</div>
+					<p>
+						In COBOL, the <code class="language-cobol">ACCEPT</code> and
+						<code class="language-cobol">DISPLAY</code> verbs are used to read from the keyboard and
+						write to the screen. Input and output using these commands is somewhat primitive because
+						they were originally designed to be used in a batch programming environment to communicate
+						with the computer operator.
+					</p>
+					<p>
+						In recent years many vendors have augmented the
+						<code class="language-cobol">ACCEPT</code> and
+						<code class="language-cobol">DISPLAY</code> syntax to facilitate the creation of on-line
+						systems by allowing such things as: cursor positioning, character attribute control and
+						auto-validation of input.
+					</p>
+					<p>
+						In this tutorial we will examine only the standard
+						<code class="language-cobol">ACCEPT</code> and
+						<code class="language-cobol">DISPLAY</code> syntax.
+					</p>
+					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
 					<h4>The DISPLAY verb</h4>
 					<aside>
-						<p align="center">
+						<p class="center-block">
 							<img height="44" src="Resources/pics/i-LightBulbTip.gif" width="42" alt="" />
 						</p>
-						<p align="left">
+						<p>
 							In the COBOL syntax diagrams ( the COBOL metalanguage) upper case words are keywords. If
 							underlined, they are mandatory.<br />
 							{ } brackets mean that one of the options must be selected<br />
 							[ ] brackets mean that the item is optional<br />
 							ellipses (...) mean that the item may be repeated at the programmer's discretion.
 						</p>
-						<p align="left">
+						<p>
 							The symbols used in the syntax diagram identifiers have the following significance:-<br />
 							<b>$</b> signifies a string item,<br />
 							<b>#</b> is numeric item,<br />
@@ -149,44 +145,41 @@
 					</aside>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<p align="left"><img height="54" src="Resources/pics/Display.gif" width="440" /></p>
-						<p align="left">
-							The <code class="language-cobol">DISPLAY</code> verb is used to send output to the computer
-							screen or to a peripheral device.
-						</p>
-						<p align="left">
-							As you can see from the ellipses (...) in the metalanguage above a single
-							<code class="language-cobol">DISPLAY</code> can be used to display several data-items or
-							literals or any combination of these.
-						</p>
-						<p align="left">
-							<b> <code class="language-cobol">DISPLAY</code> notes<br /> </b> After the items in the
-							display list have been sent to the screen, the
-							<code class="language-cobol">DISPLAY</code> automatically moves the screen cursor to the
-							next line unless a <code class="language-cobol">WITH NO ADVANCING</code> clause is present.
-						</p>
-						<p align="left">
-							Mnemonic-Names are used to make programs more readable. A Mnemonic-Name is a name devised by
-							the programmer to represent some peripheral device (such as a serial port) or control code.
-							The name is connected to the actual device or code by entries in the
-							<code class="language-cobol">ENVIRONMENT DIVISION</code>.
-						</p>
-						<p align="left">
-							When a Mnemonic-Name is used with the <code class="language-cobol">DISPLAY</code> it
-							represents an output device (serial port, parallel port etc).
-						</p>
-						<p align="left">
-							If a Mnemonic-Name is used output is sent to the device specified; otherwise, output is sent
-							to the computer screen.
-						</p>
-						<p align="left">
-							<b> <code class="language-cobol">DISPLAY</code> examples </b>
-						</p>
-					</div>
+					<p><img height="54" src="Resources/pics/Display.gif" width="440" alt="DISPLAY verb syntax diagram" /></p>
+					<p>
+						The <code class="language-cobol">DISPLAY</code> verb is used to send output to the computer
+						screen or to a peripheral device.
+					</p>
+					<p>
+						As you can see from the ellipses (...) in the metalanguage above a single
+						<code class="language-cobol">DISPLAY</code> can be used to display several data-items or
+						literals or any combination of these.
+					</p>
+					<p>
+						<b> <code class="language-cobol">DISPLAY</code> notes<br /> </b> After the items in the
+						display list have been sent to the screen, the
+						<code class="language-cobol">DISPLAY</code> automatically moves the screen cursor to the
+						next line unless a <code class="language-cobol">WITH NO ADVANCING</code> clause is present.
+					</p>
+					<p>
+						Mnemonic-Names are used to make programs more readable. A Mnemonic-Name is a name devised by
+						the programmer to represent some peripheral device (such as a serial port) or control code.
+						The name is connected to the actual device or code by entries in the
+						<code class="language-cobol">ENVIRONMENT DIVISION</code>.
+					</p>
+					<p>
+						When a Mnemonic-Name is used with the <code class="language-cobol">DISPLAY</code> it
+						represents an output device (serial port, parallel port etc).
+					</p>
+					<p>
+						If a Mnemonic-Name is used output is sent to the device specified; otherwise, output is sent
+						to the computer screen.
+					</p>
+					<p>
+						<b> <code class="language-cobol">DISPLAY</code> examples </b>
+					</p>
 					<pre
 						class="language-cobol"
-						align="left"
 					><code class="language-cobol">DISPLAY "My name is " ProgrammerName.
 DISPLAY "The vat rate is " VatRate.
 DISPLAY PrinterSetupCodes UPON PrinterPort1.
@@ -197,53 +190,43 @@ DISPLAY PrinterSetupCodes UPON PrinterPort1.
 					<h4>The ACCEPT verb</h4>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<p align="left"><img height="120" src="Resources/pics/ACCEPT.gif" width="390" /></p>
-						<p align="left">
-							The ACCEPT verb is used to get data from the keyboard, a peripheral device, or certain
-							system variables.
-						</p>
-						<p align="left">
-							<b> <code class="language-cobol">ACCEPT</code> notes<br /> </b> When the first format is
-							used, the <code class="language-cobol">ACCEPT</code> inserts the data typed at the keyboard
-							(or coming from the peripheral device), into the receiving data-item.
-						</p>
-						<p align="left">
-							When the second format is used, the <code class="language-cobol">ACCEPT</code> inserts the
-							data obtained from one of the system variables, into the receiving data-item.
-						</p>
-					</div>
+					<p><img height="120" src="Resources/pics/ACCEPT.gif" width="390" alt="ACCEPT verb syntax diagram" /></p>
+					<p>
+						The ACCEPT verb is used to get data from the keyboard, a peripheral device, or certain
+						system variables.
+					</p>
+					<p>
+						<b> <code class="language-cobol">ACCEPT</code> notes<br /> </b> When the first format is
+						used, the <code class="language-cobol">ACCEPT</code> inserts the data typed at the keyboard
+						(or coming from the peripheral device), into the receiving data-item.
+					</p>
+					<p>
+						When the second format is used, the <code class="language-cobol">ACCEPT</code> inserts the
+						data obtained from one of the system variables, into the receiving data-item.
+					</p>
 				</div>
 				<div class="section-sidebar">
 					<h4>Using the ACCEPT to get the system date and time</h4>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<div align="center">
-							<p align="left">
-								The second format of the <code class="language-cobol">ACCEPT</code> allows the
-								programmer to access the system date and time (i.e. the date and time held in the
-								computer's internal clock). The system variables provided are -
-							</p>
-							<div align="left">
-								<ul>
-									<li>Date</li>
-									<li>Day of the year</li>
-									<li>Day of the week</li>
-									<li>Time</li>
-								</ul>
-							</div>
-						</div>
-						<p align="left">
-							The declarations and comments below show the format required for data-items receiving each
-							of the system variables.
-						</p>
-					</div>
-					<div align="center">
-						<div align="left">
-							<pre
-								class="language-cobol"
-							><code class="language-cobol">*&gt; CurrentDate is the date in YYMMDD format
+					<p>
+						The second format of the <code class="language-cobol">ACCEPT</code> allows the
+						programmer to access the system date and time (i.e. the date and time held in the
+						computer's internal clock). The system variables provided are -
+					</p>
+					<ul>
+						<li>Date</li>
+						<li>Day of the year</li>
+						<li>Day of the week</li>
+						<li>Time</li>
+					</ul>
+					<p>
+						The declarations and comments below show the format required for data-items receiving each
+						of the system variables.
+					</p>
+					<pre
+						class="language-cobol"
+					><code class="language-cobol">*&gt; CurrentDate is the date in YYMMDD format
 01 CurrentDate         PIC 9(6).
 
 *&gt; DayOfYear is current day in YYDDD format
@@ -255,8 +238,6 @@ DISPLAY PrinterSetupCodes UPON PrinterPort1.
 *&gt; CurrentTime is the time in HHMMSSss format where s = S/100
 01 CurrentTime         PIC 9(8).
 </code></pre>
-						</div>
-					</div>
 				</div>
 				<div class="section-sidebar">
 					<h4>New formats for the ACCEPT</h4>
@@ -269,7 +250,7 @@ DISPLAY PrinterSetupCodes UPON PrinterPort1.
 						formats of now take additional (optional) formatting instructions to allow the programmer to
 						specify that the date is to be supplied with a 4 digit year.
 					</p>
-					<p align="left">The syntax for these new formatting instructions is:</p>
+					<p>The syntax for these new formatting instructions is:</p>
 					<ul>
 						<li><code class="language-cobol">ACCEPT DATE [YYYYMMDD]</code></li>
 						<li><code class="language-cobol">ACCEPT DAY [YYYYDDD] </code></li>
@@ -285,8 +266,8 @@ DISPLAY PrinterSetupCodes UPON PrinterPort1.
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">ACCEPT and DISPLAY example program</h4>
-					<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
+					<h4>ACCEPT and DISPLAY example program</h4>
+					<p class="center-block"><img height="44" src="Resources/pics/program.gif" width="42" alt="" /></p>
 				</div>
 				<div class="section-content">
 					<p>
@@ -352,7 +333,7 @@ Begin.
     DISPLAY "The time is " CurrentHour ":" CurrentMinute.
     STOP RUN.
 </code></pre>
-					<p align="center">
+					<p class="center-block">
 						<b>Results of running ACCEPT.CBL</b>
 					</p>
 					<pre>
@@ -370,10 +351,8 @@ The time is 14:41
 			</div>
 
 			<div class="page-content">
-				<div align="center">
-					<hr />
-					<back-to-top></back-to-top>
-				</div>
+				<hr />
+				<back-to-top></back-to-top>
 			</div>
 
 			<!-- Part 2: Assignment using the MOVE verb -->
@@ -382,7 +361,7 @@ The time is 14:41
 					<h2 id="part2">Assignment using the MOVE verb</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">Introduction</h4>
+					<h4>Introduction</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -403,10 +382,10 @@ The time is 14:41
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">The MOVE verb</h4>
+					<h4>The MOVE verb</h4>
 				</div>
 				<div class="section-content">
-					<p align="left">
+					<p>
 						<code class="language-cobol">MOVE</code> Source$#il
 						<code class="language-cobol">TO</code> Destination$#i ...
 					</p>
@@ -456,17 +435,17 @@ The time is 14:41
 						receiving data types are not permitted and will be rejected by the compiler. The valid and
 						invalid <code class="language-cobol">MOVE</code> combinations are shown in the diagram below:
 					</p>
-					<p align="center"><img height="232" src="Resources/pics/Move2.gif" width="520" /></p>
+					<p class="center-block"><img height="232" src="Resources/pics/Move2.gif" width="520" alt="Table of valid and invalid MOVE combinations between data types" /></p>
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">MOVE examples</h4>
+					<h4>MOVE examples</h4>
 				</div>
 				<div class="section-content">
 					<p id="com1">
 						Examine the examples in the animation below in combination with the MOVE rules above. Make sure
 						you understand the why the moves produce the results shown.
 					</p>
-					<p align="center">
+					<p class="center-block">
 						<a href="Resources/ppz/TC-Commands1.html"
 							><img
 								alt="Click to view the animation"
@@ -479,10 +458,8 @@ The time is 14:41
 			</div>
 
 			<div class="page-content">
-				<div align="center">
-					<hr />
-					<back-to-top></back-to-top>
-				</div>
+				<hr />
+				<back-to-top></back-to-top>
 			</div>
 
 			<!-- Part 3: Arithmetic in COBOL -->
@@ -494,17 +471,15 @@ The time is 14:41
 					<h4>Introduction</h4>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<p align="left">
-							Most procedural programming languages perform computations by assigning the result of an
-							arithmetic expression or a function to a variable. In COBOL the
-							<code class="language-cobol">COMPUTE</code> verb is used to evaluate arithmetic expressions,
-							but there are also specific commands for adding, subtracting, multiplying and dividing.
-						</p>
-					</div>
+					<p>
+						Most procedural programming languages perform computations by assigning the result of an
+						arithmetic expression or a function to a variable. In COBOL the
+						<code class="language-cobol">COMPUTE</code> verb is used to evaluate arithmetic expressions,
+						but there are also specific commands for adding, subtracting, multiplying and dividing.
+					</p>
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">Data Movement</h4>
+					<h4>Data Movement</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -522,50 +497,48 @@ The time is 14:41
 					<h4>General Rules</h4>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<p align="left">
-							All the arithmetic verbs move the result of a calculation into a receiving data-item
-							according to the rules for a numeric move; that is, with alignment along the assumed decimal
-							point and with zero-filling or truncation as necessary.
-						</p>
-						<p align="left">
-							All arithmetic verbs must use numeric literals or numeric data-items (PIC 9) that contain
-							numeric data. There is one exception. Identifiers that appear to the right of the word
-							<code class="language-cobol">GIVING</code> may refer to numeric data-items that contain
-							editing symbols.
-						</p>
-						<p align="left">
-							When the <code class="language-cobol">GIVING</code> phrase is used, the data-item following
-							the word <code class="language-cobol">GIVING</code> is the receiving field of the
-							calculation but it is <b>not</b> one of the statement operands (does not contribute to the
-							result). The original values of all the items before the word
-							<code class="language-cobol">GIVING</code> are left intact.
-						</p>
-						<p align="left">
-							If the <code class="language-cobol">GIVING</code> phrase is not used, the data-item(s) after
-							the word <code class="language-cobol">TO</code>, <code class="language-cobol">FROM</code>,
-							<code class="language-cobol">BY</code> or <code class="language-cobol">INTO</code> both
-							contribute to the result and are receiving fields for it.
-						</p>
-						<p align="left">The maximum size of each operand is 18 digits.</p>
-					</div>
+					<p>
+						All the arithmetic verbs move the result of a calculation into a receiving data-item
+						according to the rules for a numeric move; that is, with alignment along the assumed decimal
+						point and with zero-filling or truncation as necessary.
+					</p>
+					<p>
+						All arithmetic verbs must use numeric literals or numeric data-items (PIC 9) that contain
+						numeric data. There is one exception. Identifiers that appear to the right of the word
+						<code class="language-cobol">GIVING</code> may refer to numeric data-items that contain
+						editing symbols.
+					</p>
+					<p>
+						When the <code class="language-cobol">GIVING</code> phrase is used, the data-item following
+						the word <code class="language-cobol">GIVING</code> is the receiving field of the
+						calculation but it is <b>not</b> one of the statement operands (does not contribute to the
+						result). The original values of all the items before the word
+						<code class="language-cobol">GIVING</code> are left intact.
+					</p>
+					<p>
+						If the <code class="language-cobol">GIVING</code> phrase is not used, the data-item(s) after
+						the word <code class="language-cobol">TO</code>, <code class="language-cobol">FROM</code>,
+						<code class="language-cobol">BY</code> or <code class="language-cobol">INTO</code> both
+						contribute to the result and are receiving fields for it.
+					</p>
+					<p>The maximum size of each operand is 18 digits.</p>
 				</div>
 				<div class="section-sidebar">
 					<h4>The ROUNDED option</h4>
 				</div>
 				<div class="section-content">
-					<p align="left">
+					<p>
 						All the arithmetic verbs allow the <code class="language-cobol">ROUNDED</code> phrase.
 					</p>
-					<p align="left">
+					<p>
 						The <code class="language-cobol">ROUNDED</code> phrase takes effect when, after decimal point
 						alignment, the result calculated must be truncated on the right hand side. The option adds 1 to
 						the receiving item when the leftmost truncated digit has an absolute value of 5 or greater.
 					</p>
-					<table align="center" bgcolor="#E1FFE1" border="1" width="84%">
+					<table style="margin:0 auto" bgcolor="#E1FFE1" border="1" width="84%">
 						<tr>
 							<td colspan="4">
-								<div align="center">
+								<div class="center-block">
 									<b> <code class="language-cobol">ROUNDED</code> examples </b>
 								</div>
 							</td>
@@ -609,190 +582,180 @@ The time is 14:41
 					<h4>ON SIZE ERROR</h4>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<p align="left">
-							When a computation is performed it is possible for the result to be too large or too small
-							to be contained in the receiving field. When this occurs, there will be truncation of the
-							result. The <code class="language-cobol">ON SIZE ERROR</code> phrase detects this condition.
-						</p>
-						<p align="left">
-							<code class="language-cobol">ON SIZE ERROR</code> <b>notes<br /></b> All the arithmetic
-							verbs allow the <code class="language-cobol">ON SIZE ERROR</code> phrase.
-						</p>
-						<p align="left">
-							A size error condition exists when, after decimal point alignment, the result is truncated
-							on either the left or the right hand side.
-						</p>
-						<p align="left">
-							If an arithmetic statement has a <code class="language-cobol">ROUNDED</code> phrase then a
-							size error only occurs if there is truncation on the left-hand side (most significant
-							digits) because if we specify the <code class="language-cobol">ROUNDED</code> option we
-							indicate that we know there will be truncation on the right and are specifying rounding to
-							deal with it.
-						</p>
-						<p align="left">Division by 0 always causes a SIZE ERROR.</p>
-						<p align="left"><code class="language-cobol">ON SIZE ERROR</code> <b>examples</b></p>
-						<table align="center" bgcolor="#E1FFE1" border="1" cellpadding="5" cellspacing="0" width="70%">
-							<tr>
-								<th bgcolor="#FFFFCC" width="45%">
-									<div align="center">
-										<b>
-											<span style="color: #ff0000">Receiving Field</span>
-										</b>
-									</div>
-								</th>
-								<th bgcolor="#FFFFCC" width="19%">
-									<div align="center">
-										<b>
-											<span style="color: #ff0000">Actual Result</span>
-										</b>
-									</div>
-								</th>
-								<th bgcolor="#FFFFCC" width="22%">
-									<div align="center">
-										<b>
-											<span style="color: #ff0000">Truncated Result</span>
-										</b>
-									</div>
-								</th>
-								<th bgcolor="#FFFFCC" width="14%">
-									<div align="center">
-										<b>
-											<span style="color: #ff0000">Size Error?</span>
-										</b>
-									</div>
-								</th>
-							</tr>
-							<tr>
-								<td width="45%"><b>PIC 9(3)V9</b></td>
-								<td width="19%">
-									<b>&nbsp;&nbsp;245.9<span style="color: #ff0000">6</span></b>
-								</td>
-								<td width="22%">
-									<div align="left"><b>&nbsp;&nbsp;&nbsp;245.9</b></div>
-								</td>
-								<td width="14%">
-									<div align="center">
-										<b>YES</b>
-									</div>
-								</td>
-							</tr>
-							<tr>
-								<td width="45%"><b>PIC 9(3)V9</b></td>
-								<td width="19%">
-									<div align="left">
-										<b>&nbsp;&nbsp;<span style="color: #ff0000">3</span>245.9</b>
-									</div>
-								</td>
-								<td width="22%">
-									<div align="left"><b>&nbsp;&nbsp;&nbsp;245.9</b></div>
-								</td>
-								<td width="14%">
-									<div align="center">
-										<b>
-											<code class="language-cobol">YES</code>
-										</b>
-									</div>
-								</td>
-							</tr>
-							<tr>
-								<td width="45%"><b>PIC 9(3)</b></td>
-								<td width="19%">
-									<div align="left"><b>&nbsp;&nbsp;324</b></div>
-								</td>
-								<td width="22%">
-									<div align="left"><b>&nbsp;&nbsp;&nbsp;324</b></div>
-								</td>
-								<td width="14%">
-									<div align="center">
-										<b>
-											<code class="language-cobol">NO</code>
-										</b>
-									</div>
-								</td>
-							</tr>
-							<tr>
-								<td width="45%"><b>PIC 9(3)</b></td>
-								<td width="19%">
-									<div align="left">
-										<b>&nbsp;<span style="color: #ff0000">&nbsp;5</span>324</b>
-									</div>
-								</td>
-								<td width="22%">
-									<div align="left"><b>&nbsp;&nbsp;&nbsp;324</b></div>
-								</td>
-								<td width="14%">
-									<div align="center">
-										<b>
-											<code class="language-cobol">YES</code>
-										</b>
-									</div>
-								</td>
-							</tr>
-							<tr>
-								<td valign="top" width="45%"><b>PIC 9(3)V9 not Rounded</b></td>
-								<td width="19%">
-									<div align="left">
-										<b>&nbsp;&nbsp;523.3<span style="color: #ff0000">5</span></b>
-									</div>
-								</td>
-								<td width="22%">
-									<div align="left"><b>&nbsp;&nbsp;&nbsp;523.3</b></div>
-								</td>
-								<td width="14%">
-									<div align="center">
-										<b>
-											<code class="language-cobol">YES</code>
-										</b>
-									</div>
-								</td>
-							</tr>
-							<tr>
-								<td width="45%"><b>PIC 9(3)V9 Rounded</b></td>
-								<td width="19%">
-									<b>&nbsp;&nbsp;523.3<span style="color: #ff0000">5</span></b>
-								</td>
-								<td width="22%"><b>&nbsp;&nbsp;&nbsp;523.4</b></td>
-								<td width="14%">
-									<div align="center">
-										<b>
-											<code class="language-cobol">NO</code>
-										</b>
-									</div>
-								</td>
-							</tr>
-							<tr>
-								<td width="45%"><b>PIC 9(3)V9 Rounded</b></td>
-								<td width="19%">
-									<div align="left">
-										<b>
-											<span style="color: #ff0000">&nbsp;&nbsp;3</span>523.3<span
-												style="color: #ff0000"
-												>5</span
-											>
-										</b>
-									</div>
-								</td>
-								<td width="22%">
-									<div align="left"><b>&nbsp;&nbsp;&nbsp;523.4</b></div>
-								</td>
-								<td width="14%">
-									<div align="center">
-										<b>
-											<code class="language-cobol">YES</code>
-										</b>
-									</div>
-								</td>
-							</tr>
-						</table>
-						<hr width="50%" />
-					</div>
+					<p>
+						When a computation is performed it is possible for the result to be too large or too small
+						to be contained in the receiving field. When this occurs, there will be truncation of the
+						result. The <code class="language-cobol">ON SIZE ERROR</code> phrase detects this condition.
+					</p>
+					<p>
+						<code class="language-cobol">ON SIZE ERROR</code> <b>notes<br /></b> All the arithmetic
+						verbs allow the <code class="language-cobol">ON SIZE ERROR</code> phrase.
+					</p>
+					<p>
+						A size error condition exists when, after decimal point alignment, the result is truncated
+						on either the left or the right hand side.
+					</p>
+					<p>
+						If an arithmetic statement has a <code class="language-cobol">ROUNDED</code> phrase then a
+						size error only occurs if there is truncation on the left-hand side (most significant
+						digits) because if we specify the <code class="language-cobol">ROUNDED</code> option we
+						indicate that we know there will be truncation on the right and are specifying rounding to
+						deal with it.
+					</p>
+					<p>Division by 0 always causes a SIZE ERROR.</p>
+					<p><code class="language-cobol">ON SIZE ERROR</code> <b>examples</b></p>
+					<table style="margin:0 auto" bgcolor="#E1FFE1" border="1" cellpadding="5" cellspacing="0" width="70%">
+						<tr>
+							<th bgcolor="#FFFFCC" width="45%">
+								<div class="center-block">
+									<b>
+										<span style="color: #ff0000">Receiving Field</span>
+									</b>
+								</div>
+							</th>
+							<th bgcolor="#FFFFCC" width="19%">
+								<div class="center-block">
+									<b>
+										<span style="color: #ff0000">Actual Result</span>
+									</b>
+								</div>
+							</th>
+							<th bgcolor="#FFFFCC" width="22%">
+								<div class="center-block">
+									<b>
+										<span style="color: #ff0000">Truncated Result</span>
+									</b>
+								</div>
+							</th>
+							<th bgcolor="#FFFFCC" width="14%">
+								<div class="center-block">
+									<b>
+										<span style="color: #ff0000">Size Error?</span>
+									</b>
+								</div>
+							</th>
+						</tr>
+						<tr>
+							<td width="45%"><b>PIC 9(3)V9</b></td>
+							<td width="19%">
+								<b>&nbsp;&nbsp;245.9<span style="color: #ff0000">6</span></b>
+							</td>
+							<td width="22%">
+								<b>&nbsp;&nbsp;&nbsp;245.9</b>
+							</td>
+							<td width="14%">
+								<div class="center-block">
+									<b>YES</b>
+								</div>
+							</td>
+						</tr>
+						<tr>
+							<td width="45%"><b>PIC 9(3)V9</b></td>
+							<td width="19%">
+								<b>&nbsp;&nbsp;<span style="color: #ff0000">3</span>245.9</b>
+							</td>
+							<td width="22%">
+								<b>&nbsp;&nbsp;&nbsp;245.9</b>
+							</td>
+							<td width="14%">
+								<div class="center-block">
+									<b>
+										<code class="language-cobol">YES</code>
+									</b>
+								</div>
+							</td>
+						</tr>
+						<tr>
+							<td width="45%"><b>PIC 9(3)</b></td>
+							<td width="19%">
+								<b>&nbsp;&nbsp;324</b>
+							</td>
+							<td width="22%">
+								<b>&nbsp;&nbsp;&nbsp;324</b>
+							</td>
+							<td width="14%">
+								<div class="center-block">
+									<b>
+										<code class="language-cobol">NO</code>
+									</b>
+								</div>
+							</td>
+						</tr>
+						<tr>
+							<td width="45%"><b>PIC 9(3)</b></td>
+							<td width="19%">
+								<b>&nbsp;<span style="color: #ff0000">&nbsp;5</span>324</b>
+							</td>
+							<td width="22%">
+								<b>&nbsp;&nbsp;&nbsp;324</b>
+							</td>
+							<td width="14%">
+								<div class="center-block">
+									<b>
+										<code class="language-cobol">YES</code>
+									</b>
+								</div>
+							</td>
+						</tr>
+						<tr>
+							<td valign="top" width="45%"><b>PIC 9(3)V9 not Rounded</b></td>
+							<td width="19%">
+								<b>&nbsp;&nbsp;523.3<span style="color: #ff0000">5</span></b>
+							</td>
+							<td width="22%">
+								<b>&nbsp;&nbsp;&nbsp;523.3</b>
+							</td>
+							<td width="14%">
+								<div class="center-block">
+									<b>
+										<code class="language-cobol">YES</code>
+									</b>
+								</div>
+							</td>
+						</tr>
+						<tr>
+							<td width="45%"><b>PIC 9(3)V9 Rounded</b></td>
+							<td width="19%">
+								<b>&nbsp;&nbsp;523.3<span style="color: #ff0000">5</span></b>
+							</td>
+							<td width="22%"><b>&nbsp;&nbsp;&nbsp;523.4</b></td>
+							<td width="14%">
+								<div class="center-block">
+									<b>
+										<code class="language-cobol">NO</code>
+									</b>
+								</div>
+							</td>
+						</tr>
+						<tr>
+							<td width="45%"><b>PIC 9(3)V9 Rounded</b></td>
+							<td width="19%">
+								<b>
+									<span style="color: #ff0000">&nbsp;&nbsp;3</span>523.3<span
+										style="color: #ff0000"
+										>5</span
+									>
+								</b>
+							</td>
+							<td width="22%">
+								<b>&nbsp;&nbsp;&nbsp;523.4</b>
+							</td>
+							<td width="14%">
+								<div class="center-block">
+									<b>
+										<code class="language-cobol">YES</code>
+									</b>
+								</div>
+							</td>
+						</tr>
+					</table>
+					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">ADD verb</h4>
+					<h4>ADD verb</h4>
 				</div>
 				<div class="section-content">
-					<p><img height="74" src="Resources/pics/Add.gif" width="499" /></p>
+					<p><img height="74" src="Resources/pics/Add.gif" width="499" alt="ADD verb syntax diagram" /></p>
 					<p>
 						If the <code class="language-cobol">GIVING</code> phrase is used, everything before the word
 						<code class="language-cobol">GIVING</code> is added together and the <b>combined result</b> is
@@ -806,32 +769,30 @@ The time is 14:41
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">SUBTRACT verb</h4>
+					<h4>SUBTRACT verb</h4>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<p align="left"><img height="96" src="Resources/pics/Sub.gif" width="481" /></p>
-						<p align="left">
-							If the <code class="language-cobol">GIVING</code> phrase is used, everything before the word
-							<code class="language-cobol">FROM</code> is added together and the <b>combined result</b> is
-							subtracted from the Value#il item after the word
-							<code class="language-cobol">FROM</code> and the result is moved into each of the Result#i
-							items.
-						</p>
-						<p align="left">
-							If the <code class="language-cobol">GIVING</code> phrase is not used everything before the
-							word <code class="language-cobol">FROM</code> is added together and the
-							<b>combined result</b> is then subtracted from <b>each</b> of the ValueResult#i items after
-							the word <code class="language-cobol">FROM</code> in turn.
-						</p>
-					</div>
+					<p><img height="96" src="Resources/pics/Sub.gif" width="481" alt="SUBTRACT verb syntax diagram" /></p>
+					<p>
+						If the <code class="language-cobol">GIVING</code> phrase is used, everything before the word
+						<code class="language-cobol">FROM</code> is added together and the <b>combined result</b> is
+						subtracted from the Value#il item after the word
+						<code class="language-cobol">FROM</code> and the result is moved into each of the Result#i
+						items.
+					</p>
+					<p>
+						If the <code class="language-cobol">GIVING</code> phrase is not used everything before the
+						word <code class="language-cobol">FROM</code> is added together and the
+						<b>combined result</b> is then subtracted from <b>each</b> of the ValueResult#i items after
+						the word <code class="language-cobol">FROM</code> in turn.
+					</p>
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
 					<h4>MULTIPLY verb</h4>
 				</div>
 				<div class="section-content">
-					<p><img height="72" src="Resources/pics/Mult.gif" width="498" /></p>
+					<p><img height="72" src="Resources/pics/Mult.gif" width="498" alt="MULTIPLY verb syntax diagram" /></p>
 					<p>
 						If the <code class="language-cobol">GIVING</code> phrase is used, then the item to the left of
 						the word <code class="language-cobol">BY</code> is multiplied by the Value#i item to the right
@@ -852,7 +813,7 @@ The time is 14:41
 				<div class="section-content">
 					<p>The Divide has two main formats. One produces a remainder and the other does not.</p>
 					<p><b>Format1</b></p>
-					<p><img height="101" src="Resources/pics/Div1.gif" width="525" /></p>
+					<p><img height="101" src="Resources/pics/Div1.gif" width="525" alt="DIVIDE verb format 1 syntax diagram" /></p>
 					<p>
 						If the <code class="language-cobol">GIVING</code> phrase is used, the Value#il to the left of
 						<code class="language-cobol">BY</code> or <code class="language-cobol">INTO</code> is divided by
@@ -867,7 +828,7 @@ The time is 14:41
 						calculation.
 					</p>
 					<p><b>Format2</b></p>
-					<p><img height="128" src="Resources/pics/Div2.gif" width="462" /></p>
+					<p><img height="128" src="Resources/pics/Div2.gif" width="462" alt="DIVIDE verb format 2 syntax diagram with REMAINDER phrase" /></p>
 					<p>
 						In this format the Val#il to the left of <code class="language-cobol">BY</code> or
 						<code class="language-cobol">INTO</code> is divided by or into the Val#il to the right of
@@ -880,72 +841,72 @@ The time is 14:41
 					<h4>COMPUTE verb</h4>
 				</div>
 				<div class="section-content">
-					<p><img height="77" src="Resources/pics/Compute.gif" width="509" /></p>
+					<p><img height="77" src="Resources/pics/Compute.gif" width="509" alt="COMPUTE verb syntax diagram" /></p>
 					<p>
 						The <code class="language-cobol">COMPUTE</code> assigns the result of an arithmetic expression
 						to a data-item. The arithmetic expression is evaluated according to the normal arithmetic rules.
 						That is, the expression is normally evaluated from left to right but bracketing and the
 						precedence rules shown below can change the order of evaluation.
 					</p>
-					<table align="center" bgcolor="#E1FFE1" border cellpadding="7" cellspacing="1" width="259">
+					<table style="margin:0 auto" bgcolor="#E1FFE1" border cellpadding="7" cellspacing="1" width="259">
 						<tr>
 							<td bgcolor="#FFFFCC" valign="top" width="32%">
-								<p align="center">Precedence</p>
+								<p class="center-block">Precedence</p>
 							</td>
 							<td bgcolor="#FFFFCC" valign="top" width="29%">
-								<p align="center">Symbol</p>
+								<p class="center-block">Symbol</p>
 							</td>
 							<td bgcolor="#FFFFCC" valign="top" width="39%">
-								<p align="center">Meaning</p>
+								<p class="center-block">Meaning</p>
 							</td>
 						</tr>
 						<tr>
 							<td valign="top" width="32%">
-								<p align="center">1.</p>
+								<p class="center-block">1.</p>
 							</td>
 							<td valign="top" width="29%">
-								<p align="center"><b>**</b></p>
+								<p class="center-block"><b>**</b></p>
 							</td>
 							<td valign="top" width="39%">
-								<p align="center">Power</p>
+								<p class="center-block">Power</p>
 							</td>
 						</tr>
 						<tr>
 							<td rowspan="2" valign="top" width="32%">
-								<p align="center">2.</p>
+								<p class="center-block">2.</p>
 							</td>
 							<td valign="top" width="29%">
-								<p align="center"><b>*</b></p>
+								<p class="center-block"><b>*</b></p>
 							</td>
 							<td valign="top" width="39%">
-								<p align="center">multiply</p>
+								<p class="center-block">multiply</p>
 							</td>
 						</tr>
 						<tr>
 							<td valign="top" width="29%">
-								<p align="center"><b>/</b></p>
+								<p class="center-block"><b>/</b></p>
 							</td>
 							<td valign="top" width="39%">
-								<p align="center">divide</p>
+								<p class="center-block">divide</p>
 							</td>
 						</tr>
 						<tr>
 							<td rowspan="2" valign="top" width="32%">
-								<p align="center">3.</p>
+								<p class="center-block">3.</p>
 							</td>
 							<td valign="top" width="29%">
-								<p align="center"><b>+</b></p>
+								<p class="center-block"><b>+</b></p>
 							</td>
 							<td valign="top" width="39%">
-								<p align="center">add</p>
+								<p class="center-block">add</p>
 							</td>
 						</tr>
 						<tr>
 							<td valign="top" width="29%">
-								<p align="center"><b>-</b></p>
+								<p class="center-block"><b>-</b></p>
 							</td>
 							<td valign="top" width="39%">
-								<p align="center">subtract</p>
+								<p class="center-block">subtract</p>
 							</td>
 						</tr>
 					</table>
@@ -969,7 +930,7 @@ The time is 14:41
 						If you get the wrong answer, make sure you understand why the statement produces the answer
 						shown.
 					</p>
-					<p align="center">
+					<p class="center-block">
 						<a href="Resources/ppz/TC-Commands2.html"
 							><img
 								alt="Click to view the animation"

--- a/course/Search.html
+++ b/course/Search.html
@@ -63,33 +63,31 @@
 						<h4>Aims</h4>
 					</div>
 					<div class="section-content">
-						<div align="center">
-							<p align="left">
-								The task of searching a table to determine whether it contains a particular value is a
-								common operation. The method used to search a table depends heavily on how the values in
-								the table are organized.
-							</p>
-							<p align="left">
-								For instance, if the values are not ordered, the table may only be searched
-								sequentially, but if the values are ordered, then either a sequential or a binary search
-								may be used.
-							</p>
-							<p align="left">
-								In COBOL, the <code class="language-cobol">SEARCH</code> verb is used for sequential
-								searches and the <code class="language-cobol">SEARCH ALL</code> for binary searches.
-							</p>
-							<p align="left">
-								This tutorial introduces the syntax and rules of operation of the
-								<code class="language-cobol">SEARCH</code> and
-								<code class="language-cobol">SEARCH ALL</code> verbs. It introduces the extensions to
-								the <code class="language-cobol">OCCURS</code> clause that are required when the
-								<code class="language-cobol">SEARCH</code> or
-								<code class="language-cobol">SEARCH ALL</code> is used. It shows how the SET verb may be
-								used to alter the value of an index and it demonstrates how the
-								<code class="language-cobol">SEARCH</code> and
-								<code class="language-cobol">SEARCH ALL</code> may be used to search a table.
-							</p>
-						</div>
+						<p>
+							The task of searching a table to determine whether it contains a particular value is a
+							common operation. The method used to search a table depends heavily on how the values in
+							the table are organized.
+						</p>
+						<p>
+							For instance, if the values are not ordered, the table may only be searched
+							sequentially, but if the values are ordered, then either a sequential or a binary search
+							may be used.
+						</p>
+						<p>
+							In COBOL, the <code class="language-cobol">SEARCH</code> verb is used for sequential
+							searches and the <code class="language-cobol">SEARCH ALL</code> for binary searches.
+						</p>
+						<p>
+							This tutorial introduces the syntax and rules of operation of the
+							<code class="language-cobol">SEARCH</code> and
+							<code class="language-cobol">SEARCH ALL</code> verbs. It introduces the extensions to
+							the <code class="language-cobol">OCCURS</code> clause that are required when the
+							<code class="language-cobol">SEARCH</code> or
+							<code class="language-cobol">SEARCH ALL</code> is used. It shows how the SET verb may be
+							used to alter the value of an index and it demonstrates how the
+							<code class="language-cobol">SEARCH</code> and
+							<code class="language-cobol">SEARCH ALL</code> may be used to search a table.
+						</p>
 						<hr size="1" />
 					</div>
 				</div>
@@ -141,10 +139,8 @@
 					</div>
 				</div>
 				<div class="section-full">
-					<div align="center">
-						<hr />
-						<back-to-top></back-to-top>
-					</div>
+					<hr />
+					<back-to-top></back-to-top>
 				</div>
 				<div class="section-header">
 					<h2 id="part1">Occurs clause extensions</h2>
@@ -154,7 +150,7 @@
 						<h4>Introduction</h4>
 					</div>
 					<div class="section-content">
-						<p align="left">
+						<p>
 							When the <code class="language-cobol">SEARCH</code> and
 							<code class="language-cobol">SEARCH ALL</code> are used the normal table declarations are no
 							longer sufficient and the <code class="language-cobol">OCCURS</code> clause must be extended
@@ -162,7 +158,7 @@
 							<code class="language-cobol">SEARCH ALL</code>, by the
 							<code class="language-cobol">KEY IS</code> phrase.
 						</p>
-						<p align="left">
+						<p>
 							The full syntax of the <code class="language-cobol">OCCURS</code> clause, including the
 							<code class="language-cobol">INDEXED BY</code> and
 							<code class="language-cobol">KEY IS</code> phrases is shown below.
@@ -175,7 +171,7 @@
 						<h4>Full OCCURS clause syntax</h4>
 					</div>
 					<div class="section-content">
-						<p align="left"><img height="122" src="Resources/pics/Search1.gif" width="331" /></p>
+						<p><img height="122" src="Resources/pics/Search1.gif" width="331" alt="Full OCCURS clause syntax diagram showing INDEXED BY and KEY IS extensions" /></p>
 					</div>
 				</div>
 				<div class="section-grid">
@@ -183,37 +179,37 @@
 						<h4>INDEXED BY phrase - notes</h4>
 					</div>
 					<div class="section-content">
-						<p align="left">
+						<p>
 							Before the <code class="language-cobol">SEARCH</code> or
 							<code class="language-cobol">SEARCH ALL</code> can be used to search a table, the table must
 							be defined as having an index item associated with it.
 						</p>
-						<p align="left">
+						<p>
 							The index is specified by the <i>IndexName</i> given in the
 							<code class="language-cobol">INDEXED BY</code> phrase.
 						</p>
-						<p align="left">
+						<p>
 							The index defined in a table declaration is associated with that table and is the subscript
 							which the <code class="language-cobol">SEARCH</code> or
 							<code class="language-cobol">SEARCH ALL</code> uses to access the table.
 						</p>
-						<p align="left">
+						<p>
 							Using an index makes the searching more efficient. Since the index is linked to a particular
 							table, the compiler, taking into account the size of the table, can choose the most
 							efficient representation possible for the index and this speeds up the search.
 						</p>
-						<p align="left">
+						<p>
 							The only entry that needs to be made for an <i>IndexName</i> is to use it in an
 							<code class="language-cobol">INDEXED BY</code> phrase. There is no need to define a picture
 							clause for it, because the compiler handles its declaration automatically.
 						</p>
-						<p align="left">
+						<p>
 							Because an index has a special internal representation it cannot be displayed and can only
 							be assigned a value, or have its value assigned, by the
 							<code class="language-cobol">SET</code> verb. The
 							<code class="language-cobol">MOVE</code> cannot be used with a table index.
 						</p>
-						<p align="left">
+						<p>
 							Normal arithmetic cannot be performed on a table index. The
 							<code class="language-cobol">SET</code> verb must be used to increment or decrement the
 							value of an index item.
@@ -241,10 +237,8 @@
 					</div>
 				</div>
 				<div class="section-full">
-					<div align="center">
-						<hr />
-						<back-to-top></back-to-top>
-					</div>
+					<hr />
+					<back-to-top></back-to-top>
 				</div>
 				<div class="section-header">
 					<h2 id="part2">The SEARCH verb</h2>
@@ -266,7 +260,7 @@
 						<h4>SEARCH syntax</h4>
 					</div>
 					<div class="section-content">
-						<p><img height="152" src="Resources/pics/Search2.gif" width="374" /></p>
+						<p><img height="152" src="Resources/pics/Search2.gif" width="374" alt="SEARCH verb syntax diagram" /></p>
 						<p>
 							<b> <code class="language-cobol">SEARCH</code> rules </b>
 						</p>
@@ -353,13 +347,13 @@
 							assign a value to an index item, to assign the value of an index item to a variable, and to
 							increment or decrement the value of an index item.
 						</p>
-						<p><img height="148" src="Resources/pics/Search4.gif" width="326" /></p>
+						<p><img height="148" src="Resources/pics/Search4.gif" width="326" alt="SET verb syntax diagram for manipulating table indexes" /></p>
 					</div>
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>SEARCH example 1</h4>
-						<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
+						<p class="center-block"><img height="44" src="Resources/pics/program.gif" width="42" alt="" /></p>
 					</div>
 					<div class="section-content">
 						<p>
@@ -431,7 +425,7 @@ Begin.
 				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>Example program 2</h4>
-						<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
+						<p class="center-block"><img height="44" src="Resources/pics/program.gif" width="42" alt="" /></p>
 					</div>
 					<div class="section-content">
 						<p>
@@ -551,10 +545,8 @@ DisplayCountyTaxes.
 					</div>
 				</div>
 				<div class="section-full">
-					<div align="center">
-						<hr />
-						<back-to-top></back-to-top>
-					</div>
+					<hr />
+					<back-to-top></back-to-top>
 				</div>
 				<div class="section-header">
 					<h2 id="part3">Searching multi-dimension tables</h2>
@@ -564,7 +556,7 @@ DisplayCountyTaxes.
 						<h4>Introduction</h4>
 					</div>
 					<div class="section-content">
-						<p align="left">
+						<p>
 							When the <code class="language-cobol">SEARCH</code> verb is used, the target of the
 							<code class="language-cobol">SEARCH</code> must be an item in the table with both an
 							<code class="language-cobol">OCCURS</code> clause and an
@@ -575,23 +567,23 @@ DisplayCountyTaxes.
 							<code class="language-cobol">SEARCH</code>. A <code class="language-cobol">SEARCH</code> can
 							only have one controlling index.
 						</p>
-						<p align="left">
+						<p>
 							Because a <code class="language-cobol">SEARCH</code> can only have one controlling index it
 							can only be used to search a single dimension of a table at a time. If the table to be
 							searched is a multi-dimension table then the programmer must control the indexes of the
 							other dimensions.
 						</p>
-						<p align="left">
+						<p>
 							For instance, suppose a hotel keeps an Occupancy Table showing which rooms in the hotel are
 							currently occupied. The table might be described as -
 						</p>
-						<pre class="language-cobol" align="left"><code class="language-cobol">01 HotelOccupanyTable.
+						<pre class="language-cobol"><code class="language-cobol">01 HotelOccupanyTable.
    02 Floor OCCURS 5 TIMES INDEXED BY Fidx.
       03 Room OCCURS 25 TIMES INDEXED BY Ridx.
          04 CustomerId  PIC 9(6).
          04 NumOfOccupants PIC 9.</code></pre>
-						<p align="left">and we can represent this diagrammatically as follows -</p>
-						<div align="center">
+						<p>and we can represent this diagrammatically as follows -</p>
+						<div class="center-block">
 							<img
 								alt="Diagram of the hotel occupancy table showing floors and rooms"
 								height="170"
@@ -599,7 +591,7 @@ DisplayCountyTaxes.
 								width="411"
 							/>
 						</div>
-						<p align="left">
+						<p>
 							Suppose we want to search the table to discover which room is occupied by customer 126789.
 							We can't use the <code class="language-cobol">SEARCH</code> to search the whole
 							two-dimension table directly but we can use the
@@ -608,7 +600,7 @@ DisplayCountyTaxes.
 							<code class="language-cobol">SEARCH</code> to search all the rooms in a particular floor
 							table.
 						</p>
-						<p align="left">
+						<p>
 							The example program below demonstrates how the
 							<code class="language-cobol">SEARCH</code> verb may be used to search the two-dimension
 							<i>HotelOccupancyTable</i>.
@@ -617,7 +609,7 @@ DisplayCountyTaxes.
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
+						<p class="center-block"><img height="44" src="Resources/pics/program.gif" width="42" alt="" /></p>
 					</div>
 					<div class="section-content">
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
@@ -706,7 +698,7 @@ LoadTable.
       03 RacePos OCCURS 50 TIMES INDEXED BY Pidx.
          04 DriverId    PIC 9(4).</code></pre>
 						<p>We can represent this diagramatically as follows -</p>
-						<p align="center"><img height="109" src="Resources/pics/Search6.gif" width="469" /></p>
+						<p class="center-block"><img height="109" src="Resources/pics/Search6.gif" width="469" alt="Diagram of the race results table showing races and finishing positions" /></p>
 						<p>
 							In the example program below, the first dimension of the table is searched to find the
 							results for a particular venue and then the second dimension, representing the results fo
@@ -716,7 +708,7 @@ LoadTable.
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
+						<p class="center-block"><img height="44" src="Resources/pics/program.gif" width="42" alt="" /></p>
 					</div>
 					<div class="section-content">
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
@@ -810,17 +802,15 @@ END-SEARCH</code></pre>
 					</div>
 				</div>
 				<div class="section-full">
-					<div align="center">
-						<hr />
-						<back-to-top></back-to-top>
-					</div>
+					<hr />
+					<back-to-top></back-to-top>
 				</div>
 				<div class="section-header">
 					<h2 id="part4">The SEARCH ALL verb</h2>
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4 align="left">Introduction</h4>
+						<h4>Introduction</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -839,8 +829,8 @@ END-SEARCH</code></pre>
 						<h4>SEARCH ALL syntax</h4>
 					</div>
 					<div class="section-content">
-						<p align="left"><img height="302" src="Resources/pics/Search3.gif" width="492" /></p>
-						<p align="left">
+						<p><img height="302" src="Resources/pics/Search3.gif" width="492" alt="SEARCH ALL verb syntax diagram" /></p>
+						<p>
 							<b> <code class="language-cobol">SEARCH ALL</code> rules </b>
 						</p>
 						<ol>
@@ -860,17 +850,17 @@ END-SEARCH</code></pre>
 								table's <code class="language-cobol">OCCURS</code> clause.
 							</li>
 						</ol>
-						<p align="left">
+						<p>
 							<b> <code class="language-cobol">SEARCH ALL</code> notes<br /> </b> The
 							<code class="language-cobol">KEY IS</code> phrase identifies the data-item upon which the
 							table is ordered.
 						</p>
-						<p align="left">
+						<p>
 							When the <code class="language-cobol">SEARCH ALL</code> is used, the programmer does not
 							need to set the table index to a starting value because the
 							<code class="language-cobol">SEARCH ALL</code> controls it automatically.
 						</p>
-						<p align="left">
+						<p>
 							<b>Some problems using the <code class="language-cobol">SEARCH ALL</code></b
 							><br />
 							If the table to be searched is only partially populated, the
@@ -936,17 +926,17 @@ END-PERFORM</code></pre>
        SET LetterPos TO LetterIdx
        DISPLAY SearchLetter " is in position " LetterPos
 END-SEARCH.</code></pre>
-						<p align="center">
+						<p class="center-block">
 							<a href="Resources/ppz/TC-Search2.html"
 								><img height="62" src="Resources/pics/i-Animation.gif" width="62" alt=""
 							/></a>
 						</p>
-						<p align="left">The full program for searching the letter table is given below.</p>
+						<p>The full program for searching the letter table is given below.</p>
 					</div>
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
+						<p class="center-block"><img height="44" src="Resources/pics/program.gif" width="42" alt="" /></p>
 					</div>
 					<div class="section-content">
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
@@ -993,7 +983,7 @@ Begin.
 				<div class="section-grid">
 					<div class="section-sidebar">
 						<h4>Example program</h4>
-						<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
+						<p class="center-block"><img height="44" src="Resources/pics/program.gif" width="42" alt="" /></p>
 					</div>
 					<div class="section-content">
 						<p>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -61,28 +61,26 @@
 					<h4>Aims</h4>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<p align="left">
-							As we noted in the tutorial - Processing Sequential Files - it is possible to apply
-							processing to an ordered sequential file that is difficult, or impossible, when the file is
-							unordered.
-						</p>
-						<p align="left">
-							When this kind of processing is required, and the data file we have to work with is an
-							unordered Sequential file, then part of the solution to the problem must be to sort the
-							file. COBOL provides the <code class="language-cobol">SORT</code> verb for this purpose.
-						</p>
-						<p align="left">
-							Sometimes, when two or more files are ordered on the same key field or fields, we may want
-							to combine them into one single ordered file. COBOL provides the
-							<code class="language-cobol">MERGE</code> verb for this purpose.
-						</p>
-						<p align="left">
-							This tutorial explores the syntax, semantics, and use of the
-							<code class="language-cobol">SORT</code> and
-							<code class="language-cobol">MERGE</code> verbs.
-						</p>
-					</div>
+					<p>
+						As we noted in the tutorial - Processing Sequential Files - it is possible to apply
+						processing to an ordered sequential file that is difficult, or impossible, when the file is
+						unordered.
+					</p>
+					<p>
+						When this kind of processing is required, and the data file we have to work with is an
+						unordered Sequential file, then part of the solution to the problem must be to sort the
+						file. COBOL provides the <code class="language-cobol">SORT</code> verb for this purpose.
+					</p>
+					<p>
+						Sometimes, when two or more files are ordered on the same key field or fields, we may want
+						to combine them into one single ordered file. COBOL provides the
+						<code class="language-cobol">MERGE</code> verb for this purpose.
+					</p>
+					<p>
+						This tutorial explores the syntax, semantics, and use of the
+						<code class="language-cobol">SORT</code> and
+						<code class="language-cobol">MERGE</code> verbs.
+					</p>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
@@ -151,64 +149,61 @@
 					<h4>Introduction</h4>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<p align="left">
-							In COBOL programs, the <code class="language-cobol">SORT</code> verb is usually used to sort
-							Sequential files.
-						</p>
-						<p align="left">
-							Some programmers claim that <code class="language-cobol">SORT</code> verb is unnecessary,
-							preferring to use a vendor-provided or "bought in" sort. But one major advantage of using
-							the <code class="language-cobol">SORT</code> verb, is that it enhances the portability of
-							COBOL programs.
-						</p>
-						<p align="left">
-							Because the <code class="language-cobol">SORT</code> verb is available in every COBOL
-							compiler, when a program that uses the <code class="language-cobol">SORT</code> verb has to
-							be moved to a different computer system, it can make the transition without requiring any
-							changes to the <code class="language-cobol">SORT</code>. This is rarely the case when
-							programs rely on a vendor-supplied or "bought in" sort.
-						</p>
-					</div>
+					<p>
+						In COBOL programs, the <code class="language-cobol">SORT</code> verb is usually used to sort
+						Sequential files.
+					</p>
+					<p>
+						Some programmers claim that <code class="language-cobol">SORT</code> verb is unnecessary,
+						preferring to use a vendor-provided or "bought in" sort. But one major advantage of using
+						the <code class="language-cobol">SORT</code> verb, is that it enhances the portability of
+						COBOL programs.
+					</p>
+					<p>
+						Because the <code class="language-cobol">SORT</code> verb is available in every COBOL
+						compiler, when a program that uses the <code class="language-cobol">SORT</code> verb has to
+						be moved to a different computer system, it can make the transition without requiring any
+						changes to the <code class="language-cobol">SORT</code>. This is rarely the case when
+						programs rely on a vendor-supplied or "bought in" sort.
+					</p>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
 					<h4>Why sort the file?</h4>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<p align="left">
-							Sometimes, processing that is is difficult or impossible to do if the file is unordered, is
-							easy if the file is ordered. In these situations, an obvious part of the solution is to sort
-							the file. This is an approach to problem solving sometimes called, "beneficial wishful
-							thinking". We start by thinking
-							<i>if only this file were ordered, then it would be easy to write the code to process it</i
-							>, and then take the next logical step which is - "Well then, let's sort the file first".
+					<p>
+						Sometimes, processing that is is difficult or impossible to do if the file is unordered, is
+						easy if the file is ordered. In these situations, an obvious part of the solution is to sort
+						the file. This is an approach to problem solving sometimes called, "beneficial wishful
+						thinking". We start by thinking
+						<i>if only this file were ordered, then it would be easy to write the code to process it</i
+						>, and then take the next logical step which is - "Well then, let's sort the file first".
+					</p>
+					<p>Consider the following specification;</p>
+					<div class="spec-block">
+						<p>
+							A program is required to print out a monthly report detailing the value of calls made by
+							each telephone subscriber (i.e. anyone who has a telephone and who used it in the month
+							in question).
 						</p>
-						<p align="left">Consider the following specification;</p>
-						<div class="spec-block">
-							<p>
-								A program is required to print out a monthly report detailing the value of calls made by
-								each telephone subscriber (i.e. anyone who has a telephone and who used it in the month
-								in question).
-							</p>
-							<p>
-								The program will use as input, the file CALLS.DAT. This file contains a record of all
-								the calls made that month. The cost per unit is 0.10.
-							</p>
-							<p>The calls file in an unordered Sequential file. The record description is as follows;</p>
-							<pre
-								class="language-cobol"
-							><code class="language-cobol">FIELD          TYPE   LENGTH        VALUE
+						<p>
+							The program will use as input, the file CALLS.DAT. This file contains a record of all
+							the calls made that month. The cost per unit is 0.10.
+						</p>
+						<p>The calls file in an unordered Sequential file. The record description is as follows;</p>
+						<pre
+							class="language-cobol"
+						><code class="language-cobol">FIELD          TYPE   LENGTH        VALUE
 SubscriberNum    9      8    00000001 - 99999999
 UnitsUsed        9      5       00001 - 99999</code></pre>
-							<p>
-								The report must be printed on ascending subscriber number and has the following format;
-							</p>
-							<pre
-								class="language-cobol"
-							><code class="language-cobol">Telephone Analysis Monthly Report</code></pre>
-							<pre class="language-cobol"><code class="language-cobol">
+						<p>
+							The report must be printed on ascending subscriber number and has the following format;
+						</p>
+						<pre
+							class="language-cobol"
+						><code class="language-cobol">Telephone Analysis Monthly Report</code></pre>
+						<pre class="language-cobol"><code class="language-cobol">
 SubscriberNum      ValueOfCalls
 
   99999999         999,999.99
@@ -216,31 +211,30 @@ SubscriberNum      ValueOfCalls
   99999999         999,999.99
 -------------------------------
 Total value =  999,999,999.99</code></pre>
-						</div>
 					</div>
 				</div>
 				<div class="section-sidebar">
 					<h4>Solving the problem without sorting the file?</h4>
 				</div>
 				<div class="section-content">
-					<p align="left">
+					<p>
 						There are millions of telephone subscribers and, in the course of a month, they will make tens,
 						if not hundreds, of calls. So the calls file will contain tens of millions, or hundreds of
 						millions, of records. Is there any viable way for a program to produce the report, without first
 						sorting the calls file?
 					</p>
-					<p align="left">
+					<p>
 						An array or table based solution does not seem viable. For one thing, the array would have to
 						contain millions of elements. For another, new subscribers are constantly joining, so the array
 						would have to be re-dimensioned every time the program ran.
 					</p>
-					<p align="left">
+					<p>
 						If we had pointers available to us, we might try a linked list or tree based solution. But the
 						problem with these solutions is that, with millions of subscribers in the list or tree, the
 						search to find a particular subscriber would involve a serious performance hit, as well as being
 						complicated to implement.
 					</p>
-					<p align="left">
+					<p>
 						Since a Relative file may be thought of as a table on disk, a Relative file solution might
 						beckon. But while Relative file based solution would be easy to implement (though still not as
 						easy as the control break solution) there would be serious performance implications. For each of
@@ -254,11 +248,11 @@ IF the record already exists THEN
 ELSE
    Write a new Relative Record to the file
 END-IF</code></pre>
-					<p align="left">
+					<p>
 						And when the calls file ended we would have to read through the entire Relative file again to
 						create the report.
 					</p>
-					<p align="left">
+					<p>
 						We can arrive at the most viable solution by using "beneficial wishful thinking". We might think
 						-
 						<i
@@ -274,32 +268,27 @@ END-IF</code></pre>
 				<div class="section-sidebar">
 					<h4>Syntax of a simplified SORT</h4>
 					<aside>
-						<p align="center">
+						<p class="center-block">
 							<span class="i-detail" aria-hidden="true">🔍</span><br />
 							Records in LINE SEQUENTIAL files are followed by the carriage return and line feed
 							characters, but RECORD SEQUENTIAL files are organized as a simple stream of bytes.
 						</p>
 					</aside>
-					<p align="center"><img height="44" src="Resources/pics/program-fragment.svg" width="48" alt="Program fragment" /></p>
+					<p class="center-block"><img height="44" src="Resources/pics/program-fragment.svg" width="48" alt="Program fragment" /></p>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<p align="left">
-							The syntax for a simplified version of the <code class="language-cobol">SORT</code> is shown
-							below. The <code class="language-cobol">SORT</code> takes the records in the
-							<i>InFileName</i> file, sorts them on the <i>SortKeyIdentifier</i> key or keys and writes
-							the sorted records to the <i>OutFileName</i> file.
-						</p>
-						<p align="left"><img height="194" src="Resources/pics/Sort1.gif" width="436" /></p>
-						<p align="left">e.g.</p>
-					</div>
+					<p>
+						The syntax for a simplified version of the <code class="language-cobol">SORT</code> is shown
+						below. The <code class="language-cobol">SORT</code> takes the records in the
+						<i>InFileName</i> file, sorts them on the <i>SortKeyIdentifier</i> key or keys and writes
+						the sorted records to the <i>OutFileName</i> file.
+					</p>
+					<p><img height="194" src="Resources/pics/Sort1.gif" width="436" alt="Simplified SORT verb syntax diagram" /></p>
+					<p>e.g.</p>
 					<blockquote>
-						<div align="center">
-							<div align="left">
-								<pre
-									class="language-cobol"
-									align="left"
-								><code class="language-cobol">SORT WorkFile ON ASCENDING KEY CourseCode
+						<pre
+							class="language-cobol"
+						><code class="language-cobol">SORT WorkFile ON ASCENDING KEY CourseCode
      USING  StudentFile
      GIVING SortedStudentsFile.
 
@@ -307,86 +296,74 @@ SORT WorkFile ON ASCENDING ProvinceCode
                  DESCENDING VendorNumber
                  USING SalesFile
                  GIVING SortedSalesFile.</code></pre>
-							</div>
-						</div>
 					</blockquote>
-					<div align="center">
-						<p align="left">
-							<b> <code class="language-cobol">SORT</code> notes </b><br />
-							The <i>SDWorkFileName</i> identifies a temporary work file that the
-							<code class="language-cobol">SORT</code> process uses for the sort. It is defined in the
-							<code class="language-cobol">FILE SECTION</code> using an
-							<code class="language-cobol">SD</code> (Stream/Sort Description) entry. Even though the work
-							file is a temporary file, it must still have an associated
-							<code class="language-cobol">SELECT</code> and
-							<code class="language-cobol">ASSIGN</code> clause in the
-							<code class="language-cobol">ENVIRONMENT DIVISION</code>.
-						</p>
-						<p align="left">
-							The <i>SDWorkFileName</i> file is a Sequential file with an organization of
-							<code class="language-cobol">RECORD SEQUENTIAL</code>. Since this is the default
-							organization is it usually omitted; as it is in the example below.
-						</p>
-						<p align="left">
-							Each <i>SortKeyIdentifier</i> identifies a field in the record of the work file. The sorted
-							file will be in sequence on this key field(s).
-						</p>
-						<p align="left">
-							When more than one <i>SortKeyIdentifier</i> is specified, the keys decrease in significance
-							from left to right (leftmost key is most significant, rightmost is least significant).
-						</p>
-						<p align="left">
-							<i>InFileName</i> and <i>OutFileName</i>, are the names of the input and output files
-							respectively.
-						</p>
-						<p align="left">
-							If the <code class="language-cobol">DUPLICATES</code> clause is used then, when the file has
-							been sorted, the final order of records with the duplicate keys is the same as that in the
-							unsorted file. If no <code class="language-cobol">DUPLICATES</code> clause is used, the
-							order of records with duplicate keys is undefined.
-						</p>
-						<p align="left">
-							<i>AlphabetName</i> is an alphabet-name defined in the
-							<code class="language-cobol">SPECIAL-NAMES</code> paragraph of the
-							<code class="language-cobol">ENVIRONMENT DIVISION</code>. This clause is used to select the
-							character set the <code class="language-cobol">SORT</code> verb uses for collating the
-							records in the file. The character set may be <code class="language-cobol">ASCII</code> (8
-							or 7 bit ), <code class="language-cobol">EBCDIC</code>,or user-defined.
-						</p>
-						<p align="left">
-							<b>SORT rules</b>
-						</p>
-					</div>
+					<p>
+						<b> <code class="language-cobol">SORT</code> notes </b><br />
+						The <i>SDWorkFileName</i> identifies a temporary work file that the
+						<code class="language-cobol">SORT</code> process uses for the sort. It is defined in the
+						<code class="language-cobol">FILE SECTION</code> using an
+						<code class="language-cobol">SD</code> (Stream/Sort Description) entry. Even though the work
+						file is a temporary file, it must still have an associated
+						<code class="language-cobol">SELECT</code> and
+						<code class="language-cobol">ASSIGN</code> clause in the
+						<code class="language-cobol">ENVIRONMENT DIVISION</code>.
+					</p>
+					<p>
+						The <i>SDWorkFileName</i> file is a Sequential file with an organization of
+						<code class="language-cobol">RECORD SEQUENTIAL</code>. Since this is the default
+						organization is it usually omitted; as it is in the example below.
+					</p>
+					<p>
+						Each <i>SortKeyIdentifier</i> identifies a field in the record of the work file. The sorted
+						file will be in sequence on this key field(s).
+					</p>
+					<p>
+						When more than one <i>SortKeyIdentifier</i> is specified, the keys decrease in significance
+						from left to right (leftmost key is most significant, rightmost is least significant).
+					</p>
+					<p>
+						<i>InFileName</i> and <i>OutFileName</i>, are the names of the input and output files
+						respectively.
+					</p>
+					<p>
+						If the <code class="language-cobol">DUPLICATES</code> clause is used then, when the file has
+						been sorted, the final order of records with the duplicate keys is the same as that in the
+						unsorted file. If no <code class="language-cobol">DUPLICATES</code> clause is used, the
+						order of records with duplicate keys is undefined.
+					</p>
+					<p>
+						<i>AlphabetName</i> is an alphabet-name defined in the
+						<code class="language-cobol">SPECIAL-NAMES</code> paragraph of the
+						<code class="language-cobol">ENVIRONMENT DIVISION</code>. This clause is used to select the
+						character set the <code class="language-cobol">SORT</code> verb uses for collating the
+						records in the file. The character set may be <code class="language-cobol">ASCII</code> (8
+						or 7 bit ), <code class="language-cobol">EBCDIC</code>,or user-defined.
+					</p>
+					<p>
+						<b>SORT rules</b>
+					</p>
 					<ol>
 						<li>
-							<div align="left">
-								The <code class="language-cobol">SORT</code> can be used anywhere in the
-								<code class="language-cobol">PROCEDURE DIVISION</code> except in an
-								<code class="language-cobol">INPUT</code> or
-								<code class="language-cobol">OUTPUT PROCEDURE</code>, or another
-								<code class="language-cobol">SORT</code>, or a
-								<code class="language-cobol">MERGE</code>, or in the
-								<code class="language-cobol">DECLARATIVES SECTION</code>.
-							</div>
+							The <code class="language-cobol">SORT</code> can be used anywhere in the
+							<code class="language-cobol">PROCEDURE DIVISION</code> except in an
+							<code class="language-cobol">INPUT</code> or
+							<code class="language-cobol">OUTPUT PROCEDURE</code>, or another
+							<code class="language-cobol">SORT</code>, or a
+							<code class="language-cobol">MERGE</code>, or in the
+							<code class="language-cobol">DECLARATIVES SECTION</code>.
 						</li>
 						<li>
-							<div align="left">
-								The records described for the input file (<code class="language-cobol">USING</code>)
-								must be able to fit into the records described for the <i>SDWorkFileName</i>.
-							</div>
+							The records described for the input file (<code class="language-cobol">USING</code>)
+							must be able to fit into the records described for the <i>SDWorkFileName</i>.
 						</li>
 						<li>
-							<div align="left">
-								The records described for the <i>SDWorkFileName</i> must be able to fit into the records
-								described for the output file (<code class="language-cobol">GIVING</code>).
-							</div>
+							The records described for the <i>SDWorkFileName</i> must be able to fit into the records
+							described for the output file (<code class="language-cobol">GIVING</code>).
 						</li>
 						<li>
-							<div align="left">
-								The <i>SortKeyIdentifer</i> description cannot contain an
-								<code class="language-cobol">OCCURS</code> clause (i.e., it can't be a table/array) nor
-								can it be subordinate to an entry that does contain one.
-							</div>
+							The <i>SortKeyIdentifer</i> description cannot contain an
+							<code class="language-cobol">OCCURS</code> clause (i.e., it can't be a table/array) nor
+							can it be subordinate to an entry that does contain one.
 						</li>
 						<li>
 							<i>InFileName</i> and <i>OutFileName</i> files are automatically opened by the
@@ -394,11 +371,9 @@ SORT WorkFile ON ASCENDING ProvinceCode
 							<code class="language-cobol">SORT</code> executes they must <b>not</b> be open already.
 						</li>
 					</ol>
-					<div align="center">
-						<p align="left">
-							<b> <code class="language-cobol">SORT</code> example </b>
-						</p>
-					</div>
+					<p>
+						<b> <code class="language-cobol">SORT</code> example </b>
+					</p>
 					<pre class="language-cobol"><code class="language-cobol">ENVIRONMENT DIVISION.
 INPUT-OUTPUT SECTION.
 FILE-CONTROL.
@@ -444,21 +419,20 @@ Begin.
 					<h4>How a simple SORT works</h4>
 				</div>
 				<div class="section-content">
-					<p align="left">
+					<p>
 						As illustrated by the diagram below, the sort process takes records from the input file
 						(CallsFile) <i></i>and sorts them using the temporary file (WorkFile) on the field(s), and in
 						the sequence, specified in the <code class="language-cobol">KEY</code> phrase. When all the
 						records have been sorted, the sort process writes them to the output file (SortedCallsFile).
 					</p>
-					<p align="left">
+					<p>
 						Remember - the <code class="language-cobol">SORT</code> automatically opens the CallsFile and
 						the SortedCallsFile. These files must not be open when the
 						<code class="language-cobol">SORT</code> executes or it will fail.
 					</p>
-					<p align="center"><img height="270" src="Resources/pics/Sort2.gif" width="470" /></p>
+					<p class="center-block"><img height="270" src="Resources/pics/Sort2.gif" width="470" alt="Diagram showing how a simple SORT moves records from input file through work file to sorted output file" /></p>
 					<pre
 						class="language-cobol"
-						align="center"
 					><code class="language-cobol">SORT WorkFile ON ASCENDING SubscriberNumWF
      USING  CallsFile
      GIVING SortedCallsFile.
@@ -469,7 +443,7 @@ Begin.
 					<h4>Using multiple keys.</h4>
 				</div>
 				<div class="section-content">
-					<p align="left">
+					<p>
 						If you examine the <code class="language-cobol">SORT</code> syntax diagram above, carefully, you
 						will realize that, not only can a file be sorted on a number of keys, but that one key can be
 						ascending while another can be descending. This is illustrated in the table below. The table
@@ -478,22 +452,21 @@ Begin.
 					</p>
 					<pre
 						class="language-cobol"
-						align="left"
 					><code class="language-cobol">SORT WorkFile ON ASCENDING ProvinceCode
                  DESCENDING VendorNumber
                  USING SalesFile
                  GIVING SortedSalesFile</code></pre>
-					<p align="left">
+					<p>
 						Notice that ProvinceCode is the major key, and that VendorNumber is only in descending sequence,
 						<i>within</i> ProvinceCode. The first key named in a
 						<code class="language-cobol">SORT</code> statement is the major key and keys get less
 						significant with each successive declaration.
 					</p>
-					<p align="center"><b>SortedSalesFile</b></p>
-					<table align="center" bgcolor="#E1FFE1" border="1" width="36%">
+					<p class="center-block"><b>SortedSalesFile</b></p>
+					<table style="margin:0 auto" bgcolor="#E1FFE1" border="1" width="36%">
 						<tr bgcolor="#FFFFCC">
 							<td valign="top" width="58">
-								<p align="center">
+								<p class="center-block">
 									<b
 										>Ascending<br />
 										Province<br />
@@ -502,7 +475,7 @@ Begin.
 								</p>
 							</td>
 							<td valign="top" width="64">
-								<div align="center">
+								<div class="center-block">
 									<b
 										>Descending<br />
 										Vendor<br />
@@ -511,7 +484,7 @@ Begin.
 								</div>
 							</td>
 							<td valign="top" width="45">
-								<div align="center">
+								<div class="center-block">
 									<b
 										>Remaining<br />
 										Record</b
@@ -526,7 +499,7 @@ Begin.
 						</tr>
 						<tr>
 							<td valign="top" width="58">
-								<div align="center">
+								<div class="center-block">
 									<pre class="language-cobol"><code class="language-cobol">1
 1
 1
@@ -553,7 +526,7 @@ Begin.
 								</div>
 							</td>
 							<td valign="top" width="64">
-								<div align="center">
+								<div class="center-block">
 									<pre class="language-cobol"><code class="language-cobol">91234
 91234
 81234
@@ -580,7 +553,7 @@ Begin.
 								</div>
 							</td>
 							<td valign="top" width="45">
-								<div align="center">
+								<div class="center-block">
 									<pre class="language-cobol"><code class="language-cobol">etc.
 etc.
 etc.
@@ -620,7 +593,7 @@ etc.</code></pre>
 					<h2 id="part2">SORTing with an INPUT PROCEDURE</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">Introduction</h4>
+					<h4>Introduction</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -637,12 +610,12 @@ etc.</code></pre>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">SORT syntax with INPUT PROCEDURE</h4>
+					<h4>SORT syntax with INPUT PROCEDURE</h4>
 				</div>
 				<div class="section-content">
-					<p align="left"><img height="274" src="Resources/pics/Sort3.gif" width="486" /></p>
+					<p><img height="274" src="Resources/pics/Sort3.gif" width="486" alt="SORT verb syntax diagram with INPUT PROCEDURE" /></p>
 					e.g.
-					<pre class="language-cobol" align="left"><code class="language-cobol">
+					<pre class="language-cobol"><code class="language-cobol">
 SORT WorkFile ON ASCENDING CountyNumWF, VendorNumWF
               INPUT PROCEDURE RejectNorthernRecs
               GIVING SortedSalesFile.
@@ -655,26 +628,26 @@ SORT WorkFile ON ASCENDING CountryNameWF, CustomerNameWF
               INPUT PROCEDURE IS RestructureRecords
               GIVING SortedSubscriptionsFile.
 </code></pre>
-					<p align="left">
+					<p>
 						<b>INPUT PROCEDURE notes</b><br />
 						When an <code class="language-cobol">INPUT PROCEDURE</code> is used, it replaces the
 						<code class="language-cobol">USING</code> phrase. The <i>ProcName</i> in the
 						<code class="language-cobol">INPUT PROCEDURE</code> phrase, identifies a block of code, that
 						uses the <code class="language-cobol">RELEASE</code> verb to supply records to the sort process.
 					</p>
-					<p align="left">
+					<p>
 						The <code class="language-cobol">INPUT PROCEDURE</code> must finish before the sort process
 						sorts the records supplied to it by the procedure. That's why the records are
 						<code class="language-cobol">RELEASE</code>d to the work file. They are stored there until the
 						<code class="language-cobol">INPUT PROCEDURE</code> finishes and then they are sorted.
 					</p>
-					<p align="left">
+					<p>
 						An <code class="language-cobol">INPUT PROCEDURE</code> allows us to select which records, and
 						what type of records, will be submitted to the sort process. Because an
 						<code class="language-cobol">INPUT PROCEDURE</code> executes before the sort process sorts the
 						records, only the data that is actually required in the sorted file will be sorted.
 					</p>
-					<p align="left">
+					<p>
 						<b> <code class="language-cobol">INPUT PROCEDURE</code> rules </b>
 					</p>
 					<ol>
@@ -699,10 +672,10 @@ SORT WorkFile ON ASCENDING CountryNameWF, CustomerNameWF
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">How a SORT with and INPUT PROCEDURE works.</h4>
+					<h4>How a SORT with and INPUT PROCEDURE works.</h4>
 				</div>
 				<div class="section-content">
-					<p align="left">
+					<p>
 						A simple <code class="language-cobol">SORT</code> works by taking records from the
 						<code class="language-cobol">USING</code> file, sorting them, and then writing them to the
 						<code class="language-cobol">GIVING</code> file. When an
@@ -714,7 +687,7 @@ SORT WorkFile ON ASCENDING CountryNameWF, CustomerNameWF
 						<code class="language-cobol">RELEASE</code> verb to supply the records to the
 						<code class="language-cobol">SORT</code>, one at a time.
 					</p>
-					<p align="left">
+					<p>
 						Although an <code class="language-cobol">INPUT PROCEDURE</code> usually gets the records it
 						supplies to the sort process from an input file, the records can actually originate from
 						anywhere. For instance, if we wanted to sort the elements of a table, we could use an
@@ -723,17 +696,17 @@ SORT WorkFile ON ASCENDING CountryNameWF, CustomerNameWF
 						an <code class="language-cobol">INPUT PROCEDURE</code> to get the records from the user and
 						supply them to the sort process.
 					</p>
-					<p align="left">
+					<p>
 						When an <code class="language-cobol">INPUT PROCEDURE</code> gets its records from an input file
 						it can select which records to send to the sort process and can even alter the structure of the
 						records before they are sent.
 					</p>
-					<p align="left">
+					<p>
 						In the example below, an <code class="language-cobol">INPUT PROCEDURE</code> is used to select
 						only the records of foreign guests, for sorting. The diagram shows how an INPUT PROCEDURE, is
 						used to sit between the input file and the sort process, to filter the records.
 					</p>
-					<p align="center"><img height="240" src="Resources/pics/Sort5.gif" width="435" /></p>
+					<p class="center-block"><img height="240" src="Resources/pics/Sort5.gif" width="435" alt="Diagram showing INPUT PROCEDURE filtering records between input file and sort process" /></p>
 					<pre class="language-cobol"><code class="language-cobol">SORT WorkFile ON ASCENDING CountryNameWF
               INPUT PROCEDURE IS SelectForeignGuests
               GIVING SortedGuestsFile.
@@ -741,7 +714,7 @@ SORT WorkFile ON ASCENDING CountryNameWF, CustomerNameWF
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">Creating an INPUT PROCEDURE</h4>
+					<h4>Creating an INPUT PROCEDURE</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -769,7 +742,7 @@ SORT WorkFile ON ASCENDING CountryNameWF, CustomerNameWF
 						records from and input file and <code class="language-cobol">RELEASE</code>s them to the work
 						file, is shown in the table below.
 					</p>
-					<div align="center">
+					<div class="center-block">
 						<pre class="language-cobol"><code class="language-cobol">OPEN INPUT InFileName
 READ InFileName
 PERFORM UNTIL TerminatingCondition
@@ -782,15 +755,15 @@ CLOSE InFileName</code></pre>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">The Foreign Guests Report - example program</h4>
+					<h4>The Foreign Guests Report - example program</h4>
 					<aside>
-						<p align="center">
+						<p class="center-block">
 							<span class="i-detail" aria-hidden="true">🔍</span><br />
 							In this instance, since the number of countries in the world is fairly static, a table-based
 							solution might also be viable.
 						</p>
 					</aside>
-					<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
+					<p class="center-block"><img height="44" src="Resources/pics/program.gif" width="42" alt="" /></p>
 				</div>
 				<div class="section-content">
 					<p>
@@ -938,25 +911,24 @@ PrintReportBody.
 				</div>
 				<div class="section-sidebar">
 					<h4>Feeding the SORT from the keyboard - example program</h4>
-					<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
+					<p class="center-block"><img height="44" src="Resources/pics/program.gif" width="42" alt="" /></p>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<p align="left">
-							As we noted earlier, because the <code class="language-cobol">INPUT PROCEDURE</code> is
-							responsible for supplying records to the sort process, the records could be coming from
-							anywhere. We could obtain them from a table, or, as in this example, directly from the user.
-						</p>
-						<p align="left">
-							As the illustration below shows, this example program gets records from the user, sorts them
-							on ascending StudentId, and then outputs them to the StudentFile. Notice that the sort
-							process only sorts the file, when the
-							<code class="language-cobol">INPUT PROCEDURE</code> has finished.
-						</p>
-						<p align="center">
-							<img height="295" src="Resources/pics/Sort6.gif" width="515" />
-						</p>
-						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+					<p>
+						As we noted earlier, because the <code class="language-cobol">INPUT PROCEDURE</code> is
+						responsible for supplying records to the sort process, the records could be coming from
+						anywhere. We could obtain them from a table, or, as in this example, directly from the user.
+					</p>
+					<p>
+						As the illustration below shows, this example program gets records from the user, sorts them
+						on ascending StudentId, and then outputs them to the StudentFile. Notice that the sort
+						process only sorts the file, when the
+						<code class="language-cobol">INPUT PROCEDURE</code> has finished.
+					</p>
+					<p class="center-block">
+						<img height="295" src="Resources/pics/Sort6.gif" width="515" alt="Diagram showing records being accepted from the user, sorted, and written to the student file" />
+					</p>
+					<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  SortInput.
 AUTHOR.  Michael Coughlan.
@@ -1017,7 +989,6 @@ GetStudentDetails.
        RELEASE WorkRec
        ACCEPT WorkRec
     END-PERFORM.</code></pre>
-					</div>
 				</div>
 				<div class="section-full">
 					<hr />
@@ -1030,7 +1001,7 @@ GetStudentDetails.
 					<h2 id="part3">Sorting with an OUTPUT PROCEDURE</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">Introduction</h4>
+					<h4>Introduction</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1062,14 +1033,14 @@ GetStudentDetails.
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">SORT syntax with OUTPUT PROCEDURE</h4>
+					<h4>SORT syntax with OUTPUT PROCEDURE</h4>
 				</div>
 				<div class="section-content">
-					<p align="left">
+					<p>
 						The syntax diagram below is the complete syntax for the
 						<code class="language-cobol">SORT</code> verb.
 					</p>
-					<p><img height="306" src="Resources/pics/Sort4.gif" width="502" /></p>
+					<p><img height="306" src="Resources/pics/Sort4.gif" width="502" alt="Complete SORT verb syntax diagram showing both INPUT PROCEDURE and OUTPUT PROCEDURE options" /></p>
 					<p>e.g.</p>
 					<pre class="language-cobol"><code class="language-cobol">SORT WorkFile ON ASCENDING CustNameWF
      INPUT PROCEDURE IS SelectEssentialOils
@@ -1103,7 +1074,7 @@ SORT WorkFile ON ASCENDING KEY SalespersonNumWF
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">How the OUTPUT PROCEDURE works</h4>
+					<h4>How the OUTPUT PROCEDURE works</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1127,10 +1098,9 @@ SORT WorkFile ON ASCENDING KEY SalespersonNumWF
 						An <code class="language-cobol">OUTPUT PROCEDURE</code> is used because, until the records have
 						been sorted into salesperson number order, the quantities sold cannot be summed.
 					</p>
-					<p align="center"><img height="235" src="Resources/pics/Sort7.gif" width="435" /></p>
+					<p class="center-block"><img height="235" src="Resources/pics/Sort7.gif" width="435" alt="Diagram showing OUTPUT PROCEDURE summarising sorted sales records into a sales summary file" /></p>
 					<pre
 						class="language-cobol"
-						align="center"
 					><code class="language-cobol">SORT WorkFile ON ASCENDING KEY SalespersonNumWF
      USING SalesFile
      OUTPUT PROCEDURE IS SummariseSales.
@@ -1138,7 +1108,7 @@ SORT WorkFile ON ASCENDING KEY SalespersonNumWF
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">Creating an OUTPUT PROCEDURE</h4>
+					<h4>Creating an OUTPUT PROCEDURE</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1169,7 +1139,7 @@ SORT WorkFile ON ASCENDING KEY SalespersonNumWF
 						<code class="language-cobol">OUTPUT PROCEDURE</code>. The work file is automatically opened by
 						the <code class="language-cobol">SORT</code>.
 					</p>
-					<div align="center">
+					<div class="center-block">
 						<pre class="language-cobol"><code class="language-cobol">OPEN OUTPUT OutFile
 RETURN SDWorkFile RECORD
 PERFORM UNTIL TerminatingCondition
@@ -1183,8 +1153,8 @@ CLOSE OutFile
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">Sales summary file - example program</h4>
-					<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
+					<h4>Sales summary file - example program</h4>
+					<p class="center-block"><img height="44" src="Resources/pics/program.gif" width="42" alt="" /></p>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1255,8 +1225,8 @@ SummariseSales.
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">Revised Foreign Guests Report - example program</h4>
-					<p align="center"><img height="44" src="Resources/pics/program.gif" width="42" /></p>
+					<h4>Revised Foreign Guests Report - example program</h4>
+					<p class="center-block"><img height="44" src="Resources/pics/program.gif" width="42" alt="" /></p>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1388,7 +1358,7 @@ PrintReportBody.
 					<h2 id="part4">MERGEing files</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">Introduction</h4>
+					<h4>Introduction</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1408,10 +1378,10 @@ PrintReportBody.
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">MERGE syntax</h4>
+					<h4>MERGE syntax</h4>
 				</div>
 				<div class="section-content">
-					<p><img height="229" src="Resources/pics/Sort8.gif" width="494" /></p>
+					<p><img height="229" src="Resources/pics/Sort8.gif" width="494" alt="MERGE verb syntax diagram" /></p>
 					<p>e.g.</p>
 					<pre class="language-cobol"><code class="language-cobol">MERGE MergeWorkFile
    ON ASCENDING KEY TransDateWF, TransCodeWF, StudentIdWF
@@ -1435,21 +1405,21 @@ PrintReportBody.
 						in the <code class="language-cobol">INPUT-OUTPUT SECTION</code>, and an organization of RECORD
 						SEQUENTIAL.
 					</p>
-					<p align="left">
+					<p>
 						Each <i>MergeKeyIdentifier</i> identifies a field in the record of the work file. The sorted
 						file will be in sequence on this key field(s).
 					</p>
-					<p align="left">
+					<p>
 						When more than one <i>MergeKeyIdentifier</i> is specified, the keys decrease in significance
 						from left to right (leftmost key is most significant, rightmost is least significant).
 					</p>
-					<p align="left">
+					<p>
 						<i>InFileName</i> and <i>OutFileName</i>, are the names of the input and output files
 						respectively. These files are automatically opened by the
 						<code class="language-cobol">MERGE</code>. When the
 						<code class="language-cobol">MERGE</code> executes they must <b>not</b> be already open.
 					</p>
-					<p align="left">
+					<p>
 						<i>AlphabetName</i> is an alphabet-name defined in the
 						<code class="language-cobol">SPECIAL-NAMES</code> paragraph of the
 						<code class="language-cobol">ENVIRONMENT DIVISION</code>. This clause is used to select the
@@ -1471,7 +1441,7 @@ PrintReportBody.
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">MERGE example</h4>
+					<h4>MERGE example</h4>
 				</div>
 				<div class="section-content">
 					<p>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -46,35 +46,33 @@
 					<h4>Aims</h4>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<p align="left">
-							To provide a brief introduction to building modular systems using separately compiled and/or
-							contained subprograms.
-						</p>
-						<p align="left">
-							To explore the syntax, semantics, and use of the
-							<code class="language-cobol">CALL</code> verb.
-						</p>
-						<p align="left">
-							To examine how "state memory" is implemented in COBOL and to demonstrate the effects of the
-							<code class="language-cobol">IS INITIAL</code> clause and the
-							<code class="language-cobol">CANCEL</code> command.
-						</p>
-						<p align="left">
-							To examine how contained subprograms are implemented and to show how the
-							<code class="language-cobol">IS GLOBAL</code> clause may be used to implement a form of
-							"Information Hiding".
-						</p>
-						<p align="left">
-							To show how the <code class="language-cobol">IS EXTERNAL</code> clause may be used to set up
-							an area of storage that may be accessed by any program in the run-unit.
-						</p>
-						<p align="left">
-							To introduce Structured Design and to summarize its criteria for achieving good quality
-							subprograms.
-						</p>
-						<hr size="1" />
-					</div>
+					<p>
+						To provide a brief introduction to building modular systems using separately compiled and/or
+						contained subprograms.
+					</p>
+					<p>
+						To explore the syntax, semantics, and use of the
+						<code class="language-cobol">CALL</code> verb.
+					</p>
+					<p>
+						To examine how "state memory" is implemented in COBOL and to demonstrate the effects of the
+						<code class="language-cobol">IS INITIAL</code> clause and the
+						<code class="language-cobol">CANCEL</code> command.
+					</p>
+					<p>
+						To examine how contained subprograms are implemented and to show how the
+						<code class="language-cobol">IS GLOBAL</code> clause may be used to implement a form of
+						"Information Hiding".
+					</p>
+					<p>
+						To show how the <code class="language-cobol">IS EXTERNAL</code> clause may be used to set up
+						an area of storage that may be accessed by any program in the run-unit.
+					</p>
+					<p>
+						To introduce Structured Design and to summarize its criteria for achieving good quality
+						subprograms.
+					</p>
+					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
 					<h4>Objectives</h4>
@@ -151,7 +149,7 @@
 						<b>Introduction</b>
 					</h4>
 					<aside>
-						<p align="center">
+						<p class="center-block">
 							<span class="i-detail" aria-hidden="true">🔍</span><br />
 							Your vendor will have supplied a Linker with your COBOL development system. You will have to
 							read the vendor manual for the specifics of how it works.
@@ -207,10 +205,10 @@
 						<b>CALL syntax and notes</b>
 					</p>
 					<aside>
-						<p align="center">
+						<p class="center-block">
 							<img height="62" src="Resources/pics/i-BugAlert.gif" width="56" alt="" />
 						</p>
-						<p align="center">
+						<p class="center-block">
 							Passing parameters of incorrect types to a called program is a frequent source of program
 							failure (crashes).<br />
 							Always double check to make sure that the types of the parameters passed by the caller
@@ -219,8 +217,8 @@
 					</aside>
 				</div>
 				<div class="section-content">
-					<p align="center"><img height="208" src="Resources/pics/Call1.gif" width="480" /></p>
-					<p align="left"><b>CALL notes</b></p>
+					<p class="center-block"><img height="208" src="Resources/pics/Call1.gif" width="480" alt="CALL verb syntax diagram" /></p>
+					<p><b>CALL notes</b></p>
 					<ol>
 						<li>
 							If the <code class="language-cobol">CALL</code> passes parameters, then the called program
@@ -254,7 +252,7 @@
 							<code class="language-cobol">CALL</code> corresponds to the first in the
 							<code class="language-cobol">USING</code> phase of the called program, and so on.<br />
 							<br />
-							<img height="354" src="Resources/pics/Call2.gif" width="524" /><br />
+							<img height="354" src="Resources/pics/Call2.gif" width="524" alt="Diagram showing parameter correspondence by position between calling and called programs" /><br />
 							<br />
 							<br />
 						</li>
@@ -302,21 +300,21 @@
 						</li>
 					</ul>
 					<p>The diagrams and explanations below show how these mechanisms work.</p>
-					<p align="left">
+					<p>
 						<b>CALL..BY REFERENCE</b><br />
 						When data is passed <code class="language-cobol">BY REFERENCE</code>, the address of the
 						data-item is supplied to the called subprogram. So any changes made to the data-item in the
 						subprogram are also made to the data-item in the main program because both items refer to the
 						same memory location.
 					</p>
-					<p align="center"><img height="164" src="Resources/pics/call3.gif" width="490" /></p>
+					<p class="center-block"><img height="164" src="Resources/pics/call3.gif" width="490" alt="Diagram showing BY REFERENCE parameter passing where both programs share the same memory address" /></p>
 					<p>
 						<b>CALL..BY CONTENT<br /></b> When a parameter is passed
 						<code class="language-cobol">BY CONTENT</code> a copy of the data-item is made and the address
 						of the copy is supplied to subprogram. Any changes made to the data-item in the subprogram
 						affect only the copy.
 					</p>
-					<p align="center"><img height="193" src="Resources/pics/call4.gif" width="489" /></p>
+					<p class="center-block"><img height="193" src="Resources/pics/call4.gif" width="489" alt="Diagram showing BY CONTENT parameter passing where the subprogram receives a copy of the data item" /></p>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
@@ -334,7 +332,7 @@ CALL "DateValidate"
      USING BY CONTENT TempDate
      USING BY REFERENCE DateCheckResult.
 </code></pre>
-					<div align="center">
+					<div class="center-block">
 						The <code class="language-cobol">CALL</code> statement in the calling program.<br />
 					</div>
 					<pre class="language-cobol"><code class="language-cobol">
@@ -353,9 +351,9 @@ Begin.
        EXIT PROGRAM.
 ??????.
        ? ? ? ? ? ? ? ? ? ? ? ?</code></pre>
-					<div align="center">
+					<div class="center-block">
 						<p>Outline of the called program</p>
-						<p align="left">
+						<p>
 							<b>Notes<br /></b> Note that the name given in the
 							<code class="language-cobol">CALL</code> statement (i.e. "DateValidate") corresponds with
 							the name given in the <code class="language-cobol">PROGRAM-ID</code> of the called program.
@@ -437,7 +435,7 @@ Begin.
 						called with the same parameter value. But "Fickle", because it remembers its state from the
 						previous call, will produce different results when called with the same value.
 					</p>
-					<div align="center">
+					<div class="center-block">
 						<pre class="language-cobol"><code class="language-cobol">
 ? ? ? ? ? ? ? ? ? ?
 MOVE 12 TO IncrementVal.
@@ -483,39 +481,37 @@ Begin.
 </code></pre>
 						</div>
 						<div class="run-part">
-							<div align="left">
-								<div align="center">
-									<b>Example Runs<br /></b>
-									The parameter value is shown in <span style="color: #0000ff">blue</span> and the
-									result displayed is shown in <span style="color: #ff0000">red</span>.<br />
-								</div>
-								<hr />
-								<div align="center">First Run<br /></div>
-								<div align="center">
-									<span style="color: #0000ff"><b>12</b></span>
-									<b
-										><br />
-										<span style="color: #ff0000">Total = 62</span>
-									</b>
-								</div>
-								<hr />
-								<div align="center">Second Run<br /></div>
-								<div align="center">
-									<span style="color: #0000ff"><b>5</b></span>
-									<b
-										><br />
-										<span style="color: #ff0000">Total = 55</span>
-									</b>
-								</div>
-								<hr />
-								<div align="center">Third Run<br /></div>
-								<div align="center">
-									<span style="color: #0000ff"><b>12</b></span>
-									<b
-										><br />
-										<span style="color: #ff0000">Total = 62</span>
-									</b>
-								</div>
+							<div class="center-block">
+								<b>Example Runs<br /></b>
+								The parameter value is shown in <span style="color: #0000ff">blue</span> and the
+								result displayed is shown in <span style="color: #ff0000">red</span>.<br />
+							</div>
+							<hr />
+							<div class="center-block">First Run<br /></div>
+							<div class="center-block">
+								<span style="color: #0000ff"><b>12</b></span>
+								<b
+									><br />
+									<span style="color: #ff0000">Total = 62</span>
+								</b>
+							</div>
+							<hr />
+							<div class="center-block">Second Run<br /></div>
+							<div class="center-block">
+								<span style="color: #0000ff"><b>5</b></span>
+								<b
+									><br />
+									<span style="color: #ff0000">Total = 55</span>
+								</b>
+							</div>
+							<hr />
+							<div class="center-block">Third Run<br /></div>
+							<div class="center-block">
+								<span style="color: #0000ff"><b>12</b></span>
+								<b
+									><br />
+									<span style="color: #ff0000">Total = 62</span>
+								</b>
 							</div>
 						</div>
 					</div>
@@ -547,40 +543,38 @@ Begin.
 </code></pre>
 						</div>
 						<div class="run-part">
-							<div align="left">
-								<div align="center">
-									<b>Example Runs<br /></b>
-									The parameter value is shown in <span style="color: #0000ff">blue</span> and the
-									result displayed is shown in <span style="color: #ff0000">red</span>.<br />
-								</div>
-								<hr />
-								<div align="center">First Run<br /></div>
-								<div align="center">
-									<span style="color: #0000ff"><b>12</b></span>
+							<div class="center-block">
+								<b>Example Runs<br /></b>
+								The parameter value is shown in <span style="color: #0000ff">blue</span> and the
+								result displayed is shown in <span style="color: #ff0000">red</span>.<br />
+							</div>
+							<hr />
+							<div class="center-block">First Run<br /></div>
+							<div class="center-block">
+								<span style="color: #0000ff"><b>12</b></span>
+								<b
+									><br />
+									<span style="color: #ff0000">Total = 62</span>
+								</b>
+							</div>
+							<hr />
+							<div class="center-block">Second Run<br /></div>
+							<div class="center-block">
+								<div>
+									<span style="color: #0000ff"><b>5</b></span>
 									<b
 										><br />
-										<span style="color: #ff0000">Total = 62</span>
+										<span style="color: #ff0000">Total = 67</span>
 									</b>
 								</div>
 								<hr />
-								<div align="center">Second Run<br /></div>
-								<div align="center">
-									<div>
-										<span style="color: #0000ff"><b>5</b></span>
-										<b
-											><br />
-											<span style="color: #ff0000">Total = 67</span>
-										</b>
-									</div>
-									<hr />
-									Third Run<br />
-									<div align="center">
-										<span style="color: #0000ff"><b>12</b></span>
-										<b
-											><br />
-											<span style="color: #ff0000">Total = 79</span>
-										</b>
-									</div>
+								Third Run<br />
+								<div class="center-block">
+									<span style="color: #0000ff"><b>12</b></span>
+									<b
+										><br />
+										<span style="color: #ff0000">Total = 79</span>
+									</b>
 								</div>
 							</div>
 						</div>
@@ -610,7 +604,7 @@ Begin.
 						<code class="language-cobol">CANCEL</code> verb/command.
 					</p>
 					<p>The syntax of the <code class="language-cobol">CANCEL</code> verb is as follows</p>
-					<p align="center"><img height="71" src="Resources/pics/call5.gif" width="264" /></p>
+					<p class="center-block"><img height="71" src="Resources/pics/call5.gif" width="264" alt="CANCEL verb syntax diagram" /></p>
 					<p>
 						When the <code class="language-cobol">CANCEL</code> command is executed, the memory space
 						occupied by the subprogram is freed and if the subprogram is called again it will be in its
@@ -682,11 +676,11 @@ CALL "Fickle" USING BY CONTENT IncValue.</code></pre>
 					<h4>Introduction</h4>
 				</div>
 				<div class="section-content">
-					<p align="left">
+					<p>
 						COBOL subprograms can be independently compiled separate programs (linked into a single
 						executable run-unit) or they can be contained within the text of a containing program.
 					</p>
-					<p align="left">
+					<p>
 						Contained subprograms. are very similar to the procedures (or user defined functions) found in
 						other languages except that they are invoked with the
 						<code class="language-cobol">CALL</code> verb and are better protected against accidental data
@@ -710,12 +704,12 @@ CALL "Fickle" USING BY CONTENT IncValue.</code></pre>
 					<b>Defining a contained subprogram</b>
 				</div>
 				<div class="section-content">
-					<p align="left">
+					<p>
 						When contained subprograms are used, the end of the main program, and each subprogram, is
 						signalled by means of the
 						<code class="language-cobol">END PROGRAM</code> statement. This has the format:
 					</p>
-					<p align="center">
+					<p class="center-block">
 						<b>END PROGRAM ProgramIdName.</b>
 					</p>
 					<b>Contained subprogram restrictions</b>
@@ -741,23 +735,23 @@ CALL "Fickle" USING BY CONTENT IncValue.</code></pre>
 					</h4>
 				</div>
 				<div class="section-content">
-					<p align="left">
+					<p>
 						As noted above, data-items declared outside the scope of a contained subprogram cannot be seen
 						within the subprogram.
 					</p>
-					<p align="left">
+					<p>
 						Sometimes however, you may want to share some data-item within a number of contained
 						subprograms.
 					</p>
-					<p align="left">
+					<p>
 						For instance, in the example program fragments below, we want both of our subprograms to be able
 						to access the <i>NameTable</i>.
 					</p>
-					<p align="left">
+					<p>
 						When we want a data-item to be seen within contained subprograms we simply follow the item
 						declaration with the <code class="language-cobol">IS GLOBAL</code> clause.
 					</p>
-					<p align="left">
+					<p>
 						The <code class="language-cobol">IS GLOBAL</code> clause specifies that the data item is to be
 						visible within any subordinate contained subprograms.
 					</p>
@@ -798,39 +792,39 @@ END-PROGRAM ContainerProgram.</code></pre>
 					<h4>Information Hiding using the IS GLOBAL clause and contained subprograms</h4>
 				</div>
 				<div class="section-content">
-					<p align="left">
+					<p>
 						Contained subprograms. seem to offer us the opportunity to create some form of Information
 						Hiding. For instance, it looks as though we could create an Informational Strength module as
 						defined by Myres (Myres, G.J. <i>Composite/Structured Design.</i> 1979) by hiding a table
 						declaration within a containing program and then allowing access to it through the contained
 						subprograms. (see diagram below).
 					</p>
-					<p align="center"><img height="206" src="Resources/pics/call6.gif" width="401" /></p>
-					<p align="left">
+					<p class="center-block"><img height="206" src="Resources/pics/call6.gif" width="401" alt="Diagram showing information hiding with a table declaration inside a containing program accessed through contained subprograms" /></p>
+					<p>
 						Unfortunately, this arrangement is not allowed in COBOL because, although subprograms. may be
 						nested, a contained subprogram can only be called by the immediate containing program or by a
 						subprogram at the same level. So in the diagram above, the main program would not be allowed
 						direct access to the contained subprograms.
 					</p>
-					<p align="left">
+					<p>
 						The only way any kind of Informational Strength module can be achieved is for the MainProgram to
 						call the ContainerProgram and for the ContainerProgram to call the appropriate subprogram as
 						shown below.
 					</p>
-					<p align="left">
+					<p>
 						To do this the MainProgram would have to pass some sort of code to the ContainerProgram to tell
 						it which of the subprograms to use and the parameter list passed to the ContainerProgram would
 						have to be wide enough to accommodate the needs of the contained subprograms. This does not
 						cause much of a problem in the example below, but in a case where the contained programs had
 						more significant data needs it could prove a serious drawback.
 					</p>
-					<p align="left">
+					<p>
 						Glenford Myres (Myres, G.J. <i>Composite/Structured Design.</i> 1979) has produced criteria for
 						deciding whether a module (i.e. a subprogram) is good or bad. Module Coupling (i.e. the data
 						connections between modules) is one of the criteria he considers. According to his criteria the
 						ContainerProgram below exhibits both Stamp and Control coupling.
 					</p>
-					<p align="center"><img height="286" src="Resources/pics/call7.gif" width="406" /></p>
+					<p class="center-block"><img height="286" src="Resources/pics/call7.gif" width="406" alt="Diagram showing the ContainerProgram acting as intermediary between MainProgram and contained subprograms" /></p>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
@@ -863,7 +857,7 @@ END-PROGRAM ContainerProgram.</code></pre>
 						<code class="language-cobol">IS</code> and <code class="language-cobol">PROGRAM</code> are noise
 						words which may be omitted.
 					</p>
-					<p align="center"><img height="23" src="Resources/pics/call8.gif" width="495" /></p>
+					<p class="center-block"><img height="23" src="Resources/pics/call8.gif" width="495" alt="Syntax diagram for IS INITIAL and IS COMMON PROGRAM clauses in PROGRAM-ID" /></p>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
@@ -1019,7 +1013,7 @@ Begin.
 END PROGRAM DisplayTotal.
 END PROGRAM Counter.</code></pre>
 					<div style="background-color: #ffffff; padding: 5px; border-top: 1px solid">
-						<div align="center">
+						<div class="center-block">
 							<h3><b>Example Run</b></h3>
 							<p>
 								Numeric values entered by the user are shown in
@@ -1027,7 +1021,7 @@ END PROGRAM Counter.</code></pre>
 								<span style="color: #ff0000">red</span>.
 							</p>
 						</div>
-						<pre class="language-cobol" align="left"><code class="language-cobol">Enter value - 13
+						<pre class="language-cobol"><code class="language-cobol">Enter value - 13
 Fickle total    = 13
 Steadfast total = 13
 Enter value - 3
@@ -1088,11 +1082,11 @@ Value - 0</code></pre>
      01 SharedRec IS EXTERNAL.
         02 PartA     PIC X(4).
         02 PartB     PIC 9(5).</code></pre>
-					<p align="center">
+					<p class="center-block">
 						SharedRecord<br />
 						Program<br />
 						<a href="Resources/ppz/TC-Call.html"
-							><img align="middle" height="62" src="Resources/pics/i-Animation.gif" width="62" alt=""
+							><img height="62" src="Resources/pics/i-Animation.gif" width="62" alt=""
 						/></a>
 					</p>
 					<p>


### PR DESCRIPTION
## Summary
- Deep-cleaned 4 image-heavy course pages to 0 pa11y violations (WCAG 2.1 AA)
- `COBOLcommands.html`, `Search.html`, `SortMerge.html`, `Subprograms.html`

## Changes per file
- Added descriptive `alt` text to content figures (syntax diagrams)
- Stripped `align="left"` attributes (LTR default)
- Replaced `align="center"` on block elements with `class="center-block"`
- Replaced `align="center"` on `<td>`/`<th>` with `style="text-align:center"`
- Replaced `align="center"` on `<table>` with `style="margin:0 auto"`
- Unwrapped `<center>` and `<div align="center">` elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)