### PR TITLE
Consolidate CI into a single job to share npm ci

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,8 +7,8 @@ on:
     branches: [master]
 
 jobs:
-  validate:
-    name: HTML validity
+  checks:
+    name: Validate, links, and accessibility
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,27 +18,5 @@ jobs:
           cache: "npm"
       - run: npm ci
       - run: npm run validate
-
-  links:
-    name: Internal link check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "npm"
-      - run: npm ci
       - run: npm run links
-
-  a11y:
-    name: Accessibility
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "npm"
-      - run: npm ci
       - run: npm run a11y


### PR DESCRIPTION
## Summary

Replaces the three separate jobs (\`validate\`, \`links\`, \`a11y\`) in \`.github/workflows/checks.yml\` with a single \`checks\` job that runs:

1. \`actions/checkout@v4\`
2. \`actions/setup-node@v4\` (node 20, npm cache) — once
3. \`npm ci\` — once
4. \`npm run validate\`
5. \`npm run links\`
6. \`npm run a11y\`

\`npm ci\` now runs once per PR instead of three times.

Closes #211.

## Test plan

- [ ] PR check kicks off and the consolidated \`checks\` job runs all three steps
- [ ] Wall-clock time is lower than today's three-job baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)