### PR TITLE
Add Course + LearningResource schema.org JSON-LD

### DIFF
--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -3,6 +3,21 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+		<script type="application/ld+json">
+		{
+			"@context": "https://schema.org",
+			"@type": "LearningResource",
+			"name": "COBOL Iteration Constructs",
+			"description": "A tutorial covering COBOL iteration constructs including PERFORM..Proc, PERFORM..THRU, PERFORM..TIMES, PERFORM..UNTIL, and PERFORM..VARYING.",
+			"url": "https://www.csis.ul.ie/cobol/course/Iteration.html",
+			"learningResourceType": "Tutorial",
+			"educationalLevel": "Beginner",
+			"isPartOf": {
+				"@type": "Course",
+				"url": "https://www.csis.ul.ie/cobol/course/index.html"
+			}
+		}
+		</script>
 		<title>COBOL Interation Constructs</title>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />

--- a/course/index.html
+++ b/course/index.html
@@ -3,6 +3,23 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+		<script type="application/ld+json">
+		{
+			"@context": "https://schema.org",
+			"@type": "Course",
+			"name": "COBOL Programming Course",
+			"description": "On-line COBOL programming course - includes tutorials, example programs and exercises.",
+			"url": "https://www.csis.ul.ie/cobol/course/index.html",
+			"provider": {
+				"@type": "Person",
+				"name": "Michael Coughlan",
+				"affiliation": {
+					"@type": "Organization",
+					"name": "University of Limerick CSIS"
+				}
+			}
+		}
+		</script>
 		<title>COBOL Programming Course</title>
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" charset="utf-8" defer></script>


### PR DESCRIPTION
## Summary

Adds structured data so search engines can surface course rich-result cards instead of generic blue links.

- \`course/index.html\` — \`<script type="application/ld+json">\` with a \`Course\` object: \`name\`, \`description\`, \`url\`, \`provider\` (Person: Michael Coughlan, affiliation: University of Limerick CSIS).
- \`course/Iteration.html\` — companion \`LearningResource\` JSON-LD: \`name\`, \`description\`, \`url\`, \`learningResourceType: "Tutorial"\`, \`educationalLevel: "Beginner"\`, \`isPartOf\` pointing back at the course.

The \`LearningResource\` markup on \`Iteration.html\` is a proof-of-concept; replicating it across the remaining \`course/*.html\` pages is a follow-up task (left open in #215's wake — happy to spin out a separate issue if useful).

Closes #215.

## Test plan

- [x] \`npm run validate\` passes
- [x] Both JSON-LD blocks parse cleanly via \`JSON.parse\`
- [ ] Validate via [Google's Rich Results Test](https://search.google.com/test/rich-results) once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)