### PR TITLE
Add accessible names to PDF lecture iframes + back-to-lectures links

### DIFF
--- a/course/Resources/ppz/TC-Call.html
+++ b/course/Resources/ppz/TC-Call.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-Call.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL CALL statement animation (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/course/Resources/ppz/TC-CobIntro1.html
+++ b/course/Resources/ppz/TC-CobIntro1.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-CobIntro1.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="Introduction to COBOL animation part 1 (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/course/Resources/ppz/TC-CobIntro2.html
+++ b/course/Resources/ppz/TC-CobIntro2.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-CobIntro2.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="Introduction to COBOL animation part 2 (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/course/Resources/ppz/TC-CobIntro3.html
+++ b/course/Resources/ppz/TC-CobIntro3.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-CobIntro3.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="Introduction to COBOL animation part 3 (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/course/Resources/ppz/TC-CobIntro4.html
+++ b/course/Resources/ppz/TC-CobIntro4.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-CobIntro4.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="Introduction to COBOL animation part 4 (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/course/Resources/ppz/TC-CobIntro5.html
+++ b/course/Resources/ppz/TC-CobIntro5.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-CobIntro5.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="Introduction to COBOL animation part 5 (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/course/Resources/ppz/TC-CobIntro6.html
+++ b/course/Resources/ppz/TC-CobIntro6.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-CobIntro6.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="Introduction to COBOL animation part 6 (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/course/Resources/ppz/TC-Commands1.html
+++ b/course/Resources/ppz/TC-Commands1.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-Commands1.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL commands animation part 1 (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/course/Resources/ppz/TC-Commands2.html
+++ b/course/Resources/ppz/TC-Commands2.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-Commands2.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL commands animation part 2 (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/course/Resources/ppz/TC-Condition1.html
+++ b/course/Resources/ppz/TC-Condition1.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-Condition1.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL conditions animation part 1 (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/course/Resources/ppz/TC-Condition2.html
+++ b/course/Resources/ppz/TC-Condition2.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-Condition2.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL conditions animation part 2 (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/course/Resources/ppz/TC-Data1.html
+++ b/course/Resources/ppz/TC-Data1.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-Data1.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL data division animation part 1 (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/course/Resources/ppz/TC-Data2.html
+++ b/course/Resources/ppz/TC-Data2.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-Data2.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL data division animation part 2 (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/course/Resources/ppz/TC-Perform1.html
+++ b/course/Resources/ppz/TC-Perform1.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-Perform1.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL PERFORM statement animation part 1 (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/course/Resources/ppz/TC-Perform2.html
+++ b/course/Resources/ppz/TC-Perform2.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-Perform2.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL PERFORM statement animation part 2 (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/course/Resources/ppz/TC-Search2.html
+++ b/course/Resources/ppz/TC-Search2.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-Search2.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL SEARCH statement animation part 2 (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/course/Resources/ppz/TC-SeqFile1.html
+++ b/course/Resources/ppz/TC-SeqFile1.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-SeqFile1.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="Sequential files in COBOL animation part 1 (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/course/Resources/ppz/TC-SeqFile2a.html
+++ b/course/Resources/ppz/TC-SeqFile2a.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-SeqFile2a.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="Sequential files in COBOL animation part 2a (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/course/Resources/ppz/TC-SeqFile2b.html
+++ b/course/Resources/ppz/TC-SeqFile2b.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-SeqFile2b.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="Sequential files in COBOL animation part 2b (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/course/Resources/ppz/TC-SeqFile2c.html
+++ b/course/Resources/ppz/TC-SeqFile2c.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-SeqFile2c.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="Sequential files in COBOL animation part 2c (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/course/Resources/ppz/TC-SeqFile2d.html
+++ b/course/Resources/ppz/TC-SeqFile2d.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-SeqFile2d.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="Sequential files in COBOL animation part 2d (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/course/Resources/ppz/TC-SeqFile2e.html
+++ b/course/Resources/ppz/TC-SeqFile2e.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-SeqFile2e.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="Sequential files in COBOL animation part 2e (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/course/Resources/ppz/TC-SeqFile3a.html
+++ b/course/Resources/ppz/TC-SeqFile3a.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-SeqFile3a.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="Sequential files in COBOL animation part 3a (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/course/Resources/ppz/TC-Tables1.html
+++ b/course/Resources/ppz/TC-Tables1.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-Tables1.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL tables animation part 1 (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/course/Resources/ppz/TC-Tables2.html
+++ b/course/Resources/ppz/TC-Tables2.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-Tables2.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL tables animation part 2 (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/course/Resources/ppz/TC-Tables3.html
+++ b/course/Resources/ppz/TC-Tables3.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-Tables3.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL tables animation part 3 (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/course/Resources/ppz/TC-Tables4.html
+++ b/course/Resources/ppz/TC-Tables4.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-Tables4.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL tables animation part 4 (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/course/Resources/ppz/TC-Tables5.html
+++ b/course/Resources/ppz/TC-Tables5.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-Tables5.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL tables animation part 5 (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/course/Resources/ppz/TC-Tables7.html
+++ b/course/Resources/ppz/TC-Tables7.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-Tables7.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL tables animation part 7 (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/course/Resources/ppz/TC-Tables8.html
+++ b/course/Resources/ppz/TC-Tables8.html
@@ -8,6 +8,7 @@
 		<iframe
 			src="../pdf-viewer.html?src=ppz/TC-Tables8.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL tables animation part 8 (PDF)"
 		></iframe>
 	</body>
 </html>

--- a/lectures/Basics2.html
+++ b/lectures/Basics2.html
@@ -137,9 +137,14 @@
 		</style>
 	</head>
 	<body style="margin: 0; padding: 0">
+		<a
+			href="index.html"
+			style="position: fixed; top: 8px; left: 8px; z-index: 9999; background: #fff; padding: 4px 8px; border: 1px solid #999; border-radius: 3px; font-family: sans-serif; font-size: 0.85rem; text-decoration: none; color: #333"
+		>&#8592; Back to Lectures</a>
 		<iframe
 			src="../course/Resources/pdf-viewer.html?src=../../lectures/basics2.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL Basics part 2 lecture (PDF slides)"
 		></iframe>
 	</body>
 </html>

--- a/lectures/COPY.html
+++ b/lectures/COPY.html
@@ -137,9 +137,14 @@
 		</style>
 	</head>
 	<body style="margin: 0; padding: 0">
+		<a
+			href="index.html"
+			style="position: fixed; top: 8px; left: 8px; z-index: 9999; background: #fff; padding: 4px 8px; border: 1px solid #999; border-radius: 3px; font-family: sans-serif; font-size: 0.85rem; text-decoration: none; color: #333"
+		>&#8592; Back to Lectures</a>
 		<iframe
 			src="../course/Resources/pdf-viewer.html?src=../../lectures/COPY.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL COPY statement lecture (PDF slides)"
 		></iframe>
 	</body>
 </html>

--- a/lectures/GenIntro.html
+++ b/lectures/GenIntro.html
@@ -137,9 +137,14 @@
 		</style>
 	</head>
 	<body style="margin: 0; padding: 0">
+		<a
+			href="index.html"
+			style="position: fixed; top: 8px; left: 8px; z-index: 9999; background: #fff; padding: 4px 8px; border: 1px solid #999; border-radius: 3px; font-family: sans-serif; font-size: 0.85rem; text-decoration: none; color: #333"
+		>&#8592; Back to Lectures</a>
 		<iframe
 			src="../course/Resources/pdf-viewer.html?src=../../lectures/GenIntro.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="General introduction to COBOL lecture (PDF slides)"
 		></iframe>
 	</body>
 </html>

--- a/lectures/ReportWriterWeb.html
+++ b/lectures/ReportWriterWeb.html
@@ -302,6 +302,7 @@
 							height="575"
 							src="../course/Resources/pdf-viewer.html?src=../../lectures/TC-RepWrite1.pdf"
 							style="border: 1px solid #ccc; width: 100%; aspect-ratio: 425/575"
+							title="Report Writer animated commentary part 1 (PDF slides)"
 							width="425"
 						></iframe>
 						<hr />
@@ -602,6 +603,7 @@ Programmer - Michael Coughlan               Page :  1
 							height="575"
 							src="../course/Resources/pdf-viewer.html?src=../../lectures/TC-RepWrite2.pdf"
 							style="border: 1px solid #ccc; width: 100%; aspect-ratio: 425/575"
+							title="Report Writer animated commentary part 2 (PDF slides)"
 							width="425"
 						></iframe>
 					</div>

--- a/lectures/SeqFile3.html
+++ b/lectures/SeqFile3.html
@@ -137,9 +137,14 @@
 		</style>
 	</head>
 	<body style="margin: 0; padding: 0">
+		<a
+			href="index.html"
+			style="position: fixed; top: 8px; left: 8px; z-index: 9999; background: #fff; padding: 4px 8px; border: 1px solid #999; border-radius: 3px; font-family: sans-serif; font-size: 0.85rem; text-decoration: none; color: #333"
+		>&#8592; Back to Lectures</a>
 		<iframe
 			src="../course/Resources/pdf-viewer.html?src=../../lectures/SeqFile3.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="Sequential files in COBOL part 3 lecture (PDF slides)"
 		></iframe>
 	</body>
 </html>

--- a/lectures/Unstring.html
+++ b/lectures/Unstring.html
@@ -137,9 +137,14 @@
 		</style>
 	</head>
 	<body style="margin: 0; padding: 0">
+		<a
+			href="index.html"
+			style="position: fixed; top: 8px; left: 8px; z-index: 9999; background: #fff; padding: 4px 8px; border: 1px solid #999; border-radius: 3px; font-family: sans-serif; font-size: 0.85rem; text-decoration: none; color: #333"
+		>&#8592; Back to Lectures</a>
 		<iframe
 			src="../course/Resources/pdf-viewer.html?src=../../lectures/Unstring.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL UNSTRING statement lecture (PDF slides)"
 		></iframe>
 	</body>
 </html>

--- a/lectures/Usage.html
+++ b/lectures/Usage.html
@@ -137,9 +137,14 @@
 		</style>
 	</head>
 	<body style="margin: 0; padding: 0">
+		<a
+			href="index.html"
+			style="position: fixed; top: 8px; left: 8px; z-index: 9999; background: #fff; padding: 4px 8px; border: 1px solid #999; border-radius: 3px; font-family: sans-serif; font-size: 0.85rem; text-decoration: none; color: #333"
+		>&#8592; Back to Lectures</a>
 		<iframe
 			src="../course/Resources/pdf-viewer.html?src=../../lectures/Usage.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL USAGE clause lecture (PDF slides)"
 		></iframe>
 	</body>
 </html>

--- a/lectures/arithmetic.html
+++ b/lectures/arithmetic.html
@@ -137,9 +137,14 @@
 		</style>
 	</head>
 	<body style="margin: 0; padding: 0">
+		<a
+			href="index.html"
+			style="position: fixed; top: 8px; left: 8px; z-index: 9999; background: #fff; padding: 4px 8px; border: 1px solid #999; border-radius: 3px; font-family: sans-serif; font-size: 0.85rem; text-decoration: none; color: #333"
+		>&#8592; Back to Lectures</a>
 		<iframe
 			src="../course/Resources/pdf-viewer.html?src=../../lectures/Arithmetic.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="Arithmetic in COBOL lecture (PDF slides)"
 		></iframe>
 	</body>
 </html>

--- a/lectures/basics1.html
+++ b/lectures/basics1.html
@@ -137,9 +137,14 @@
 		</style>
 	</head>
 	<body style="margin: 0; padding: 0">
+		<a
+			href="index.html"
+			style="position: fixed; top: 8px; left: 8px; z-index: 9999; background: #fff; padding: 4px 8px; border: 1px solid #999; border-radius: 3px; font-family: sans-serif; font-size: 0.85rem; text-decoration: none; color: #333"
+		>&#8592; Back to Lectures</a>
 		<iframe
 			src="../course/Resources/pdf-viewer.html?src=../../lectures/Basics1.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL Basics part 1 lecture (PDF slides)"
 		></iframe>
 	</body>
 </html>

--- a/lectures/call.html
+++ b/lectures/call.html
@@ -137,9 +137,14 @@
 		</style>
 	</head>
 	<body style="margin: 0; padding: 0">
+		<a
+			href="index.html"
+			style="position: fixed; top: 8px; left: 8px; z-index: 9999; background: #fff; padding: 4px 8px; border: 1px solid #999; border-radius: 3px; font-family: sans-serif; font-size: 0.85rem; text-decoration: none; color: #333"
+		>&#8592; Back to Lectures</a>
 		<iframe
 			src="../course/Resources/pdf-viewer.html?src=../../lectures/call.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL CALL statement lecture (PDF slides)"
 		></iframe>
 	</body>
 </html>

--- a/lectures/cobintro.html
+++ b/lectures/cobintro.html
@@ -137,9 +137,14 @@
 		</style>
 	</head>
 	<body style="margin: 0; padding: 0">
+		<a
+			href="index.html"
+			style="position: fixed; top: 8px; left: 8px; z-index: 9999; background: #fff; padding: 4px 8px; border: 1px solid #999; border-radius: 3px; font-family: sans-serif; font-size: 0.85rem; text-decoration: none; color: #333"
+		>&#8592; Back to Lectures</a>
 		<iframe
 			src="../course/Resources/pdf-viewer.html?src=../../lectures/cobintro.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="Introduction to COBOL lecture (PDF slides)"
 		></iframe>
 	</body>
 </html>

--- a/lectures/conditions.html
+++ b/lectures/conditions.html
@@ -137,9 +137,14 @@
 		</style>
 	</head>
 	<body style="margin: 0; padding: 0">
+		<a
+			href="index.html"
+			style="position: fixed; top: 8px; left: 8px; z-index: 9999; background: #fff; padding: 4px 8px; border: 1px solid #999; border-radius: 3px; font-family: sans-serif; font-size: 0.85rem; text-decoration: none; color: #333"
+		>&#8592; Back to Lectures</a>
 		<iframe
 			src="../course/Resources/pdf-viewer.html?src=../../lectures/Conditions.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL Conditions lecture (PDF slides)"
 		></iframe>
 	</body>
 </html>

--- a/lectures/design.html
+++ b/lectures/design.html
@@ -137,9 +137,14 @@
 		</style>
 	</head>
 	<body style="margin: 0; padding: 0">
+		<a
+			href="index.html"
+			style="position: fixed; top: 8px; left: 8px; z-index: 9999; background: #fff; padding: 4px 8px; border: 1px solid #999; border-radius: 3px; font-family: sans-serif; font-size: 0.85rem; text-decoration: none; color: #333"
+		>&#8592; Back to Lectures</a>
 		<iframe
 			src="../course/Resources/pdf-viewer.html?src=../../lectures/design.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL program design lecture (PDF slides)"
 		></iframe>
 	</body>
 </html>

--- a/lectures/direct1.html
+++ b/lectures/direct1.html
@@ -137,9 +137,14 @@
 		</style>
 	</head>
 	<body style="margin: 0; padding: 0">
+		<a
+			href="index.html"
+			style="position: fixed; top: 8px; left: 8px; z-index: 9999; background: #fff; padding: 4px 8px; border: 1px solid #999; border-radius: 3px; font-family: sans-serif; font-size: 0.85rem; text-decoration: none; color: #333"
+		>&#8592; Back to Lectures</a>
 		<iframe
 			src="../course/Resources/pdf-viewer.html?src=../../lectures/direct1.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="Direct access files in COBOL lecture (PDF slides)"
 		></iframe>
 	</body>
 </html>

--- a/lectures/dsr1.html
+++ b/lectures/dsr1.html
@@ -137,9 +137,14 @@
 		</style>
 	</head>
 	<body style="margin: 0; padding: 0">
+		<a
+			href="index.html"
+			style="position: fixed; top: 8px; left: 8px; z-index: 9999; background: #fff; padding: 4px 8px; border: 1px solid #999; border-radius: 3px; font-family: sans-serif; font-size: 0.85rem; text-decoration: none; color: #333"
+		>&#8592; Back to Lectures</a>
 		<iframe
 			src="../course/Resources/pdf-viewer.html?src=../../lectures/dsr1.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="Data structures and records lecture (PDF slides)"
 		></iframe>
 	</body>
 </html>

--- a/lectures/indexed.html
+++ b/lectures/indexed.html
@@ -137,9 +137,14 @@
 		</style>
 	</head>
 	<body style="margin: 0; padding: 0">
+		<a
+			href="index.html"
+			style="position: fixed; top: 8px; left: 8px; z-index: 9999; background: #fff; padding: 4px 8px; border: 1px solid #999; border-radius: 3px; font-family: sans-serif; font-size: 0.85rem; text-decoration: none; color: #333"
+		>&#8592; Back to Lectures</a>
 		<iframe
 			src="../course/Resources/pdf-viewer.html?src=../../lectures/Indexed.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="Indexed files in COBOL lecture (PDF slides)"
 		></iframe>
 	</body>
 </html>

--- a/lectures/inspect.html
+++ b/lectures/inspect.html
@@ -137,9 +137,14 @@
 		</style>
 	</head>
 	<body style="margin: 0; padding: 0">
+		<a
+			href="index.html"
+			style="position: fixed; top: 8px; left: 8px; z-index: 9999; background: #fff; padding: 4px 8px; border: 1px solid #999; border-radius: 3px; font-family: sans-serif; font-size: 0.85rem; text-decoration: none; color: #333"
+		>&#8592; Back to Lectures</a>
 		<iframe
 			src="../course/Resources/pdf-viewer.html?src=../../lectures/Inspect.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL INSPECT statement lecture (PDF slides)"
 		></iframe>
 	</body>
 </html>

--- a/lectures/perform.html
+++ b/lectures/perform.html
@@ -137,9 +137,14 @@
 		</style>
 	</head>
 	<body style="margin: 0; padding: 0">
+		<a
+			href="index.html"
+			style="position: fixed; top: 8px; left: 8px; z-index: 9999; background: #fff; padding: 4px 8px; border: 1px solid #999; border-radius: 3px; font-family: sans-serif; font-size: 0.85rem; text-decoration: none; color: #333"
+		>&#8592; Back to Lectures</a>
 		<iframe
 			src="../course/Resources/pdf-viewer.html?src=../../lectures/perform.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL PERFORM statement lecture (PDF slides)"
 		></iframe>
 	</body>
 </html>

--- a/lectures/relative.html
+++ b/lectures/relative.html
@@ -137,9 +137,14 @@
 		</style>
 	</head>
 	<body style="margin: 0; padding: 0">
+		<a
+			href="index.html"
+			style="position: fixed; top: 8px; left: 8px; z-index: 9999; background: #fff; padding: 4px 8px; border: 1px solid #999; border-radius: 3px; font-family: sans-serif; font-size: 0.85rem; text-decoration: none; color: #333"
+		>&#8592; Back to Lectures</a>
 		<iframe
 			src="../course/Resources/pdf-viewer.html?src=../../lectures/Relative.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="Relative files in COBOL lecture (PDF slides)"
 		></iframe>
 	</body>
 </html>

--- a/lectures/search.html
+++ b/lectures/search.html
@@ -137,9 +137,14 @@
 		</style>
 	</head>
 	<body style="margin: 0; padding: 0">
+		<a
+			href="index.html"
+			style="position: fixed; top: 8px; left: 8px; z-index: 9999; background: #fff; padding: 4px 8px; border: 1px solid #999; border-radius: 3px; font-family: sans-serif; font-size: 0.85rem; text-decoration: none; color: #333"
+		>&#8592; Back to Lectures</a>
 		<iframe
 			src="../course/Resources/pdf-viewer.html?src=../../lectures/Search.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL SEARCH statement lecture (PDF slides)"
 		></iframe>
 	</body>
 </html>

--- a/lectures/seqfile1.html
+++ b/lectures/seqfile1.html
@@ -137,9 +137,14 @@
 		</style>
 	</head>
 	<body style="margin: 0; padding: 0">
+		<a
+			href="index.html"
+			style="position: fixed; top: 8px; left: 8px; z-index: 9999; background: #fff; padding: 4px 8px; border: 1px solid #999; border-radius: 3px; font-family: sans-serif; font-size: 0.85rem; text-decoration: none; color: #333"
+		>&#8592; Back to Lectures</a>
 		<iframe
 			src="../course/Resources/pdf-viewer.html?src=../../lectures/SeqFile1.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="Sequential files in COBOL part 1 lecture (PDF slides)"
 		></iframe>
 	</body>
 </html>

--- a/lectures/seqfile2.html
+++ b/lectures/seqfile2.html
@@ -137,9 +137,14 @@
 		</style>
 	</head>
 	<body style="margin: 0; padding: 0">
+		<a
+			href="index.html"
+			style="position: fixed; top: 8px; left: 8px; z-index: 9999; background: #fff; padding: 4px 8px; border: 1px solid #999; border-radius: 3px; font-family: sans-serif; font-size: 0.85rem; text-decoration: none; color: #333"
+		>&#8592; Back to Lectures</a>
 		<iframe
 			src="../course/Resources/pdf-viewer.html?src=../../lectures/SeqFile2.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="Sequential files in COBOL part 2 lecture (PDF slides)"
 		></iframe>
 	</body>
 </html>

--- a/lectures/sort.html
+++ b/lectures/sort.html
@@ -137,9 +137,14 @@
 		</style>
 	</head>
 	<body style="margin: 0; padding: 0">
+		<a
+			href="index.html"
+			style="position: fixed; top: 8px; left: 8px; z-index: 9999; background: #fff; padding: 4px 8px; border: 1px solid #999; border-radius: 3px; font-family: sans-serif; font-size: 0.85rem; text-decoration: none; color: #333"
+		>&#8592; Back to Lectures</a>
 		<iframe
 			src="../course/Resources/pdf-viewer.html?src=../../lectures/SORT.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL SORT statement lecture (PDF slides)"
 		></iframe>
 	</body>
 </html>

--- a/lectures/string.html
+++ b/lectures/string.html
@@ -137,9 +137,14 @@
 		</style>
 	</head>
 	<body style="margin: 0; padding: 0">
+		<a
+			href="index.html"
+			style="position: fixed; top: 8px; left: 8px; z-index: 9999; background: #fff; padding: 4px 8px; border: 1px solid #999; border-radius: 3px; font-family: sans-serif; font-size: 0.85rem; text-decoration: none; color: #333"
+		>&#8592; Back to Lectures</a>
 		<iframe
 			src="../course/Resources/pdf-viewer.html?src=../../lectures/String.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL STRING statement lecture (PDF slides)"
 		></iframe>
 	</body>
 </html>

--- a/lectures/tables1.html
+++ b/lectures/tables1.html
@@ -137,9 +137,14 @@
 		</style>
 	</head>
 	<body style="margin: 0; padding: 0">
+		<a
+			href="index.html"
+			style="position: fixed; top: 8px; left: 8px; z-index: 9999; background: #fff; padding: 4px 8px; border: 1px solid #999; border-radius: 3px; font-family: sans-serif; font-size: 0.85rem; text-decoration: none; color: #333"
+		>&#8592; Back to Lectures</a>
 		<iframe
 			src="../course/Resources/pdf-viewer.html?src=../../lectures/Tables1.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL tables part 1 lecture (PDF slides)"
 		></iframe>
 	</body>
 </html>

--- a/lectures/tables2.html
+++ b/lectures/tables2.html
@@ -137,9 +137,14 @@
 		</style>
 	</head>
 	<body style="margin: 0; padding: 0">
+		<a
+			href="index.html"
+			style="position: fixed; top: 8px; left: 8px; z-index: 9999; background: #fff; padding: 4px 8px; border: 1px solid #999; border-radius: 3px; font-family: sans-serif; font-size: 0.85rem; text-decoration: none; color: #333"
+		>&#8592; Back to Lectures</a>
 		<iframe
 			src="../course/Resources/pdf-viewer.html?src=../../lectures/Tables2.pdf"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+			title="COBOL tables part 2 lecture (PDF slides)"
 		></iframe>
 	</body>
 </html>


### PR DESCRIPTION
## Summary

Every \`<iframe>\` embedding a PDF was missing a \`title\` attribute — screen readers announced them as bare "frame". Also added a small "← Back to Lectures" link on each lecture-viewer wrapper so users who deep-link into a single deck can navigate back to siblings.

**56 files modified, 157 insertions:**

- 24 \`lectures/*.html\` full-page wrappers (e.g. \`cobintro.html\`, \`arithmetic.html\`) — added \`title="… lecture (PDF slides)"\` and a fixed-position "← Back to Lectures" anchor (white background, light border, top-left overlay).
- \`lectures/ReportWriterWeb.html\` — both inline iframes got descriptive titles.
- 30 \`course/Resources/ppz/TC-*.html\` animation wrappers — \`title="… animation (PDF)"\`. No back link added (these are course pages, not lecture wrappers).
- 8 course pages already had \`title=\` on their iframes — no changes needed.

Closes #218.

## Test plan

- [x] \`npm run validate\` passes
- [ ] Visual: open \`lectures/cobintro.html\` — "← Back to Lectures" link visible top-left, returns to \`lectures/\`
- [ ] A11y: tab through the page, screen reader announces the iframe title

🤖 Generated with [Claude Code](https://claude.com/claude-code)