### PR TITLE
Improve animation alt text specificity in course/COBOLcommands.html

### DIFF
--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -448,7 +448,7 @@ The time is 14:41
 					<p class="center-block">
 						<a href="Resources/ppz/TC-Commands1.html"
 							><img
-								alt="Click to view the animation"
+								alt="Click for animation: MOVE statement examples"
 								height="62"
 								src="Resources/pics/i-Animation.gif"
 								width="62"
@@ -933,7 +933,7 @@ The time is 14:41
 					<p class="center-block">
 						<a href="Resources/ppz/TC-Commands2.html"
 							><img
-								alt="Click to view the animation"
+								alt="Click for animation: Arithmetic statement examples"
 								height="62"
 								src="Resources/pics/i-Animation.gif"
 								width="62"


### PR DESCRIPTION
## Summary

- Replaces generic `alt="Click to view the animation"` on both linked animation images in `course/COBOLcommands.html` with descriptive labels
- `TC-Commands1.html` link → `alt="Click for animation: MOVE statement examples"`
- `TC-Commands2.html` link → `alt="Click for animation: Arithmetic statement examples"`

## Why

`COBOLcommands.html` was made pa11y-clean in an earlier pass using the placeholder `"Click to view the animation"`, which passes the basic non-empty alt check but doesn't tell screen reader users *what* animation they're activating. The recent a11y sprint (PR #200) established the more descriptive `"Click for animation: …"` pattern across all other course pages — this brings this file in line.

## Test plan

- [x] `html-validate course/COBOLcommands.html` passes with no errors
- [ ] `npm run a11y` passes (requires local server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)