### PR TITLE
Make Usage, RefMod, Intro2DirectAccess, index pa11y-clean

### DIFF
--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -254,7 +254,7 @@
 								src="Resources/pdf-viewer.html?src=ppz/seqintro.pdf"
 								style="border: 1px solid #ccc; width: 100%; aspect-ratio: 525/600"
 								width="525"
-							></iframe>
+							 title="Sequential file operations animation"></iframe>
 						</p>
 						<hr />
 					</div>
@@ -349,7 +349,7 @@
 							this number allows the record to be accessed directly because the system can use
 						</p>
 						<blockquote>
-							<div align="left">
+							<div>
 								the start position of the file on disk,<br />
 								the size of the record,<br />
 								and the Relative Record Number
@@ -384,7 +384,7 @@
 									src="Resources/pdf-viewer.html?src=ppz/relintro.pdf"
 									style="border: 1px solid #ccc; width: 100%; aspect-ratio: 354/416"
 									width="354"
-								></iframe>
+								 title="Relative file operations animation"></iframe>
 							</div>
 						</div>
 						<hr />
@@ -484,14 +484,12 @@
 ELSE
    go to next index record
 END-IF</code></pre>
-						<div align="center">
-							<iframe
-								height="325"
+						<iframe
+							height="325"
 								src="Resources/pdf-viewer.html?src=ppz/idxintro.pdf"
 								style="border: 1px solid #ccc; width: 100%; aspect-ratio: 486/325"
-								width="486"
-							></iframe>
-						</div>
+							width="486"
+						 title="Indexed file operations animation"></iframe>
 						<hr />
 					</div>
 				</div>
@@ -532,11 +530,11 @@ END-IF</code></pre>
 						<h4>Sequential files</h4>
 					</div>
 					<div class="section-content">
-						<h4 align="center">Disadvantages</h4>
+						<h4 class="center-block">Disadvantages</h4>
 						<table border="3" cellpadding="4" width="100%">
 							<tr>
 								<td bgcolor="#E8E8E8" width="150">
-									<div align="center"><b>Slow</b></div>
+									<div class="center-block"><b>Slow</b></div>
 								</td>
 								<td width="404">
 									<p>
@@ -554,7 +552,7 @@ END-IF</code></pre>
 							</tr>
 							<tr>
 								<td bgcolor="#E8E8E8" width="150">
-									<div align="center"><b>Complicated</b></div>
+									<div class="center-block"><b>Complicated</b></div>
 								</td>
 								<td width="404">
 									<p>
@@ -570,11 +568,11 @@ END-IF</code></pre>
 								</td>
 							</tr>
 						</table>
-						<h4 align="center">Advantages</h4>
+						<h4 class="center-block">Advantages</h4>
 						<table border="1" cellpadding="4" width="101%">
 							<tr>
 								<td bgcolor="#E8E8E8" valign="middle" width="150">
-									<div align="center"><b>Fast</b></div>
+									<div class="center-block"><b>Fast</b></div>
 								</td>
 								<td valign="top" width="364">
 									<p>
@@ -586,7 +584,7 @@ END-IF</code></pre>
 							</tr>
 							<tr>
 								<td bgcolor="#E8E8E8" valign="middle" width="150">
-									<div align="center"><b>Most storage efficient</b></div>
+									<div class="center-block"><b>Most storage efficient</b></div>
 								</td>
 								<td valign="top" width="364">
 									<p>
@@ -598,7 +596,7 @@ END-IF</code></pre>
 							</tr>
 							<tr>
 								<td bgcolor="#E8E8E8" valign="middle" width="150">
-									<div align="center"><b>Simple organization</b></div>
+									<div class="center-block"><b>Simple organization</b></div>
 								</td>
 								<td valign="top" width="364">
 									<p>This is the simplest file organization. Records are held serially.</p>
@@ -606,7 +604,7 @@ END-IF</code></pre>
 							</tr>
 							<tr>
 								<td bgcolor="#E8E8E8" valign="middle" width="150">
-									<div align="center"><b>Files may be stored on serial media</b></div>
+									<div class="center-block"><b>Files may be stored on serial media</b></div>
 								</td>
 								<td valign="top" width="364">
 									<p>Sequential files may be stored on serial media such as magnetica tape.</p>
@@ -622,13 +620,13 @@ END-IF</code></pre>
 						<h4>Relative files</h4>
 					</div>
 					<div class="section-content">
-						<h4 align="center">Disadvantages</h4>
+						<h4 class="center-block">Disadvantages</h4>
 						<table border="3" cellpadding="4" width="100%">
 							<tr>
 								<td bgcolor="#E8E8E8" width="150">
-									<div align="center">
+									<div class="center-block">
 										<b>Wastes storage if the file is only partially populated</b>
-									</div>
+										</div>
 								</td>
 								<td width="433">
 									<p>
@@ -649,9 +647,9 @@ END-IF</code></pre>
 							</tr>
 							<tr>
 								<td bgcolor="#E8E8E8" width="150">
-									<div align="center">
+									<div class="center-block">
 										<b>Cannot recover space from deleted records</b>
-									</div>
+										</div>
 								</td>
 								<td width="433">
 									<p>Relative files cannot recover the space from deleted records.</p>
@@ -668,7 +666,7 @@ END-IF</code></pre>
 							</tr>
 							<tr>
 								<td bgcolor="#E8E8E8" width="150">
-									<div align="center"><b>Only a single key allowed</b></div>
+									<div class="center-block"><b>Only a single key allowed</b></div>
 								</td>
 								<td width="433">
 									<p>The usefulness of Relative files is severely constrained by the fact that;</p>
@@ -687,7 +685,7 @@ END-IF</code></pre>
 							</tr>
 							<tr>
 								<td bgcolor="#E8E8E8" width="150">
-									<div align="center"><b>The key must be numeric</b></div>
+									<div class="center-block"><b>The key must be numeric</b></div>
 								</td>
 								<td width="433">
 									<p>
@@ -699,7 +697,7 @@ END-IF</code></pre>
 							</tr>
 							<tr>
 								<td bgcolor="#E8E8E8" width="150">
-									<div align="center"><b>The key is inflexible</b></div>
+									<div class="center-block"><b>The key is inflexible</b></div>
 								</td>
 								<td width="433">
 									<p>
@@ -746,11 +744,11 @@ END-IF</code></pre>
 								</td>
 							</tr>
 						</table>
-						<h4 align="center">Advantages</h4>
+						<h4 class="center-block">Advantages</h4>
 						<table border="1" cellpadding="4" width="101%">
 							<tr>
 								<td bgcolor="#E8E8E8" width="150">
-									<div align="center"><b>Fastest direct access organization</b></div>
+									<div class="center-block"><b>Fastest direct access organization</b></div>
 								</td>
 								<td width="73%">
 									<p>
@@ -761,7 +759,7 @@ END-IF</code></pre>
 							</tr>
 							<tr>
 								<td bgcolor="#E8E8E8" width="150">
-									<div align="center"><b>Very little storage overhead</b></div>
+									<div class="center-block"><b>Very little storage overhead</b></div>
 								</td>
 								<td width="73%">
 									<p>
@@ -772,7 +770,7 @@ END-IF</code></pre>
 							</tr>
 							<tr>
 								<td bgcolor="#E8E8E8" width="150">
-									<div align="center"><b>Can be read sequentially</b></div>
+									<div class="center-block"><b>Can be read sequentially</b></div>
 								</td>
 								<td width="73%">
 									<p>
@@ -790,11 +788,11 @@ END-IF</code></pre>
 						<h4>Indexed files</h4>
 					</div>
 					<div class="section-content">
-						<h4 align="center">Disadvantages</h4>
+						<h4 class="center-block">Disadvantages</h4>
 						<table border="3" cellpadding="4" width="100%">
 							<tr>
 								<td bgcolor="#E8E8E8" width="150">
-									<div align="center"><b>Slowest direct access organization</b></div>
+									<div class="center-block"><b>Slowest direct access organization</b></div>
 								</td>
 								<td width="73%">
 									<p>
@@ -818,7 +816,7 @@ END-IF</code></pre>
 							</tr>
 							<tr>
 								<td bgcolor="#E8E8E8" width="150">
-									<div align="center"><b>Not very storage efficient</b></div>
+									<div class="center-block"><b>Not very storage efficient</b></div>
 								</td>
 								<td width="73%">
 									<p>
@@ -836,7 +834,7 @@ END-IF</code></pre>
 							</tr>
 							<tr>
 								<td bgcolor="#E8E8E8" width="150">
-									<div align="center"><b>Must be stored on direct access media</b></div>
+									<div class="center-block"><b>Must be stored on direct access media</b></div>
 								</td>
 								<td width="73%">
 									Because Indexed files are direct access files they must be stored on direct access
@@ -844,11 +842,11 @@ END-IF</code></pre>
 								</td>
 							</tr>
 						</table>
-						<h4 align="center">Advantages</h4>
+						<h4 class="center-block">Advantages</h4>
 						<table border="1" cellpadding="4" width="101%">
 							<tr>
 								<td bgcolor="#E8E8E8" width="27%">
-									<div align="center"><b>Versatile keys</b></div>
+									<div class="center-block"><b>Versatile keys</b></div>
 								</td>
 								<td width="73%">
 									<p>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -128,7 +128,7 @@
 					<blockquote>
 						<p><b>DataName(</b><i>StartPos</i> [<b>:</b><i>SubStrLength</i>]<b>)</b></p>
 					</blockquote>
-					<p align="left">
+					<p>
 						<i>StartPos</i> is the character position of the first character in the sub-string and
 						<i>SubStrLength</i> is number of characters in the substring.
 					</p>
@@ -148,12 +148,13 @@
 01 nString    PIC 9(5)V99 VALUE 34526.56.
 01 SubStrSize PIC 99 VALUE 12.
 01 StartPos   PIC 99 VALUE 18.</code></pre>
-					<p align="center">
+					<p class="center-block">
 						<iframe
 							height="333"
 							src="Resources/pdf-viewer.html?src=ppz/TC-RefModEg.pdf"
 							style="border: 1px solid #ccc; width: 100%; aspect-ratio: 520/333"
 							width="520"
+							title="Reference modification examples animation"
 						></iframe>
 					</p>
 					<hr />
@@ -239,7 +240,7 @@
 							arguments.
 						</li>
 					</ol>
-					<p align="left">The template for Intrinsic Functions is shown below:</p>
+					<p>The template for Intrinsic Functions is shown below:</p>
 					<blockquote>
 						<p><code class="language-cobol">FUNCTION</code> FunctionName(<i>Parameters</i>)</p>
 					</blockquote>
@@ -305,8 +306,7 @@ MOVE FUNCTION ORD-MAX(IntElement(ALL)) TO OrdPos             </code></pre>
 				</div>
 				<div class="section-content">
 					<div class="table-scroll">
-						<div align="center">
-							<table bgcolor="#E1FFE1" border="2" cellpadding="7" cellspacing="0" width="502">
+													<table bgcolor="#E1FFE1" border="2" cellpadding="7" cellspacing="0" width="502">
 								<tr>
 									<th scope="col" width="34%">Function Name</th>
 									<th scope="col" width="20%">Result Type</th>
@@ -317,7 +317,7 @@ MOVE FUNCTION ORD-MAX(IntElement(ALL)) TO OrdPos             </code></pre>
 										<p>CHAR(PosInt)</p>
 									</td>
 									<td valign="top" width="20%">
-										<div align="center">Alphanumeric</div>
+										<div class="center-block">Alphanumeric</div>
 									</td>
 									<td valign="top" width="46%">
 										<p>
@@ -331,7 +331,7 @@ MOVE FUNCTION ORD-MAX(IntElement(ALL)) TO OrdPos             </code></pre>
 										<p>ORD(Alph)</p>
 									</td>
 									<td valign="top" width="20%">
-										<div align="center">Integer</div>
+										<div class="center-block">Integer</div>
 									</td>
 									<td valign="top" width="46%">
 										<p>Returns the ordinal position of character <b>Alph</b>.</p>
@@ -342,7 +342,7 @@ MOVE FUNCTION ORD-MAX(IntElement(ALL)) TO OrdPos             </code></pre>
 										<p>ORD-MAX({Any}...)<br /></p>
 									</td>
 									<td valign="top" width="20%">
-										<div align="center">Integer</div>
+										<div class="center-block">Integer</div>
 									</td>
 									<td valign="top" width="46%">
 										Returns the ordinal position of whichever of the parameters has the highest
@@ -353,7 +353,7 @@ MOVE FUNCTION ORD-MAX(IntElement(ALL)) TO OrdPos             </code></pre>
 								<tr>
 									<td valign="top" width="34%">ORD-MIN({Any}...)</td>
 									<td valign="top" width="20%">
-										<div align="center">Integer</div>
+										<div class="center-block">Integer</div>
 									</td>
 									<td valign="top" width="46%">
 										Returns the ordinal position of whichever of the parameters has the lowest
@@ -365,7 +365,7 @@ MOVE FUNCTION ORD-MAX(IntElement(ALL)) TO OrdPos             </code></pre>
 										<p>LENGTH(Any)</p>
 									</td>
 									<td valign="top" width="20%">
-										<div align="center">Integer</div>
+										<div class="center-block">Integer</div>
 									</td>
 									<td valign="top" width="46%">
 										<p>Returns the number of characters in <b>Any</b>.</p>
@@ -376,7 +376,7 @@ MOVE FUNCTION ORD-MAX(IntElement(ALL)) TO OrdPos             </code></pre>
 										<p>REVERSE(Alph)</p>
 									</td>
 									<td valign="top" width="20%">
-										<div align="center">Alphanumeric</div>
+										<div class="center-block">Alphanumeric</div>
 									</td>
 									<td valign="top" width="46%">
 										<p>
@@ -390,7 +390,7 @@ MOVE FUNCTION ORD-MAX(IntElement(ALL)) TO OrdPos             </code></pre>
 										<p>LOWER-CASE(Alph)</p>
 									</td>
 									<td valign="top" width="20%">
-										<div align="center">Alphanumeric</div>
+										<div class="center-block">Alphanumeric</div>
 									</td>
 									<td valign="top" width="46%">
 										<p>
@@ -404,7 +404,7 @@ MOVE FUNCTION ORD-MAX(IntElement(ALL)) TO OrdPos             </code></pre>
 										<p>UPPER-CASE(Alph)</p>
 									</td>
 									<td valign="top" width="20%">
-										<div align="center">Alphanumeric</div>
+										<div class="center-block">Alphanumeric</div>
 									</td>
 									<td valign="top" width="46%">
 										<p>
@@ -414,7 +414,6 @@ MOVE FUNCTION ORD-MAX(IntElement(ALL)) TO OrdPos             </code></pre>
 									</td>
 								</tr>
 							</table>
-						</div>
 					</div>
 					<hr />
 				</div>
@@ -456,8 +455,7 @@ Begin.
   DISPLAY FUNCTION LOWER-CASE(xString)
   STOP RUN.</code></pre>
 					<hr />
-					<div align="center">
-						<div class="results-box">
+											<div class="results-box">
 							<div class="results-box-header">Results</div>
 							<div class="results-two-col">
 								<div>
@@ -485,7 +483,6 @@ Begin.
 								</div>
 							</div>
 						</div>
-					</div>
 					<hr />
 				</div>
 			</div>
@@ -499,8 +496,7 @@ Begin.
 				</div>
 				<div class="section-content">
 					<div class="table-scroll">
-						<div align="center">
-							<table bgcolor="#E1FFE1" border="2" cellpadding="7" cellspacing="0" width="502">
+													<table bgcolor="#E1FFE1" border="2" cellpadding="7" cellspacing="0" width="502">
 								<tr>
 									<th scope="col" width="36%">Function Name</th>
 									<th scope="col" width="20%">Result Type</th>
@@ -511,7 +507,7 @@ Begin.
 										<p>CURRENT-DATE</p>
 									</td>
 									<td valign="top" width="20%">
-										<div align="center">Alphanumeric</div>
+										<div class="center-block">Alphanumeric</div>
 									</td>
 									<td valign="top" width="44%">
 										<p>
@@ -528,7 +524,7 @@ Begin.
 										<p>DATE-OF-INTEGER(PosInt)</p>
 									</td>
 									<td valign="top" width="20%">
-										<div align="center">Integer</div>
+										<div class="center-block">Integer</div>
 									</td>
 									<td valign="top" width="44%">
 										<p>
@@ -543,7 +539,7 @@ Begin.
 										<p>DAY-OF-INTEGER(PosInt)</p>
 									</td>
 									<td valign="top" width="20%">
-										<div align="center">Integer</div>
+										<div class="center-block">Integer</div>
 									</td>
 									<td valign="top" width="44%">
 										<p>
@@ -557,7 +553,7 @@ Begin.
 										<p>INTEGER-OF-DATE(PosInt)</p>
 									</td>
 									<td valign="top" width="20%">
-										<div align="center">Integer</div>
+										<div class="center-block">Integer</div>
 									</td>
 									<td valign="top" width="44%">
 										<p>
@@ -571,7 +567,7 @@ Begin.
 										<p>INTEGER-OF-DAY(PosInt)</p>
 									</td>
 									<td valign="top" width="20%">
-										<div align="center">Integer</div>
+										<div class="center-block">Integer</div>
 									</td>
 									<td valign="top" width="44%">
 										<p>
@@ -585,7 +581,7 @@ Begin.
 										<p>WHEN-COMPILED</p>
 									</td>
 									<td valign="top" width="20%">
-										<div align="center">Integer</div>
+										<div class="center-block">Integer</div>
 									</td>
 									<td valign="top" width="44%">
 										<p>
@@ -595,7 +591,6 @@ Begin.
 									</td>
 								</tr>
 							</table>
-						</div>
 					</div>
 					<hr />
 				</div>
@@ -681,8 +676,7 @@ Begin.
   STOP RUN.
 </code></pre>
 					<hr />
-					<div align="center">
-						<div class="results-box">
+											<div class="results-box">
 							<div class="results-box-header">Results</div>
 							<div>
 								Current Date is 01/26/1998<br />
@@ -694,7 +688,6 @@ Begin.
 								The date in 365 days time will be 01/27/1999
 							</div>
 						</div>
-					</div>
 					<hr />
 				</div>
 			</div>
@@ -708,8 +701,7 @@ Begin.
 				</div>
 				<div class="section-content">
 					<div class="table-scroll">
-						<div align="center">
-							<table bgcolor="#E1FFE1" border="2" cellpadding="7" cellspacing="0" width="502">
+													<table bgcolor="#E1FFE1" border="2" cellpadding="7" cellspacing="0" width="502">
 								<tr>
 									<th scope="col" width="36%">Function Name</th>
 									<th scope="col" width="21%">Result Type</th>
@@ -720,7 +712,7 @@ Begin.
 										<p>ACOS(Num)</p>
 									</td>
 									<td valign="top" width="21%">
-										<div align="center">Numeric</div>
+										<div class="center-block">Numeric</div>
 									</td>
 									<td valign="top" width="43%">
 										<p>
@@ -738,7 +730,7 @@ Begin.
 										<p>ANNUITY(Num PosInt)</p>
 									</td>
 									<td valign="top" width="21%">
-										<div align="center">Numeric</div>
+										<div class="center-block">Numeric</div>
 									</td>
 									<td valign="top" width="43%">
 										Returns a numeric value approximating the ratio of an annuity paid at the end of
@@ -752,7 +744,7 @@ Begin.
 										<p>ASIN(Num)</p>
 									</td>
 									<td valign="top" width="21%">
-										<div align="center">Numeric</div>
+										<div class="center-block">Numeric</div>
 									</td>
 									<td valign="top" width="43%">
 										<p>
@@ -766,7 +758,7 @@ Begin.
 										<p>ATAN(Num)</p>
 									</td>
 									<td valign="top" width="21%">
-										<div align="center">Numeric</div>
+										<div class="center-block">Numeric</div>
 									</td>
 									<td valign="top" width="43%">
 										<p>
@@ -780,7 +772,7 @@ Begin.
 										<p>FACTORIAL(PosInt)</p>
 									</td>
 									<td valign="top" width="21%">
-										<div align="center">Integer</div>
+										<div class="center-block">Integer</div>
 									</td>
 									<td valign="top" width="43%">
 										<p>Returns an integer that is the factorial of <b>PosInt</b>.</p>
@@ -791,7 +783,7 @@ Begin.
 										<p>INTEGER(Num)</p>
 									</td>
 									<td valign="top" width="21%">
-										<div align="center">Integer</div>
+										<div class="center-block">Integer</div>
 									</td>
 									<td valign="top" width="43%">
 										<p>
@@ -804,7 +796,7 @@ Begin.
 								<tr>
 									<td valign="top" width="36%">INTEGER-PART(Num)</td>
 									<td valign="top" width="21%">
-										<div align="center">Integer</div>
+										<div class="center-block">Integer</div>
 									</td>
 									<td valign="top" width="43%">
 										Returns the integer part of <b>Num</b> so a value of -1.5 is returned as -1 and
@@ -816,7 +808,7 @@ Begin.
 										<p>LOG(PosNum)</p>
 									</td>
 									<td valign="top" width="21%">
-										<div align="center">Numeric</div>
+										<div class="center-block">Numeric</div>
 									</td>
 									<td valign="top" width="43%">
 										<p>
@@ -829,7 +821,7 @@ Begin.
 								<tr>
 									<td valign="top" width="36%">LOG10(PosNum)</td>
 									<td valign="top" width="21%">
-										<div align="center">Numeric</div>
+										<div class="center-block">Numeric</div>
 									</td>
 									<td valign="top" width="43%">
 										Returns a numeric value that approximates the logarithm to the base 10 of
@@ -858,7 +850,7 @@ Begin.
 								<tr>
 									<td valign="top" width="36%">MEAN({Num}...)</td>
 									<td valign="top" width="21%">
-										<div align="center">Numeric</div>
+										<div class="center-block">Numeric</div>
 									</td>
 									<td valign="top" width="43%">
 										Returns a numeric value that is the arithmetic mean (average) of its parameters.
@@ -868,7 +860,7 @@ Begin.
 								<tr>
 									<td valign="top" width="36%">MEDIAN({Num}...)</td>
 									<td valign="top" width="21%">
-										<div align="center">Numeric</div>
+										<div class="center-block">Numeric</div>
 									</td>
 									<td valign="top" width="43%">
 										Returns the middle value of a list of values after the values have been arranged
@@ -878,7 +870,7 @@ Begin.
 								<tr>
 									<td valign="top" width="36%">MIDRANGE({Num}...)</td>
 									<td valign="top" width="21%">
-										<div align="center">Numeric</div>
+										<div class="center-block">Numeric</div>
 									</td>
 									<td valign="top" width="43%">
 										Returns a numeric value that is the arithmetic mean (average) of the minimum
@@ -900,7 +892,7 @@ Begin.
 								<tr>
 									<td valign="top" width="36%">MOD(Int1 Int2)</td>
 									<td valign="top" width="21%">
-										<div align="center">Integer</div>
+										<div class="center-block">Integer</div>
 									</td>
 									<td valign="top" width="43%">
 										<p>
@@ -913,7 +905,7 @@ Begin.
 								<tr>
 									<td valign="top" width="36%">NUMVAL(Alph)</td>
 									<td valign="top" width="21%">
-										<div align="center">Numeric</div>
+										<div class="center-block">Numeric</div>
 									</td>
 									<td valign="top" width="43%">
 										Converts the edited numeric string contained in <b>Alph</b> to a numeric item.
@@ -927,7 +919,7 @@ Begin.
 										{Num2}...)
 									</td>
 									<td valign="top" width="21%">
-										<div align="center">Numeric</div>
+										<div class="center-block">Numeric</div>
 									</td>
 									<td valign="top" width="43%">
 										<p>
@@ -948,7 +940,7 @@ Begin.
 										</p>
 									</td>
 									<td valign="top" width="21%">
-										<div align="center">Numeric</div>
+										<div class="center-block">Numeric</div>
 									</td>
 									<td valign="top" width="43%">
 										<p>
@@ -962,7 +954,7 @@ Begin.
 								<tr>
 									<td valign="top" width="36%">RANGE({Num1}...)</td>
 									<td valign="top" width="21%">
-										<div align="center">Integer if all parameter are Integer else Numeric</div>
+										<div class="center-block">Integer if all parameter are Integer else Numeric</div>
 									</td>
 									<td valign="top" width="43%">
 										Examines a list of parameters and returns a value that is equal to the value of
@@ -972,7 +964,7 @@ Begin.
 								<tr>
 									<td valign="top" width="36%">REM(Num1 Num2)</td>
 									<td valign="top" width="21%">
-										<div align="center">Numeric</div>
+										<div class="center-block">Numeric</div>
 									</td>
 									<td valign="top" width="43%">
 										Returns a numeric value that is the remainder of <b>Num1</b> divided by
@@ -982,7 +974,7 @@ Begin.
 								<tr>
 									<td valign="top" width="36%">SIN(Num)</td>
 									<td valign="top" width="21%">
-										<div align="center">Numeric</div>
+										<div class="center-block">Numeric</div>
 									</td>
 									<td valign="top" width="43%">
 										Returns an approximation of the sine of an angle or arc, expressed in radians,
@@ -992,7 +984,7 @@ Begin.
 								<tr>
 									<td valign="top" width="36%">SQRT(Num)</td>
 									<td valign="top" width="21%">
-										<div align="center">Numeric</div>
+										<div class="center-block">Numeric</div>
 									</td>
 									<td valign="top" width="43%">
 										Returns an approximation of the square root of <b>Num</b>.
@@ -1001,7 +993,7 @@ Begin.
 								<tr>
 									<td valign="top" width="36%">STANDARD-DEVIATION({Num}...)</td>
 									<td valign="top" width="21%">
-										<div align="center">Numeric</div>
+										<div class="center-block">Numeric</div>
 									</td>
 									<td valign="top" width="43%">
 										Returns an approximation of the standard deviation of its parameters.
@@ -1010,14 +1002,14 @@ Begin.
 								<tr>
 									<td valign="top" width="36%">SUM({Num}...)</td>
 									<td valign="top" width="21%">
-										<div align="center">Integer if all parameter are Integer else Numeric</div>
+										<div class="center-block">Integer if all parameter are Integer else Numeric</div>
 									</td>
 									<td valign="top" width="43%">Returns the sum of the parameters.</td>
 								</tr>
 								<tr>
 									<td valign="top" width="36%">TAN(Num)</td>
 									<td valign="top" width="21%">
-										<div align="center">Numeric</div>
+										<div class="center-block">Numeric</div>
 									</td>
 									<td valign="top" width="43%">
 										Returns an approximation of the tangent of an angle or arc, expressed in
@@ -1027,14 +1019,13 @@ Begin.
 								<tr>
 									<td valign="top" width="36%">VARIANCE({Num}...)</td>
 									<td valign="top" width="21%">
-										<div align="center">Numeric</div>
+										<div class="center-block">Numeric</div>
 									</td>
 									<td valign="top" width="43%">
 										Returns an approximation of the variance of its arguments
 									</td>
 								</tr>
 							</table>
-						</div>
 					</div>
 					<hr />
 				</div>
@@ -1092,8 +1083,7 @@ Begin.
   DISPLAY "The variance of the values is " IResult
   STOP RUN.</code></pre>
 					<hr />
-					<div align="center">
-						<div class="results-box">
+											<div class="results-box">
 							<div class="results-box-header">Results</div>
 							<div>
 								<p>
@@ -1107,7 +1097,6 @@ Begin.
 								</p>
 							</div>
 						</div>
-					</div>
 					<hr />
 				</div>
 				<div class="section-sidebar">

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -42,28 +42,26 @@
 					<h4>Aims</h4>
 				</div>
 				<div class="section-content">
-					<div align="center">
-						<p align="left">
-							The internal representation of data can be an important consideration for program
-							efficiency. Unfortunately the default representation used by COBOL for numeric data items
-							can negatively impact the speed of computations. A more efficient format for numeric data
-							can be specified by using the USAGE clause.
-						</p>
-						<p align="left">
-							This unit introduces the concept of internal data representations, it discusses the default
-							representation used in COBOL and outlines how that representation, used for numeric data,
-							might cause inefficiencies.
-						</p>
-						<p align="left">
-							The syntax of the <code class="language-cobol">USAGE</code> clause is given and the various
-							options explained.
-						</p>
-						<p align="left">
-							The <code class="language-cobol">SYNCHRONIZED</code> clause is introduced and a generalized
-							example given.
-						</p>
-						<hr size="1" />
-					</div>
+<p>
+	The internal representation of data can be an important consideration for program
+	efficiency. Unfortunately the default representation used by COBOL for numeric data items
+	can negatively impact the speed of computations. A more efficient format for numeric data
+	can be specified by using the USAGE clause.
+</p>
+<p>
+	This unit introduces the concept of internal data representations, it discusses the default
+	representation used in COBOL and outlines how that representation, used for numeric data,
+	might cause inefficiencies.
+</p>
+<p>
+	The syntax of the <code class="language-cobol">USAGE</code> clause is given and the various
+	options explained.
+</p>
+<p>
+	The <code class="language-cobol">SYNCHRONIZED</code> clause is introduced and a generalized
+	example given.
+</p>
+<hr size="1" />
 				</div>
 				<div class="section-sidebar">
 					<h4>Objectives</h4>
@@ -108,34 +106,28 @@
 					</ul>
 				</div>
 				<div class="section-full">
-					<div align="center">
-						<hr />
-						<back-to-top></back-to-top>
-					</div>
+<hr />
+<back-to-top></back-to-top>
 				</div>
 				<div class="section-header">
 					<h2 id="part1">The USAGE clause</h2>
 				</div>
 				<div class="section-sidebar">
 					<h4><b>Introduction</b></h4>
-					<div align="center">
-						<span class="i-detail" aria-hidden="true">🔍</span>
-					</div>
-					<div align="center">
-						<p>
-							<br />
-							<b>ASCII</b><br />
-							<b>A</b>merican <b>S</b>tandard <b>C</b>ode for <b>I</b>nformation <b>I</b>nterchange
-						</p>
-						<p>
-							<b>EBCDIC<br /></b>
-							<b>E</b>xtended <b>B</b>inary <b>C</b>oded <b>D</b>ecimal <b>I</b>nterchange <b>C</b>ode
-						</p>
-						<p>
-							<b>BCD</b><br />
-							<b>B</b>inary <b>C</b>oded <b>D</b>ecimal
-						</p>
-					</div>
+<span class="i-detail" aria-hidden="true">🔍</span>
+<p>
+	<br />
+	<b>ASCII</b><br />
+	<b>A</b>merican <b>S</b>tandard <b>C</b>ode for <b>I</b>nformation <b>I</b>nterchange
+</p>
+<p>
+	<b>EBCDIC<br /></b>
+	<b>E</b>xtended <b>B</b>inary <b>C</b>oded <b>D</b>ecimal <b>I</b>nterchange <b>C</b>ode
+</p>
+<p>
+	<b>BCD</b><br />
+	<b>B</b>inary <b>C</b>oded <b>D</b>ecimal
+</p>
 				</div>
 				<div class="section-content">
 					<p>
@@ -149,7 +141,7 @@
 						represent a particular character. For instance, the diagram below shows the bit configuration
 						used to represent an upper case "A" in the ASCII and the EBCDIC encoding sequences.
 					</p>
-					<p align="center"><img height="102" src="Resources/pics/Usage1.gif" width="396" /></p>
+					<p class="center-block"><img height="102" src="Resources/pics/Usage1.gif" width="396" / alt="Bit representations of the letter A in ASCII (01000001) and EBCDIC (11000001) encoding"></p>
 					<p>
 						Numeric data can be held as text digits (ASCII digits) or as pure binary numbers (in the case of
 						cardinal values), or as twos complement binary numbers (in the case of integers), or as decimal
@@ -167,11 +159,11 @@
 				</div>
 				<div class="section-sidebar">
 					<h4><b>Problems with USAGE IS DISPLAY</b></h4>
-					<p align="center">
+					<p class="center-block">
 						<img height="44" src="Resources/pics/program-fragment.svg" width="48" alt="Program fragment" />
 					</p>
 					<aside>
-						<p align="center">
+						<p class="center-block">
 							<img height="44" src="Resources/pics/aai-LightBulbTip.gif" width="42" alt="" />
 						</p>
 						<p>
@@ -245,7 +237,7 @@ Begin.
 						which is the ASCII code for the lower case letter "e".
 					</p>
 					<p>The sum <b>4 + 1 = e</b> does not compute.</p>
-					<p align="center"><img height="202" src="Resources/pics/Usage2.gif" width="439" /></p>
+					<p class="center-block"><img height="202" src="Resources/pics/Usage2.gif" width="439" / alt="ASCII table showing that adding digits 4 and 1 produces 01100101, the code for the letter e"></p>
 					<p>
 						When calculations are done with numeric data items whose
 						<code class="language-cobol">USAGE IS DISPLAY</code>, the computer has to convert the numeric
@@ -258,1875 +250,1873 @@ Begin.
 						usages optimized for computation such as
 						<code class="language-cobol">USAGE IS COMPUTATIONAL</code>.
 					</p>
-					<div align="center">
-						<p><b>ASCII Table</b></p>
-						<table align="center" border="1" cellpadding="0" cellspacing="0">
-							<tr bgcolor="#FFFFCC">
-								<th scope="col" width="114">Char</th>
-								<th scope="col" width="66">Dec</th>
-								<th scope="col" width="60">Hex</th>
-								<th scope="col" width="108">Binary</th>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^@ (NUL)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">0</p>
-								</td>
-								<td width="60">
-									<p align="center">00</p>
-								</td>
-								<td width="108">
-									<p align="center">00000000</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^A (SOX)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">1</p>
-								</td>
-								<td width="60">
-									<p align="center">01</p>
-								</td>
-								<td width="108">
-									<p align="center">00000001</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^B (STX)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">2</p>
-								</td>
-								<td width="60">
-									<p align="center">02</p>
-								</td>
-								<td width="108">
-									<p align="center">00000010</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^C (ETX)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">3</p>
-								</td>
-								<td width="60">
-									<p align="center">03</p>
-								</td>
-								<td width="108">
-									<p align="center">00000011</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^D (EOT)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">4</p>
-								</td>
-								<td width="60">
-									<p align="center">04</p>
-								</td>
-								<td width="108">
-									<p align="center">00000100</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^E (ENQ)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">5</p>
-								</td>
-								<td width="60">
-									<p align="center">05</p>
-								</td>
-								<td width="108">
-									<p align="center">00000101</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^F (ACK)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">6</p>
-								</td>
-								<td width="60">
-									<p align="center">06</p>
-								</td>
-								<td width="108">
-									<p align="center">00000110</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^G (BEL)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">7</p>
-								</td>
-								<td width="60">
-									<p align="center">07</p>
-								</td>
-								<td width="108">
-									<p align="center">00000111</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^H (BS)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">8</p>
-								</td>
-								<td width="60">
-									<p align="center">08</p>
-								</td>
-								<td width="108">
-									<p align="center">00001000</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^I (HT)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">9</p>
-								</td>
-								<td width="60">
-									<p align="center">09</p>
-								</td>
-								<td width="108">
-									<p align="center">00001001</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^J (NL)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">10</p>
-								</td>
-								<td width="60">
-									<p align="center">0A</p>
-								</td>
-								<td width="108">
-									<p align="center">00001010</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^K (VT)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">11</p>
-								</td>
-								<td width="60">
-									<p align="center">0B</p>
-								</td>
-								<td width="108">
-									<p align="center">00001011</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^L (NP)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">12</p>
-								</td>
-								<td width="60">
-									<p align="center">0C</p>
-								</td>
-								<td width="108">
-									<p align="center">00001100</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^M (CR)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">13</p>
-								</td>
-								<td width="60">
-									<p align="center">0D</p>
-								</td>
-								<td width="108">
-									<p align="center">00001101</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^N (SO)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">14</p>
-								</td>
-								<td width="60">
-									<p align="center">0E</p>
-								</td>
-								<td width="108">
-									<p align="center">00001110</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^O (SI)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">15</p>
-								</td>
-								<td width="60">
-									<p align="center">0F</p>
-								</td>
-								<td width="108">
-									<p align="center">00001111</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^P (DLE)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">16</p>
-								</td>
-								<td width="60">
-									<p align="center">10</p>
-								</td>
-								<td width="108">
-									<p align="center">00010000</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^Q (DS1)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">17</p>
-								</td>
-								<td width="60">
-									<p align="center">11</p>
-								</td>
-								<td width="108">
-									<p align="center">00010001</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^R (DS2)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">18</p>
-								</td>
-								<td width="60">
-									<p align="center">12</p>
-								</td>
-								<td width="108">
-									<p align="center">00010010</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^S (DS3)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">19</p>
-								</td>
-								<td width="60">
-									<p align="center">13</p>
-								</td>
-								<td width="108">
-									<p align="center">00010011</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^T (DC4)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">20</p>
-								</td>
-								<td width="60">
-									<p align="center">14</p>
-								</td>
-								<td width="108">
-									<p align="center">00010100</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^U (NAK)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">21</p>
-								</td>
-								<td width="60">
-									<p align="center">15</p>
-								</td>
-								<td width="108">
-									<p align="center">00010101</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^V (SYN)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">22</p>
-								</td>
-								<td width="60">
-									<p align="center">16</p>
-								</td>
-								<td width="108">
-									<p align="center">00010110</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^W (ETB)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">23</p>
-								</td>
-								<td width="60">
-									<p align="center">17</p>
-								</td>
-								<td width="108">
-									<p align="center">00010111</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^X (CAN)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">24</p>
-								</td>
-								<td width="60">
-									<p align="center">18</p>
-								</td>
-								<td width="108">
-									<p align="center">00011000</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^Y (EM)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">25</p>
-								</td>
-								<td width="60">
-									<p align="center">19</p>
-								</td>
-								<td width="108">
-									<p align="center">00011001</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^Z (SUB)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">26</p>
-								</td>
-								<td width="60">
-									<p align="center">1A</p>
-								</td>
-								<td width="108">
-									<p align="center">00011010</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^[ (ESC)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">27</p>
-								</td>
-								<td width="60">
-									<p align="center">1B</p>
-								</td>
-								<td width="108">
-									<p align="center">00011011</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^\ (FS)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">28</p>
-								</td>
-								<td width="60">
-									<p align="center">1C</p>
-								</td>
-								<td width="108">
-									<p align="center">00011100</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^] (GS)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">29</p>
-								</td>
-								<td width="60">
-									<p align="center">1D</p>
-								</td>
-								<td width="108">
-									<p align="center">00011101</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^^ (RS)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">30</p>
-								</td>
-								<td width="60">
-									<p align="center">1E</p>
-								</td>
-								<td width="108">
-									<p align="center">00011110</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^_ (US)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">31</p>
-								</td>
-								<td width="60">
-									<p align="center">1F</p>
-								</td>
-								<td width="108">
-									<p align="center">00011111</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>(SP)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">32</p>
-								</td>
-								<td width="60">
-									<p align="center">20</p>
-								</td>
-								<td width="108">
-									<p align="center">00100000</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>!</b></p>
-								</td>
-								<td width="66">
-									<p align="center">33</p>
-								</td>
-								<td width="60">
-									<p align="center">21</p>
-								</td>
-								<td width="108">
-									<p align="center">00100001</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>"</b></p>
-								</td>
-								<td width="66">
-									<p align="center">34</p>
-								</td>
-								<td width="60">
-									<p align="center">22</p>
-								</td>
-								<td width="108">
-									<p align="center">00100010</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>#</b></p>
-								</td>
-								<td width="66">
-									<p align="center">35</p>
-								</td>
-								<td width="60">
-									<p align="center">23</p>
-								</td>
-								<td width="108">
-									<p align="center">00100011</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>$</b></p>
-								</td>
-								<td width="66">
-									<p align="center">36</p>
-								</td>
-								<td width="60">
-									<p align="center">24</p>
-								</td>
-								<td width="108">
-									<p align="center">00100100</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>%</b></p>
-								</td>
-								<td width="66">
-									<p align="center">37</p>
-								</td>
-								<td width="60">
-									<p align="center">25</p>
-								</td>
-								<td width="108">
-									<p align="center">00100101</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>&</b></p>
-								</td>
-								<td width="66">
-									<p align="center">38</p>
-								</td>
-								<td width="60">
-									<p align="center">26</p>
-								</td>
-								<td width="108">
-									<p align="center">00100110</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>'</b></p>
-								</td>
-								<td width="66">
-									<p align="center">39</p>
-								</td>
-								<td width="60">
-									<p align="center">27</p>
-								</td>
-								<td width="108">
-									<p align="center">00100111</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>(</b></p>
-								</td>
-								<td width="66">
-									<p align="center">40</p>
-								</td>
-								<td width="60">
-									<p align="center">28</p>
-								</td>
-								<td width="108">
-									<p align="center">00101000</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">41</p>
-								</td>
-								<td width="60">
-									<p align="center">29</p>
-								</td>
-								<td width="108">
-									<p align="center">00101001</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>*</b></p>
-								</td>
-								<td width="66">
-									<p align="center">42</p>
-								</td>
-								<td width="60">
-									<p align="center">2A</p>
-								</td>
-								<td width="108">
-									<p align="center">00101010</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>+</b></p>
-								</td>
-								<td width="66">
-									<p align="center">43</p>
-								</td>
-								<td width="60">
-									<p align="center">2B</p>
-								</td>
-								<td width="108">
-									<p align="center">00101011</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>,</b></p>
-								</td>
-								<td width="66">
-									<p align="center">44</p>
-								</td>
-								<td width="60">
-									<p align="center">2C</p>
-								</td>
-								<td width="108">
-									<p align="center">00101100</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>-</b></p>
-								</td>
-								<td width="66">
-									<p align="center">45</p>
-								</td>
-								<td width="60">
-									<p align="center">2D</p>
-								</td>
-								<td width="108">
-									<p align="center">00101101</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>.</b></p>
-								</td>
-								<td width="66">
-									<p align="center">46</p>
-								</td>
-								<td width="60">
-									<p align="center">2E</p>
-								</td>
-								<td width="108">
-									<p align="center">00101110</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>/</b></p>
-								</td>
-								<td width="66">
-									<p align="center">47</p>
-								</td>
-								<td width="60">
-									<p align="center">2F</p>
-								</td>
-								<td width="108">
-									<p align="center">00101111</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>0</b></p>
-								</td>
-								<td width="66">
-									<p align="center">48</p>
-								</td>
-								<td width="60">
-									<p align="center">30</p>
-								</td>
-								<td width="108">
-									<p align="center">00110000</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center">
-										<b>
-											<span style="color: #ff0000">1</span>
-										</b>
-									</p>
-								</td>
-								<td width="66">
-									<p align="center">
-										<b>
-											<span style="color: #ff0000">49</span>
-										</b>
-									</p>
-								</td>
-								<td width="60">
-									<p align="center">
-										<b>
-											<span style="color: #ff0000">31</span>
-										</b>
-									</p>
-								</td>
-								<td width="108">
-									<p align="center">
-										<b>
-											<span style="color: #ff0000">00110001</span>
-										</b>
-									</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>2</b></p>
-								</td>
-								<td width="66">
-									<p align="center">50</p>
-								</td>
-								<td width="60">
-									<p align="center">32</p>
-								</td>
-								<td width="108">
-									<p align="center">00110010</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>3</b></p>
-								</td>
-								<td width="66">
-									<p align="center">51</p>
-								</td>
-								<td width="60">
-									<p align="center">33</p>
-								</td>
-								<td width="108">
-									<p align="center">00110011</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center">
-										<b>
-											<span style="color: #ff0000">4</span>
-										</b>
-									</p>
-								</td>
-								<td width="66">
-									<p align="center">
-										<b>
-											<span style="color: #ff0000">52</span>
-										</b>
-									</p>
-								</td>
-								<td width="60">
-									<p align="center">
-										<b>
-											<span style="color: #ff0000">34</span>
-										</b>
-									</p>
-								</td>
-								<td width="108">
-									<p align="center">
-										<b>
-											<span style="color: #ff0000">00110100</span>
-										</b>
-									</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>5</b></p>
-								</td>
-								<td width="66">
-									<p align="center">53</p>
-								</td>
-								<td width="60">
-									<p align="center">35</p>
-								</td>
-								<td width="108">
-									<p align="center">00110101</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>6</b></p>
-								</td>
-								<td width="66">
-									<p align="center">54</p>
-								</td>
-								<td width="60">
-									<p align="center">36</p>
-								</td>
-								<td width="108">
-									<p align="center">00110110</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>7</b></p>
-								</td>
-								<td width="66">
-									<p align="center">55</p>
-								</td>
-								<td width="60">
-									<p align="center">37</p>
-								</td>
-								<td width="108">
-									<p align="center">00110111</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>8</b></p>
-								</td>
-								<td width="66">
-									<p align="center">56</p>
-								</td>
-								<td width="60">
-									<p align="center">38</p>
-								</td>
-								<td width="108">
-									<p align="center">00111000</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>9</b></p>
-								</td>
-								<td width="66">
-									<p align="center">57</p>
-								</td>
-								<td width="60">
-									<p align="center">39</p>
-								</td>
-								<td width="108">
-									<p align="center">00111001</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>:</b></p>
-								</td>
-								<td width="66">
-									<p align="center">58</p>
-								</td>
-								<td width="60">
-									<p align="center">3A</p>
-								</td>
-								<td width="108">
-									<p align="center">00111010</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>;</b></p>
-								</td>
-								<td width="66">
-									<p align="center">59</p>
-								</td>
-								<td width="60">
-									<p align="center">3B</p>
-								</td>
-								<td width="108">
-									<p align="center">00111011</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>&lt;</b></p>
-								</td>
-								<td width="66">
-									<p align="center">60</p>
-								</td>
-								<td width="60">
-									<p align="center">3C</p>
-								</td>
-								<td width="108">
-									<p align="center">00111100</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>=</b></p>
-								</td>
-								<td width="66">
-									<p align="center">61</p>
-								</td>
-								<td width="60">
-									<p align="center">3D</p>
-								</td>
-								<td width="108">
-									<p align="center">00111101</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>&gt;</b></p>
-								</td>
-								<td width="66">
-									<p align="center">62</p>
-								</td>
-								<td width="60">
-									<p align="center">3E</p>
-								</td>
-								<td width="108">
-									<p align="center">00111110</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>?</b></p>
-								</td>
-								<td width="66">
-									<p align="center">63</p>
-								</td>
-								<td width="60">
-									<p align="center">3F</p>
-								</td>
-								<td width="108">
-									<p align="center">00111111</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>@</b></p>
-								</td>
-								<td width="66">
-									<p align="center">64</p>
-								</td>
-								<td width="60">
-									<p align="center">40</p>
-								</td>
-								<td width="108">
-									<p align="center">01000000</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>A</b></p>
-								</td>
-								<td width="66">
-									<p align="center">65</p>
-								</td>
-								<td width="60">
-									<p align="center">41</p>
-								</td>
-								<td width="108">
-									<p align="center">01000001</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>B</b></p>
-								</td>
-								<td width="66">
-									<p align="center">66</p>
-								</td>
-								<td width="60">
-									<p align="center">42</p>
-								</td>
-								<td width="108">
-									<p align="center">01000010</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>C</b></p>
-								</td>
-								<td width="66">
-									<p align="center">67</p>
-								</td>
-								<td width="60">
-									<p align="center">43</p>
-								</td>
-								<td width="108">
-									<p align="center">01000011</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>D</b></p>
-								</td>
-								<td width="66">
-									<p align="center">68</p>
-								</td>
-								<td width="60">
-									<p align="center">44</p>
-								</td>
-								<td width="108">
-									<p align="center">01000100</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>E</b></p>
-								</td>
-								<td width="66">
-									<p align="center">69</p>
-								</td>
-								<td width="60">
-									<p align="center">45</p>
-								</td>
-								<td width="108">
-									<p align="center">01000101</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>F</b></p>
-								</td>
-								<td width="66">
-									<p align="center">70</p>
-								</td>
-								<td width="60">
-									<p align="center">46</p>
-								</td>
-								<td width="108">
-									<p align="center">01000110</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>G</b></p>
-								</td>
-								<td width="66">
-									<p align="center">71</p>
-								</td>
-								<td width="60">
-									<p align="center">47</p>
-								</td>
-								<td width="108">
-									<p align="center">01000111</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>H</b></p>
-								</td>
-								<td width="66">
-									<p align="center">72</p>
-								</td>
-								<td width="60">
-									<p align="center">48</p>
-								</td>
-								<td width="108">
-									<p align="center">01001000</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>I</b></p>
-								</td>
-								<td width="66">
-									<p align="center">73</p>
-								</td>
-								<td width="60">
-									<p align="center">49</p>
-								</td>
-								<td width="108">
-									<p align="center">01001001</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>J</b></p>
-								</td>
-								<td width="66">
-									<p align="center">74</p>
-								</td>
-								<td width="60">
-									<p align="center">4A</p>
-								</td>
-								<td width="108">
-									<p align="center">01001010</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>K</b></p>
-								</td>
-								<td width="66">
-									<p align="center">75</p>
-								</td>
-								<td width="60">
-									<p align="center">4B</p>
-								</td>
-								<td width="108">
-									<p align="center">01001011</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>L</b></p>
-								</td>
-								<td width="66">
-									<p align="center">76</p>
-								</td>
-								<td width="60">
-									<p align="center">4C</p>
-								</td>
-								<td width="108">
-									<p align="center">01001100</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>M</b></p>
-								</td>
-								<td width="66">
-									<p align="center">77</p>
-								</td>
-								<td width="60">
-									<p align="center">4D</p>
-								</td>
-								<td width="108">
-									<p align="center">01001101</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>N</b></p>
-								</td>
-								<td width="66">
-									<p align="center">78</p>
-								</td>
-								<td width="60">
-									<p align="center">4E</p>
-								</td>
-								<td width="108">
-									<p align="center">01001110</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>O</b></p>
-								</td>
-								<td width="66">
-									<p align="center">79</p>
-								</td>
-								<td width="60">
-									<p align="center">4F</p>
-								</td>
-								<td width="108">
-									<p align="center">01001111</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>P</b></p>
-								</td>
-								<td width="66">
-									<p align="center">80</p>
-								</td>
-								<td width="60">
-									<p align="center">50</p>
-								</td>
-								<td width="108">
-									<p align="center">01010000</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>Q</b></p>
-								</td>
-								<td width="66">
-									<p align="center">81</p>
-								</td>
-								<td width="60">
-									<p align="center">51</p>
-								</td>
-								<td width="108">
-									<p align="center">01010001</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>R</b></p>
-								</td>
-								<td width="66">
-									<p align="center">82</p>
-								</td>
-								<td width="60">
-									<p align="center">52</p>
-								</td>
-								<td width="108">
-									<p align="center">01010010</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>S</b></p>
-								</td>
-								<td width="66">
-									<p align="center">83</p>
-								</td>
-								<td width="60">
-									<p align="center">53</p>
-								</td>
-								<td width="108">
-									<p align="center">01010011</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>T</b></p>
-								</td>
-								<td width="66">
-									<p align="center">84</p>
-								</td>
-								<td width="60">
-									<p align="center">54</p>
-								</td>
-								<td width="108">
-									<p align="center">01010100</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>U</b></p>
-								</td>
-								<td width="66">
-									<p align="center">85</p>
-								</td>
-								<td width="60">
-									<p align="center">55</p>
-								</td>
-								<td width="108">
-									<p align="center">01010101</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>V</b></p>
-								</td>
-								<td width="66">
-									<p align="center">86</p>
-								</td>
-								<td width="60">
-									<p align="center">56</p>
-								</td>
-								<td width="108">
-									<p align="center">01010110</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>W</b></p>
-								</td>
-								<td width="66">
-									<p align="center">87</p>
-								</td>
-								<td width="60">
-									<p align="center">57</p>
-								</td>
-								<td width="108">
-									<p align="center">01010111</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>X</b></p>
-								</td>
-								<td width="66">
-									<p align="center">88</p>
-								</td>
-								<td width="60">
-									<p align="center">58</p>
-								</td>
-								<td width="108">
-									<p align="center">01011000</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>Y</b></p>
-								</td>
-								<td width="66">
-									<p align="center">89</p>
-								</td>
-								<td width="60">
-									<p align="center">59</p>
-								</td>
-								<td width="108">
-									<p align="center">01011001</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>Z</b></p>
-								</td>
-								<td width="66">
-									<p align="center">90</p>
-								</td>
-								<td width="60">
-									<p align="center">5A</p>
-								</td>
-								<td width="108">
-									<p align="center">01011010</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>[</b></p>
-								</td>
-								<td width="66">
-									<p align="center">91</p>
-								</td>
-								<td width="60">
-									<p align="center">5B</p>
-								</td>
-								<td width="108">
-									<p align="center">01011011</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>\</b></p>
-								</td>
-								<td width="66">
-									<p align="center">92</p>
-								</td>
-								<td width="60">
-									<p align="center">5C</p>
-								</td>
-								<td width="108">
-									<p align="center">01011100</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>]</b></p>
-								</td>
-								<td width="66">
-									<p align="center">93</p>
-								</td>
-								<td width="60">
-									<p align="center">5D</p>
-								</td>
-								<td width="108">
-									<p align="center">01011101</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^</b></p>
-								</td>
-								<td width="66">
-									<p align="center">94</p>
-								</td>
-								<td width="60">
-									<p align="center">5E</p>
-								</td>
-								<td width="108">
-									<p align="center">01011110</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>_</b></p>
-								</td>
-								<td width="66">
-									<p align="center">95</p>
-								</td>
-								<td width="60">
-									<p align="center">5F</p>
-								</td>
-								<td width="108">
-									<p align="center">01011111</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>`</b></p>
-								</td>
-								<td width="66">
-									<p align="center">96</p>
-								</td>
-								<td width="60">
-									<p align="center">60</p>
-								</td>
-								<td width="108">
-									<p align="center">01100000</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>a</b></p>
-								</td>
-								<td width="66">
-									<p align="center">97</p>
-								</td>
-								<td width="60">
-									<p align="center">61</p>
-								</td>
-								<td width="108">
-									<p align="center">01100001</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>b</b></p>
-								</td>
-								<td width="66">
-									<p align="center">98</p>
-								</td>
-								<td width="60">
-									<p align="center">62</p>
-								</td>
-								<td width="108">
-									<p align="center">01100010</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>c</b></p>
-								</td>
-								<td width="66">
-									<p align="center">99</p>
-								</td>
-								<td width="60">
-									<p align="center">63</p>
-								</td>
-								<td width="108">
-									<p align="center">01100011</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>d</b></p>
-								</td>
-								<td width="66">
-									<p align="center">100</p>
-								</td>
-								<td width="60">
-									<p align="center">64</p>
-								</td>
-								<td width="108">
-									<p align="center">01100100</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center">
-										<b>
-											<span style="color: #ff0000">e</span>
-										</b>
-									</p>
-								</td>
-								<td width="66">
-									<p align="center">
-										<b>
-											<span style="color: #ff0000">101</span>
-										</b>
-									</p>
-								</td>
-								<td width="60">
-									<p align="center">
-										<b>
-											<span style="color: #ff0000">65</span>
-										</b>
-									</p>
-								</td>
-								<td width="108">
-									<p align="center">
-										<b>
-											<span style="color: #ff0000">01100101</span>
-										</b>
-									</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>f</b></p>
-								</td>
-								<td width="66">
-									<p align="center">102</p>
-								</td>
-								<td width="60">
-									<p align="center">66</p>
-								</td>
-								<td width="108">
-									<p align="center">01100110</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>g</b></p>
-								</td>
-								<td width="66">
-									<p align="center">103</p>
-								</td>
-								<td width="60">
-									<p align="center">67</p>
-								</td>
-								<td width="108">
-									<p align="center">01100111</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>h</b></p>
-								</td>
-								<td width="66">
-									<p align="center">104</p>
-								</td>
-								<td width="60">
-									<p align="center">68</p>
-								</td>
-								<td width="108">
-									<p align="center">01101000</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>i</b></p>
-								</td>
-								<td width="66">
-									<p align="center">105</p>
-								</td>
-								<td width="60">
-									<p align="center">69</p>
-								</td>
-								<td width="108">
-									<p align="center">01101001</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>j</b></p>
-								</td>
-								<td width="66">
-									<p align="center">106</p>
-								</td>
-								<td width="60">
-									<p align="center">6A</p>
-								</td>
-								<td width="108">
-									<p align="center">01101010</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>k</b></p>
-								</td>
-								<td width="66">
-									<p align="center">107</p>
-								</td>
-								<td width="60">
-									<p align="center">6B</p>
-								</td>
-								<td width="108">
-									<p align="center">01101011</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>l</b></p>
-								</td>
-								<td width="66">
-									<p align="center">108</p>
-								</td>
-								<td width="60">
-									<p align="center">6C</p>
-								</td>
-								<td width="108">
-									<p align="center">01101100</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>m</b></p>
-								</td>
-								<td width="66">
-									<p align="center">109</p>
-								</td>
-								<td width="60">
-									<p align="center">6D</p>
-								</td>
-								<td width="108">
-									<p align="center">01101101</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>n</b></p>
-								</td>
-								<td width="66">
-									<p align="center">110</p>
-								</td>
-								<td width="60">
-									<p align="center">6E</p>
-								</td>
-								<td width="108">
-									<p align="center">01101110</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>o</b></p>
-								</td>
-								<td width="66">
-									<p align="center">111</p>
-								</td>
-								<td width="60">
-									<p align="center">6F</p>
-								</td>
-								<td width="108">
-									<p align="center">01101111</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>p</b></p>
-								</td>
-								<td width="66">
-									<p align="center">112</p>
-								</td>
-								<td width="60">
-									<p align="center">70</p>
-								</td>
-								<td width="108">
-									<p align="center">01110000</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>q</b></p>
-								</td>
-								<td width="66">
-									<p align="center">113</p>
-								</td>
-								<td width="60">
-									<p align="center">71</p>
-								</td>
-								<td width="108">
-									<p align="center">01110001</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>r</b></p>
-								</td>
-								<td width="66">
-									<p align="center">114</p>
-								</td>
-								<td width="60">
-									<p align="center">72</p>
-								</td>
-								<td width="108">
-									<p align="center">01110010</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>s</b></p>
-								</td>
-								<td width="66">
-									<p align="center">115</p>
-								</td>
-								<td width="60">
-									<p align="center">73</p>
-								</td>
-								<td width="108">
-									<p align="center">01110011</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>t</b></p>
-								</td>
-								<td width="66">
-									<p align="center">116</p>
-								</td>
-								<td width="60">
-									<p align="center">74</p>
-								</td>
-								<td width="108">
-									<p align="center">01110100</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>u</b></p>
-								</td>
-								<td width="66">
-									<p align="center">117</p>
-								</td>
-								<td width="60">
-									<p align="center">75</p>
-								</td>
-								<td width="108">
-									<p align="center">01110101</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>v</b></p>
-								</td>
-								<td width="66">
-									<p align="center">118</p>
-								</td>
-								<td width="60">
-									<p align="center">76</p>
-								</td>
-								<td width="108">
-									<p align="center">01110110</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>w</b></p>
-								</td>
-								<td width="66">
-									<p align="center">119</p>
-								</td>
-								<td width="60">
-									<p align="center">77</p>
-								</td>
-								<td width="108">
-									<p align="center">01110111</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>x</b></p>
-								</td>
-								<td width="66">
-									<p align="center">120</p>
-								</td>
-								<td width="60">
-									<p align="center">78</p>
-								</td>
-								<td width="108">
-									<p align="center">01111000</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>y</b></p>
-								</td>
-								<td width="66">
-									<p align="center">121</p>
-								</td>
-								<td width="60">
-									<p align="center">79</p>
-								</td>
-								<td width="108">
-									<p align="center">01111001</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>z</b></p>
-								</td>
-								<td width="66">
-									<p align="center">122</p>
-								</td>
-								<td width="60">
-									<p align="center">7A</p>
-								</td>
-								<td width="108">
-									<p align="center">01111010</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>{</b></p>
-								</td>
-								<td width="66">
-									<p align="center">123</p>
-								</td>
-								<td width="60">
-									<p align="center">7B</p>
-								</td>
-								<td width="108">
-									<p align="center">01111011</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>|</b></p>
-								</td>
-								<td width="66">
-									<p align="center">124</p>
-								</td>
-								<td width="60">
-									<p align="center">7C</p>
-								</td>
-								<td width="108">
-									<p align="center">01111100</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>}</b></p>
-								</td>
-								<td width="66">
-									<p align="center">125</p>
-								</td>
-								<td width="60">
-									<p align="center">7D</p>
-								</td>
-								<td width="108">
-									<p align="center">01111101</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>~</b></p>
-								</td>
-								<td width="66">
-									<p align="center">126</p>
-								</td>
-								<td width="60">
-									<p align="center">7E</p>
-								</td>
-								<td width="108">
-									<p align="center">01111110</p>
-								</td>
-							</tr>
-							<tr>
-								<td width="114">
-									<p align="center"><b>^? (DEL)</b></p>
-								</td>
-								<td width="66">
-									<p align="center">127</p>
-								</td>
-								<td width="60">
-									<p align="center">7F</p>
-								</td>
-								<td width="108">
-									<p align="center">01111111</p>
-								</td>
-							</tr>
-						</table>
-					</div>
+<p><b>ASCII Table</b></p>
+<table style="margin:0 auto" border="1" cellpadding="0" cellspacing="0">
+	<tr bgcolor="#FFFFCC">
+		<th scope="col" width="114">Char</th>
+		<th scope="col" width="66">Dec</th>
+		<th scope="col" width="60">Hex</th>
+		<th scope="col" width="108">Binary</th>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^@ (NUL)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">0</p>
+		</td>
+		<td width="60">
+			<p class="center-block">00</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00000000</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^A (SOX)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">1</p>
+		</td>
+		<td width="60">
+			<p class="center-block">01</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00000001</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^B (STX)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">2</p>
+		</td>
+		<td width="60">
+			<p class="center-block">02</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00000010</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^C (ETX)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">3</p>
+		</td>
+		<td width="60">
+			<p class="center-block">03</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00000011</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^D (EOT)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">4</p>
+		</td>
+		<td width="60">
+			<p class="center-block">04</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00000100</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^E (ENQ)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">5</p>
+		</td>
+		<td width="60">
+			<p class="center-block">05</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00000101</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^F (ACK)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">6</p>
+		</td>
+		<td width="60">
+			<p class="center-block">06</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00000110</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^G (BEL)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">7</p>
+		</td>
+		<td width="60">
+			<p class="center-block">07</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00000111</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^H (BS)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">8</p>
+		</td>
+		<td width="60">
+			<p class="center-block">08</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00001000</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^I (HT)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">9</p>
+		</td>
+		<td width="60">
+			<p class="center-block">09</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00001001</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^J (NL)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">10</p>
+		</td>
+		<td width="60">
+			<p class="center-block">0A</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00001010</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^K (VT)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">11</p>
+		</td>
+		<td width="60">
+			<p class="center-block">0B</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00001011</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^L (NP)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">12</p>
+		</td>
+		<td width="60">
+			<p class="center-block">0C</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00001100</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^M (CR)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">13</p>
+		</td>
+		<td width="60">
+			<p class="center-block">0D</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00001101</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^N (SO)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">14</p>
+		</td>
+		<td width="60">
+			<p class="center-block">0E</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00001110</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^O (SI)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">15</p>
+		</td>
+		<td width="60">
+			<p class="center-block">0F</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00001111</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^P (DLE)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">16</p>
+		</td>
+		<td width="60">
+			<p class="center-block">10</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00010000</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^Q (DS1)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">17</p>
+		</td>
+		<td width="60">
+			<p class="center-block">11</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00010001</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^R (DS2)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">18</p>
+		</td>
+		<td width="60">
+			<p class="center-block">12</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00010010</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^S (DS3)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">19</p>
+		</td>
+		<td width="60">
+			<p class="center-block">13</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00010011</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^T (DC4)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">20</p>
+		</td>
+		<td width="60">
+			<p class="center-block">14</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00010100</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^U (NAK)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">21</p>
+		</td>
+		<td width="60">
+			<p class="center-block">15</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00010101</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^V (SYN)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">22</p>
+		</td>
+		<td width="60">
+			<p class="center-block">16</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00010110</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^W (ETB)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">23</p>
+		</td>
+		<td width="60">
+			<p class="center-block">17</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00010111</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^X (CAN)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">24</p>
+		</td>
+		<td width="60">
+			<p class="center-block">18</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00011000</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^Y (EM)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">25</p>
+		</td>
+		<td width="60">
+			<p class="center-block">19</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00011001</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^Z (SUB)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">26</p>
+		</td>
+		<td width="60">
+			<p class="center-block">1A</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00011010</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^[ (ESC)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">27</p>
+		</td>
+		<td width="60">
+			<p class="center-block">1B</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00011011</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^\ (FS)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">28</p>
+		</td>
+		<td width="60">
+			<p class="center-block">1C</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00011100</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^] (GS)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">29</p>
+		</td>
+		<td width="60">
+			<p class="center-block">1D</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00011101</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^^ (RS)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">30</p>
+		</td>
+		<td width="60">
+			<p class="center-block">1E</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00011110</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^_ (US)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">31</p>
+		</td>
+		<td width="60">
+			<p class="center-block">1F</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00011111</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>(SP)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">32</p>
+		</td>
+		<td width="60">
+			<p class="center-block">20</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00100000</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>!</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">33</p>
+		</td>
+		<td width="60">
+			<p class="center-block">21</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00100001</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>"</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">34</p>
+		</td>
+		<td width="60">
+			<p class="center-block">22</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00100010</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>#</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">35</p>
+		</td>
+		<td width="60">
+			<p class="center-block">23</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00100011</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>$</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">36</p>
+		</td>
+		<td width="60">
+			<p class="center-block">24</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00100100</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>%</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">37</p>
+		</td>
+		<td width="60">
+			<p class="center-block">25</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00100101</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>&</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">38</p>
+		</td>
+		<td width="60">
+			<p class="center-block">26</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00100110</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>'</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">39</p>
+		</td>
+		<td width="60">
+			<p class="center-block">27</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00100111</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>(</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">40</p>
+		</td>
+		<td width="60">
+			<p class="center-block">28</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00101000</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">41</p>
+		</td>
+		<td width="60">
+			<p class="center-block">29</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00101001</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>*</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">42</p>
+		</td>
+		<td width="60">
+			<p class="center-block">2A</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00101010</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>+</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">43</p>
+		</td>
+		<td width="60">
+			<p class="center-block">2B</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00101011</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>,</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">44</p>
+		</td>
+		<td width="60">
+			<p class="center-block">2C</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00101100</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>-</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">45</p>
+		</td>
+		<td width="60">
+			<p class="center-block">2D</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00101101</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>.</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">46</p>
+		</td>
+		<td width="60">
+			<p class="center-block">2E</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00101110</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>/</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">47</p>
+		</td>
+		<td width="60">
+			<p class="center-block">2F</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00101111</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>0</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">48</p>
+		</td>
+		<td width="60">
+			<p class="center-block">30</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00110000</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block">
+				<b>
+					<span style="color: #ff0000">1</span>
+				</b>
+			</p>
+		</td>
+		<td width="66">
+			<p class="center-block">
+				<b>
+					<span style="color: #ff0000">49</span>
+				</b>
+			</p>
+		</td>
+		<td width="60">
+			<p class="center-block">
+				<b>
+					<span style="color: #ff0000">31</span>
+				</b>
+			</p>
+		</td>
+		<td width="108">
+			<p class="center-block">
+				<b>
+					<span style="color: #ff0000">00110001</span>
+				</b>
+			</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>2</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">50</p>
+		</td>
+		<td width="60">
+			<p class="center-block">32</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00110010</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>3</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">51</p>
+		</td>
+		<td width="60">
+			<p class="center-block">33</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00110011</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block">
+				<b>
+					<span style="color: #ff0000">4</span>
+				</b>
+			</p>
+		</td>
+		<td width="66">
+			<p class="center-block">
+				<b>
+					<span style="color: #ff0000">52</span>
+				</b>
+			</p>
+		</td>
+		<td width="60">
+			<p class="center-block">
+				<b>
+					<span style="color: #ff0000">34</span>
+				</b>
+			</p>
+		</td>
+		<td width="108">
+			<p class="center-block">
+				<b>
+					<span style="color: #ff0000">00110100</span>
+				</b>
+			</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>5</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">53</p>
+		</td>
+		<td width="60">
+			<p class="center-block">35</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00110101</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>6</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">54</p>
+		</td>
+		<td width="60">
+			<p class="center-block">36</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00110110</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>7</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">55</p>
+		</td>
+		<td width="60">
+			<p class="center-block">37</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00110111</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>8</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">56</p>
+		</td>
+		<td width="60">
+			<p class="center-block">38</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00111000</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>9</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">57</p>
+		</td>
+		<td width="60">
+			<p class="center-block">39</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00111001</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>:</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">58</p>
+		</td>
+		<td width="60">
+			<p class="center-block">3A</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00111010</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>;</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">59</p>
+		</td>
+		<td width="60">
+			<p class="center-block">3B</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00111011</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>&lt;</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">60</p>
+		</td>
+		<td width="60">
+			<p class="center-block">3C</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00111100</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>=</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">61</p>
+		</td>
+		<td width="60">
+			<p class="center-block">3D</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00111101</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>&gt;</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">62</p>
+		</td>
+		<td width="60">
+			<p class="center-block">3E</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00111110</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>?</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">63</p>
+		</td>
+		<td width="60">
+			<p class="center-block">3F</p>
+		</td>
+		<td width="108">
+			<p class="center-block">00111111</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>@</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">64</p>
+		</td>
+		<td width="60">
+			<p class="center-block">40</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01000000</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>A</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">65</p>
+		</td>
+		<td width="60">
+			<p class="center-block">41</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01000001</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>B</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">66</p>
+		</td>
+		<td width="60">
+			<p class="center-block">42</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01000010</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>C</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">67</p>
+		</td>
+		<td width="60">
+			<p class="center-block">43</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01000011</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>D</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">68</p>
+		</td>
+		<td width="60">
+			<p class="center-block">44</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01000100</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>E</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">69</p>
+		</td>
+		<td width="60">
+			<p class="center-block">45</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01000101</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>F</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">70</p>
+		</td>
+		<td width="60">
+			<p class="center-block">46</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01000110</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>G</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">71</p>
+		</td>
+		<td width="60">
+			<p class="center-block">47</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01000111</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>H</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">72</p>
+		</td>
+		<td width="60">
+			<p class="center-block">48</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01001000</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>I</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">73</p>
+		</td>
+		<td width="60">
+			<p class="center-block">49</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01001001</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>J</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">74</p>
+		</td>
+		<td width="60">
+			<p class="center-block">4A</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01001010</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>K</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">75</p>
+		</td>
+		<td width="60">
+			<p class="center-block">4B</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01001011</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>L</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">76</p>
+		</td>
+		<td width="60">
+			<p class="center-block">4C</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01001100</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>M</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">77</p>
+		</td>
+		<td width="60">
+			<p class="center-block">4D</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01001101</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>N</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">78</p>
+		</td>
+		<td width="60">
+			<p class="center-block">4E</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01001110</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>O</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">79</p>
+		</td>
+		<td width="60">
+			<p class="center-block">4F</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01001111</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>P</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">80</p>
+		</td>
+		<td width="60">
+			<p class="center-block">50</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01010000</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>Q</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">81</p>
+		</td>
+		<td width="60">
+			<p class="center-block">51</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01010001</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>R</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">82</p>
+		</td>
+		<td width="60">
+			<p class="center-block">52</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01010010</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>S</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">83</p>
+		</td>
+		<td width="60">
+			<p class="center-block">53</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01010011</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>T</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">84</p>
+		</td>
+		<td width="60">
+			<p class="center-block">54</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01010100</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>U</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">85</p>
+		</td>
+		<td width="60">
+			<p class="center-block">55</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01010101</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>V</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">86</p>
+		</td>
+		<td width="60">
+			<p class="center-block">56</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01010110</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>W</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">87</p>
+		</td>
+		<td width="60">
+			<p class="center-block">57</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01010111</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>X</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">88</p>
+		</td>
+		<td width="60">
+			<p class="center-block">58</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01011000</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>Y</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">89</p>
+		</td>
+		<td width="60">
+			<p class="center-block">59</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01011001</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>Z</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">90</p>
+		</td>
+		<td width="60">
+			<p class="center-block">5A</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01011010</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>[</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">91</p>
+		</td>
+		<td width="60">
+			<p class="center-block">5B</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01011011</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>\</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">92</p>
+		</td>
+		<td width="60">
+			<p class="center-block">5C</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01011100</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>]</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">93</p>
+		</td>
+		<td width="60">
+			<p class="center-block">5D</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01011101</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">94</p>
+		</td>
+		<td width="60">
+			<p class="center-block">5E</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01011110</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>_</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">95</p>
+		</td>
+		<td width="60">
+			<p class="center-block">5F</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01011111</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>`</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">96</p>
+		</td>
+		<td width="60">
+			<p class="center-block">60</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01100000</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>a</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">97</p>
+		</td>
+		<td width="60">
+			<p class="center-block">61</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01100001</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>b</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">98</p>
+		</td>
+		<td width="60">
+			<p class="center-block">62</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01100010</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>c</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">99</p>
+		</td>
+		<td width="60">
+			<p class="center-block">63</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01100011</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>d</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">100</p>
+		</td>
+		<td width="60">
+			<p class="center-block">64</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01100100</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block">
+				<b>
+					<span style="color: #ff0000">e</span>
+				</b>
+			</p>
+		</td>
+		<td width="66">
+			<p class="center-block">
+				<b>
+					<span style="color: #ff0000">101</span>
+				</b>
+			</p>
+		</td>
+		<td width="60">
+			<p class="center-block">
+				<b>
+					<span style="color: #ff0000">65</span>
+				</b>
+			</p>
+		</td>
+		<td width="108">
+			<p class="center-block">
+				<b>
+					<span style="color: #ff0000">01100101</span>
+				</b>
+			</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>f</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">102</p>
+		</td>
+		<td width="60">
+			<p class="center-block">66</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01100110</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>g</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">103</p>
+		</td>
+		<td width="60">
+			<p class="center-block">67</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01100111</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>h</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">104</p>
+		</td>
+		<td width="60">
+			<p class="center-block">68</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01101000</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>i</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">105</p>
+		</td>
+		<td width="60">
+			<p class="center-block">69</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01101001</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>j</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">106</p>
+		</td>
+		<td width="60">
+			<p class="center-block">6A</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01101010</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>k</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">107</p>
+		</td>
+		<td width="60">
+			<p class="center-block">6B</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01101011</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>l</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">108</p>
+		</td>
+		<td width="60">
+			<p class="center-block">6C</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01101100</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>m</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">109</p>
+		</td>
+		<td width="60">
+			<p class="center-block">6D</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01101101</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>n</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">110</p>
+		</td>
+		<td width="60">
+			<p class="center-block">6E</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01101110</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>o</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">111</p>
+		</td>
+		<td width="60">
+			<p class="center-block">6F</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01101111</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>p</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">112</p>
+		</td>
+		<td width="60">
+			<p class="center-block">70</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01110000</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>q</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">113</p>
+		</td>
+		<td width="60">
+			<p class="center-block">71</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01110001</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>r</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">114</p>
+		</td>
+		<td width="60">
+			<p class="center-block">72</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01110010</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>s</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">115</p>
+		</td>
+		<td width="60">
+			<p class="center-block">73</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01110011</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>t</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">116</p>
+		</td>
+		<td width="60">
+			<p class="center-block">74</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01110100</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>u</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">117</p>
+		</td>
+		<td width="60">
+			<p class="center-block">75</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01110101</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>v</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">118</p>
+		</td>
+		<td width="60">
+			<p class="center-block">76</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01110110</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>w</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">119</p>
+		</td>
+		<td width="60">
+			<p class="center-block">77</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01110111</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>x</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">120</p>
+		</td>
+		<td width="60">
+			<p class="center-block">78</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01111000</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>y</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">121</p>
+		</td>
+		<td width="60">
+			<p class="center-block">79</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01111001</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>z</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">122</p>
+		</td>
+		<td width="60">
+			<p class="center-block">7A</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01111010</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>{</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">123</p>
+		</td>
+		<td width="60">
+			<p class="center-block">7B</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01111011</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>|</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">124</p>
+		</td>
+		<td width="60">
+			<p class="center-block">7C</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01111100</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>}</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">125</p>
+		</td>
+		<td width="60">
+			<p class="center-block">7D</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01111101</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>~</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">126</p>
+		</td>
+		<td width="60">
+			<p class="center-block">7E</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01111110</p>
+		</td>
+	</tr>
+	<tr>
+		<td width="114">
+			<p class="center-block"><b>^? (DEL)</b></p>
+		</td>
+		<td width="66">
+			<p class="center-block">127</p>
+		</td>
+		<td width="60">
+			<p class="center-block">7F</p>
+		</td>
+		<td width="108">
+			<p class="center-block">01111111</p>
+		</td>
+	</tr>
+</table>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
 					<p>
 						<b>USAGE syntax and notes</b>
 					</p>
-					<p align="center">
+					<p class="center-block">
 						<img height="44" src="Resources/pics/program-fragment.svg" width="48" alt="Program fragment" />
 					</p>
 					<aside>
-						<p align="center">
+						<p class="center-block">
 							<img height="62" src="Resources/pics/aai-BugAlert.gif" width="56" alt="" />
 						</p>
-						<p align="center">
+						<p class="center-block">
 							Group items are always treated as alphanumeric and this can cause problems when there are
 							subordinate COMP items.
 						</p>
-						<p align="center">
+						<p class="center-block">
 							For instance, suppose we had a statement like -<br />
 							<code class="language-cobol">MOVE ZEROS TO GROUP2</code>.<br />
 							in the program opposite.<br />
@@ -2140,8 +2130,8 @@ Begin.
 					</aside>
 				</div>
 				<div class="section-content">
-					<p align="center">
-						<img height="118" src="Resources/pics/UsageSyn1.gif" width="214" />
+					<p class="center-block">
+						<img height="118" src="Resources/pics/UsageSyn1.gif" width="214" / alt="USAGE clause syntax diagram">
 					</p>
 					<p><b>USAGE notes</b></p>
 					<ul>
@@ -2218,7 +2208,7 @@ Begin.
 						complement numbers. The storage requirements for fields described as
 						<code class="language-cobol">COMP</code> are as follows:
 					</p>
-					<table align="center" border="1" cellpadding="1" cellspacing="1" width="293">
+					<table style="margin:0 auto" border="1" cellpadding="1" cellspacing="1" width="293">
 						<tr bgcolor="#FFFFCC">
 							<th scope="col" width="133">Number of Digits</th>
 							<th scope="col" width="166">Storage Required.</th>
@@ -2246,7 +2236,7 @@ Begin.
 						held in a nibble (half a byte). The sign is held in a separate nibble in the least significant
 						position of the item (see diagram below).
 					</p>
-					<p align="center"><img height="155" src="Resources/pics/Usage3.gif" width="406" /></p>
+					<p class="center-block"><img height="155" src="Resources/pics/Usage3.gif" width="406" / alt="PACKED-DECIMAL (BCD) storage format diagram showing digit nibbles and sign nibble"></p>
 					<p>
 						<br />
 						<b>General USAGE notes</b><br />
@@ -2314,7 +2304,7 @@ Begin.
 						of the number in Word2 and the second to get the second part of the number in Word3. This double
 						fetch slows down calculations.
 					</p>
-					<p align="center"><img height="164" src="Resources/pics/Usage4.gif" width="492" /></p>
+					<p class="center-block"><img height="164" src="Resources/pics/Usage4.gif" width="492" / alt="Diagram showing a COMP item straddling a word boundary, requiring two fetch cycles"></p>
 					<p>
 						Now consider the impact of using the
 						<code class="language-cobol">SYNCHRONIZED</code> clause. The number in <i>TwoBytes</i> is now
@@ -2322,7 +2312,7 @@ Begin.
 						number from memory. This speeds up processing but at the expense of wasting some storage (the
 						second byte of Word2 is no longer used).
 					</p>
-					<p align="center"><img height="164" src="Resources/pics/Usage5.gif" width="492" /></p>
+					<p class="center-block"><img height="164" src="Resources/pics/Usage5.gif" width="492" / alt="Diagram showing a COMP item aligned on a word boundary with SYNCHRONIZED, requiring only one fetch cycle"></p>
 					<hr size="1" />
 				</div>
 			</div>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -141,7 +141,7 @@
 						represent a particular character. For instance, the diagram below shows the bit configuration
 						used to represent an upper case "A" in the ASCII and the EBCDIC encoding sequences.
 					</p>
-					<p class="center-block"><img height="102" src="Resources/pics/Usage1.gif" width="396" / alt="Bit representations of the letter A in ASCII (01000001) and EBCDIC (11000001) encoding"></p>
+					<p class="center-block"><img height="102" src="Resources/pics/Usage1.gif" width="396" alt="Bit representations of the letter A in ASCII (01000001) and EBCDIC (11000001) encoding" /></p>
 					<p>
 						Numeric data can be held as text digits (ASCII digits) or as pure binary numbers (in the case of
 						cardinal values), or as twos complement binary numbers (in the case of integers), or as decimal
@@ -237,7 +237,7 @@ Begin.
 						which is the ASCII code for the lower case letter "e".
 					</p>
 					<p>The sum <b>4 + 1 = e</b> does not compute.</p>
-					<p class="center-block"><img height="202" src="Resources/pics/Usage2.gif" width="439" / alt="ASCII table showing that adding digits 4 and 1 produces 01100101, the code for the letter e"></p>
+					<p class="center-block"><img height="202" src="Resources/pics/Usage2.gif" width="439" alt="ASCII table showing that adding digits 4 and 1 produces 01100101, the code for the letter e" /></p>
 					<p>
 						When calculations are done with numeric data items whose
 						<code class="language-cobol">USAGE IS DISPLAY</code>, the computer has to convert the numeric
@@ -2131,7 +2131,7 @@ Begin.
 				</div>
 				<div class="section-content">
 					<p class="center-block">
-						<img height="118" src="Resources/pics/UsageSyn1.gif" width="214" / alt="USAGE clause syntax diagram">
+						<img height="118" src="Resources/pics/UsageSyn1.gif" width="214" alt="USAGE clause syntax diagram" />
 					</p>
 					<p><b>USAGE notes</b></p>
 					<ul>
@@ -2236,7 +2236,7 @@ Begin.
 						held in a nibble (half a byte). The sign is held in a separate nibble in the least significant
 						position of the item (see diagram below).
 					</p>
-					<p class="center-block"><img height="155" src="Resources/pics/Usage3.gif" width="406" / alt="PACKED-DECIMAL (BCD) storage format diagram showing digit nibbles and sign nibble"></p>
+					<p class="center-block"><img height="155" src="Resources/pics/Usage3.gif" width="406" alt="PACKED-DECIMAL (BCD) storage format diagram showing digit nibbles and sign nibble" /></p>
 					<p>
 						<br />
 						<b>General USAGE notes</b><br />
@@ -2304,7 +2304,7 @@ Begin.
 						of the number in Word2 and the second to get the second part of the number in Word3. This double
 						fetch slows down calculations.
 					</p>
-					<p class="center-block"><img height="164" src="Resources/pics/Usage4.gif" width="492" / alt="Diagram showing a COMP item straddling a word boundary, requiring two fetch cycles"></p>
+					<p class="center-block"><img height="164" src="Resources/pics/Usage4.gif" width="492" alt="Diagram showing a COMP item straddling a word boundary, requiring two fetch cycles" /></p>
 					<p>
 						Now consider the impact of using the
 						<code class="language-cobol">SYNCHRONIZED</code> clause. The number in <i>TwoBytes</i> is now
@@ -2312,7 +2312,7 @@ Begin.
 						number from memory. This speeds up processing but at the expense of wasting some storage (the
 						second byte of Word2 is no longer used).
 					</p>
-					<p class="center-block"><img height="164" src="Resources/pics/Usage5.gif" width="492" / alt="Diagram showing a COMP item aligned on a word boundary with SYNCHRONIZED, requiring only one fetch cycle"></p>
+					<p class="center-block"><img height="164" src="Resources/pics/Usage5.gif" width="492" alt="Diagram showing a COMP item aligned on a word boundary with SYNCHRONIZED, requiring only one fetch cycle" /></p>
 					<hr size="1" />
 				</div>
 			</div>

--- a/course/index.html
+++ b/course/index.html
@@ -204,7 +204,7 @@
 					<img src="../pics/T-Dept.gif" width="297" height="36" alt="" /><br />
 					&nbsp;COBOL Programming Course
 				</h1>
-				<p align="center">
+				<p class="center-block">
 					<b
 						>Includes COBOL tutorials, COBOL example programs, COBOL programming exercises and COBOL self
 						assessment questions.</b
@@ -216,7 +216,7 @@
 				<table width="100%" border="1" height="100" cellpadding="2" cellspacing="0">
 					<tr>
 						<td colspan="2" height="29">
-							<div align="center"><img src="Resources/pics/aai-Legend.gif" alt="Legend" /></div>
+							<div class="center-block"><img src="Resources/pics/aai-Legend.gif" alt="Legend" /></div>
 						</td>
 					</tr>
 					<tr>


### PR DESCRIPTION
## Summary
- Deep-cleaned 4 course pages to 0 pa11y violations (WCAG 2.1 AA)
- `Usage.html` (~530 align attrs cleaned), `RefMod.html`, `Intro2DirectAccess.html`, `index.html`

## Changes per file
- Added descriptive `alt` text to content figures (syntax diagrams)
- Stripped `align="left"` attributes (LTR default)
- Replaced `align="center"` on block elements with `class="center-block"`
- Replaced `align="center"` on `<td>`/`<th>` with `style="text-align:center"`
- Replaced `align="center"` on `<table>` with `style="margin:0 auto"`
- Unwrapped `<center>` and `<div align="center">` elements
- Added `title` attributes to iframes

🤖 Generated with [Claude Code](https://claude.com/claude-code)