### PR TITLE
Add asset-reference checker (catches broken <img src> links)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,6 +19,18 @@ jobs:
       - run: npm ci
       - run: npm run validate
 
+  check-assets:
+    name: Asset reference check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+      - run: npm run check:assets
+
   links:
     name: Internal link check
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 		"links": "start-server-and-test serve http://localhost:8000 links:run",
 		"a11y:run": "pa11y-ci --config .pa11yci.json",
 		"a11y": "start-server-and-test serve http://localhost:8000 a11y:run",
+		"check:assets": "node scripts/check-assets.js",
 		"check": "npm run validate && npm run links && npm run a11y"
 	},
 	"devDependencies": {

--- a/scripts/check-assets.js
+++ b/scripts/check-assets.js
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * check-assets.js
+ *
+ * Walk every *.html file in the repo (skipping node_modules, .git, .claude,
+ * .playwright-mcp) and verify that every src/href attribute that points to a
+ * local file actually exists on disk.
+ *
+ * Exit code 0  – no broken references found.
+ * Exit code 1  – one or more broken references found.
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+
+const SKIP_DIRS = new Set([
+  "node_modules",
+  ".git",
+  ".claude",
+  ".playwright-mcp",
+]);
+
+// Patterns that should never be treated as local file references.
+const SKIP_PREFIXES = [
+  "http://",
+  "https://",
+  "ftp://",
+  "mailto:",
+  "data:",
+  "//",
+  "#",
+];
+
+// ---------------------------------------------------------------------------
+// Walk the directory tree and collect *.html files
+// ---------------------------------------------------------------------------
+
+function walkHtmlFiles(dir, results = []) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return results;
+  }
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (!SKIP_DIRS.has(entry.name)) {
+        walkHtmlFiles(path.join(dir, entry.name), results);
+      }
+    } else if (entry.isFile() && entry.name.endsWith(".html")) {
+      results.push(path.join(dir, entry.name));
+    }
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Extract asset references from an HTML file
+// ---------------------------------------------------------------------------
+
+// Match src="..." href="..." (both " and ' delimiters).
+const ATTR_RE =
+  /(?:src|href)\s*=\s*(?:"([^"]+)"|'([^']+)')/gi;
+
+function extractRefs(html) {
+  const refs = [];
+  let match;
+  ATTR_RE.lastIndex = 0;
+  while ((match = ATTR_RE.exec(html)) !== null) {
+    refs.push(match[1] ?? match[2]);
+  }
+  return refs;
+}
+
+function isLocalRef(ref) {
+  for (const prefix of SKIP_PREFIXES) {
+    if (ref.startsWith(prefix)) return false;
+  }
+  // Empty string
+  if (!ref.trim()) return false;
+  return true;
+}
+
+function stripQueryAndFragment(ref) {
+  // Remove query string and fragment
+  return ref.replace(/[?#].*$/, "");
+}
+
+function decodeHtmlEntities(str) {
+  // Decode the handful of entities that commonly appear in href/src values.
+  return str
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(Number(code)))
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) =>
+      String.fromCharCode(parseInt(hex, 16))
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const htmlFiles = walkHtmlFiles(REPO_ROOT);
+
+let totalBroken = 0;
+const report = [];
+
+for (const htmlFile of htmlFiles) {
+  const htmlDir = path.dirname(htmlFile);
+  let html;
+  try {
+    html = fs.readFileSync(htmlFile, "utf8");
+  } catch {
+    continue;
+  }
+
+  const refs = extractRefs(html);
+  const broken = [];
+
+  for (const rawRef of refs) {
+    if (!isLocalRef(rawRef)) continue;
+
+    const cleanRef = stripQueryAndFragment(decodeHtmlEntities(rawRef));
+    if (!cleanRef) continue;
+
+    const resolved = path.resolve(htmlDir, cleanRef);
+    if (!fs.existsSync(resolved)) {
+      broken.push({ ref: rawRef, resolved });
+    }
+  }
+
+  if (broken.length > 0) {
+    totalBroken += broken.length;
+    report.push({ file: path.relative(REPO_ROOT, htmlFile), broken });
+  }
+}
+
+if (report.length === 0) {
+  console.log("check-assets: all asset references resolve. ✓");
+  process.exit(0);
+}
+
+console.error(`check-assets: found ${totalBroken} broken asset reference(s).\n`);
+
+for (const { file, broken } of report) {
+  console.error(`  ${file}`);
+  for (const { ref } of broken) {
+    console.error(`    ✗ ${ref}`);
+  }
+  console.error("");
+}
+
+process.exit(1);


### PR DESCRIPTION
## Summary

\`linkinator\` only follows \`<a href>\`; \`<img src>\`, \`<link href>\`, and \`<script src>\` slip through. This adds a small Node script that walks every HTML file and verifies each local asset reference resolves on disk.

- New \`scripts/check-assets.js\` (zero deps, just \`fs\`/\`path\`/regex):
  - Skips \`node_modules/\`, \`.git/\`, \`.claude/\`, \`.playwright-mcp/\`
  - Skips absolute URLs (\`http://\`, \`https://\`, \`ftp://\`, \`mailto:\`, \`data:\`, \`//\`) and anchor-only refs
  - Decodes HTML entities before resolving (caught two real files with \`&\` in their names — \`Input&OutputFiles.doc\` and \`InFiles2ODF&OSF.cbl\` — referenced as \`&amp;\` in HTML)
  - Strips \`?query\` and \`#fragment\` before \`fs.existsSync\` check
- New \`npm run check:assets\` script in \`package.json\`
- New \`check-assets\` job step in \`.github/workflows/checks.yml\`

Closes #221.

## Test plan

- [x] \`npm run check:assets\` exits 0 against current master
- [x] \`npm run validate\` passes
- [ ] Manually break an \`<img src>\` and confirm the script reports it and exits non-zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)