### PR TITLE
Add prev/next lesson navigation across course pages

### DIFF
--- a/components/lesson-nav.js
+++ b/components/lesson-nav.js
@@ -1,0 +1,64 @@
+// Light-DOM custom element that renders Previous / Next lesson links.
+// Mirrors the style of page-hero.js and back-to-top.js: no shadow DOM so
+// course.css link colours and the .lesson-nav rule from course-components.css
+// apply without any extra piercing selectors.
+//
+// The lesson sequence below is derived from the ordered tutorial links in
+// course/index.html (exercises and SAQ links are intentionally excluded).
+const LESSONS = [
+	{ file: "COBOLIntro.html",       title: "The structure of COBOL programs" },
+	{ file: "DataDeclaration.html",   title: "Declaring data in COBOL" },
+	{ file: "COBOLcommands.html",     title: "Basic Procedure Division commands" },
+	{ file: "Selection.html",         title: "Selection in COBOL" },
+	{ file: "Iteration.html",         title: "Iteration in COBOL" },
+	{ file: "SequentialFiles1.html",  title: "Introduction to Sequential files" },
+	{ file: "SequentialFiles2.html",  title: "Processing Sequential files" },
+	{ file: "EditedPics.html",        title: "Edited Pictures" },
+	{ file: "Usage.html",             title: "The USAGE clause" },
+	{ file: "SequentialFiles3.html",  title: "COBOL print files and variable-length records" },
+	{ file: "SortMerge.html",         title: "Sorting and Merging" },
+	{ file: "Intro2DirectAccess.html", title: "Introduction to direct access files" },
+	{ file: "RelativeFiles.html",     title: "Relative Files" },
+	{ file: "IndexedFiles.html",      title: "Indexed Files" },
+	{ file: "Tables1.html",           title: "Using tables" },
+	{ file: "Tables2.html",           title: "Creating tables - syntax and semantics" },
+	{ file: "Search.html",            title: "Searching tables" },
+	{ file: "Subprograms.html",       title: "Contained and external sub-programs" },
+	{ file: "Copy.html",              title: "The COPY verb" },
+	{ file: "Inspect.html",           title: "Inspect" },
+	{ file: "String.html",            title: "String" },
+	{ file: "Unstring.html",          title: "Unstring" },
+	{ file: "RefMod.html",            title: "Reference modification and Intrinsic Functions" },
+	{ file: "ReportWriter.html",      title: "Report Writer by example" },
+	{ file: "ReportWriterSS.html",    title: "Report Writer syntax and semantics" },
+];
+
+class LessonNav extends HTMLElement {
+	connectedCallback() {
+		// Determine the current page filename from the URL path.
+		const segments = window.location.pathname.split("/");
+		const currentFile = segments[segments.length - 1];
+
+		const index = LESSONS.findIndex((l) => l.file === currentFile);
+		if (index === -1) {
+			// Not a known lesson page — render nothing.
+			return;
+		}
+
+		const prev = index > 0 ? LESSONS[index - 1] : null;
+		const next = index < LESSONS.length - 1 ? LESSONS[index + 1] : null;
+
+		// Build the two link slots. An empty span preserves space-between layout
+		// when only one link is present.
+		const prevHTML = prev
+			? `<a class="lesson-nav-prev" href="${prev.file}">← Previous: ${prev.title}</a>`
+			: `<span></span>`;
+		const nextHTML = next
+			? `<a class="lesson-nav-next" href="${next.file}">Next: ${next.title} →</a>`
+			: `<span></span>`;
+
+		this.innerHTML = `<nav class="lesson-nav" aria-label="Lesson navigation">${prevHTML}${nextHTML}</nav>`;
+	}
+}
+
+customElements.define("lesson-nav", LessonNav);

--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -36,6 +36,7 @@
 		</style>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -1180,6 +1181,7 @@ DisplayGreeting.
 				</div>
 				<div class="page-footer">
 					<hr />
+					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>
 				</div>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -11,6 +11,7 @@
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -942,6 +943,7 @@ The time is 14:41
 				</div>
 				<div class="page-footer">
 					<hr />
+					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>
 				</div>

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -23,6 +23,7 @@
 		</style>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -1011,6 +1012,7 @@ COPY CopyFile7 REPLACING N1 BY Num1
 			<!-- Footer -->
 			<div class="page-footer">
 				<hr />
+				<lesson-nav></lesson-nav>
 				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -11,6 +11,7 @@
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
@@ -695,6 +696,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 				</div>
 				<div class="page-footer">
 					<hr />
+					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>
 				</div>

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -11,6 +11,7 @@
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -1422,6 +1423,7 @@ B 0 / , + - CR DB 9</code></pre>
 
 			<div class="page-footer">
 				<hr />
+				<lesson-nav></lesson-nav>
 				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -17,6 +17,7 @@
 		</style>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
@@ -1069,6 +1070,7 @@ ProcessOneBook.
 			</div>
 			<div class="page-footer">
 				<hr />
+				<lesson-nav></lesson-nav>
 				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -11,6 +11,7 @@
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
@@ -564,6 +565,7 @@ END-PERFORM</code></pre>
 			</div>
 			<div class="page-footer">
 				<hr />
+				<lesson-nav></lesson-nav>
 				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -11,6 +11,7 @@
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
@@ -895,6 +896,7 @@ END-IF</code></pre>
 
 			<div class="page-footer">
 				<hr />
+				<lesson-nav></lesson-nav>
 				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -11,6 +11,7 @@
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -1173,6 +1174,7 @@ CountMileage.
 				</div>
 				<div class="page-footer">
 					<hr />
+					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>
 				</div>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -11,6 +11,7 @@
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
@@ -1161,6 +1162,7 @@ Begin.
 			</div>
 			<div class="page-footer">
 				<hr />
+				<lesson-nav></lesson-nav>
 				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -11,6 +11,7 @@
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
@@ -683,6 +684,7 @@ Begin.</code></pre>
 			</div>
 			<div class="page-footer">
 				<hr />
+				<lesson-nav></lesson-nav>
 				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -11,6 +11,7 @@
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -983,6 +984,7 @@ Programmer - Michael Coughlan               Page :  1 </code></pre>
 
 					<div class="page-footer">
 						<hr />
+						<lesson-nav></lesson-nav>
 						<back-to-top></back-to-top>
 						<copyright-notice></copyright-notice>
 					</div>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -11,6 +11,7 @@
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -1169,6 +1170,7 @@ END DECLARATIVES.</code></pre>
 			</div>
 			<div class="page-footer">
 				<hr />
+				<lesson-nav></lesson-nav>
 				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>

--- a/course/Resources/css/course-components.css
+++ b/course/Resources/css/course-components.css
@@ -65,6 +65,33 @@
 	vertical-align: middle;
 }
 
+/* Lesson-level Prev / Next navigation bar. Rendered by lesson-nav.js.
+   Flex row with space-between keeps Prev on the left and Next on the right.
+   min-height: 2em reserves space even when one side is absent so the bar does
+   not collapse. Inherits link colours from course.css (light and dark mode). */
+.lesson-nav {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 0.5em;
+	padding: 0.75em 0;
+	border-top: 1px solid;
+	margin-top: 1em;
+	min-height: 2em;
+}
+
+.lesson-nav-prev,
+.lesson-nav-next {
+	font-size: 0.95em;
+}
+
+@media (prefers-color-scheme: dark) {
+	.lesson-nav {
+		border-top-color: var(--color-border-soft, #444);
+	}
+}
+
 /* ============================================================================
    Page-component classes migrated from per-page <style> blocks (Phase 5).
    Each rule belongs to a single course page in HTML usage. Rules that

--- a/course/Search.html
+++ b/course/Search.html
@@ -11,6 +11,7 @@
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -1097,6 +1098,7 @@ DisplayCountyTaxes.
 			</div>
 			<div class="page-footer">
 				<hr />
+				<lesson-nav></lesson-nav>
 				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -23,6 +23,7 @@
 		</style>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -1354,6 +1355,7 @@ END-EVALUATE
 
 				<div class="page-footer">
 					<hr />
+					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>
 				</div>

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -11,6 +11,7 @@
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -750,6 +751,7 @@ GetStudentRecord.
 			</div>
 			<div class="page-footer">
 				<hr />
+				<lesson-nav></lesson-nav>
 				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -11,6 +11,7 @@
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -504,6 +505,7 @@ END-PERFORM
 			</div>
 			<div class="page-footer">
 				<hr />
+				<lesson-nav></lesson-nav>
 				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -11,6 +11,7 @@
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -912,6 +913,7 @@ DisplayTransactions.
 				</div>
 				<div class="page-footer">
 					<hr />
+					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>
 				</div>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -11,6 +11,7 @@
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -1499,6 +1500,7 @@ Begin.
 			</div>
 			<div class="page-footer">
 				<hr />
+				<lesson-nav></lesson-nav>
 				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>

--- a/course/String.html
+++ b/course/String.html
@@ -11,6 +11,7 @@
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
@@ -407,6 +408,7 @@ END-STRING.</code></pre>
 			</div>
 			<div class="page-footer">
 				<hr />
+				<lesson-nav></lesson-nav>
 				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -11,6 +11,7 @@
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -1154,6 +1155,7 @@ Value - 0</code></pre>
 			</div>
 			<div class="page-footer">
 				<hr />
+				<lesson-nav></lesson-nav>
 				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -11,6 +11,7 @@
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -581,6 +582,7 @@ Begin.
 
 			<div class="page-footer">
 				<hr />
+				<lesson-nav></lesson-nav>
 				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -47,6 +47,7 @@
 		</style>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -1375,6 +1376,7 @@ DisplayCountyTaxes.
 				</div>
 				<div class="page-footer">
 					<hr />
+					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>
 				</div>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -11,6 +11,7 @@
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
@@ -533,6 +534,7 @@ Begin.
 			</div>
 			<div class="page-footer">
 				<hr />
+				<lesson-nav></lesson-nav>
 				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -11,6 +11,7 @@
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
@@ -2318,6 +2319,7 @@ Begin.
 			</div>
 			<div class="page-footer">
 				<hr />
+				<lesson-nav></lesson-nav>
 				<back-to-top></back-to-top>
 				<copyright-notice></copyright-notice>
 			</div>


### PR DESCRIPTION
## Summary

Adds a \`<lesson-nav>\` Light-DOM custom element (mirrors the existing \`<page-hero>\`/\`<back-to-top>\` pattern) so learners can walk the curriculum linearly instead of bouncing back to \`course/index.html\` between every lesson.

- New \`components/lesson-nav.js\` — hardcodes the 25-lesson curriculum sequence (extracted from \`course/index.html\`), reads \`window.location.pathname\` to identify the current page, renders \`← Previous: <title>\` / \`Next: <title> →\` links. Empty \`<span>\` placeholder on the boundary so the flex row holds at the first/last lessons.
- \`course/Resources/css/course-components.css\` — adds \`.lesson-nav\` flex layout (space-between, border-top, themed colors).
- All 25 curriculum \`course/*.html\` pages — \`<script src="../components/lesson-nav.js" defer>\` after \`back-to-top.js\`, and \`<lesson-nav></lesson-nav>\` placed inside \`.page-footer\` just before \`<back-to-top>\`.

Closes #206.

## Test plan

- [x] \`npm run validate\` passes
- [ ] Visual: open \`course/Iteration.html\`, see "← Previous: Selection" and "Next: Tables (1) →"
- [ ] Visual: open the first lesson — only Next visible; open the last lesson — only Previous visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)