### PR TITLE
Make ReportWriterSS, Copy, Tables1, IndexedFiles pa11y-clean

### DIFF
--- a/course/Copy.html
+++ b/course/Copy.html
@@ -68,30 +68,30 @@
 					<h4>Aims</h4>
 				</div>
 				<div>
-					<div align="center">
-						<p align="left">
-							In a large software system it is often very useful to be able keep record, file and table
-							descriptions in a central source text library and then to import those descriptions into the
-							programs that require them. In COBOL the
-							<code class="language-cobol">COPY</code> verb allows us to do this.
-						</p>
-						<p align="left">This unit introduces the <code class="language-cobol">COPY</code> verb.</p>
-						<p align="left">
-							It describes some problems of large software systems which use of the
-							<code class="language-cobol">COPY</code> helps to alleviate.
-						</p>
-						<p align="left">
-							It introduces the syntax of the <code class="language-cobol">COPY</code> verb and discusses
-							how the <code class="language-cobol">COPY</code> verb, and in particular they
-							<code class="language-cobol">COPY..REPLACING</code>, works.
-						</p>
-						<p align="left">
-							It introduces the notion of a text word and describes the role that these play in matching
-							the text in the <code class="language-cobol">REPLACING</code> phrase with the text in the
-							library file.
-						</p>
-						<p align="left">The unit ends with a number of example programs.</p>
-					</div>
+					
+					<p>
+						In a large software system it is often very useful to be able keep record, file and table
+						descriptions in a central source text library and then to import those descriptions into the
+						programs that require them. In COBOL the
+						<code class="language-cobol">COPY</code> verb allows us to do this.
+					</p>
+					<p>This unit introduces the <code class="language-cobol">COPY</code> verb.</p>
+					<p>
+						It describes some problems of large software systems which use of the
+						<code class="language-cobol">COPY</code> helps to alleviate.
+					</p>
+					<p>
+						It introduces the syntax of the <code class="language-cobol">COPY</code> verb and discusses
+						how the <code class="language-cobol">COPY</code> verb, and in particular they
+						<code class="language-cobol">COPY..REPLACING</code>, works.
+					</p>
+					<p>
+						It introduces the notion of a text word and describes the role that these play in matching
+						the text in the <code class="language-cobol">REPLACING</code> phrase with the text in the
+						library file.
+					</p>
+					<p>The unit ends with a number of example programs.</p>
+				
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
@@ -142,10 +142,10 @@
 				</div>
 				<!-- Navigation -->
 				<div class="section-full">
-					<div align="center">
-						<hr />
-						<back-to-top></back-to-top>
-					</div>
+					
+					<hr />
+					<back-to-top></back-to-top>
+				
 				</div>
 				<!-- Section: Using the COPY verb -->
 				<div class="section-header">
@@ -155,34 +155,34 @@
 					<h4>Introduction</h4>
 				</div>
 				<div>
-					<div align="center">
-						<p align="left">
-							<code class="language-cobol">COPY</code> statements in a COBOL program are very different
-							from other COBOL statements. While other statements are executed at run time,
-							<code class="language-cobol">COPY</code> statements are executed at compile time.<br />
-						</p>
-						<p align="left">
-							A <code class="language-cobol">COPY</code> statement is similar to the "Include" used in
-							languages like C and C++. It allows programs to include frequently used source code text.
-						</p>
-						<p align="left">
-							When a <code class="language-cobol">COPY</code> statement is used in a COBOL program the
-							source code text is copied into the program from from a copy file or from a copy library
-							before the program is compiled.
-						</p>
-						<p align="left">A copy file, is a file containing a segment of COBOL code.</p>
-						<p align="left">
-							A copy library, is a collection code segment each of which can be referenced using a name.
-							Each program that wants to use items described in the copy library uses the
-							<code class="language-cobol">COPY</code> verb to include the descriptions it requires.
-						</p>
-						<p align="left">
-							When <code class="language-cobol">COPY</code> statements include source code in a program,
-							the code can be included without change or the text can be changed as it is copied into the
-							program. The ability to change the code as it being included greatly adds to the versatility
-							of the <code class="language-cobol">COPY</code> verb.
-						</p>
-					</div>
+					
+					<p>
+						<code class="language-cobol">COPY</code> statements in a COBOL program are very different
+						from other COBOL statements. While other statements are executed at run time,
+						<code class="language-cobol">COPY</code> statements are executed at compile time.<br />
+					</p>
+					<p>
+						A <code class="language-cobol">COPY</code> statement is similar to the "Include" used in
+						languages like C and C++. It allows programs to include frequently used source code text.
+					</p>
+					<p>
+						When a <code class="language-cobol">COPY</code> statement is used in a COBOL program the
+						source code text is copied into the program from from a copy file or from a copy library
+						before the program is compiled.
+					</p>
+					<p>A copy file, is a file containing a segment of COBOL code.</p>
+					<p>
+						A copy library, is a collection code segment each of which can be referenced using a name.
+						Each program that wants to use items described in the copy library uses the
+						<code class="language-cobol">COPY</code> verb to include the descriptions it requires.
+					</p>
+					<p>
+						When <code class="language-cobol">COPY</code> statements include source code in a program,
+						the code can be included without change or the text can be changed as it is copied into the
+						program. The ability to change the code as it being included greatly adds to the versatility
+						of the <code class="language-cobol">COPY</code> verb.
+					</p>
+				
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
@@ -230,10 +230,10 @@
 				</div>
 				<!-- Navigation -->
 				<div class="section-full">
-					<div align="center">
-						<hr />
-						<back-to-top></back-to-top>
-					</div>
+					
+					<hr />
+					<back-to-top></back-to-top>
+				
 				</div>
 				<!-- Section: COPY Syntax and Semantics -->
 				<div class="section-header">
@@ -247,7 +247,7 @@
 				<div class="section-sidebar">
 					<h4>COPY Syntax</h4>
 					<aside>
-						<p align="center">
+						<p class="center-block">
 							<span class="i-detail" aria-hidden="true">🔍</span><br />
 							The syntax diagram shown opposite has been simplified for the sake of completeness and
 							clarity. It is the author's opinion that the standard syntax diagram does not clearly
@@ -256,51 +256,51 @@
 					</aside>
 				</div>
 				<div>
-					<div align="center">
-						<p align="center">
-							<img height="98" src="Resources/pics/CopySyn1.gif" width="366" />
-						</p>
-						<p align="left">
-							<b>Text Words<br /></b> The matching procedure in the
-							<code class="language-cobol">REPLACING</code> phrase operates on text words.<br />
-						</p>
-						<p align="left">A text word is defined as ;<br /></p>
-						<div align="left">
-							<ul>
-								<li>
-									Any COBOL text enclosed in double equal signs (e.g. ==ADD 1==). This text is known
-									as PseudoText and it allows us to replace a series of words or characters as opposed
-									to an individual identifier, literal or word.<br />
-									<br />
-								</li>
-								<li>
-									Any literal including opening and closing quotes<br />
-									<br />
-								</li>
-								<li>
-									Any separator other than;<br />
-									&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;A space<br />
-									&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;A Pseudo-Text delimiter<br />
-									&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;A Comma
-								</li>
-							</ul>
-							<ul>
-								<li>
-									Any COBOL reserved word<br />
-									<br />
-								</li>
-								<li>Any Identifier.<br /></li>
-							</ul>
-							<ul>
-								<li>
-									Any other sequence of contiguous characters bounded by separators.<br />
-									<br />
-								</li>
-							</ul>
-						</div>
-						<p align="left"><b>Text Word examples</b></p>
+					
+					<p class="center-block">
+						<img height="98" src="Resources/pics/CopySyn1.gif" width="366" alt="COPY statement syntax diagram" />
+					</p>
+					<p>
+						<b>Text Words<br /></b> The matching procedure in the
+						<code class="language-cobol">REPLACING</code> phrase operates on text words.<br />
+					</p>
+					<p>A text word is defined as ;<br /></p>
+					<div>
+						<ul>
+							<li>
+								Any COBOL text enclosed in double equal signs (e.g. ==ADD 1==). This text is known
+								as PseudoText and it allows us to replace a series of words or characters as opposed
+								to an individual identifier, literal or word.<br />
+								<br />
+							</li>
+							<li>
+								Any literal including opening and closing quotes<br />
+								<br />
+							</li>
+							<li>
+								Any separator other than;<br />
+								&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;A space<br />
+								&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;A Pseudo-Text delimiter<br />
+								&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;A Comma
+							</li>
+						</ul>
+						<ul>
+							<li>
+								Any COBOL reserved word<br />
+								<br />
+							</li>
+							<li>Any Identifier.<br /></li>
+						</ul>
+						<ul>
+							<li>
+								Any other sequence of contiguous characters bounded by separators.<br />
+								<br />
+							</li>
+						</ul>
+					
+						<p><b>Text Word examples</b></p>
 						<blockquote>
-							<p align="left">
+							<p>
 								<b>MOVE</b><br />
 								1 Text Word<br />
 								<br />
@@ -313,7 +313,7 @@
 									</span>
 								</b>
 							</p>
-							<p align="left">
+							<p>
 								<b>MOVE Total TO Print-Total.</b><br />
 								5 Text Words - <span style="color: #0000ff"><b>MOVE</b></span>
 								<b>
@@ -323,7 +323,7 @@
 									<span style="color: #0000ff">.</span>
 								</b>
 							</p>
-							<p align="left">
+							<p>
 								<b>PIC S9(4)V9(6)</b><br />
 								9 Text words -
 								<b>
@@ -334,7 +334,7 @@
 									</span>
 								</b>
 							</p>
-							<p align="left">
+							<p>
 								<b>"PIC S9(4)V9(6)"</b><br />
 								1 Text word - <span style="color: #0000ff"><b>"PIC S9(4)V9(6)"</b></span
 								><br />
@@ -434,10 +434,10 @@ COPY CopyFile4 IN EGLIB.</code></pre>
 				</div>
 				<!-- Navigation -->
 				<div class="section-full">
-					<div align="center">
-						<hr />
-						<back-to-top></back-to-top>
-					</div>
+					
+					<hr />
+					<back-to-top></back-to-top>
+				
 				</div>
 				<!-- Section: COPY examples -->
 				<div class="section-header">
@@ -448,7 +448,7 @@ COPY CopyFile4 IN EGLIB.</code></pre>
 					<p>
 						<b>COPY Example1</b>
 					</p>
-					<p align="center">
+					<p class="center-block">
 						<b>
 							<img height="62" src="Resources/pics/aai-Legend.gif" width="65" alt="" />
 						</b>
@@ -476,9 +476,9 @@ COPY CopyFile4 IN EGLIB.</code></pre>
 				</div>
 				<div>
 					<div class="code-section">
-						<div align="center">
-							<b>Source Text</b>
-						</div>
+						
+						<b>Source Text</b>
+					
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. COPYEG1.
@@ -511,10 +511,10 @@ BeginProg.
 </code></pre>
 					</div>
 					<div class="code-section white-bg">
-						<div align="center">
-							<b>Text in COPYFILE1</b><br />
-							<br />
-						</div>
+						
+						<b>Text in COPYFILE1</b><br />
+						<br />
+					
 						<pre class="language-cobol"><code class="language-cobol">
 01  StudentRec.
     88  EndOfSF      VALUE HIGH-VALUES.
@@ -525,9 +525,9 @@ BeginProg.
     02  AmountPaid                   PIC 9(4)V99.</code></pre>
 					</div>
 					<div class="code-section">
-						<div align="center">
-							<b>Source Text after processing<br /> </b>
-						</div>
+						
+						<b>Source Text after processing<br /> </b>
+					
 						<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
@@ -574,39 +574,39 @@ BeginProg.
 						<b>COPY Example2</b>
 					</p>
 					<aside>
-						<p align="center">
+						<p class="center-block">
 							<span class="i-detail" aria-hidden="true">🔍</span>
 						</p>
-						<p align="left">
+						<p>
 							<b>Note1</b><br />
 							The TextWord XYZ in the library text is replaced by 120.
 						</p>
-						<p align="left">
+						<p>
 							<b>Note2</b><br />
 							The PseudoText symbols tell us that we are looking for the text word R in the library text.
 							Other R's in the text which might be part of a word are not matched because they are not
 							text words. The replaced R is a text word because it is bounded by two other text words i.e.
 							the parentheses ( and ).
 						</p>
-						<p align="left">
+						<p>
 							<b>Note3</b><br />
 							The PseudoText ==V99== is replaced by nothing; effectively deleting it.
 						</p>
-						<p align="left">
+						<p>
 							<b>Note4</b><br />
 							The literal "KEY" in the library text is replaced by "ABC"
 						</p>
-						<p align="left">
+						<p>
 							<b>Note5</b><br />
 							In this case the library text is copied without change because the literal "KEY" in the
 							library text is not the same as the word <i>KEY</i> in TextWord2.
 						</p>
-						<p align="left">
+						<p>
 							<b>Note6</b><br />
 							Similar to the previous example demonstrates the difference between CustKey and the literal
 							"CustKey". A literal text word includes the opening and closing quotes.
 						</p>
-						<p align="left">
+						<p>
 							<b>Note7</b><br />
 							Replaces "KEY" by two lines of text. Note that we are only replacing the literal "KEY" in
 							the library text. So the full stop after "KEY" is not replaced and that is why there is no
@@ -616,9 +616,9 @@ BeginProg.
 				</div>
 				<div>
 					<div class="code-section">
-						<div align="center">
-							<b>Source Text</b>
-						</div>
+						
+						<b>Source Text</b>
+					
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. COPYEG2.
@@ -658,41 +658,41 @@ BeginProg.
 STOP RUN.</code></pre>
 					</div>
 					<div class="code-section white-bg">
-						<div align="center">
-							<b>Text in CopyFile2</b><br />
-							<br />
-						</div>
+						
+						<b>Text in CopyFile2</b><br />
+						<br />
+					
 						<pre class="language-cobol"><code class="language-cobol">
     02 StudName PIC X(20) OCCURS XYZ TIMES.</code></pre>
 					</div>
 					<div class="code-section white-bg">
-						<div align="center">
-							<b>Text in CopyFile3</b><br />
-							<br />
-						</div>
+						
+						<b>Text in CopyFile3</b><br />
+						<br />
+					
 						<pre class="language-cobol"><code class="language-cobol">
     02  CustOrder           PIC 9(R).</code></pre>
 					</div>
 					<div class="code-section white-bg">
-						<div align="center">
-							<b>Text in CopyFile4</b><br />
-							<br />
-						</div>
+						
+						<b>Text in CopyFile4</b><br />
+						<br />
+					
 						<pre class="language-cobol"><code class="language-cobol">
     02 CustOrder2           PIC 9(6)V99.</code></pre>
 					</div>
 					<div class="code-section white-bg">
-						<div align="center">
-							<b>Text in CopyFile5</b><br />
-							<br />
-						</div>
+						
+						<b>Text in CopyFile5</b><br />
+						<br />
+					
 						<pre class="language-cobol"><code class="language-cobol">
     02 CustKey              PIC X(3) VALUE "KEY".</code></pre>
 					</div>
 					<div class="code-section">
-						<div align="center">
-							<b>Source Text after processing<br /> </b>
-						</div>
+						
+						<b>Source Text after processing<br /> </b>
+					
 						<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
@@ -750,27 +750,27 @@ STOP RUN.
 						<b>COPY Example3</b>
 					</p>
 					<aside>
-						<p align="center">
+						<p class="center-block">
 							<span class="i-detail" aria-hidden="true">🔍</span>
 						</p>
-						<p align="left">
+						<p>
 							Note that these COPY statements, which are themselves syntactically correct, result in
 							statements which cause syntax errors. This is a clear indication that COPY statements are
 							processed before the resulting program is compiled.
 						</p>
-						<p align="left">
+						<p>
 							<b>Note1</b><br />
 							The text word ( in the library text is replaced by @. Demonstrates that ( is a text word.
 						</p>
-						<p align="left">
+						<p>
 							<b>Note2</b><br />
 							Demonstrates that the 3 between ( and ) is a text word.
 						</p>
-						<p align="left">
+						<p>
 							Note3<br />
 							Demonstrates that ) is a textword.
 						</p>
-						<p align="left">
+						<p>
 							<b>Note4</b><br />
 							Demonstrates that the X before (3) is a textword and is replaced by the PseudoText "Replace
 							the X"
@@ -795,16 +795,16 @@ STOP RUN.
 							<b>Note8</b><br />
 							But the letter P in PIC is not a textword by itself and so is not replaced.
 						</p>
-						<p align="left">
+						<p>
 							<br />
 						</p>
 					</aside>
 				</div>
 				<div>
 					<div class="code-section">
-						<div align="center">
-							<b>Source Text</b>
-						</div>
+						
+						<b>Source Text</b>
+					
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. COPYEG3.
@@ -843,17 +843,17 @@ BeginProg.
    STOP RUN.</code></pre>
 					</div>
 					<div class="code-section white-bg">
-						<div align="center">
-							<b>Library Text in CopyFile5</b><br />
-							<br />
-						</div>
+						
+						<b>Library Text in CopyFile5</b><br />
+						<br />
+					
 						<pre class="language-cobol"><code class="language-cobol">
     02 CustKey              PIC X(3) VALUE "KEY".</code></pre>
 					</div>
 					<div class="code-section">
-						<div align="center">
-							<b>Source Text after processing<br /> </b>
-						</div>
+						
+						<b>Source Text after processing<br /> </b>
+					
 						<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
@@ -910,15 +910,15 @@ BeginProg.
 						<b>COPY Example4</b>
 					</p>
 					<aside>
-						<p align="center">
+						<p class="center-block">
 							<span class="i-detail" aria-hidden="true">🔍</span>
 						</p>
-						<p align="left">
+						<p>
 							<b>Note1</b><br />
 							This example demonstrates that a single COPY statement can be used to replace more than one
 							set of items.
 						</p>
-						<p align="left">
+						<p>
 							<b>Note2</b><br />
 							As above.
 						</p>
@@ -926,9 +926,9 @@ BeginProg.
 				</div>
 				<div>
 					<div class="code-section">
-						<div align="center">
-							<b>Source Text</b>
-						</div>
+						
+						<b>Source Text</b>
+					
 						<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
@@ -957,26 +957,26 @@ COPY CopyFile7 REPLACING N1 BY Num1
 </code></pre>
 					</div>
 					<div class="code-section white-bg">
-						<div align="center">
-							<b>Library Text in CopyFile6</b><br />
-							<br />
-						</div>
+						
+						<b>Library Text in CopyFile6</b><br />
+						<br />
+					
 						<pre class="language-cobol"><code class="language-cobol">
     02 CustKey              PIC X(4) VALUE "Mike".
 01  NameTable               PIC X(10)  OCCURS ?? TIMES.</code></pre>
 					</div>
 					<div class="code-section white-bg">
-						<div align="center">
-							<b>Library Text in CopyFile7</b><br />
-							<br />
-						</div>
+						
+						<b>Library Text in CopyFile7</b><br />
+						<br />
+					
 						<pre class="language-cobol"><code class="language-cobol">
     ADD N1, N2 GIVING R1.</code></pre>
 					</div>
 					<div class="code-section">
-						<div align="center">
-							<b>Source Text after processing<br /> </b>
-						</div>
+						
+						<b>Source Text after processing<br /> </b>
+					
 						<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -124,7 +124,7 @@
 						<h2 id="progs">A look at some programs that use Indexed files</h2>
 					</div>
 					<div class="section-sidebar">
-						<h4 align="left">Example program - Creating an Indexed file</h4>
+						<h4>Example program - Creating an Indexed file</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -376,7 +376,7 @@ VIDEO STATUS :- 23</code></pre>
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h4 align="left">Animation of the primary and alternate key indexes</h4>
+						<h4>Animation of the primary and alternate key indexes</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -393,14 +393,14 @@ VIDEO STATUS :- 23</code></pre>
 ELSE
    go to next index record
 END-IF</code></pre>
-						<div align="center">
-							<iframe
-								height="325"
-								src="Resources/pdf-viewer.html?src=ppz/IdxFile4.pdf"
-								style="border: 1px solid #ccc; width: 100%; aspect-ratio: 486/325"
-								width="486"
-							></iframe>
-						</div>
+						
+						<iframe
+							height="325"
+							src="Resources/pdf-viewer.html?src=ppz/IdxFile4.pdf"
+							style="border: 1px solid #ccc; width: 100%; aspect-ratio: 486/325"
+							width="486"
+						></iframe>
+					
 					</div>
 				</div>
 				<div>
@@ -427,7 +427,7 @@ END-IF</code></pre>
 						<h4>Select and Assign clause syntax</h4>
 					</div>
 					<div class="section-content">
-						<p><img height="245" src="Resources/pics/I-DFidx1.gif" width="474" alt="" /></p>
+						<p><img height="245" src="Resources/pics/I-DFidx1.gif" width="474" alt="Indexed file SELECT and ASSIGN clause syntax diagram" /></p>
 					</div>
 					<div class="section-sidebar">
 						<h4>The Record Key phrase</h4>
@@ -448,21 +448,21 @@ END-IF</code></pre>
 						<h4>The Alternate Record Key phrase</h4>
 					</div>
 					<div class="section-content">
-						<div align="center">
-							<div align="left">
-								<p>
-									In addition to the primary key, up to 254 alternate keys may be defined for the
-									file.
-								</p>
-								<p>
-									Just as with the primary key, these alternate keys must be fields in the file's
-									record description.
-								</p>
-								<p>
-									Each alternate key may be unique or may have duplicate values (for this the WITH
-									DUPLICATES clause is required).
-								</p>
-							</div>
+						
+						<div>
+							<p>
+								In addition to the primary key, up to 254 alternate keys may be defined for the
+								file.
+							</p>
+							<p>
+								Just as with the primary key, these alternate keys must be fields in the file's
+								record description.
+							</p>
+							<p>
+								Each alternate key may be unique or may have duplicate values (for this the WITH
+								DUPLICATES clause is required).
+							</p>
+						
 						</div>
 					</div>
 				</div>
@@ -534,7 +534,7 @@ END-IF</code></pre>
 						<h4>Reading Sequentially</h4>
 					</div>
 					<div class="section-content">
-						<p><img src="Resources/pics/I-DFrel4.gif" alt="" /></p>
+						<p><img src="Resources/pics/I-DFrel4.gif" alt="READ NEXT syntax diagram for sequential access of an Indexed file with DYNAMIC access mode" /></p>
 						<p>
 							<b>Notes</b><b><br /></b> This format is used when the ACCESS MODE is DYNAMIC and we wish to
 							read the file sequentially.
@@ -564,7 +564,7 @@ END-IF</code></pre>
 						<h4>Reading using a key</h4>
 					</div>
 					<div class="section-content">
-						<p><img src="Resources/pics/I-DFrel3.gif" alt="" /></p>
+						<p><img src="Resources/pics/I-DFrel3.gif" alt="Direct READ syntax diagram for reading an Indexed file by key value" /></p>
 						<p>
 							The syntax of the direct READ is the same as that for Relative files but the semantics are
 							somewhat different
@@ -615,7 +615,7 @@ END-IF</code></pre>
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h4 align="left">The WRITE, REWRITE and DELETE verbs.</h4>
+						<h4>The WRITE, REWRITE and DELETE verbs.</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -645,7 +645,7 @@ END-IF</code></pre>
 							Where the START verb appears in a program it is usually followed by a sequential READ or
 							WRITE .
 						</p>
-						<p><img src="Resources/pics/I-DFrel8.gif" alt="" /></p>
+						<p><img src="Resources/pics/I-DFrel8.gif" alt="START verb syntax diagram for positioning the next record pointer in an Indexed file" /></p>
 						<p>
 							<b>Operation<br /></b> To establish a key as the Key of Reference and position the Next
 							Record Pointer at a particular record
@@ -697,10 +697,10 @@ END-IF</code></pre>
 						<h2 id="example">An Comprehensive Example Program</h2>
 					</div>
 					<div class="section-sidebar">
-						<h4 align="left">Program Specification</h4>
+						<h4>Program Specification</h4>
 					</div>
 					<div class="section-content">
-						<p align="center">ROYALTY PAYMENT REPORT PROGRAM.</p>
+						<p class="center-block">ROYALTY PAYMENT REPORT PROGRAM.</p>
 						<p>
 							<b>Introduction</b><br />
 							Each time a book is borrowed, the Niklaus Wirth Memorial Library pays the author a small sum
@@ -727,96 +727,96 @@ END-IF</code></pre>
 						<table border="1" width="100%">
 							<tr>
 								<td width="26%">
-									<div align="center"><b>Field</b></div>
+									<b>Field</b>
 								</td>
-								<td align="center" width="25%">
-									<div align="center"><b>Key Type</b></div>
+								<td width="25%" style="text-align:center">
+									<b>Key Type</b>
 								</td>
-								<td align="center" width="17%">
-									<div align="center"><b>Type</b></div>
+								<td width="17%" style="text-align:center">
+									<b>Type</b>
 								</td>
-								<td align="center" width="14%">
-									<div align="center"><b>Length</b></div>
+								<td width="14%" style="text-align:center">
+									<b>Length</b>
 								</td>
-								<td align="center" width="18%">
-									<div align="center"><b>Value</b></div>
+								<td width="18%" style="text-align:center">
+									<b>Value</b>
 								</td>
 							</tr>
 							<tr>
 								<td width="26%">BookNumber</td>
-								<td align="center" width="25%">primary</td>
-								<td align="center" width="17%">N</td>
-								<td align="center" width="14%">7</td>
-								<td align="center" width="18%">1-9999999</td>
+								<td width="25%" style="text-align:center">primary</td>
+								<td width="17%" style="text-align:center">N</td>
+								<td width="14%" style="text-align:center">7</td>
+								<td width="18%" style="text-align:center">1-9999999</td>
 							</tr>
 							<tr>
 								<td width="26%">BookName</td>
-								<td align="center" width="25%">-</td>
-								<td align="center" width="17%">X</td>
-								<td align="center" width="14%">25</td>
-								<td align="center" width="18%">-</td>
+								<td width="25%" style="text-align:center">-</td>
+								<td width="17%" style="text-align:center">X</td>
+								<td width="14%" style="text-align:center">25</td>
+								<td width="18%" style="text-align:center">-</td>
 							</tr>
 							<tr>
 								<td width="26%">AuthorNumber</td>
-								<td align="center" width="25%">alt with duplicates</td>
-								<td align="center" width="17%">N</td>
-								<td align="center" width="14%">7</td>
-								<td align="center" width="18%">1-9999999</td>
+								<td width="25%" style="text-align:center">alt with duplicates</td>
+								<td width="17%" style="text-align:center">N</td>
+								<td width="14%" style="text-align:center">7</td>
+								<td width="18%" style="text-align:center">1-9999999</td>
 							</tr>
 							<tr>
 								<td width="26%">RoyaltyRate</td>
-								<td align="center" width="25%">-</td>
-								<td align="center" width="17%">N</td>
-								<td align="center" width="14%">3</td>
-								<td align="center" width="18%">.001-.999</td>
+								<td width="25%" style="text-align:center">-</td>
+								<td width="17%" style="text-align:center">N</td>
+								<td width="14%" style="text-align:center">3</td>
+								<td width="18%" style="text-align:center">.001-.999</td>
 							</tr>
 							<tr>
 								<td width="26%">QuarterBorrowings</td>
-								<td align="center" width="25%">-</td>
-								<td align="center" width="17%">N</td>
-								<td align="center" width="14%">3</td>
-								<td align="center" width="18%">0-999</td>
+								<td width="25%" style="text-align:center">-</td>
+								<td width="17%" style="text-align:center">N</td>
+								<td width="14%" style="text-align:center">3</td>
+								<td width="18%" style="text-align:center">0-999</td>
 							</tr>
 						</table>
 						<p>The indexed file AUTHOR.DAT has the following record description;-</p>
 						<table border="1" width="100%">
 							<tr>
 								<td width="26%">
-									<div align="center"><b>Field</b></div>
+									<b>Field</b>
 								</td>
-								<td align="center" width="25%">
-									<div align="center"><b>Key Type</b></div>
+								<td width="25%" style="text-align:center">
+									<b>Key Type</b>
 								</td>
-								<td align="center" width="17%">
-									<div align="center"><b>Type</b></div>
+								<td width="17%" style="text-align:center">
+									<b>Type</b>
 								</td>
-								<td align="center" width="14%">
-									<div align="center"><b>Length</b></div>
+								<td width="14%" style="text-align:center">
+									<b>Length</b>
 								</td>
-								<td align="center" width="18%">
-									<div align="center"><b>Value</b></div>
+								<td width="18%" style="text-align:center">
+									<b>Value</b>
 								</td>
 							</tr>
 							<tr>
 								<td width="26%">AuthorNumber</td>
-								<td align="center" width="25%">primary</td>
-								<td align="center" width="17%">N</td>
-								<td align="center" width="14%">7</td>
-								<td align="center" width="18%">1-9999999</td>
+								<td width="25%" style="text-align:center">primary</td>
+								<td width="17%" style="text-align:center">N</td>
+								<td width="14%" style="text-align:center">7</td>
+								<td width="18%" style="text-align:center">1-9999999</td>
 							</tr>
 							<tr>
 								<td width="26%">AuthorName</td>
-								<td align="center" width="25%">-</td>
-								<td align="center" width="17%">X</td>
-								<td align="center" width="14%">25</td>
-								<td align="center" width="18%">-</td>
+								<td width="25%" style="text-align:center">-</td>
+								<td width="17%" style="text-align:center">X</td>
+								<td width="14%" style="text-align:center">25</td>
+								<td width="18%" style="text-align:center">-</td>
 							</tr>
 							<tr>
 								<td width="26%">AgentName</td>
-								<td align="center" width="25%">alt with duplicates</td>
-								<td align="center" width="17%">X</td>
-								<td align="center" width="14%">25</td>
-								<td align="center" width="18%">-</td>
+								<td width="25%" style="text-align:center">alt with duplicates</td>
+								<td width="17%" style="text-align:center">X</td>
+								<td width="14%" style="text-align:center">25</td>
+								<td width="18%" style="text-align:center">-</td>
 							</tr>
 						</table>
 						<p>
@@ -852,7 +852,7 @@ END-IF</code></pre>
 					</div>
 					<div class="section-full">
 						<hr />
-						<h2 align="center">Example program</h2>
+						<h2 class="center-block">Example program</h2>
 					</div>
 					<pre
 						class="section-full language-cobol"
@@ -1055,11 +1055,11 @@ ProcessOneBook.
     END-REWRITE.</code></pre>
 					<hr />
 					<div class="section-full">
-						<div align="center">
-							<p>
-								<a href="Resources/progs/wirthmemlib.cbl">Download this example program</a>
-							</p>
-						</div>
+						
+						<p>
+							<a href="Resources/progs/wirthmemlib.cbl">Download this example program</a>
+						</p>
+					
 					</div>
 				</div>
 			</div>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -127,7 +127,7 @@
 					</div>
 				</div>
 				<div class="section-full">
-					<div align="center">
+					<div>
 						<hr />
 						<back-to-top></back-to-top>
 					</div>
@@ -193,7 +193,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4 align="left">File Section entries</h4>
+						<h4>File Section entries</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -202,8 +202,8 @@ RD  SalesReport
 							replaced by phrase which points to the Report Description (RD) in the Report Section. The
 							syntax of the phrase is -
 						</p>
-						<p align="center">
-							<img height="48" src="Resources/pics/rwReportIS.gif" width="222" />
+						<p class="center-block">
+							<img height="48" src="Resources/pics/rwReportIS.gif" width="222" alt="REPORT IS clause syntax diagram linking an FD entry to a Report Description" />
 						</p>
 						<p>
 							The <i>ReportName</i> must be the same as the <i>ReportName</i> used in the Report
@@ -252,20 +252,20 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4 align="left">The Report Description (RD) entries - Syntax</h4>
+						<h4>The Report Description (RD) entries - Syntax</h4>
 					</div>
 					<div class="section-content">
 						<p>The syntax for the Report Description (RD) entries is shown below -</p>
-						<p align="center"><img height="277" src="Resources/pics/rwRD.gif" width="360" /></p>
+						<p class="center-block"><img height="277" src="Resources/pics/rwRD.gif" width="360" alt="Report Description (RD) entry syntax diagram" /></p>
 						<hr />
 					</div>
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4 align="left">The Report Description (RD) entries - Semantics</h4>
+						<h4>The Report Description (RD) entries - Semantics</h4>
 					</div>
 					<div class="section-content">
-						<p align="center"><b>RD Rules</b></p>
+						<p class="center-block"><b>RD Rules</b></p>
 						<ol>
 							<li>The <i>ReportName</i> can only appear in one RD entry.</li>
 							<li>
@@ -276,7 +276,7 @@ RD  SalesReport
 							</li>
 						</ol>
 						<hr width="50%" />
-						<p align="center">
+						<p class="center-block">
 							<b><code class="language-cobol">CONTROL</code> Rules</b>
 						</p>
 						<ol>
@@ -295,7 +295,7 @@ RD  SalesReport
 							</li>
 						</ol>
 						<hr width="50%" />
-						<p align="center"><b>PAGE Rules</b></p>
+						<p class="center-block"><b>PAGE Rules</b></p>
 						<ol>
 							<li><i>HeadingLine#l</i> must be greater than or equal to 1.</li>
 							<li>
@@ -353,19 +353,19 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4 align="left">Defining a Report Group Record - Syntax</h4>
+						<h4>Defining a Report Group Record - Syntax</h4>
 					</div>
 					<div class="section-content">
 						<p>
 							<b>Report Group Definition</b>
 						</p>
-						<p><img height="512" src="Resources/pics/rwGroupType.gif" width="405" /></p>
+						<p><img height="512" src="Resources/pics/rwGroupType.gif" width="405" alt="Report Group Definition syntax diagram showing TYPE clause options" /></p>
 						<hr />
 					</div>
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4 align="left"><i>ReportGroupName</i> Rules</h4>
+						<h4><i>ReportGroupName</i> Rules</h4>
 					</div>
 					<div class="section-content">
 						<p>The <i>ReportGroupName</i> is required only when the group -</p>
@@ -386,7 +386,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4 align="left">The <code class="language-cobol">LINE NUMBER</code> clause</h4>
+						<h4>The <code class="language-cobol">LINE NUMBER</code> clause</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -433,7 +433,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4 align="left">The NEXT GROUP clause</h4>
+						<h4>The NEXT GROUP clause</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -470,7 +470,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4 align="left">The TYPE clause</h4>
+						<h4>The TYPE clause</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -520,7 +520,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4 align="left">Introduction</h4>
+						<h4>Introduction</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -534,7 +534,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4 align="left">Defining Report Lines</h4>
+						<h4>Defining Report Lines</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -546,13 +546,13 @@ RD  SalesReport
 						<p>
 							If the <i>ReportLineName</i> is used its only purpose is to qualify a sum counter reference.
 						</p>
-						<p><img height="74" src="Resources/pics/rwGroupDesc1.gif" width="364" /></p>
+						<p><img height="74" src="Resources/pics/rwGroupDesc1.gif" width="364" alt="Report line definition syntax diagram" /></p>
 						<hr />
 					</div>
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4 align="center">Defining Elementary print items in a report group</h4>
+						<h4>Defining Elementary print items in a report group</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -571,13 +571,13 @@ RD  SalesReport
 							The <i>PrintItemName</i> can only be referenced if the entry uses the
 							<code class="language-cobol">SUM</code> clause to define a sum counter.
 						</p>
-						<p><img height="456" src="Resources/pics/rwGroupDesc2.gif" width="413" /></p>
+						<p><img height="456" src="Resources/pics/rwGroupDesc2.gif" width="413" alt="Elementary print item definition syntax diagram" /></p>
 						<hr />
 					</div>
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4 align="left">The COLUMN NUMBER clause</h4>
+						<h4>The COLUMN NUMBER clause</h4>
 					</div>
 					<div class="section-content">
 						<p>
@@ -760,13 +760,13 @@ RD  SalesReport
 						<h4>Introduction</h4>
 					</div>
 					<div class="section-content">
-						<div align="center">
-							<p align="left">
-								The Report Writer maintains two special registers for each report declared in the Report
-								Section. The two registers are -
-							</p>
-						</div>
-						<p align="center">
+						
+						<p>
+							The Report Writer maintains two special registers for each report declared in the Report
+							Section. The two registers are -
+						</p>
+					
+						<p class="center-block">
 							the <code class="language-cobol">LINE-COUNTER</code><br />
 							and<br />
 							the <code class="language-cobol">PAGE-COUNTER</code>
@@ -778,22 +778,22 @@ RD  SalesReport
 						<h4>The <code class="language-cobol">LINE-COUNTER</code> register</h4>
 					</div>
 					<div class="section-content">
-						<p align="left">
+						<p>
 							The reserved word <code class="language-cobol">LINE-COUNTER</code> can be used to access a
 							special register that the Report Writer maintains for each report in the Report Section.
 						</p>
-						<p align="left">
+						<p>
 							The Report Writer uses the <code class="language-cobol">LINE-COUNTER</code> register to keep
 							track of where the lines are being printed on the report. It uses this information and the
 							information specified in the <code class="language-cobol">PAGE LIMIT</code> clause in the RD
 							entry to decide when a new page is required.
 						</p>
-						<p align="left">
+						<p>
 							While the <code class="language-cobol">LINE-COUNTER</code> register can be used as a
 							<code class="language-cobol">SOURCE</code> item in the report no statements in the Procedure
 							Division can alter the value in the register.
 						</p>
-						<p align="left">
+						<p>
 							References to the <code class="language-cobol">LINE-COUNTER</code> register can be qualified
 							by referring to the name of the report given in the RD entry.
 						</p>
@@ -805,29 +805,29 @@ RD  SalesReport
 						<h4>The <code class="language-cobol">PAGE-COUNTER</code> register</h4>
 					</div>
 					<div class="section-content">
-						<div align="center">
-							<p align="left">
-								The reserved word <code class="language-cobol">PAGE-COUNTER</code> can be used to access
-								a special register that the Report Writer maintains for each report in the Report
-								Section.
-							</p>
-							<p align="left">
-								The <code class="language-cobol">PAGE-COUNTER</code> is used to count the number of
-								pages in the report.
-							</p>
-							<p align="left">
-								The <code class="language-cobol">PAGE-COUNTER</code> register can be used as a
-								<code class="language-cobol">SOURCE</code> item in the report but the value of the
-								<code class="language-cobol">PAGE-COUNTER</code> may also be changed by statements in
-								the Procedure Division.
-							</p>
-							<pre class="language-cobol"><code class="language-cobol">01  TYPE IS PAGE FOOTING.
+						
+						<p>
+							The reserved word <code class="language-cobol">PAGE-COUNTER</code> can be used to access
+							a special register that the Report Writer maintains for each report in the Report
+							Section.
+						</p>
+						<p>
+							The <code class="language-cobol">PAGE-COUNTER</code> is used to count the number of
+							pages in the report.
+						</p>
+						<p>
+							The <code class="language-cobol">PAGE-COUNTER</code> register can be used as a
+							<code class="language-cobol">SOURCE</code> item in the report but the value of the
+							<code class="language-cobol">PAGE-COUNTER</code> may also be changed by statements in
+							the Procedure Division.
+						</p>
+						<pre class="language-cobol"><code class="language-cobol">01  TYPE IS PAGE FOOTING.
     02 LINE IS 53.
        03 COLUMN 1      PIC X(29)
                         VALUE "Programmer - Michael Coughlan".
        03 COLUMN 45     PIC X(6) VALUE "Page :".
        03 COLUMN 52     PIC Z9 SOURCE PAGE-COUNTER.</code></pre>
-						</div>
+					
 						<hr />
 					</div>
 				</div>
@@ -839,28 +839,28 @@ RD  SalesReport
 						<h4>Introduction</h4>
 					</div>
 					<div class="section-content">
-						<div align="center">
-							<p align="left">
-								The Report Writer introduces four new verbs for processing reports. These are -
-							</p>
-						</div>
+						
+						<p>
+							The Report Writer introduces four new verbs for processing reports. These are -
+						</p>
+					
 						<ol>
 							<li><code class="language-cobol">INITIATE</code></li>
 							<li><code class="language-cobol">GENERATE</code></li>
 							<li><code class="language-cobol">TERMINATE</code></li>
 							<li><code class="language-cobol">SUPPRESS PRINTING</code></li>
 						</ol>
-						<div align="center">
-							<p align="left">
-								The first three are normal Procedure Division verbs but the last can only be used in the
-								Declaratives Section.
-							</p>
-							<p align="left">
-								The normal Procedure Division verbs will be covered in this section. Please see the
-								section on Declaratives for the
-								<code class="language-cobol">SUPPRESS PRINTING</code> statement.
-							</p>
-						</div>
+						
+						<p>
+							The first three are normal Procedure Division verbs but the last can only be used in the
+							Declaratives Section.
+						</p>
+						<p>
+							The normal Procedure Division verbs will be covered in this section. Please see the
+							section on Declaratives for the
+							<code class="language-cobol">SUPPRESS PRINTING</code> statement.
+						</p>
+					
 						<hr />
 					</div>
 				</div>
@@ -869,7 +869,7 @@ RD  SalesReport
 						<h4>Syntax</h4>
 					</div>
 					<div class="section-content">
-						<p><img height="144" src="Resources/pics/rwVerbs.gif" width="238" /></p>
+						<p><img height="144" src="Resources/pics/rwVerbs.gif" width="238" alt="Report Writer Procedure Division verbs syntax diagram (INITIATE, GENERATE, TERMINATE, SUPPRESS PRINTING)" /></p>
 						<hr />
 					</div>
 				</div>
@@ -1035,7 +1035,7 @@ Programmer - Michael Coughlan               Page :  1</code></pre>
 							Declaratives may also be used to handle file operation errors. In this case the
 							<code class="language-cobol">USE</code> clause should use the following syntax -
 						</p>
-						<p align="center"><img height="173" src="Resources/pics/rwUSE1.gif" width="495" /></p>
+						<p class="center-block"><img height="173" src="Resources/pics/rwUSE1.gif" width="495" alt="USE clause syntax diagram for Declaratives file error handling" /></p>
 						<hr />
 					</div>
 				</div>
@@ -1057,20 +1057,20 @@ Programmer - Michael Coughlan               Page :  1</code></pre>
 							When Declaratives are used with the Report Writer the
 							<code class="language-cobol">USE</code> syntax shown below must be used
 						</p>
-						<p align="center"><img height="22" src="Resources/pics/rwUSE2.gif" width="402" /></p>
-						<p align="left"><b>Rules:</b></p>
-						<p align="left">
+						<p class="center-block"><img height="22" src="Resources/pics/rwUSE2.gif" width="402" alt="USE BEFORE REPORTING syntax diagram for Report Writer Declaratives" /></p>
+						<p><b>Rules:</b></p>
+						<p>
 							The ReportGroupName must not appear in more than one
 							<code class="language-cobol">USE</code> statement.
 						</p>
-						<p align="left">
+						<p>
 							The <code class="language-cobol">GENERATE</code>,
 							<code class="language-cobol">INITIATE</code> and
 							<code class="language-cobol">TERMINATE</code> statements must not appear in the
 							Declaratives.
 						</p>
-						<p align="left">The value of any control data items must not be altered in the Declaratives.</p>
-						<p align="left">
+						<p>The value of any control data items must not be altered in the Declaratives.</p>
+						<p>
 							Statements in the Declaratives must not reference non-declarative procedures.
 						</p>
 					</div>
@@ -1080,8 +1080,8 @@ Programmer - Michael Coughlan               Page :  1</code></pre>
 						<h4>Declaratives Example</h4>
 					</div>
 					<div class="section-content">
-						<div align="center">
-							<pre class="language-cobol"><code class="language-cobol">PROCEDURE DIVISION.
+						
+						<pre class="language-cobol"><code class="language-cobol">PROCEDURE DIVISION.
 DECLARATIVES.
 Calc SECTION.
     USE BEFORE REPORTING SalesPersonGrp.
@@ -1097,7 +1097,7 @@ Begin.
     OPEN INPUT SalesFile.
     OPEN OUTPUT PrintFile.
     *> etc </code></pre>
-						</div>
+					
 						<hr />
 					</div>
 				</div>
@@ -1110,16 +1110,16 @@ Begin.
 							The <code class="language-cobol">SUPPRESS PRINTING</code> statement is used in a Declarative
 							section to stop a particular report group from being printed.
 						</p>
-						<p align="left">
+						<p>
 							The report group suppressed is the one mentioned in the
 							<code class="language-cobol">USE</code> statement associated with the section containing the
 							<code class="language-cobol">SUPPRESS PRINTING</code> statement.
 						</p>
-						<p align="left">
+						<p>
 							The <code class="language-cobol">SUPPRESS PRINTING</code> statement must be executed each
 							time you want to stop the report group from being printed.
 						</p>
-						<p align="left">
+						<p>
 							In the example below we only want to print the ShopTotalGrp if the sales for the shop are
 							greater than or equal to 10,000.
 						</p>
@@ -1140,30 +1140,30 @@ END DECLARATIVES.</code></pre>
 						<h4>Control Break Registers</h4>
 					</div>
 					<div class="section-content">
-						<div align="center">
-							<p align="left">
-								A control break occurs when the value in a control break item changes. This causes an
-								interesting problem when the control break item is used as the
-								<code class="language-cobol">SOURCE</code> value in a control footing because by the
-								time the control footing is printed, the control break item no longer contains the
-								correct value. When we print a control footing and refer to a control break item we
-								normally want to access the previous value of the item not the current one.
-							</p>
-							<p align="left">
-								The Report Writer deals with this problem by maintaining a special control break
-								register for each control break item mentioned in the
-								<code class="language-cobol">CONTROLS ARE</code> phrase in the RD entry.
-							</p>
-							<p align="left">
-								When a control break item is referred to in a control footing or in the Declaratives the
-								Report Writer supplies the value held in the control break register and not the value in
-								the item itself.
-							</p>
-							<p align="left">
-								If a control break has just occurred the value in the control break register is the
-								previous value of the control break item.
-							</p>
-						</div>
+						
+						<p>
+							A control break occurs when the value in a control break item changes. This causes an
+							interesting problem when the control break item is used as the
+							<code class="language-cobol">SOURCE</code> value in a control footing because by the
+							time the control footing is printed, the control break item no longer contains the
+							correct value. When we print a control footing and refer to a control break item we
+							normally want to access the previous value of the item not the current one.
+						</p>
+						<p>
+							The Report Writer deals with this problem by maintaining a special control break
+							register for each control break item mentioned in the
+							<code class="language-cobol">CONTROLS ARE</code> phrase in the RD entry.
+						</p>
+						<p>
+							When a control break item is referred to in a control footing or in the Declaratives the
+							Report Writer supplies the value held in the control break register and not the value in
+							the item itself.
+						</p>
+						<p>
+							If a control break has just occurred the value in the control break register is the
+							previous value of the control break item.
+						</p>
+					
 					</div>
 				</div>
 			</div>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -55,16 +55,16 @@
 					<h4>Aims</h4>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<p align="left">
-							In most programming languages the term "array" is used to describe repeated, or multiple-
-							occurrence, data-items. COBOL uses the term - "table".
-						</p>
-						<p align="left">
-							In this tutorial you will discover why a table, or array, is a useful structure for solving
-							certain kinds of problems.
-						</p>
-					</div>
+					
+					<p>
+						In most programming languages the term "array" is used to describe repeated, or multiple-
+						occurrence, data-items. COBOL uses the term - "table".
+					</p>
+					<p>
+						In this tutorial you will discover why a table, or array, is a useful structure for solving
+						certain kinds of problems.
+					</p>
+				
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
@@ -102,10 +102,10 @@
 					</ul>
 				</div>
 				<div class="section-full">
-					<div align="center">
-						<hr />
-						<back-to-top></back-to-top>
-					</div>
+					
+					<hr />
+					<back-to-top></back-to-top>
+				
 				</div>
 			</div>
 
@@ -116,32 +116,32 @@
 				</div>
 				<div class="section-sidebar">
 					<h4>Introduction</h4>
-					<p align="center"><img height="44" src="Resources/pics/program-fragment.svg" width="48" alt="Program fragment" /></p>
+					<p class="center-block"><img height="44" src="Resources/pics/program-fragment.svg" width="48" alt="Program fragment" /></p>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<p align="left">
-							Let's start our discussion of tables and table handling, by looking at a programming
-							problem.
-						</p>
-						<p align="left">
-							Suppose we are asked to write a program to sum the taxes paid by people all over the
-							country. The data is obtained from a file containing the amount paid in taxes by PAYE
-							workers all over the country. The TaxFile is a sequential file sequenced on ascending
-							PAYENum and its records have the following description.
-						</p>
-						<pre class="language-cobol"><code class="language-cobol">01 TaxRec.
+					
+					<p>
+						Let's start our discussion of tables and table handling, by looking at a programming
+						problem.
+					</p>
+					<p>
+						Suppose we are asked to write a program to sum the taxes paid by people all over the
+						country. The data is obtained from a file containing the amount paid in taxes by PAYE
+						workers all over the country. The TaxFile is a sequential file sequenced on ascending
+						PAYENum and its records have the following description.
+					</p>
+					<pre class="language-cobol"><code class="language-cobol">01 TaxRec.
    88 EndOfTaxFile  VALUE HIGH-VALUES.
    02 PAYENum    PIC 9(8)
    02 CountyCode PIC 99.
    02 TaxPaid    PIC 9(7)V99.
 </code></pre>
-						<p align="left">
-							The program to perform this task is very simple. All we have to do is to set up a variable
-							to hold the tax total and then add the TaxPaid from each record to the TaxTotal. The program
-							to do this is shown below;
-						</p>
-						<pre class="language-cobol"><code class="language-cobol">PROCEDURE DIVISION.
+					<p>
+						The program to perform this task is very simple. All we have to do is to set up a variable
+						to hold the tax total and then add the TaxPaid from each record to the TaxTotal. The program
+						to do this is shown below;
+					</p>
+					<pre class="language-cobol"><code class="language-cobol">PROCEDURE DIVISION.
 Begin.
    OPEN INPUT TaxFile
    READ TaxFile
@@ -157,98 +157,98 @@ Begin.
    CLOSE TaxFile
    STOP RUN.
 </code></pre>
-						<p align="left">
-							But what if, instead of just calculating the tax total for the whole country, we were asked
-							to produce a breakdown of the tax totals by county. How could we solve that problem?
-						</p>
-					</div>
+					<p>
+						But what if, instead of just calculating the tax total for the whole country, we were asked
+						to produce a breakdown of the tax totals by county. How could we solve that problem?
+					</p>
+				
 				</div>
 				<div class="section-sidebar">
 					<h4>Exploring the problem</h4>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<p align="left">
-							One approach to the problem of producing the County Tax Report would be to sort the file on
-							CountyCode. This would turn the problem into a simple control break problem (i.e. process
-							all the records for one county, output the result and then go on to the next). But the
-							TaxFile contains millions of records and sorting is a comparatively slow, disk-intensive,
-							procedure. We will only sort the file as a last resort. Is there any other way to solve the
-							problem?
-						</p>
-						<p align="left">
-							Another solution that we might adopt is to create 26 variables to hold the county tax
-							totals. Then, in the program, we could use an
-							<code class="language-cobol">EVALUATE</code> statement to add the TaxPaid to the appropriate
-							total. For example -
-						</p>
-					</div>
+					
+					<p>
+						One approach to the problem of producing the County Tax Report would be to sort the file on
+						CountyCode. This would turn the problem into a simple control break problem (i.e. process
+						all the records for one county, output the result and then go on to the next). But the
+						TaxFile contains millions of records and sorting is a comparatively slow, disk-intensive,
+						procedure. We will only sort the file as a last resort. Is there any other way to solve the
+						problem?
+					</p>
+					<p>
+						Another solution that we might adopt is to create 26 variables to hold the county tax
+						totals. Then, in the program, we could use an
+						<code class="language-cobol">EVALUATE</code> statement to add the TaxPaid to the appropriate
+						total. For example -
+					</p>
+				
 					<blockquote>
-						<div align="center">
-							<div align="left">
-								<pre class="language-cobol" align="left"><code class="language-cobol">
+						
+						<div>
+							<pre class="language-cobol"><code class="language-cobol">
 EVALUATE CountyCode
    WHEN 1 ADD TaxPaid TO County1TaxTotal
    WHEN 2 ADD TaxPaid TO County2TaxTotal
    WHEN 3 ADD TaxPaid TO County3TaxTotal
    ..... 23 more WHEN branches
 END-EVALUATE</code></pre>
-							</div>
+						
 						</div>
 					</blockquote>
-					<div align="center">
-						<div align="left">
-							<p>
-								But this solution is not very satisfactory. We have to have a specific
-								<code class="language-cobol">WHEN</code> branch to process each county and we have to
-								declare 26 variables to hold the tax totals. And when we want to print the results we
-								have to have 26 <code class="language-cobol">DISPLAY</code> statements such as -
-							</p>
-						</div>
+					
+					<div>
+						<p>
+							But this solution is not very satisfactory. We have to have a specific
+							<code class="language-cobol">WHEN</code> branch to process each county and we have to
+							declare 26 variables to hold the tax totals. And when we want to print the results we
+							have to have 26 <code class="language-cobol">DISPLAY</code> statements such as -
+						</p>
+					
 					</div>
 					<blockquote>
-						<div align="center">
-							<div align="left">
-								<pre
-									class="language-cobol"
-								><code class="language-cobol">DISPLAY "County 1 total is ", County1TaxTotal
+						
+						<div>
+							<pre
+								class="language-cobol"
+							><code class="language-cobol">DISPLAY "County 1 total is ", County1TaxTotal
 DISPLAY "County 2 total is ", County2TaxTotal
 DISPLAY "County 3 total is ", County3TaxTotal
         ..... 23 more DISPLAY statements </code></pre>
-							</div>
+						
 						</div>
 					</blockquote>
-					<div align="center">
-						<div align="left">
-							<p>
-								But the suggestion above does contain the germ of a satisfactory solution to the
-								problem. It is interesting to note that the processing of each
-								<code class="language-cobol">WHEN</code> branch is exactly the same - the TaxPaid is
-								added to a particular county total variable. We could replace all 26
-								<code class="language-cobol">WHEN</code> branches with one statement if we could
-								generalize it to something like -
-								<i>ADD the TaxPaid TO the CountyTotal location indicated by the CountyCode</i>.
-							</p>
-							<p>
-								There is also something interesting we can note about the 26 variables.They all have
-								exactly the same <code class="language-cobol">PICTURE</code> and they all have, more or
-								less, the same name - CountyTaxTotal. The only way we distinguish between one
-								CountyTaxTotal and another is by attaching a number to the name e.g. County1TaxTotal,
-								County2TaxTotal, County3TaxTotal etc.
-							</p>
-							<p>
-								When we see a group of variables which all have the same name and the same description
-								and are only distinguished from one another by some number attached to the name, we know
-								that we have a problem crying out for a table-based solution.
-							</p>
-						</div>
+					
+					<div>
+						<p>
+							But the suggestion above does contain the germ of a satisfactory solution to the
+							problem. It is interesting to note that the processing of each
+							<code class="language-cobol">WHEN</code> branch is exactly the same - the TaxPaid is
+							added to a particular county total variable. We could replace all 26
+							<code class="language-cobol">WHEN</code> branches with one statement if we could
+							generalize it to something like -
+							<i>ADD the TaxPaid TO the CountyTotal location indicated by the CountyCode</i>.
+						</p>
+						<p>
+							There is also something interesting we can note about the 26 variables.They all have
+							exactly the same <code class="language-cobol">PICTURE</code> and they all have, more or
+							less, the same name - CountyTaxTotal. The only way we distinguish between one
+							CountyTaxTotal and another is by attaching a number to the name e.g. County1TaxTotal,
+							County2TaxTotal, County3TaxTotal etc.
+						</p>
+						<p>
+							When we see a group of variables which all have the same name and the same description
+							and are only distinguished from one another by some number attached to the name, we know
+							that we have a problem crying out for a table-based solution.
+						</p>
+					
 					</div>
 				</div>
 				<div class="section-full">
-					<div align="center">
-						<hr />
-						<back-to-top></back-to-top>
-					</div>
+					
+					<hr />
+					<back-to-top></back-to-top>
+				
 				</div>
 			</div>
 
@@ -285,7 +285,7 @@ DISPLAY "County 3 total is ", County3TaxTotal
 				</div>
 				<div class="section-sidebar">
 					<h4>Declaring the CountyTax table</h4>
-					<h4 align="center">
+					<h4>
 						<a href="Resources/ppz/TC-Tables1.html"
 							><img height="62" src="Resources/pics/i-Animation.gif" width="62" alt=""
 						/></a>
@@ -294,30 +294,29 @@ DISPLAY "County 3 total is ", County3TaxTotal
 					when they execute. Click on the diagram or the icon to see an animated answer.
 				</div>
 				<div class="section-content">
-					<p align="left">
+					<p>
 						In COBOL, a table is declared by specifying the type (or structure) of a single item (element)
 						of the table and then specifying that the data-item is to be repeated
 						<i>x</i> number of times. For instance, the CountyTax table might be defined as -
 					</p>
-					<pre class="language-cobol" align="left"><code class="language-cobol">01 CountyTaxTable.
+					<pre class="language-cobol"><code class="language-cobol">01 CountyTaxTable.
    02 CountyTax       PIC 9(8)V99  OCCURS 26 TIMES.</code></pre>
-					<p align="left">
+					<p>
 						The CountyTax table can be represented diagrammatically as shown below. All the elements of the
 						table have the name CountyTax and we can refer to a specific one by using that name, followed by
 						an integer value in brackets. So CountyTax(2) refers to the second element of the table and
 						CountyTax(23) refers to the twenty third element.
 					</p>
-					<p align="left">
+					<p>
 						But when we refer to an element we don't have to use an numeric literal. We can use anything
 						that evaluates to a numeric value between 1 and the size of the table; even a simple arithmetic
 						expression.
 					</p>
-					<p align="left">
+					<p>
 						<a href="Resources/ppz/TC-Tables1.html"
-							><img height="71" src="Resources/pics/Tables1.gif" width="456"
-						/></a>
+							><img height="71" src="Resources/pics/Tables1.gif" width="456" alt="Diagram of the CountyTax table showing 26 elements indexed by CountyCode" /></a>
 					</p>
-					<pre class="language-cobol" align="left"><code class="language-cobol">MOVE 10 TO CountyTax(3)
+					<pre class="language-cobol"><code class="language-cobol">MOVE 10 TO CountyTax(3)
 ADD TaxPaid TO CountyTax(CountyCode)
 ADD TaxPaid TO CountyTax(CountyCode + 1)
 ADD TaxPaid TO CountyTax(CountyCode - 2)</code></pre>
@@ -325,7 +324,7 @@ ADD TaxPaid TO CountyTax(CountyCode - 2)</code></pre>
 				</div>
 				<div class="section-sidebar">
 					<h4>The County Tax Report program</h4>
-					<p align="center"><img height="44" src="Resources/pics/program-fragment.svg" width="48" alt="Program fragment" /></p>
+					<p class="center-block"><img height="44" src="Resources/pics/program-fragment.svg" width="48" alt="Program fragment" /></p>
 				</div>
 				<div class="section-content">
 					<p>
@@ -362,10 +361,10 @@ Begin.
    STOP RUN.</code></pre>
 				</div>
 				<div class="section-full">
-					<div align="center">
-						<hr />
-						<back-to-top></back-to-top>
-					</div>
+					
+					<hr />
+					<back-to-top></back-to-top>
+				
 				</div>
 			</div>
 
@@ -378,27 +377,27 @@ Begin.
 					<h4>Introduction</h4>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<p align="left">
-							When the program above displays the accumulated tax totals, instead of displaying a county
-							name, it displays a county code. The problem with this is that, if the user is going to make
-							any sense of the report, he has to remember which codes represent which counties. In a real
-							environment, you couldn't present the user with the information in this form. The county
-							name would have to be displayed.
-						</p>
-						<p align="left">So how would we go about displaying the county name?</p>
-					</div>
+					
+					<p>
+						When the program above displays the accumulated tax totals, instead of displaying a county
+						name, it displays a county code. The problem with this is that, if the user is going to make
+						any sense of the report, he has to remember which codes represent which counties. In a real
+						environment, you couldn't present the user with the information in this form. The county
+						name would have to be displayed.
+					</p>
+					<p>So how would we go about displaying the county name?</p>
+				
 				</div>
 				<div class="section-sidebar">
 					<h4>A table-based solution</h4>
-					<p align="center"><img height="44" src="Resources/pics/program-fragment.svg" width="48" alt="Program fragment" /></p>
+					<p class="center-block"><img height="44" src="Resources/pics/program-fragment.svg" width="48" alt="Program fragment" /></p>
 				</div>
 				<div class="section-content">
 					<p>
 						One solution might be to use an <code class="language-cobol">EVALUATE</code> to examine the
 						CountyCode and then display the appropriate message. For example -
 					</p>
-					<pre class="language-cobol" align="left"><code class="language-cobol">EVALUATE CountyCode
+					<pre class="language-cobol"><code class="language-cobol">EVALUATE CountyCode
   WHEN 1 DISPLAY "Carlow tax total is " CountyTax(1)
   WHEN 2 DISPLAY "Cavan tax total is "  CountyTax(2)
    .... 24 more WHEN branches
@@ -441,28 +440,28 @@ Begin.
 					<h4>A diagrammatic representation of the CountyName table</h4>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<p align="left">
-							In the next tutorial we will examine how we can use the
-							<code class="language-cobol">REDEFINES</code> clause to set up a predefined table of values.
-							For the moment, we won't concern ourselves with the exact mechanics of setting up the
-							CountyName table but we can represent it diagrammatically as follows;
-						</p>
-						<p align="center">
-							<img height="81" src="Resources/pics/Tables2.gif" width="459" />
-						</p>
-						<p align="left">
-							The elements of the table may be referenced in the usual way, so the statement
-							<code class="language-cobol">DISPLAY</code> CountyName(3) will display the value "Cork" and
-							<code class="language-cobol">DISPLAY</code> CountyName(5) will display "Dublin".
-						</p>
-					</div>
+					
+					<p>
+						In the next tutorial we will examine how we can use the
+						<code class="language-cobol">REDEFINES</code> clause to set up a predefined table of values.
+						For the moment, we won't concern ourselves with the exact mechanics of setting up the
+						CountyName table but we can represent it diagrammatically as follows;
+					</p>
+					<p class="center-block">
+						<img height="81" src="Resources/pics/Tables2.gif" width="459" alt="Diagram of the CountyName table showing county names indexed by position" />
+					</p>
+					<p>
+						The elements of the table may be referenced in the usual way, so the statement
+						<code class="language-cobol">DISPLAY</code> CountyName(3) will display the value "Cork" and
+						<code class="language-cobol">DISPLAY</code> CountyName(5) will display "Dublin".
+					</p>
+				
 				</div>
 				<div class="section-full">
-					<div align="center">
-						<hr />
-						<back-to-top></back-to-top>
-					</div>
+					
+					<hr />
+					<back-to-top></back-to-top>
+				
 				</div>
 			</div>
 
@@ -472,7 +471,7 @@ Begin.
 					<h2 id="part4">Using one table to index into another</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4 align="left">Introduction</h4>
+					<h4>Introduction</h4>
 				</div>
 				<div class="section-content">
 					<p>
@@ -501,13 +500,13 @@ Begin.
 					<h4>An EVALUATE based solution</h4>
 				</div>
 				<div class="section-content">
-					<p align="left">
+					<p>
 						If the tax record contains a county name instead of a county code then we must devise some way
 						to convert the county name into a numeric value that we can use as a table index. What we need
 						to do, is to convert the first county name into the value 1, the second into the value 2 and so
 						on.
 					</p>
-					<p align="left">
+					<p>
 						One approach we might try, is the now discredited
 						<code class="language-cobol">EVALUATE</code> based solution. For example -
 					</p>
@@ -517,42 +516,41 @@ Begin.
    ..... 24 more WHEN branches
 END-EVALUATE
 ADD TaxPaid TO CountyTax(CountyNum)</code></pre>
-					<p align="left">
+					<p>
 						But by now we realise that there must be a more elegant solution. The question is - what is it?
 					</p>
 				</div>
 				<div class="section-sidebar">
 					<h4>Using the subscript from one table as the index into another</h4>
-					<p align="center"><img height="44" src="Resources/pics/program-fragment.svg" width="48" alt="Program fragment" /></p>
+					<p class="center-block"><img height="44" src="Resources/pics/program-fragment.svg" width="48" alt="Program fragment" /></p>
 				</div>
 				<div class="section-content">
-					<p align="left">
+					<p>
 						To convert the county name to a numeric value, we can use the table of CountyNames that we
 						created in the previous section. We will compare the county name in the record with the contents
 						of each element of the CountyName table and, when they match, we will use the value of the
 						CountyName subscript as an index into the CountyTax table.
 					</p>
-					<p align="left">
+					<p>
 						To compare the value of County with each element of the CountyNames table we can use a
 						<code class="language-cobol">PERFORM..VARYING</code>. For example -
 					</p>
 					<pre
 						class="language-cobol"
-						align="left"
 					><code class="language-cobol">    PERFORM VARYING CountyNum FROM 1 BY 1
          UNTIL CountyName(CountyNum) = County
     END-PERFORM
     ADD TaxPaid TO CountyTax(CountyNum)</code></pre>
-					<p align="left">
+					<p>
 						You can see how this <code class="language-cobol">PERFORM..VARYING</code> works, in the
 						following animation -
 					</p>
-					<p align="center">
+					<p class="center-block">
 						<a href="Resources/ppz/TC-Tables2.html"
 							><img height="62" src="Resources/pics/i-Animation.gif" width="62" alt=""
 						/></a>
 					</p>
-					<p align="left">
+					<p>
 						and you can see where it fits into the County Tax Report program, in the example below.
 					</p>
 					<pre class="language-cobol"><code class="language-cobol">PROCEDURE DIVISION.


### PR DESCRIPTION
## Summary
- Deep-cleaned 4 course pages to 0 pa11y violations (WCAG 2.1 AA)
- `ReportWriterSS.html`, `Copy.html`, `Tables1.html`, `IndexedFiles.html`

## Changes per file
- Added descriptive `alt` text to content figures (syntax diagrams, report structure diagrams)
- Stripped `align="left"` attributes (LTR default)
- Replaced `align="center"` on block elements with `class="center-block"`
- Replaced `align="center"` on `<td>`/`<th>` with `style="text-align:center"`
- Replaced `align="center"` on `<table>` with `style="margin:0 auto"`
- Unwrapped `<center>` and `<div align="center">` elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)