### PR TITLE
Add <main> landmark and skip-to-content link

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -40,6 +40,8 @@
 	</head>
 
 	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
 		<div class="page-wrapper">
 			<div class="section-grid">
 				<div class="section-full">
@@ -1185,5 +1187,6 @@ DisplayGreeting.
 				</div>
 			</div>
 		</div>
+		</main>
 	</body>
 </html>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -15,6 +15,8 @@
 	</head>
 
 	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
 		<div class="page-wrapper">
 			<div class="page-content">
 				<page-hero title="Basic Procedure Division Commands"></page-hero>
@@ -947,5 +949,6 @@ The time is 14:41
 				</div>
 			</div>
 		</div>
+		</main>
 	</body>
 </html>

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -27,6 +27,8 @@
 	</head>
 
 	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
 		<div class="page-wrapper">
 			<div class="section-grid">
 				<!-- Header -->
@@ -1015,5 +1017,6 @@ COPY CopyFile7 REPLACING N1 BY Num1
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>
+		</main>
 	</body>
 </html>

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -14,6 +14,8 @@
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
 		<div class="page-wrapper">
 			<div class="section-grid">
 				<div class="section-full">
@@ -700,5 +702,6 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 				</div>
 			</div>
 		</div>
+		</main>
 	</body>
 </html>

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -15,6 +15,8 @@
 	</head>
 
 	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
 		<div class="page-wrapper">
 			<div class="page-content">
 				<page-hero title="Edited Pictures"></page-hero>
@@ -1426,5 +1428,6 @@ B 0 / , + - CR DB 9</code></pre>
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>
+		</main>
 	</body>
 </html>

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -20,6 +20,8 @@
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
 		<div class="page-wrapper">
 			<div class="page-content">
 				<page-hero title="Indexed Files"></page-hero>
@@ -1073,5 +1075,6 @@ ProcessOneBook.
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>
+		</main>
 	</body>
 </html>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -14,6 +14,8 @@
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
 		<div class="page-wrapper">
 			<div class="page-content">
 				<page-hero title="The INSPECT verb"></page-hero>
@@ -568,5 +570,6 @@ END-PERFORM</code></pre>
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>
+		</main>
 	</body>
 </html>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -14,6 +14,8 @@
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
 		<div class="page-wrapper">
 			<div class="page-content">
 				<page-hero title="Introduction to Direct Access Files"></page-hero>
@@ -899,5 +901,6 @@ END-IF</code></pre>
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>
+		</main>
 	</body>
 </html>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -15,6 +15,8 @@
 	</head>
 
 	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
 		<div class="page-wrapper">
 			<div class="page-content">
 				<page-hero title="COBOL Iteration Constructs"></page-hero>
@@ -1178,5 +1180,6 @@ CountMileage.
 				</div>
 			</div>
 		</div>
+		</main>
 	</body>
 </html>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -14,6 +14,8 @@
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
 		<div class="page-wrapper">
 			<div class="page-content">
 				<page-hero title="Reference Modification and Intrinsic Functions"></page-hero>
@@ -1165,5 +1167,6 @@ Begin.
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>
+		</main>
 	</body>
 </html>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -14,6 +14,8 @@
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
 		<div class="page-wrapper">
 			<div class="page-content">
 				<page-hero title="Relative Files"></page-hero>
@@ -687,5 +689,6 @@ Begin.</code></pre>
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>
+		</main>
 	</body>
 </html>

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -15,6 +15,8 @@
 	</head>
 
 	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
 		<div class="page-wrapper">
 			<div class="page-content">
 				<div>
@@ -989,5 +991,6 @@ Programmer - Michael Coughlan               Page :  1 </code></pre>
 				</div>
 			</div>
 		</div>
+		</main>
 	</body>
 </html>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -15,6 +15,8 @@
 	</head>
 
 	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
 		<div class="page-wrapper">
 			<div class="page-content">
 				<div>
@@ -1173,5 +1175,6 @@ END DECLARATIVES.</code></pre>
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>
+		</main>
 	</body>
 </html>

--- a/course/Resources/css/course.css
+++ b/course/Resources/css/course.css
@@ -162,6 +162,31 @@ body {
 	}
 }
 
+/* Skip-to-content link: visually hidden until focused, then visible at top-left */
+.skip-link {
+	position: absolute;
+	left: -9999px;
+	top: auto;
+	width: 1px;
+	height: 1px;
+	overflow: hidden;
+}
+
+.skip-link:focus {
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: auto;
+	height: auto;
+	overflow: visible;
+	padding: 0.5em 1em;
+	background-color: var(--color-header-bg);
+	color: var(--color-header-text);
+	font-weight: bold;
+	z-index: 9999;
+	text-decoration: none;
+}
+
 ul.toc {
 	list-style-image: url(../pics/BallGreenG.gif);
 	padding-left: 2.5em;

--- a/course/Search.html
+++ b/course/Search.html
@@ -15,6 +15,8 @@
 	</head>
 
 	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
 		<div class="page-wrapper">
 			<div class="page-content">
 				<div>
@@ -1101,5 +1103,6 @@ DisplayCountyTaxes.
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>
+		</main>
 	</body>
 </html>

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -27,6 +27,8 @@
 	</head>
 
 	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
 		<div class="page-wrapper">
 			<!-- Header / TOC -->
 			<div class="page-content">
@@ -1359,5 +1361,6 @@ END-EVALUATE
 				</div>
 			</div>
 		</div>
+		</main>
 	</body>
 </html>

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -15,6 +15,8 @@
 	</head>
 
 	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
 		<div class="page-wrapper">
 			<div class="page-content">
 				<page-hero title="Introduction to Sequential Files"></page-hero>
@@ -754,5 +756,6 @@ GetStudentRecord.
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>
+		</main>
 	</body>
 </html>

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -15,6 +15,8 @@
 	</head>
 
 	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
 		<div class="page-wrapper">
 			<div class="page-content">
 				<page-hero title="Processing Sequential Files"></page-hero>
@@ -508,5 +510,6 @@ END-PERFORM
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>
+		</main>
 	</body>
 </html>

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -15,6 +15,8 @@
 	</head>
 
 	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
 		<div class="page-wrapper">
 			<div class="page-content">
 				<page-hero title="Print files and variable-length records"></page-hero>
@@ -917,5 +919,6 @@ DisplayTransactions.
 				</div>
 			</div>
 		</div>
+		</main>
 	</body>
 </html>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -15,6 +15,8 @@
 	</head>
 
 	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
 		<div class="page-wrapper">
 			<div class="page-content">
 				<div>
@@ -1503,5 +1505,6 @@ Begin.
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>
+		</main>
 	</body>
 </html>

--- a/course/String.html
+++ b/course/String.html
@@ -14,6 +14,8 @@
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
 		<div class="page-wrapper">
 			<div class="page-content">
 				<page-hero title="The STRING verb"></page-hero>
@@ -411,5 +413,6 @@ END-STRING.</code></pre>
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>
+		</main>
 	</body>
 </html>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -15,6 +15,8 @@
 	</head>
 
 	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
 		<div class="page-wrapper">
 			<div class="page-content">
 				<page-hero title="Subprograms"></page-hero>
@@ -1158,5 +1160,6 @@ Value - 0</code></pre>
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>
+		</main>
 	</body>
 </html>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -15,6 +15,8 @@
 	</head>
 
 	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
 		<div class="page-wrapper">
 			<div class="page-content">
 				<page-hero title="Using Tables"></page-hero>
@@ -585,5 +587,6 @@ Begin.
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>
+		</main>
 	</body>
 </html>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -51,6 +51,8 @@
 	</head>
 
 	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
 		<div class="page-wrapper">
 			<div class="section-grid">
 				<div class="section-full">
@@ -1380,5 +1382,6 @@ DisplayCountyTaxes.
 				</div>
 			</div>
 		</div>
+		</main>
 	</body>
 </html>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -14,6 +14,8 @@
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
 		<div class="page-wrapper">
 			<div class="page-content">
 				<page-hero title="The UNSTRING verb"></page-hero>
@@ -537,5 +539,6 @@ Begin.
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>
+		</main>
 	</body>
 </html>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -15,6 +15,8 @@
 	</head>
 
 	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
 		<div class="page-wrapper">
 			<div class="section-grid">
 				<div class="section-full">
@@ -2322,5 +2324,6 @@ Begin.
 				<copyright-notice></copyright-notice>
 			</div>
 		</div>
+		</main>
 	</body>
 </html>

--- a/course/index.html
+++ b/course/index.html
@@ -191,10 +191,37 @@
 					filter: none;
 				}
 			}
+
+			/* Skip-to-content link */
+			.skip-link {
+				position: absolute;
+				left: -9999px;
+				top: auto;
+				width: 1px;
+				height: 1px;
+				overflow: hidden;
+			}
+
+			.skip-link:focus {
+				position: fixed;
+				top: 0;
+				left: 0;
+				width: auto;
+				height: auto;
+				overflow: visible;
+				padding: 0.5em 1em;
+				background-color: #993300;
+				color: #ffff00;
+				font-weight: bold;
+				z-index: 9999;
+				text-decoration: none;
+			}
 		</style>
 	</head>
 	<body>
-		<!-- Header: flex row replaces 3-column layout table -->
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+				<!-- Header: flex row replaces 3-column layout table -->
 		<div class="course-header">
 			<div class="course-header-icon">
 				<img src="../pics/I-TEACHER.GIF" width="40" height="42" style="margin: 4px" alt="" />
@@ -703,5 +730,6 @@
 				</div>
 			</div>
 		</div>
+		</main>
 	</body>
 </html>

--- a/examples/default.html
+++ b/examples/default.html
@@ -171,12 +171,39 @@
 				color: #800000;
 				font-family: Arial, Helvetica, sans-serif;
 			}
+
+			/* Skip-to-content link */
+			.skip-link {
+				position: absolute;
+				left: -9999px;
+				top: auto;
+				width: 1px;
+				height: 1px;
+				overflow: hidden;
+			}
+
+			.skip-link:focus {
+				position: fixed;
+				top: 0;
+				left: 0;
+				width: auto;
+				height: auto;
+				overflow: visible;
+				padding: 0.5em 1em;
+				background-color: #993300;
+				color: #ffff00;
+				font-weight: bold;
+				z-index: 9999;
+				text-decoration: none;
+			}
 		</style>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 
 	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
-		<h2>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+				<h2>
 			<img height="42" src="../pics/i-program.gif" width="40" alt="" />
 			<img height="36" hspace="5" src="../pics/T-Dept.gif" width="297" alt="" />&nbsp;<br />
 			COBOL Example Programs
@@ -1785,5 +1812,6 @@
 				</td>
 			</tr>
 		</table>
+		</main>
 	</body>
 </html>

--- a/exercises/index.html
+++ b/exercises/index.html
@@ -168,11 +168,38 @@
 				color: #800000;
 				font-family: Arial, Helvetica, sans-serif;
 			}
+
+			/* Skip-to-content link */
+			.skip-link {
+				position: absolute;
+				left: -9999px;
+				top: auto;
+				width: 1px;
+				height: 1px;
+				overflow: hidden;
+			}
+
+			.skip-link:focus {
+				position: fixed;
+				top: 0;
+				left: 0;
+				width: auto;
+				height: auto;
+				overflow: visible;
+				padding: 0.5em 1em;
+				background-color: #993300;
+				color: #ffff00;
+				font-weight: bold;
+				z-index: 9999;
+				text-decoration: none;
+			}
 		</style>
 		<script src="../components/copyright-notice.js" defer></script>
 	</head>
 	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
-		<h2>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+				<h2>
 			<img border="1" height="40" src="../pics/i-AtComputer.gif" width="40" alt="" /><img
 				height="36"
 				hspace="5"
@@ -649,5 +676,6 @@
 				</tr>
 			</table>
 		</ul>
+		</main>
 	</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -80,10 +80,37 @@
 					font-size: medium;
 				}
 			}
+
+			/* Skip-to-content link */
+			.skip-link {
+				position: absolute;
+				left: -9999px;
+				top: auto;
+				width: 1px;
+				height: 1px;
+				overflow: hidden;
+			}
+
+			.skip-link:focus {
+				position: fixed;
+				top: 0;
+				left: 0;
+				width: auto;
+				height: auto;
+				overflow: visible;
+				padding: 0.5em 1em;
+				background-color: #993300;
+				color: #ffff00;
+				font-weight: bold;
+				z-index: 9999;
+				text-decoration: none;
+			}
 		</style>
 	</head>
 	<body text="#000000" bgcolor="#FFFFFF" link="#0000FF" vlink="#FF0000" alink="#009B00">
-		<div id="page-header">
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+				<div id="page-header">
 			<div class="header-icon">
 				<img src="pics/i-program.gif" height="42" width="40" alt="" />
 			</div>
@@ -127,5 +154,6 @@
 			</li>
 			<li><a href="https://bushidocodes.github.io/klein-cobol-faq/">COBOL FAQ</a></li>
 		</ul>
+		</main>
 	</body>
 </html>

--- a/lectures/index.html
+++ b/lectures/index.html
@@ -136,11 +136,38 @@
 					margin: 0.2em 0;
 				}
 			}
+
+			/* Skip-to-content link */
+			.skip-link {
+				position: absolute;
+				left: -9999px;
+				top: auto;
+				width: 1px;
+				height: 1px;
+				overflow: hidden;
+			}
+
+			.skip-link:focus {
+				position: fixed;
+				top: 0;
+				left: 0;
+				width: auto;
+				height: auto;
+				overflow: visible;
+				padding: 0.5em 1em;
+				background-color: #993300;
+				color: #ffff00;
+				font-weight: bold;
+				z-index: 9999;
+				text-decoration: none;
+			}
 		</style>
 	</head>
 
 	<body alink="#009B00" bgcolor="#FFFFFF" link="#0000FF" text="#000000" vlink="#FF0000">
-		<h2>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+				<h2>
 			<img align="top" border="0" height="42" src="../pics/I-TEACHER.GIF" width="40" alt="" />&nbsp;
 			<img align="top" height="36" src="../pics/T-Dept.gif" width="297" alt="" /><br />
 			COBOL lectures and tutorials
@@ -366,5 +393,6 @@
 				</td>
 			</tr>
 		</table>
+		</main>
 	</body>
 </html>


### PR DESCRIPTION
## Summary

Adds the standard a11y bypass for landmark + skip link across every content page.

**31 files, 245 insertions:**

- \`course/Resources/css/course.css\` — new \`.skip-link\` rule: visually hidden by default (\`position: absolute; left: -9999px\`), revealed on \`:focus\` as a fixed top-left banner using existing \`--color-header-bg\` / \`--color-header-text\` tokens, \`z-index: 9999\`.
- 25 \`course/*.html\` content pages — \`<a class="skip-link" href="#main-content">Skip to main content</a>\` as first child of \`<body>\`, content wrapped in \`<main id="main-content">…</main>\`.
- 5 standalone pages (\`course/index.html\`, \`examples/default.html\`, \`exercises/index.html\`, \`lectures/index.html\`, root \`index.html\`) — same treatment, with \`.skip-link\` CSS duplicated into their inline \`<style>\` blocks since they don't yet load \`course.css\`. The duplication self-resolves once #205 (theme migration) merges.

Closes #207. Helps unblock #210's existing pa11y ignore list — landmark+skip link will be load-bearing once heading-level rules tighten.

## Test plan

- [x] \`npm run validate\` passes
- [ ] Tab on a fresh page load → focus lands on the skip link
- [ ] Screen reader announces a \`main\` landmark on each page

🤖 Generated with [Claude Code](https://claude.com/claude-code)