### PR TITLE
Fix typos: Interation → Iteration, assessement → assessment

### DIFF
--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-		<title>COBOL Interation Constructs</title>
+		<title>COBOL Iteration Constructs</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/index.html
+++ b/course/index.html
@@ -233,7 +233,7 @@
 					</tr>
 					<tr valign="middle">
 						<td width="14%" height="8"><img src="Resources/pics/i-SAQ.gif" vspace="0" hspace="2" alt="" /></td>
-						<td width="86%" height="8">Self assessement questions</td>
+						<td width="86%" height="8">Self assessment questions</td>
 					</tr>
 				</table>
 			</div>

--- a/examples/Strings/RefMod.html
+++ b/examples/Strings/RefMod.html
@@ -192,7 +192,7 @@ Begin.
 *&gt;   Solution 1 
 *&gt;   Use the REVERSE intrinsic function to reverse the string
 *&gt;   then use the INSPECT tallying to count the number of spaces at the
-*&gt;   begining of the reversed string.  The substring length is then the
+*&gt;   beginning of the reversed string.  The substring length is then the
 *&gt;   FullSringLength - CharCount.
 *&gt;   Use reference modification of get the substring.
     DISPLAY "Task4 Before = " xStr "&lt;&lt;&lt;&lt;&lt;&lt;"

--- a/examples/default.html
+++ b/examples/default.html
@@ -343,7 +343,7 @@
 			<tr bgcolor="#990000" valign="top">
 				<td colspan="4">
 					<h2 style="text-align:center" id="Selection">
-						<b> Selection and Interation </b>
+						<b> Selection and Iteration</b>
 					</h2>
 				</td>
 			</tr>


### PR DESCRIPTION
## Summary

- `course/Iteration.html` `<title>` — "COBOL Interation Constructs" → "COBOL Iteration Constructs"
- `examples/default.html` — "Selection and Interation" → "Selection and Iteration"
- `course/index.html` — "Self assessement questions" → "Self assessment questions"
- `examples/Strings/RefMod.html` — COBOL comment "begining of the reversed string" → "beginning" (caught while sweeping with `rg -i 'seperate|recieve|occured|untill|teh |adn |begining|recomend' --type html`)

Closes #212.

## Test plan

- [x] `npm run validate` passes
- [ ] Visual: tab title on `course/Iteration.html` reads "COBOL Iteration Constructs"

🤖 Generated with [Claude Code](https://claude.com/claude-code)