### PR TITLE
Apply shared theme + dark mode to root index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,12 +20,8 @@
 		<meta name="author" content="Michael Coughlan" />
 		<meta name="robots" content="All" />
 		<meta name="rating" content="General" />
+		<link rel="stylesheet" href="course/Resources/css/course.css" />
 		<style type="text/css">
-			h1 img {
-				max-width: 100%;
-				height: auto;
-			}
-
 			#page-header {
 				display: grid;
 				grid-template-columns: 40px 1fr;
@@ -47,20 +43,9 @@
 
 			ul.toc {
 				list-style-image: url(pics/BallBlueG.gif);
-				padding-left: 2.5em;
-				margin: 1em 0;
-			}
-
-			ul.toc > li {
-				padding-left: 0.4em;
-				margin-bottom: 0.6em;
 			}
 
 			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-				}
-
 				#page-header {
 					grid-template-columns: 40px 1fr;
 					width: 100%;
@@ -82,7 +67,7 @@
 			}
 		</style>
 	</head>
-	<body text="#000000" bgcolor="#FFFFFF" link="#0000FF" vlink="#FF0000" alink="#009B00">
+	<body>
 		<div id="page-header">
 			<div class="header-icon">
 				<img src="pics/i-program.gif" height="42" width="40" alt="" />


### PR DESCRIPTION
## Summary

Brings the site landing page into the shared theme system so it honors \`prefers-color-scheme: dark\`. Previously the entrypoint stayed pure white in dark mode while every course page flipped — a jarring first impression.

- Added \`<link rel="stylesheet" href="course/Resources/css/course.css">\` to \`<head>\` (after the meta tags; viewport stays first per the FOUC-prevention rule).
- Removed legacy \`<body text=... bgcolor=... link=... vlink=... alink=...>\` attributes; CSS variables now drive theming.
- Deduped inline \`<style>\` rules already covered by \`course.css\` (\`h1 img\` sizing, \`ul.toc\` defaults, \`@media (max-width: 600px) { body { margin: 4px } }\`).
- Kept page-specific rules: \`#page-header\` grid layout, \`#page-description\`, and \`ul.toc { list-style-image: url(pics/BallBlueG.gif) }\` (overrides the shared sheet's green ball with the page's blue ball).

Closes #204.

## Test plan

- [x] \`npm run validate\` passes
- [ ] Visual: load \`/\` with \`prefers-color-scheme: dark\` — page renders in dark theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)