### PR TITLE
Phase 1 of #217: remove hspace/vspace attributes (77 occurrences)

### DIFF
--- a/course/index.html
+++ b/course/index.html
@@ -221,18 +221,18 @@
 					</tr>
 					<tr>
 						<td width="14%" height="15">
-							<img src="Resources/pics/i-Tuts.gif" width="22" height="21" vspace="1" hspace="2" alt="" />
+							<img src="Resources/pics/i-Tuts.gif" width="22" height="21" alt="" style="margin-left: 2px; margin-right: 2px; margin-top: 1px; margin-bottom: 1px;"/>
 						</td>
 						<td width="86%" height="15">COBOL tutorial</td>
 					</tr>
 					<tr>
 						<td width="14%">
-							<img src="Resources/pics/i-exercises.gif" width="21" height="21" hspace="2" vspace="1" alt="" />
+							<img src="Resources/pics/i-exercises.gif" width="21" height="21" alt="" style="margin-left: 2px; margin-right: 2px; margin-top: 1px; margin-bottom: 1px;"/>
 						</td>
 						<td width="86%">COBOL programming exercise</td>
 					</tr>
 					<tr valign="middle">
-						<td width="14%" height="8"><img src="Resources/pics/i-SAQ.gif" vspace="0" hspace="2" alt="" /></td>
+						<td width="14%" height="8"><img src="Resources/pics/i-SAQ.gif" alt="" style="margin-left: 2px; margin-right: 2px;"/></td>
 						<td width="86%" height="8">Self assessement questions</td>
 					</tr>
 				</table>
@@ -245,7 +245,7 @@
 			<div class="course-topics">
 				<!-- Introduction to COBOL -->
 				<div class="topic-label">
-					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" alt="" /><b>Introduction to COBOL</b>
+					<img src="../pics/BallRedG.gif" height="13" width="13" alt="" style="margin-left: 4px; margin-right: 4px;"/><b>Introduction to COBOL</b>
 				</div>
 				<div class="topic-links">
 					<div class="course-link">
@@ -254,10 +254,9 @@
 								src="Resources/pics/i-Tut.gif"
 								width="22"
 								height="21"
-								vspace="4"
-								hspace="5"
-								alt="COBOL tutorial"
-						/></span>
+							
+							
+								alt="COBOL tutorial" style="margin-left: 5px; margin-right: 5px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="COBOLIntro.html">The structure of COBOL programs</a>
 					</div>
 					<div class="course-link">
@@ -266,10 +265,9 @@
 								src="Resources/pics/i-Tut.gif"
 								width="22"
 								height="21"
-								vspace="4"
-								hspace="5"
-								alt="COBOL tutorial"
-						/></span>
+							
+							
+								alt="COBOL tutorial" style="margin-left: 5px; margin-right: 5px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="DataDeclaration.html">Declaring data in COBOL</a>
 					</div>
 					<div class="course-link">
@@ -278,22 +276,19 @@
 								src="Resources/pics/i-Tut.gif"
 								width="22"
 								height="21"
-								vspace="4"
-								hspace="5"
-								alt="COBOL tutorial"
-						/></span>
+							
+							
+								alt="COBOL tutorial" style="margin-left: 5px; margin-right: 5px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="COBOLcommands.html">Basic Procedure Division commands</a>
 					</div>
 					<div class="course-link">
 						<span class="course-link-icon"
-							><img src="Resources/pics/i-exercise.gif" width="21" height="21" vspace="4" hspace="5" alt=""
-						/></span>
+							><img src="Resources/pics/i-exercise.gif" width="21" height="21" alt="" style="margin-left: 5px; margin-right: 5px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="../exercises/GettingStarted.html">Getting Started</a>
 					</div>
 					<div class="course-link">
 						<span class="course-link-icon"
-							><img src="Resources/pics/i-SAQ.gif" hspace="5" vspace="4" alt=""
-						/></span>
+							><img src="Resources/pics/i-SAQ.gif" alt="" style="margin-left: 5px; margin-right: 5px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="../exercises/GettingStarted.html">These will be self assessment questions</a>
 					</div>
 				</div>
@@ -301,7 +296,7 @@
 
 				<!-- COBOL Control structures -->
 				<div class="topic-label">
-					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" alt="" /><b>COBOL Control structures</b>
+					<img src="../pics/BallRedG.gif" height="13" width="13" alt="" style="margin-left: 4px; margin-right: 4px;"/><b>COBOL Control structures</b>
 				</div>
 				<div class="topic-links">
 					<div class="course-link">
@@ -310,10 +305,9 @@
 								src="Resources/pics/i-Tut.gif"
 								width="22"
 								height="21"
-								vspace="4"
-								hspace="5"
-								alt="COBOL tutorial"
-						/></span>
+							
+							
+								alt="COBOL tutorial" style="margin-left: 5px; margin-right: 5px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="Selection.html">Selection in COBOL</a>
 					</div>
 					<div class="course-link">
@@ -322,22 +316,19 @@
 								src="Resources/pics/i-Tut.gif"
 								width="22"
 								height="21"
-								vspace="4"
-								hspace="5"
-								alt="COBOL tutorial"
-						/></span>
+							
+							
+								alt="COBOL tutorial" style="margin-left: 5px; margin-right: 5px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="Iteration.html">Iteration in COBOL</a>
 					</div>
 					<div class="course-link">
 						<span class="course-link-icon"
-							><img src="Resources/pics/i-exercise.gif" width="21" height="21" vspace="4" hspace="5" alt=""
-						/></span>
+							><img src="Resources/pics/i-exercise.gif" width="21" height="21" alt="" style="margin-left: 5px; margin-right: 5px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="../exercises/CountDown.html">The Calculator and Countdown exercise</a>
 					</div>
 					<div class="course-link">
 						<span class="course-link-icon"
-							><img src="Resources/pics/i-SAQ.gif" hspace="5" vspace="5" alt=""
-						/></span>
+							><img src="Resources/pics/i-SAQ.gif" alt="" style="margin-left: 5px; margin-right: 5px; margin-top: 5px; margin-bottom: 5px;"/></span>
 						<a href="../exercises/GettingStarted.html">These will be self assessment questions</a>
 					</div>
 				</div>
@@ -345,7 +336,7 @@
 
 				<!-- Simple Sequential Files -->
 				<div class="topic-label">
-					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" alt="" /><b>Simple Sequential Files</b>
+					<img src="../pics/BallRedG.gif" height="13" width="13" alt="" style="margin-left: 4px; margin-right: 4px;"/><b>Simple Sequential Files</b>
 				</div>
 				<div class="topic-links">
 					<div class="course-link">
@@ -354,10 +345,9 @@
 								src="Resources/pics/i-Tut.gif"
 								width="22"
 								height="21"
-								vspace="4"
-								hspace="4"
-								alt="COBOL tutorial"
-						/></span>
+							
+							
+								alt="COBOL tutorial" style="margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="SequentialFiles1.html">Introduction to Sequential files</a>
 					</div>
 					<div class="course-link">
@@ -366,22 +356,19 @@
 								src="Resources/pics/i-Tut.gif"
 								width="22"
 								height="21"
-								vspace="4"
-								hspace="4"
-								alt="COBOL tutorial"
-						/></span>
+							
+							
+								alt="COBOL tutorial" style="margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="SequentialFiles2.html">Processing Sequential files</a>
 					</div>
 					<div class="course-link">
 						<span class="course-link-icon"
-							><img src="Resources/pics/i-exercise.gif" width="21" height="21" vspace="4" hspace="4" alt=""
-						/></span>
+							><img src="Resources/pics/i-exercise.gif" width="21" height="21" alt="" style="margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="../exercises/SeqRead.html">Reading Sequential Files</a>
 					</div>
 					<div class="course-link">
 						<span class="course-link-icon"
-							><img src="Resources/pics/i-exercise.gif" width="21" height="21" vspace="4" hspace="4" alt=""
-						/></span>
+							><img src="Resources/pics/i-exercise.gif" width="21" height="21" alt="" style="margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="../exercises/SeqReadIf.html">Counting records in a Sequential File</a>
 					</div>
 				</div>
@@ -389,7 +376,7 @@
 
 				<!-- Advanced data declaration -->
 				<div class="topic-label">
-					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" alt="" /><b>Advanced data declaration</b>
+					<img src="../pics/BallRedG.gif" height="13" width="13" alt="" style="margin-left: 4px; margin-right: 4px;"/><b>Advanced data declaration</b>
 				</div>
 				<div class="topic-links">
 					<div class="course-link">
@@ -398,10 +385,9 @@
 								src="Resources/pics/i-Tut.gif"
 								width="22"
 								height="21"
-								vspace="4"
-								hspace="4"
-								alt="COBOL tutorial"
-						/></span>
+							
+							
+								alt="COBOL tutorial" style="margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="EditedPics.html">Edited Pictures</a>
 					</div>
 					<div class="course-link">
@@ -410,22 +396,19 @@
 								src="Resources/pics/i-Tut.gif"
 								width="22"
 								height="21"
-								vspace="4"
-								hspace="4"
-								alt="COBOL tutorial"
-						/></span>
+							
+							
+								alt="COBOL tutorial" style="margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="Usage.html">The USAGE clause</a>
 					</div>
 					<div class="course-link">
 						<span class="course-link-icon"
-							><img src="Resources/pics/i-exercise.gif" width="21" height="21" vspace="4" hspace="4" alt=""
-						/></span>
+							><img src="Resources/pics/i-exercise.gif" width="21" height="21" alt="" style="margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="../exercises/SeqWrite.html">Writing records to a Sequential File</a>
 					</div>
 					<div class="course-link">
 						<span class="course-link-icon"
-							><img src="Resources/pics/i-exercise.gif" width="21" height="21" vspace="4" hspace="4" alt=""
-						/></span>
+							><img src="Resources/pics/i-exercise.gif" width="21" height="21" alt="" style="margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="../exercises/SeqInsert.html">Inserting records in a Sequential File</a>
 					</div>
 				</div>
@@ -433,7 +416,7 @@
 
 				<!-- Advanced Sequential Files -->
 				<div class="topic-label">
-					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" alt="" /><b>Advanced Sequential Files</b>
+					<img src="../pics/BallRedG.gif" height="13" width="13" alt="" style="margin-left: 4px; margin-right: 4px;"/><b>Advanced Sequential Files</b>
 				</div>
 				<div class="topic-links">
 					<div class="course-link">
@@ -442,10 +425,9 @@
 								src="Resources/pics/i-Tut.gif"
 								width="22"
 								height="21"
-								vspace="4"
-								hspace="4"
-								alt="COBOL tutorial"
-						/></span>
+							
+							
+								alt="COBOL tutorial" style="margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="SequentialFiles3.html">COBOL print files and variable-length records</a>
 					</div>
 					<div class="course-link">
@@ -454,10 +436,9 @@
 								src="Resources/pics/i-Tut.gif"
 								width="22"
 								height="21"
-								vspace="4"
-								hspace="4"
-								alt="COBOL tutorial"
-						/></span>
+							
+							
+								alt="COBOL tutorial" style="margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="SortMerge.html">Sorting and Merging</a>
 					</div>
 					<div class="course-link">
@@ -466,22 +447,19 @@
 								src="Resources/pics/i-Tut.gif"
 								width="22"
 								height="21"
-								vspace="4"
-								hspace="4"
-								alt="COBOL tutorial"
-						/></span>
+							
+							
+								alt="COBOL tutorial" style="margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="COBOLcommands.html">Basic Procedure Division commands</a>
 					</div>
 					<div class="course-link">
 						<span class="course-link-icon"
-							><img src="Resources/pics/i-exercise.gif" width="21" height="21" vspace="4" hspace="4" alt=""
-						/></span>
+							><img src="Resources/pics/i-exercise.gif" width="21" height="21" alt="" style="margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="../exercises/SeqUpdate.html">Updating a Sequential File</a>
 					</div>
 					<div class="course-link">
 						<span class="course-link-icon"
-							><img src="Resources/pics/i-exercise.gif" width="21" height="21" vspace="4" hspace="4" alt=""
-						/></span>
+							><img src="Resources/pics/i-exercise.gif" width="21" height="21" alt="" style="margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="../exercises/SortIP.html">Sorting a Sequential File</a>
 					</div>
 				</div>
@@ -489,7 +467,7 @@
 
 				<!-- Direct access files -->
 				<div class="topic-label">
-					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" alt="" /><b>Direct access files</b>
+					<img src="../pics/BallRedG.gif" height="13" width="13" alt="" style="margin-left: 4px; margin-right: 4px;"/><b>Direct access files</b>
 				</div>
 				<div class="topic-links">
 					<div class="course-link">
@@ -498,10 +476,9 @@
 								src="Resources/pics/i-Tut.gif"
 								width="22"
 								height="21"
-								vspace="4"
-								hspace="4"
-								alt="COBOL tutorial"
-						/></span>
+							
+							
+								alt="COBOL tutorial" style="margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="Intro2DirectAccess.html">Introduction to direct access files</a>
 					</div>
 					<div class="course-link">
@@ -510,10 +487,9 @@
 								src="Resources/pics/i-Tut.gif"
 								width="22"
 								height="21"
-								vspace="4"
-								hspace="4"
-								alt="COBOL tutorial"
-						/></span>
+							
+							
+								alt="COBOL tutorial" style="margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="RelativeFiles.html">Relative Files</a>
 					</div>
 					<div class="course-link">
@@ -522,10 +498,9 @@
 								src="Resources/pics/i-Tut.gif"
 								width="22"
 								height="21"
-								vspace="4"
-								hspace="4"
-								alt="COBOL tutorial"
-						/></span>
+							
+							
+								alt="COBOL tutorial" style="margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="IndexedFiles.html">Indexed Files</a>
 					</div>
 				</div>
@@ -533,7 +508,7 @@
 
 				<!-- COBOL tables -->
 				<div class="topic-label">
-					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" alt="" /><b>COBOL tables</b>
+					<img src="../pics/BallRedG.gif" height="13" width="13" alt="" style="margin-left: 4px; margin-right: 4px;"/><b>COBOL tables</b>
 				</div>
 				<div class="topic-links">
 					<div class="course-link">
@@ -542,10 +517,9 @@
 								src="Resources/pics/i-Tut.gif"
 								width="22"
 								height="21"
-								vspace="4"
-								hspace="4"
-								alt="COBOL tutorial"
-						/></span>
+							
+							
+								alt="COBOL tutorial" style="margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="Tables1.html">Using tables</a>
 					</div>
 					<div class="course-link">
@@ -554,10 +528,9 @@
 								src="Resources/pics/i-Tut.gif"
 								width="22"
 								height="21"
-								vspace="4"
-								hspace="4"
-								alt="COBOL tutorial"
-						/></span>
+							
+							
+								alt="COBOL tutorial" style="margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="Tables2.html">Creating tables - syntax and semantics</a>
 					</div>
 					<div class="course-link">
@@ -566,16 +539,14 @@
 								src="Resources/pics/i-Tut.gif"
 								width="22"
 								height="21"
-								vspace="4"
-								hspace="4"
-								alt="COBOL tutorial"
-						/></span>
+							
+							
+								alt="COBOL tutorial" style="margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="Search.html">Searching tables</a>
 					</div>
 					<div class="course-link">
 						<span class="course-link-icon"
-							><img src="Resources/pics/i-exercise.gif" width="21" height="21" vspace="4" hspace="4" alt=""
-						/></span>
+							><img src="Resources/pics/i-exercise.gif" width="21" height="21" alt="" style="margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="../exercises/MonthTable.html">Using Tables</a>
 					</div>
 				</div>
@@ -583,7 +554,7 @@
 
 				<!-- Constructing large systems -->
 				<div class="topic-label">
-					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" alt="" /><b
+					<img src="../pics/BallRedG.gif" height="13" width="13" alt="" style="margin-left: 4px; margin-right: 4px;"/><b
 						>Constructing large systems</b
 					>
 				</div>
@@ -594,10 +565,9 @@
 								src="Resources/pics/i-Tut.gif"
 								width="22"
 								height="21"
-								vspace="4"
-								hspace="4"
-								alt="COBOL tutorial"
-						/></span>
+							
+							
+								alt="COBOL tutorial" style="margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="Subprograms.html">Contained and external sub-programs</a>
 					</div>
 					<div class="course-link">
@@ -606,10 +576,9 @@
 								src="Resources/pics/i-Tut.gif"
 								width="22"
 								height="21"
-								vspace="4"
-								hspace="4"
-								alt="COBOL tutorial"
-						/></span>
+							
+							
+								alt="COBOL tutorial" style="margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="Copy.html">The COPY verb</a>
 					</div>
 				</div>
@@ -617,7 +586,7 @@
 
 				<!-- COBOL string handling -->
 				<div class="topic-label">
-					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" alt="" /><b>COBOL string handling</b>
+					<img src="../pics/BallRedG.gif" height="13" width="13" alt="" style="margin-left: 4px; margin-right: 4px;"/><b>COBOL string handling</b>
 				</div>
 				<div class="topic-links">
 					<div class="course-link">
@@ -626,10 +595,9 @@
 								src="Resources/pics/i-Tut.gif"
 								width="22"
 								height="21"
-								vspace="4"
-								hspace="4"
-								alt="COBOL tutorial"
-						/></span>
+							
+							
+								alt="COBOL tutorial" style="margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="Inspect.html">Inspect</a>
 					</div>
 					<div class="course-link">
@@ -638,10 +606,9 @@
 								src="Resources/pics/i-Tut.gif"
 								width="22"
 								height="21"
-								vspace="4"
-								hspace="4"
-								alt="COBOL tutorial"
-						/></span>
+							
+							
+								alt="COBOL tutorial" style="margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="String.html">String</a>
 					</div>
 					<div class="course-link">
@@ -650,10 +617,9 @@
 								src="Resources/pics/i-Tut.gif"
 								width="22"
 								height="21"
-								vspace="4"
-								hspace="4"
-								alt="COBOL tutorial"
-						/></span>
+							
+							
+								alt="COBOL tutorial" style="margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="Unstring.html">Unstring</a>
 					</div>
 					<div class="course-link">
@@ -662,10 +628,9 @@
 								src="Resources/pics/i-Tut.gif"
 								width="22"
 								height="21"
-								vspace="4"
-								hspace="4"
-								alt="COBOL tutorial"
-						/></span>
+							
+							
+								alt="COBOL tutorial" style="margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="RefMod.html">Reference modification and Intrinsic Functions</a>
 					</div>
 				</div>
@@ -673,7 +638,7 @@
 
 				<!-- The COBOL Report Writer -->
 				<div class="topic-label">
-					<img src="../pics/BallRedG.gif" hspace="4" height="13" width="13" alt="" /><b>The COBOL Report Writer</b>
+					<img src="../pics/BallRedG.gif" height="13" width="13" alt="" style="margin-left: 4px; margin-right: 4px;"/><b>The COBOL Report Writer</b>
 				</div>
 				<div class="topic-links">
 					<div class="course-link">
@@ -682,10 +647,9 @@
 								src="Resources/pics/i-Tut.gif"
 								width="22"
 								height="21"
-								vspace="4"
-								hspace="4"
-								alt="COBOL tutorial"
-						/></span>
+							
+							
+								alt="COBOL tutorial" style="margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="ReportWriter.html">Report Writer by example</a>
 					</div>
 					<div class="course-link">
@@ -694,10 +658,9 @@
 								src="Resources/pics/i-Tut.gif"
 								width="22"
 								height="21"
-								vspace="4"
-								hspace="4"
-								alt="COBOL tutorial"
-						/></span>
+							
+							
+								alt="COBOL tutorial" style="margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px;"/></span>
 						<a href="ReportWriterSS.html">Report Writer syntax and semantics</a>
 					</div>
 				</div>

--- a/examples/default.html
+++ b/examples/default.html
@@ -178,7 +178,7 @@
 	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
 		<h2>
 			<img height="42" src="../pics/i-program.gif" width="40" alt="" />
-			<img height="36" hspace="5" src="../pics/T-Dept.gif" width="297" alt="" />&nbsp;<br />
+			<img height="36" src="../pics/T-Dept.gif" width="297" alt="" style="margin-left: 5px; margin-right: 5px;"/>&nbsp;<br />
 			COBOL Example Programs
 		</h2>
 		<hr />

--- a/exercises/GettingStarted.html
+++ b/exercises/GettingStarted.html
@@ -195,7 +195,7 @@
 		</p>
 		<h2>Compiling the program</h2>
 		<p>
-			Click on the tick icon<img src="i-tick.gif" hspace="7" height="24" width="24" alt="" />in the NetExpress toolbar.
+			Click on the tick icon<img src="i-tick.gif" height="24" width="24" alt="" style="margin-left: 7px; margin-right: 7px;"/>in the NetExpress toolbar.
 			This compiles the program.
 		</p>
 		<h2>Starting to run the program</h2>
@@ -249,10 +249,9 @@
 		<p>
 			From the NetExpress toolbar select the Step icon&nbsp;<img
 				src="i-step.gif"
-				hspace="7"
+			
 				height="23"
-				width="23" alt=""
-			/>(if you position the cursor over each icon for a short time the computer will display a label for it). You
+				width="23" alt="" style="margin-left: 7px; margin-right: 7px;"/>(if you position the cursor over each icon for a short time the computer will display a label for it). You
 			can also select step from the <b><i>Animate</i></b> menu or by pressing Ctrl-S.
 		</p>
 		<p>

--- a/exercises/SeqRead.html
+++ b/exercises/SeqRead.html
@@ -165,11 +165,11 @@
 		<h2>Examining SeqRead</h2>
 		Examine the program carefully, paying particular attention to the way the end of file is handled.&nbsp; Note the
 		use of&nbsp; the condition name EndOfStudentFile.
-		<p>Compile the program.&nbsp;<img src="i-tick.gif" hspace="7" height="24" width="24" alt="" /></p>
+		<p>Compile the program.&nbsp;<img src="i-tick.gif" height="24" width="24" alt="" style="margin-left: 7px; margin-right: 7px;"/></p>
 		<p>
 			Set a breakpoint at the first statement in the Procedure Division (move the cursor over the statement,
 			right-click and select Set Breakpoint from the menu which appears).<br />
-			Use the Animator to step&nbsp;<img src="i-step.gif" hspace="7" height="23" width="23" alt="" />through the program.
+			Use the Animator to step&nbsp;<img src="i-step.gif" height="23" width="23" alt="" style="margin-left: 7px; margin-right: 7px;"/>through the program.
 		</p>
 		<p>
 			Assign the variables StudentDetails, StudentName, Initials, DateOfBirth and MOBirth to the watch list

--- a/exercises/index.html
+++ b/exercises/index.html
@@ -175,10 +175,9 @@
 		<h2>
 			<img border="1" height="40" src="../pics/i-AtComputer.gif" width="40" alt="" /><img
 				height="36"
-				hspace="5"
+			
 				src="../pics/T-Dept.gif"
-				width="297" alt=""
-			/>&nbsp;<br />
+				width="297" alt="" style="margin-left: 5px; margin-right: 5px;"/>&nbsp;<br />
 			COBOL Programming Exercises&nbsp;
 		</h2>
 		<hr width="800" />
@@ -270,7 +269,7 @@
 			<table border="0" cellpadding="0" cellspacing="0" width="750">
 				<tr>
 					<td height="37" valign="top" width="27%">
-						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" alt="" /><a href="Exm-StudFeesRpt/Exm-StudPay.html">Student Fees Report</a>
+						<img height="13" src="../pics/BallGreenG.gif" width="13" alt="" style="margin-left: 4px; margin-right: 4px;"/><a href="Exm-StudFeesRpt/Exm-StudPay.html">Student Fees Report</a>
 					</td>
 					<td height="37" valign="top" width="73%">
 						<p>
@@ -288,7 +287,7 @@
 				</tr>
 				<tr>
 					<td height="47" valign="top" width="27%">
-						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" alt="" /><a
+						<img height="13" src="../pics/BallGreenG.gif" width="13" alt="" style="margin-left: 4px; margin-right: 4px;"/><a
 							href="Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html"
 							>Aromamora Summary Sales</a
 						>
@@ -305,7 +304,7 @@
 				</tr>
 				<tr>
 					<td height="62" valign="top" width="27%">
-						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" alt="" /><a
+						<img height="13" src="../pics/BallGreenG.gif" width="13" alt="" style="margin-left: 4px; margin-right: 4px;"/><a
 							href="Exm-FlyByNightTravel/Exm-FlyByNight.html"
 							>FlyByNight Summary File</a
 						>
@@ -323,7 +322,7 @@
 				</tr>
 				<tr>
 					<td height="103" valign="top" width="27%">
-						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" alt="" /><a
+						<img height="13" src="../pics/BallGreenG.gif" width="13" alt="" style="margin-left: 4px; margin-right: 4px;"/><a
 							href="Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html"
 							>AromamoraMaint&amp;Report</a
 						>
@@ -346,7 +345,7 @@
 				</tr>
 				<tr>
 					<td height="2" valign="top" width="27%">
-						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" alt="" /><a
+						<img height="13" src="../pics/BallGreenG.gif" width="13" alt="" style="margin-left: 4px; margin-right: 4px;"/><a
 							href="Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html"
 							>BookshopLecturerReqRpt</a
 						>
@@ -368,7 +367,7 @@
 				</tr>
 				<tr>
 					<td height="93" valign="top" width="27%">
-						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" alt="" /><a
+						<img height="13" src="../pics/BallGreenG.gif" width="13" alt="" style="margin-left: 4px; margin-right: 4px;"/><a
 							href="Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html"
 							>ACME Stock Reorder</a
 						>
@@ -392,7 +391,7 @@
 				</tr>
 				<tr>
 					<td height="93" valign="top" width="27%">
-						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" alt="" /><a
+						<img height="13" src="../pics/BallGreenG.gif" width="13" alt="" style="margin-left: 4px; margin-right: 4px;"/><a
 							href="Exm-FileConversion/Exm-FileConversion.html"
 							>File Conversion</a
 						>
@@ -412,7 +411,7 @@
 				</tr>
 				<tr>
 					<td height="29" valign="top" width="27%">
-						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" alt="" /><a
+						<img height="13" src="../pics/BallGreenG.gif" width="13" alt="" style="margin-left: 4px; margin-right: 4px;"/><a
 							href="Exm-USSRshipRpt/Exm-USSRshipRpt.html"
 							>USSR Ship Report</a
 						>
@@ -429,7 +428,7 @@
 				</tr>
 				<tr>
 					<td height="57" valign="top" width="27%">
-						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" alt="" /><a
+						<img height="13" src="../pics/BallGreenG.gif" width="13" alt="" style="margin-left: 4px; margin-right: 4px;"/><a
 							href="Exm-SFbyMail/Exm-SFbyMai.html"
 							>Science Fiction by mail</a
 						>
@@ -446,7 +445,7 @@
 				</tr>
 				<tr>
 					<td height="65" valign="top" width="27%">
-						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" alt="" /><a
+						<img height="13" src="../pics/BallGreenG.gif" width="13" alt="" style="margin-left: 4px; margin-right: 4px;"/><a
 							href="Exm-CSISEmailDomain/Exm-CSISEmailDomain.html"
 							>CSISEmailDomain</a
 						>
@@ -464,7 +463,7 @@
 				</tr>
 				<tr>
 					<td height="110" valign="top" width="27%">
-						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" alt="" /><a
+						<img height="13" src="../pics/BallGreenG.gif" width="13" alt="" style="margin-left: 4px; margin-right: 4px;"/><a
 							href="Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html"
 							>LibraryRoyaltiesRpt</a
 						>
@@ -486,7 +485,7 @@
 				</tr>
 				<tr>
 					<td height="49" valign="top" width="27%">
-						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" alt="" /><a
+						<img height="13" src="../pics/BallGreenG.gif" width="13" alt="" style="margin-left: 4px; margin-right: 4px;"/><a
 							href="Exm-TopSupplierRpt/Exm-TopSupplierRpt.html"
 							>TopSupplierRpt</a
 						>
@@ -505,7 +504,7 @@
 				</tr>
 				<tr>
 					<td height="56" valign="top" width="27%">
-						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" alt="" /><a
+						<img height="13" src="../pics/BallGreenG.gif" width="13" alt="" style="margin-left: 4px; margin-right: 4px;"/><a
 							href="Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html"
 							>FolioBestSellersRpt</a
 						>
@@ -520,7 +519,7 @@
 				</tr>
 				<tr>
 					<td height="56" valign="top" width="27%">
-						<img height="13" hspace="4" src="../pics/BallGreenG.gif" width="13" alt="" /><a
+						<img height="13" src="../pics/BallGreenG.gif" width="13" alt="" style="margin-left: 4px; margin-right: 4px;"/><a
 							href="Exm-DueSubsRpt/Exm-DueSubsRpt.html"
 							>DueSubsRpt</a
 						>
@@ -546,7 +545,7 @@
 				<tr>
 					<td height="156" valign="top" width="27%">
 						<p>
-							<img height="12" hspace="4" src="../pics/BallOrangeG.gif" width="12" alt="" /><a
+							<img height="12" src="../pics/BallOrangeG.gif" width="12" alt="" style="margin-left: 4px; margin-right: 4px;"/><a
 								href="Proj-CSISEvalform/CSISEvalForm.html"
 								>CSIS evaluation form report</a
 							>
@@ -577,7 +576,7 @@
 				<tr>
 					<td height="68" valign="top" width="27%">
 						<p>
-							<img height="12" hspace="4" src="../pics/BallOrangeG.gif" width="12" alt="" /><a
+							<img height="12" src="../pics/BallOrangeG.gif" width="12" alt="" style="margin-left: 4px; margin-right: 4px;"/><a
 								href="Prj-AromaSalesRpt/Prj-AromaSalesRpt.html"
 								>Aroma Sales Report</a
 							>
@@ -593,7 +592,7 @@
 				</tr>
 				<tr>
 					<td height="42" valign="top" width="27%">
-						<img height="12" hspace="4" src="../pics/BallOrangeG.gif" width="12" alt="" /><a
+						<img height="12" src="../pics/BallOrangeG.gif" width="12" alt="" style="margin-left: 4px; margin-right: 4px;"/><a
 							href="Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html"
 							>Newtronics File Maintenance</a
 						>
@@ -608,7 +607,7 @@
 				</tr>
 				<tr>
 					<td height="42" valign="top" width="27%">
-						<img height="12" hspace="4" src="../pics/BallOrangeG.gif" width="12" alt="" /><a
+						<img height="12" src="../pics/BallOrangeG.gif" width="12" alt="" style="margin-left: 4px; margin-right: 4px;"/><a
 							href="Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html"
 							>Aroma Invoices Report</a
 						>
@@ -622,7 +621,7 @@
 				</tr>
 				<tr>
 					<td height="42" valign="top" width="27%">
-						<img height="12" hspace="4" src="../pics/BallOrangeG.gif" width="12" alt="" /><a
+						<img height="12" src="../pics/BallOrangeG.gif" width="12" alt="" style="margin-left: 4px; margin-right: 4px;"/><a
 							href="Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html"
 							>MunsterSurnamesFreqRpt</a
 						>
@@ -635,7 +634,7 @@
 				</tr>
 				<tr>
 					<td height="42" valign="top" width="27%">
-						<img height="12" hspace="4" src="../pics/BallOrangeG.gif" width="12" alt="" /><a
+						<img height="12" src="../pics/BallOrangeG.gif" width="12" alt="" style="margin-left: 4px; margin-right: 4px;"/><a
 							href="Prj-CAOPointsCalc/Prj-CAOcalculator.html"
 							>CAO points calculator</a
 						>

--- a/lectures/index.html
+++ b/lectures/index.html
@@ -158,14 +158,13 @@
 		<p>Each lecture topic in the module outline is followed by these two clickable buttons -</p>
 		<ul>
 			<a href="#Contents"
-				><img align="texttop" border="0" height="52" hspace="5" src="../pics/B-BackArrow.gif" width="52" alt="" /></a
-			><img align="texttop" height="52" hspace="10" src="../pics/B-BrowserPPT2.gif" width="52" alt="" /><img
+				><img align="texttop" border="0" height="52" src="../pics/B-BackArrow.gif" width="52" alt="" style="margin-left: 5px; margin-right: 5px;"/></a
+			><img align="texttop" height="52" src="../pics/B-BrowserPPT2.gif" width="52" alt="" style="margin-left: 10px; margin-right: 10px;"/><img
 				align="texttop"
 				height="52"
-				hspace="5"
+			
 				src="../pics/B-ZippedPPT2.gif"
-				width="52" alt=""
-			/><br />
+				width="52" alt="" style="margin-left: 5px; margin-right: 5px;"/><br />
 			The first button returns you to the module contents. Try it now.<br />
 			The second runs the presentation in your browser.<br />
 			The last button downloads the .pptx file containing the presentation
@@ -173,148 +172,148 @@
 		<hr />
 		<h2 id="Contents">Module Contents</h2>
 		<h4>
-			<img height="13" hspace="5" src="../pics/BallBlueG.gif" width="13" alt="" /><a href="CS4312Topics.html#General"
+			<img height="13" src="../pics/BallBlueG.gif" width="13" alt="" style="margin-left: 5px; margin-right: 5px;"/><a href="CS4312Topics.html#General"
 				>General Introduction</a
 			>
 		</h4>
 		<h4>
-			<img height="13" hspace="5" src="../pics/BallBlueG.gif" width="13" alt="" /><a
+			<img height="13" src="../pics/BallBlueG.gif" width="13" alt="" style="margin-left: 5px; margin-right: 5px;"/><a
 				href="CS4312Topics.html#Introduction"
 				>Introduction to COBOL</a
 			>
 		</h4>
 		<h4>
-			<img height="13" hspace="5" src="../pics/BallBlueG.gif" width="13" alt="" /><a href="CS4312Topics.html#Basics1"
+			<img height="13" src="../pics/BallBlueG.gif" width="13" alt="" style="margin-left: 5px; margin-right: 5px;"/><a href="CS4312Topics.html#Basics1"
 				>COBOL Basics 1</a
 			>
 		</h4>
 		<h4>
-			<img height="13" hspace="5" src="../pics/BallBlueG.gif" width="13" alt="" /><a href="CS4312Topics.html#Basics2"
+			<img height="13" src="../pics/BallBlueG.gif" width="13" alt="" style="margin-left: 5px; margin-right: 5px;"/><a href="CS4312Topics.html#Basics2"
 				>COBOL Basics 2</a
 			>
 		</h4>
 		<h4>
-			<img height="13" hspace="5" src="../pics/BallBlueG.gif" width="13" alt="" /><a
+			<img height="13" src="../pics/BallBlueG.gif" width="13" alt="" style="margin-left: 5px; margin-right: 5px;"/><a
 				href="CS4312Topics.html#IntroSeqFiles"
 				>Introduction to Sequential Files</a
 			>
 		</h4>
 		<h4>
-			<img height="13" hspace="5" src="../pics/BallBlueG.gif" width="13" alt="" /><a
+			<img height="13" src="../pics/BallBlueG.gif" width="13" alt="" style="margin-left: 5px; margin-right: 5px;"/><a
 				href="CS4312Topics.html#ProcessingSeqFiles"
 				>Processing Sequential Files</a
 			>
 		</h4>
 		<h4>
-			<img height="13" hspace="5" src="../pics/BallBlueG.gif" width="13" alt="" /><a href="CS4312Topics.html#PERFORM"
+			<img height="13" src="../pics/BallBlueG.gif" width="13" alt="" style="margin-left: 5px; margin-right: 5px;"/><a href="CS4312Topics.html#PERFORM"
 				>Simple iteration with the PERFORM verb</a
 			>
 		</h4>
 		<h4>
-			<img height="13" hspace="5" src="../pics/BallBlueG.gif" width="13" alt="" /><a href="CS4312Topics.html#Arithmetic"
+			<img height="13" src="../pics/BallBlueG.gif" width="13" alt="" style="margin-left: 5px; margin-right: 5px;"/><a href="CS4312Topics.html#Arithmetic"
 				>Arithmetic and Edited Pictures</a
 			>
 		</h4>
 		<h4>
-			<img height="13" hspace="5" src="../pics/BallBlueG.gif" width="13" alt="" /><a href="CS4312Topics.html#Conditions"
+			<img height="13" src="../pics/BallBlueG.gif" width="13" alt="" style="margin-left: 5px; margin-right: 5px;"/><a href="CS4312Topics.html#Conditions"
 				>Conditions</a
 			>
 		</h4>
 		<h4>
-			<img height="13" hspace="5" src="../pics/BallBlueG.gif" width="13" alt="" /><a href="CS4312Topics.html#Designing"
+			<img height="13" src="../pics/BallBlueG.gif" width="13" alt="" style="margin-left: 5px; margin-right: 5px;"/><a href="CS4312Topics.html#Designing"
 				>Designing Programs</a
 			>
 		</h4>
 		<h4>
-			<img height="13" hspace="5" src="../pics/BallBlueG.gif" width="13" alt="" /><a href="CS4312Topics.html#DSR1"
+			<img height="13" src="../pics/BallBlueG.gif" width="13" alt="" style="margin-left: 5px; margin-right: 5px;"/><a href="CS4312Topics.html#DSR1"
 				>Introduction to Diagrammatic Stepwise Refinement</a
 			>
 		</h4>
 		<h4>
-			<img height="13" hspace="5" src="../pics/BallBlueG.gif" width="13" alt="" /><a href="CS4312Topics.html#SORT"
+			<img height="13" src="../pics/BallBlueG.gif" width="13" alt="" style="margin-left: 5px; margin-right: 5px;"/><a href="CS4312Topics.html#SORT"
 				>SORT and MERGE</a
 			>
 		</h4>
 		<h4>
-			<img height="13" hspace="5" src="../pics/BallBlueG.gif" width="13" alt="" /><a href="CS4312Topics.html#Tables"
+			<img height="13" src="../pics/BallBlueG.gif" width="13" alt="" style="margin-left: 5px; margin-right: 5px;"/><a href="CS4312Topics.html#Tables"
 				>Tables and the PERFORM ... VARYING</a
 			>
 		</h4>
 		<h4>
-			<img height="13" hspace="5" src="../pics/BallBlueG.gif" width="13" alt="" /><a
+			<img height="13" src="../pics/BallBlueG.gif" width="13" alt="" style="margin-left: 5px; margin-right: 5px;"/><a
 				href="CS4312Topics.html#AdvancedTables"
 				>Advanced Tables</a
 			>
 		</h4>
 		<h4>
-			<img height="13" hspace="5" src="../pics/BallBlueG.gif" width="13" alt="" /><a
+			<img height="13" src="../pics/BallBlueG.gif" width="13" alt="" style="margin-left: 5px; margin-right: 5px;"/><a
 				href="CS4312Topics.html#SearchingTAbles"
 				>Searching Tables</a
 			>
 		</h4>
 		<h4>
-			<img height="13" hspace="5" src="../pics/BallBlueG.gif" width="13" alt="" /><a
+			<img height="13" src="../pics/BallBlueG.gif" width="13" alt="" style="margin-left: 5px; margin-right: 5px;"/><a
 				href="CS4312Topics.html#AdvancedSeqFiles"
 				>Advanced Sequential Files</a
 			>
 		</h4>
 		<h4>
-			<img height="13" hspace="5" src="../pics/BallBlueG.gif" width="13" alt="" /><a
+			<img height="13" src="../pics/BallBlueG.gif" width="13" alt="" style="margin-left: 5px; margin-right: 5px;"/><a
 				href="CS4312Topics.html#IntroDirectAccessFiles"
 				>Introduction to Direct Access Files</a
 			>
 		</h4>
 		<h4>
-			<img height="13" hspace="5" src="../pics/BallBlueG.gif" width="13" alt="" /><a
+			<img height="13" src="../pics/BallBlueG.gif" width="13" alt="" style="margin-left: 5px; margin-right: 5px;"/><a
 				href="CS4312Topics.html#RelativeFiles"
 				>Relative Files</a
 			>
 		</h4>
 		<h4>
-			<img height="13" hspace="5" src="../pics/BallBlueG.gif" width="13" alt="" /><a
+			<img height="13" src="../pics/BallBlueG.gif" width="13" alt="" style="margin-left: 5px; margin-right: 5px;"/><a
 				href="CS4312Topics.html#IndexedFiles"
 				>Indexed Files</a
 			>
 		</h4>
 		<h4>
-			<img height="13" hspace="5" src="../pics/BallBlueG.gif" width="13" alt="" /><a href="CS4312Topics.html#Calling"
+			<img height="13" src="../pics/BallBlueG.gif" width="13" alt="" style="margin-left: 5px; margin-right: 5px;"/><a href="CS4312Topics.html#Calling"
 				>Calling Subprograms</a
 			>
 		</h4>
 		<h4>
-			<img height="13" hspace="5" src="../pics/BallBlueG.gif" width="13" alt="" /><a href="CS4312Topics.html#Inspect"
+			<img height="13" src="../pics/BallBlueG.gif" width="13" alt="" style="margin-left: 5px; margin-right: 5px;"/><a href="CS4312Topics.html#Inspect"
 				>The INSPECT</a
 			>
 		</h4>
 		<h4>
-			<img height="13" hspace="5" src="../pics/BallBlueG.gif" width="13" alt="" /><a href="CS4312Topics.html#String"
+			<img height="13" src="../pics/BallBlueG.gif" width="13" alt="" style="margin-left: 5px; margin-right: 5px;"/><a href="CS4312Topics.html#String"
 				>The STRING</a
 			>
 		</h4>
 		<h4>
-			<img height="13" hspace="5" src="../pics/BallBlueG.gif" width="13" alt="" /><a href="CS4312Topics.html#Unstring"
+			<img height="13" src="../pics/BallBlueG.gif" width="13" alt="" style="margin-left: 5px; margin-right: 5px;"/><a href="CS4312Topics.html#Unstring"
 				>The UNSTRING</a
 			>
 		</h4>
 		<h4>
-			<img height="13" hspace="5" src="../pics/BallBlueG.gif" width="13" alt="" /><a href="CS4312Topics.html#Usage"
+			<img height="13" src="../pics/BallBlueG.gif" width="13" alt="" style="margin-left: 5px; margin-right: 5px;"/><a href="CS4312Topics.html#Usage"
 				>The USAGE clause</a
 			>
 		</h4>
 		<h4>
-			<img height="13" hspace="5" src="../pics/BallBlueG.gif" width="13" alt="" /><a
+			<img height="13" src="../pics/BallBlueG.gif" width="13" alt="" style="margin-left: 5px; margin-right: 5px;"/><a
 				href="CS4312Topics.html#ReportWriter1"
 				>The COBOL Report Writer - A worked example</a
 			>
 		</h4>
 		<h4>
-			<img height="13" hspace="5" src="../pics/BallBlueG.gif" width="13" alt="" /><a
+			<img height="13" src="../pics/BallBlueG.gif" width="13" alt="" style="margin-left: 5px; margin-right: 5px;"/><a
 				href="CS4312Topics.html#ReportWriter2"
 				>The COBOL Report Writer - Syntax and Semantics</a
 			>
 		</h4>
 		<h4>
-			<img height="13" hspace="5" src="../pics/BallBlueG.gif" width="13" alt="" /><a href="CS4312Topics.html#Copy"
+			<img height="13" src="../pics/BallBlueG.gif" width="13" alt="" style="margin-left: 5px; margin-right: 5px;"/><a href="CS4312Topics.html#Copy"
 				>The COPY</a
 			>
 		</h4>


### PR DESCRIPTION
## Summary

First pass on #217. Removes every \`hspace=\` and \`vspace=\` attribute from \`<img>\` tags across the site — these don't validate as HTML5 and have no native equivalent. Where the spacing was load-bearing, replaced with inline \`style="margin-..."\` in pixels.

**6 files modified, 77 attribute occurrences removed:**
- \`course/index.html\` (90 attribute instances across 45 img tags)
- \`lectures/index.html\` (30 — ball-bullet icons + nav buttons)
- \`exercises/index.html\` (21 — ball-bullets)
- \`exercises/GettingStarted.html\` (2)
- \`exercises/SeqRead.html\` (2)
- \`examples/default.html\` (1 — department logo)

**Phase 2+** (still open under #217): \`bgcolor\`, \`align\`, \`valign\`, \`border\`, \`<font>\`, \`<center>\` are separate sweeps.

References #217 (does not close).

## Test plan

- [x] \`npm run validate\` passes
- [x] \`rg --type html ' (hspace|vspace)='\` returns zero matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)