### PR TITLE
Phase 1 of #222: convert .section-sidebar <h4> to <h3>

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -78,7 +78,7 @@
 					<h2 id="intro">Introduction</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Aims</h4>
+					<h3>Aims</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -90,7 +90,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Objectives</h4>
+					<h3>Objectives</h3>
 				</div>
 				<div class="section-content">
 					<p>By the end of this unit you should -</p>
@@ -111,7 +111,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Prerequisites</h4>
+					<h3>Prerequisites</h3>
 				</div>
 				<div class="section-content">
 					<p>None. This is the first unit in the course.</p>
@@ -126,7 +126,7 @@
 					<h2 id="part1">What is COBOL?</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -149,7 +149,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>How widely used is COBOL?</h4>
+					<h3>How widely used is COBOL?</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -184,7 +184,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Surprised by COBOL's success?</h4>
+					<h3>Surprised by COBOL's success?</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -235,7 +235,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Some characteristics of COBOL applications</h4>
+					<h3>Some characteristics of COBOL applications</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -266,7 +266,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Some characteristics that contribute to COBOL's success</h4>
+					<h3>Some characteristics that contribute to COBOL's success</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -365,7 +365,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>References and further reading</h4>
+					<h3>References and further reading</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -458,7 +458,7 @@
 					<h2 id="part2">Introduction to Programming</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -473,7 +473,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Let's write a program</h4>
+					<h3>Let's write a program</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -499,7 +499,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Sequence Program Specification</h4>
+					<h3>Sequence Program Specification</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -518,7 +518,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Program Statements and Data items</h4>
+					<h3>Program Statements and Data items</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -552,7 +552,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Getting the Algorithm right</h4>
+					<h3>Getting the Algorithm right</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -611,7 +611,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>An annotated look at the COBOL program</h4>
+					<h3>An annotated look at the COBOL program</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -627,7 +627,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Selection Program Specification</h4>
+					<h3>Selection Program Specification</h3>
 					<aside>
 						<p class="center-block">
 							<span class="i-detail" aria-hidden="true">🔍</span><br />
@@ -653,7 +653,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Iteration Program Specification</h4>
+					<h3>Iteration Program Specification</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -682,7 +682,7 @@
 					<h2 id="part3">COBOL basics</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -693,7 +693,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>COBOL idiosyncrasies</h4>
+					<h3>COBOL idiosyncrasies</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -721,7 +721,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>COBOL syntax</h4>
+					<h3>COBOL syntax</h3>
 				</div>
 				<div class="section-content">
 					<p>COBOL syntax is defined using particular notation sometimes called the COBOL MetaLanguage.</p>
@@ -750,7 +750,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Some notes on syntax diagrams</h4>
+					<h3>Some notes on syntax diagrams</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -795,7 +795,7 @@
 					</blockquote>
 				</div>
 				<div class="section-sidebar">
-					<h4>An example syntax diagram</h4>
+					<h3>An example syntax diagram</h3>
 					<aside>
 						<p class="center-block">
 							<span class="i-detail" aria-hidden="true">🔍</span><br />
@@ -847,7 +847,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>COBOL coding rules</h4>
+					<h3>COBOL coding rules</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -885,7 +885,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Name construction</h4>
+					<h3>Name construction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -908,7 +908,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>The structure of COBOL programs</h4>
+					<h3>The structure of COBOL programs</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -981,7 +981,7 @@ PROGRAM-ID.</code></pre>
 					<h2 id="part4">The Four Divisions</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1011,7 +1011,7 @@ PROGRAM-ID.</code></pre>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>The IDENTIFICATION DIVISION</h4>
+					<h3>The IDENTIFICATION DIVISION</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1053,7 +1053,7 @@ AUTHOR. Michael Coughlan.</code></pre>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>The <code class="language-cobol">ENVIRONMENT DIVISION</code></h4>
+					<h3>The <code class="language-cobol">ENVIRONMENT DIVISION</code></h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1077,7 +1077,7 @@ AUTHOR. Michael Coughlan.</code></pre>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>The DATA DIVISION</h4>
+					<h3>The DATA DIVISION</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1121,7 +1121,7 @@ WORKING-STORAGE SECTION.
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>The PROCEDURE DIVISION</h4>
+					<h3>The PROCEDURE DIVISION</h3>
 				</div>
 				<div class="section-content">
 					<p>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -47,7 +47,7 @@
 					<h2 id="intro">Introduction</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Aims</h4>
+					<h3>Aims</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -63,7 +63,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Objectives</h4>
+					<h3>Objectives</h3>
 				</div>
 				<div class="section-content">
 					<p>By the end of this unit you should -</p>
@@ -77,7 +77,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Prerequisites</h4>
+					<h3>Prerequisites</h3>
 				</div>
 				<div class="section-content">
 					<ul>
@@ -98,7 +98,7 @@
 					<h2 id="part1">Basic User Input and Output</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -123,7 +123,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>The DISPLAY verb</h4>
+					<h3>The DISPLAY verb</h3>
 					<aside>
 						<p class="center-block">
 							<img height="44" src="Resources/pics/i-LightBulbTip.gif" width="42" alt="" />
@@ -187,7 +187,7 @@ DISPLAY PrinterSetupCodes UPON PrinterPort1.
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>The ACCEPT verb</h4>
+					<h3>The ACCEPT verb</h3>
 				</div>
 				<div class="section-content">
 					<p><img height="120" src="Resources/pics/ACCEPT.gif" width="390" alt="ACCEPT verb syntax diagram" /></p>
@@ -206,7 +206,7 @@ DISPLAY PrinterSetupCodes UPON PrinterPort1.
 					</p>
 				</div>
 				<div class="section-sidebar">
-					<h4>Using the ACCEPT to get the system date and time</h4>
+					<h3>Using the ACCEPT to get the system date and time</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -240,7 +240,7 @@ DISPLAY PrinterSetupCodes UPON PrinterPort1.
 </code></pre>
 				</div>
 				<div class="section-sidebar">
-					<h4>New formats for the ACCEPT</h4>
+					<h3>New formats for the ACCEPT</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -266,7 +266,7 @@ DISPLAY PrinterSetupCodes UPON PrinterPort1.
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>ACCEPT and DISPLAY example program</h4>
+					<h3>ACCEPT and DISPLAY example program</h3>
 					<p class="center-block"><img height="44" src="Resources/pics/program.gif" width="42" alt="" /></p>
 				</div>
 				<div class="section-content">
@@ -361,7 +361,7 @@ The time is 14:41
 					<h2 id="part2">Assignment using the MOVE verb</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -382,7 +382,7 @@ The time is 14:41
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>The MOVE verb</h4>
+					<h3>The MOVE verb</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -438,7 +438,7 @@ The time is 14:41
 					<p class="center-block"><img height="232" src="Resources/pics/Move2.gif" width="520" alt="Table of valid and invalid MOVE combinations between data types" /></p>
 				</div>
 				<div class="section-sidebar">
-					<h4>MOVE examples</h4>
+					<h3>MOVE examples</h3>
 				</div>
 				<div class="section-content">
 					<p id="com1">
@@ -468,7 +468,7 @@ The time is 14:41
 					<h2 id="part3">Arithmetic in COBOL</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -479,7 +479,7 @@ The time is 14:41
 					</p>
 				</div>
 				<div class="section-sidebar">
-					<h4>Data Movement</h4>
+					<h3>Data Movement</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -494,7 +494,7 @@ The time is 14:41
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>General Rules</h4>
+					<h3>General Rules</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -524,7 +524,7 @@ The time is 14:41
 					<p>The maximum size of each operand is 18 digits.</p>
 				</div>
 				<div class="section-sidebar">
-					<h4>The ROUNDED option</h4>
+					<h3>The ROUNDED option</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -579,7 +579,7 @@ The time is 14:41
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>ON SIZE ERROR</h4>
+					<h3>ON SIZE ERROR</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -752,7 +752,7 @@ The time is 14:41
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>ADD verb</h4>
+					<h3>ADD verb</h3>
 				</div>
 				<div class="section-content">
 					<p><img height="74" src="Resources/pics/Add.gif" width="499" alt="ADD verb syntax diagram" /></p>
@@ -769,7 +769,7 @@ The time is 14:41
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>SUBTRACT verb</h4>
+					<h3>SUBTRACT verb</h3>
 				</div>
 				<div class="section-content">
 					<p><img height="96" src="Resources/pics/Sub.gif" width="481" alt="SUBTRACT verb syntax diagram" /></p>
@@ -789,7 +789,7 @@ The time is 14:41
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>MULTIPLY verb</h4>
+					<h3>MULTIPLY verb</h3>
 				</div>
 				<div class="section-content">
 					<p><img height="72" src="Resources/pics/Mult.gif" width="498" alt="MULTIPLY verb syntax diagram" /></p>
@@ -808,7 +808,7 @@ The time is 14:41
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>DIVIDE verb</h4>
+					<h3>DIVIDE verb</h3>
 				</div>
 				<div class="section-content">
 					<p>The Divide has two main formats. One produces a remainder and the other does not.</p>
@@ -838,7 +838,7 @@ The time is 14:41
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>COMPUTE verb</h4>
+					<h3>COMPUTE verb</h3>
 				</div>
 				<div class="section-content">
 					<p><img height="77" src="Resources/pics/Compute.gif" width="509" alt="COMPUTE verb syntax diagram" /></p>
@@ -917,7 +917,7 @@ The time is 14:41
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Arithmetic examples</h4>
+					<h3>Arithmetic examples</h3>
 				</div>
 				<div class="section-content">
 					<p id="com2">

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -65,7 +65,7 @@
 					<h2 id="intro">Introduction</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Aims</h4>
+					<h3>Aims</h3>
 				</div>
 				<div>
 					
@@ -95,7 +95,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Objectives</h4>
+					<h3>Objectives</h3>
 				</div>
 				<div>
 					<p>By the end of this unit you should -</p>
@@ -116,7 +116,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Prerequisites</h4>
+					<h3>Prerequisites</h3>
 				</div>
 				<div>
 					<ul>
@@ -152,7 +152,7 @@
 					<h2 id="part1">Using the COPY verb</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div>
 					
@@ -186,9 +186,9 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>
+					<h3>
 						<b>Using the COPY verb in large software systems</b>
-					</h4>
+					</h3>
 				</div>
 				<div>
 					<p>
@@ -245,7 +245,7 @@
 					</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>COPY Syntax</h4>
+					<h3>COPY Syntax</h3>
 					<aside>
 						<p class="center-block">
 							<span class="i-detail" aria-hidden="true">🔍</span><br />
@@ -344,9 +344,9 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>
+					<h3>
 						<b>How the COPY works</b>
-					</h4>
+					</h3>
 				</div>
 				<div>
 					<p>
@@ -368,7 +368,7 @@ COPY CopyFile4 IN EGLIB.</code></pre>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>How the REPLACING phrase works</h4>
+					<h3>How the REPLACING phrase works</h3>
 				</div>
 				<div>
 					<p>
@@ -387,7 +387,7 @@ COPY CopyFile4 IN EGLIB.</code></pre>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>COPY Rules</h4>
+					<h3>COPY Rules</h3>
 				</div>
 				<div>
 					<ol>

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -45,7 +45,7 @@
 					<h2 id="intro">Introduction</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Aims</h4>
+					<h3>Aims</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -55,7 +55,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Objectives</h4>
+					<h3>Objectives</h3>
 				</div>
 				<div class="section-content">
 					<p>By the end of this unit you should -</p>
@@ -72,7 +72,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Prerequisites</h4>
+					<h3>Prerequisites</h3>
 				</div>
 				<div class="section-content">
 					<p>Introduction to COBOL.</p>
@@ -84,7 +84,7 @@
 					</ul>
 				</div>
 				<div class="section-sidebar">
-					<h4>Further reading</h4>
+					<h3>Further reading</h3>
 				</div>
 				<div class="section-content">
 					<p>More information on declaring data items in COBOL can be found in the units covering -</p>
@@ -104,7 +104,7 @@
 					<h2 id="part1">Categories of COBOL data</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>There are three categories of data item used in COBOL programs:</p>
@@ -116,7 +116,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Variables</h4>
+					<h3>Variables</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -134,7 +134,7 @@
 					</p>
 				</div>
 				<div class="section-sidebar">
-					<h4>Variable Data types</h4>
+					<h3>Variable Data types</h3>
 					<aside>
 						<p class="center-block">
 							<img height="62" src="Resources/pics/i-BugAlert.gif" width="56" alt="" /><br />
@@ -175,7 +175,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Literals</h4>
+					<h3>Literals</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -189,14 +189,14 @@
 					</ul>
 				</div>
 				<div class="section-sidebar">
-					<h4>String Literals</h4>
+					<h3>String Literals</h3>
 				</div>
 				<div class="section-content">
 					<p>String/Alphanumeric literals are enclosed in quotes and consist of alphanumeric characters.</p>
 					<p>For example: "Michael Ryan", "-123", "123.45"</p>
 				</div>
 				<div class="section-sidebar">
-					<h4>Numeric Literals</h4>
+					<h3>Numeric Literals</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -207,7 +207,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Figurative Constants</h4>
+					<h3>Figurative Constants</h3>
 					<aside>
 						<p class="center-block">
 							<span class="i-detail" aria-hidden="true">🔍</span>
@@ -301,7 +301,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Using COBOL data — examples</h4>
+					<h3>Using COBOL data — examples</h3>
 				</div>
 				<div class="section-content">
 					<p id="data1">
@@ -328,7 +328,7 @@
 					<h2 id="part2">Declaring Data-Items in COBOL</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -352,7 +352,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>COBOL picture clauses</h4>
+					<h3>COBOL picture clauses</h3>
 					<aside>
 						<p class="center-block">
 							<span class="i-detail" aria-hidden="true">🔍</span><br />
@@ -438,7 +438,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Picture clause notes</h4>
+					<h3>Picture clause notes</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -466,7 +466,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 					<h2 id="part3">Group and Elementary data-items</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -480,7 +480,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 					</p>
 				</div>
 				<div class="section-sidebar">
-					<h4>Elementary items</h4>
+					<h3>Elementary items</h3>
 					<aside>
 						<p class="center-block">
 							<span class="i-detail" aria-hidden="true">🔍</span><br />
@@ -521,7 +521,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Group items</h4>
+					<h3>Group items</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -565,7 +565,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Level Numbers</h4>
+					<h3>Level Numbers</h3>
 					<aside>
 						<p class="center-block">
 							<img height="44" src="Resources/pics/i-LightBulbTip.gif" width="42" alt="" /><br />
@@ -618,7 +618,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 					</div>
 				</div>
 				<div class="section-sidebar">
-					<h4>Some observations on Record-A</h4>
+					<h3>Some observations on Record-A</h3>
 				</div>
 				<div class="section-content">
 					<p>It is useful to examine Record-A above and to answer the following questions:</p>
@@ -651,7 +651,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 					</div>
 				</div>
 				<div class="section-sidebar">
-					<h4>Level number notes</h4>
+					<h3>Level number notes</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -674,7 +674,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Building a record structure</h4>
+					<h3>Building a record structure</h3>
 				</div>
 				<div class="section-content">
 					<p>

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -49,7 +49,7 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Aims</h4>
+					<h3>Aims</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -70,7 +70,7 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Objectives</h4>
+					<h3>Objectives</h3>
 				</div>
 				<div class="section-content">
 					<p>By the end of this unit you should -</p>
@@ -82,7 +82,7 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Prerequisites</h4>
+					<h3>Prerequisites</h3>
 				</div>
 				<div class="section-content">
 					<ul>
@@ -110,7 +110,7 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -162,7 +162,7 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Edit Symbols</h4>
+					<h3>Edit Symbols</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -188,7 +188,7 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Types of editing picture</h4>
+					<h3>Types of editing picture</h3>
 				</div>
 				<div class="section-content">
 					<p>COBOL permits two basic types of editing picture:</p>
@@ -218,7 +218,7 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Editing symbols</h4>
+					<h3>Editing symbols</h3>
 				</div>
 				<div class="section-content">
 					<p>COBOL permits two basic types of editing picture:&gt;</p>
@@ -289,7 +289,7 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>There are four types of Insertion Editing:-</p>
@@ -307,7 +307,7 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Simple Insertion editing</h4>
+					<h3>Simple Insertion editing</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -344,7 +344,7 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Simple Insertion examples</h4>
+					<h3>Simple Insertion examples</h3>
 					<p class="center-block"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
 				</div>
 				<div class="section-content">
@@ -533,7 +533,7 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Special Insertion</h4>
+					<h3>Special Insertion</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -554,7 +554,7 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Special Insertion examples</h4>
+					<h3>Special Insertion examples</h3>
 					<p class="center-block"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
 				</div>
 				<div class="section-content">
@@ -677,7 +677,7 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Fixed Insertion</h4>
+					<h3>Fixed Insertion</h3>
 					<aside>
 						<p class="center-block">
 							<span class="i-detail" aria-hidden="true">🔍</span>
@@ -731,7 +731,7 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Fixed Insertion examples</h4>
+					<h3>Fixed Insertion examples</h3>
 					<p class="center-block"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
 				</div>
 				<div class="section-content">
@@ -962,7 +962,7 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Floating Insertion</h4>
+					<h3>Floating Insertion</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -993,7 +993,7 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Floating Insertion examples</h4>
+					<h3>Floating Insertion examples</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1181,7 +1181,7 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1211,7 +1211,7 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Suppression and Replacement editing examples</h4>
+					<h3>Suppression and Replacement editing examples</h3>
 					<p class="center-block"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
 				</div>
 				<div class="section-content">
@@ -1372,7 +1372,7 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Picture string restrictions</h4>
+					<h3>Picture string restrictions</h3>
 				</div>
 				<div class="section-content">
 					<p>

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -65,7 +65,7 @@
 						<h2 id="intro">Introduction</h2>
 					</div>
 					<div class="section-sidebar">
-						<h4>Aims</h4>
+						<h3>Aims</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -76,7 +76,7 @@
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h4>Objectives</h4>
+						<h3>Objectives</h3>
 					</div>
 					<div class="section-content">
 						<p>By the end of this unit you should:</p>
@@ -105,7 +105,7 @@
 						</ol>
 					</div>
 					<div class="section-sidebar">
-						<h4>Prerequisites</h4>
+						<h3>Prerequisites</h3>
 					</div>
 					<div class="section-content">
 						<p>You should be familiar with the material covered in the unit;</p>
@@ -124,7 +124,7 @@
 						<h2 id="progs">A look at some programs that use Indexed files</h2>
 					</div>
 					<div class="section-sidebar">
-						<h4>Example program - Creating an Indexed file</h4>
+						<h3>Example program - Creating an Indexed file</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -153,7 +153,7 @@
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h4>Example program - Reading an Indexed file sequentially</h4>
+						<h3>Example program - Reading an Indexed file sequentially</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -243,7 +243,7 @@ Enter key : 1=VideoCode, 2=VideoTitle -&gt;2
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h4>Example program - Reading an Indexed file directly</h4>
+						<h3>Example program - Reading an Indexed file directly</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -304,7 +304,7 @@ VIDEO STATUS :- 23</code></pre>
 						<h2 id="org">Indexed file organization</h2>
 					</div>
 					<div class="section-sidebar">
-						<h4>Introduction</h4>
+						<h3>Introduction</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -337,7 +337,7 @@ VIDEO STATUS :- 23</code></pre>
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h4>Primary Key Index</h4>
+						<h3>Primary Key Index</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -354,7 +354,7 @@ VIDEO STATUS :- 23</code></pre>
 						</p>
 					</div>
 					<div class="section-sidebar">
-						<h4>Alternate Key Index</h4>
+						<h3>Alternate Key Index</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -379,7 +379,7 @@ VIDEO STATUS :- 23</code></pre>
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h4>Animation of the primary and alternate key indexes</h4>
+						<h3>Animation of the primary and alternate key indexes</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -417,7 +417,7 @@ END-IF</code></pre>
 						<h2 id="declar">Indexed file - Declarations</h2>
 					</div>
 					<div class="section-sidebar">
-						<h4>Introduction</h4>
+						<h3>Introduction</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -428,13 +428,13 @@ END-IF</code></pre>
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h4>Select and Assign clause syntax</h4>
+						<h3>Select and Assign clause syntax</h3>
 					</div>
 					<div class="section-content">
 						<p><img height="245" src="Resources/pics/I-DFidx1.gif" width="474" alt="Indexed file SELECT and ASSIGN clause syntax diagram" /></p>
 					</div>
 					<div class="section-sidebar">
-						<h4>The Record Key phrase</h4>
+						<h3>The Record Key phrase</h3>
 					</div>
 					<div class="section-content">
 						<p>The RECORD KEY phrase defines the Indexed file's primary key.</p>
@@ -449,7 +449,7 @@ END-IF</code></pre>
 						<p>The key field must be a numeric or alphanumeric data item.</p>
 					</div>
 					<div class="section-sidebar">
-						<h4>The Alternate Record Key phrase</h4>
+						<h3>The Alternate Record Key phrase</h3>
 					</div>
 					<div class="section-content">
 						
@@ -481,7 +481,7 @@ END-IF</code></pre>
 						<h2 id="verbs">Indexed file - file processing verbs</h2>
 					</div>
 					<div class="section-sidebar">
-						<h4>Introduction</h4>
+						<h3>Introduction</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -499,7 +499,7 @@ END-IF</code></pre>
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h4>The READ verb</h4>
+						<h3>The READ verb</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -510,7 +510,7 @@ END-IF</code></pre>
 						</p>
 					</div>
 					<div class="section-sidebar">
-						<h4>Key Of Reference</h4>
+						<h3>Key Of Reference</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -535,7 +535,7 @@ END-IF</code></pre>
 						<p>When the file is opened the primary key is, by default, the Key Of Reference.</p>
 					</div>
 					<div class="section-sidebar">
-						<h4>Reading Sequentially</h4>
+						<h3>Reading Sequentially</h3>
 					</div>
 					<div class="section-content">
 						<p><img src="Resources/pics/I-DFrel4.gif" alt="READ NEXT syntax diagram for sequential access of an Indexed file with DYNAMIC access mode" /></p>
@@ -565,7 +565,7 @@ END-IF</code></pre>
 						</ol>
 					</div>
 					<div class="section-sidebar">
-						<h4>Reading using a key</h4>
+						<h3>Reading using a key</h3>
 					</div>
 					<div class="section-content">
 						<p><img src="Resources/pics/I-DFrel3.gif" alt="Direct READ syntax diagram for reading an Indexed file by key value" /></p>
@@ -619,7 +619,7 @@ END-IF</code></pre>
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h4>The WRITE, REWRITE and DELETE verbs.</h4>
+						<h3>The WRITE, REWRITE and DELETE verbs.</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -638,7 +638,7 @@ END-IF</code></pre>
 						<hr />
 					</div>
 					<div class="section-sidebar">
-						<h4>The START verb</h4>
+						<h3>The START verb</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -701,7 +701,7 @@ END-IF</code></pre>
 						<h2 id="example">An Comprehensive Example Program</h2>
 					</div>
 					<div class="section-sidebar">
-						<h4>Program Specification</h4>
+						<h3>Program Specification</h3>
 					</div>
 					<div class="section-content">
 						<p class="center-block">ROYALTY PAYMENT REPORT PROGRAM.</p>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -56,7 +56,7 @@
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>Aims</h4>
+					<h3>Aims</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -73,7 +73,7 @@
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>Objectives</h4>
+					<h3>Objectives</h3>
 				</div>
 				<div class="section-content">
 					<p>By the end of this unit you should:</p>
@@ -89,7 +89,7 @@
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>Prerequisites</h4>
+					<h3>Prerequisites</h3>
 				</div>
 				<div class="section-content">
 					<p>You should be familiar with the following material;</p>
@@ -105,7 +105,7 @@
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>Syntax legend</h4>
+					<h3>Syntax legend</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -146,7 +146,7 @@
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>The INSPECT has four formats;</p>
@@ -164,7 +164,7 @@
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>Example program Counting letter occurences using the INSPECT</h4>
+					<h3>Example program Counting letter occurences using the INSPECT</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -213,7 +213,7 @@ Begin.
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>How the INSPECT works.</h4>
+					<h3>How the INSPECT works.</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -232,7 +232,7 @@ Begin.
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>The modifying phrases</h4>
+					<h3>The modifying phrases</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -269,7 +269,7 @@ Begin.
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>Notes</h4>
+					<h3>Notes</h3>
 				</div>
 				<div class="section-content">
 					<p>If Compare$il or Delim$il is a figurative constant it is 1 character in size.</p>
@@ -281,7 +281,7 @@ Begin.
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>Examples</h4>
+					<h3>Examples</h3>
 				</div>
 				<div class="section-content">
 					<pre
@@ -308,7 +308,7 @@ INSPECT SourceLine TALLYING ECount
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>Rules</h4>
+					<h3>Rules</h3>
 				</div>
 				<div class="section-content">
 					<p>The sizes of Compare$il and Replace$il must be equal.</p>
@@ -323,10 +323,10 @@ INSPECT SourceLine TALLYING ECount
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>
+					<h3>
 						Example 1<br />
 						with animation
-					</h4>
+					</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -368,7 +368,7 @@ INSPECT SourceLine TALLYING ECount
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>Example 2</h4>
+					<h3>Example 2</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -385,10 +385,10 @@ END-PERFORM</code></pre>
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>
+					<h3>
 						Example 3<br />
 						with animation
-					</h4>
+					</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -446,7 +446,7 @@ END-PERFORM</code></pre>
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>How this format of the INSPECT works</h4>
+					<h3>How this format of the INSPECT works</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -463,7 +463,7 @@ END-PERFORM</code></pre>
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>Rules</h4>
+					<h3>Rules</h3>
 				</div>
 				<div class="section-content">
 					<ol class="spaced">
@@ -479,10 +479,10 @@ END-PERFORM</code></pre>
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>
+					<h3>
 						Example 1<br />
 						with animation
-					</h4>
+					</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -515,7 +515,7 @@ END-PERFORM</code></pre>
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>Example 2</h4>
+					<h3>Example 2</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -534,7 +534,7 @@ END-PERFORM</code></pre>
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>Example 3</h4>
+					<h3>Example 3</h3>
 				</div>
 				<div class="section-content">
 					<p>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -51,7 +51,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Aims</h4>
+						<h3>Aims</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -64,7 +64,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Objectives</h4>
+						<h3>Objectives</h3>
 					</div>
 					<div class="section-content">
 						<p>By the end of this unit you should:</p>
@@ -91,7 +91,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Prerequisites</h4>
+						<h3>Prerequisites</h3>
 					</div>
 					<div class="section-content">
 						<p>You should be familiar with the material covered in the unit;</p>
@@ -112,7 +112,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Introduction</h4>
+						<h3>Introduction</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -134,7 +134,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Problems accessing ordered Sequential files.</h4>
+						<h3>Problems accessing ordered Sequential files.</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -160,7 +160,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Contrast with direct access files</h4>
+						<h3>Contrast with direct access files</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -177,7 +177,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Inserting records in an ordered Sequential file</h4>
+						<h3>Inserting records in an ordered Sequential file</h3>
 					</div>
 					<div class="section-content">
 						<p>To insert a record in an ordered Sequential file:</p>
@@ -198,7 +198,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Deleting records from an ordered Sequential file</h4>
+						<h3>Deleting records from an ordered Sequential file</h3>
 					</div>
 					<div class="section-content">
 						<p>To delete a record in an ordered Sequential file:</p>
@@ -219,7 +219,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Amending records in an ordered Sequential file</h4>
+						<h3>Amending records in an ordered Sequential file</h3>
 					</div>
 					<div class="section-content">
 						<p>To amend a record in an ordered Sequential file:</p>
@@ -241,7 +241,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Sequential files - animation</h4>
+						<h3>Sequential files - animation</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -261,7 +261,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Summary</h4>
+						<h3>Summary</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -287,7 +287,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Introduction</h4>
+						<h3>Introduction</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -305,7 +305,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Organization of Relative files</h4>
+						<h3>Organization of Relative files</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -341,7 +341,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Accessing records in a Relative file</h4>
+						<h3>Accessing records in a Relative file</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -366,7 +366,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Animation - Organization and use of Relative files</h4>
+						<h3>Animation - Organization and use of Relative files</h3>
 					</div>
 					<div class="section-content">
 						<div class="two-col">
@@ -392,7 +392,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Summary</h4>
+						<h3>Summary</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -414,7 +414,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Introduction</h4>
+						<h3>Introduction</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -431,7 +431,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Organization of Indexed files</h4>
+						<h3>Organization of Indexed files</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -465,7 +465,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Animation - Organization and use of Indexed files</h4>
+						<h3>Animation - Organization and use of Indexed files</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -495,7 +495,7 @@ END-IF</code></pre>
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Summary</h4>
+						<h3>Summary</h3>
 					</div>
 					<div class="section-content">
 						<p>An Indexed file may have multiple, alphanumeric, keys.</p>
@@ -515,7 +515,7 @@ END-IF</code></pre>
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Introduction</h4>
+						<h3>Introduction</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -527,7 +527,7 @@ END-IF</code></pre>
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Sequential files</h4>
+						<h3>Sequential files</h3>
 					</div>
 					<div class="section-content">
 						<h4 class="center-block">Disadvantages</h4>
@@ -617,7 +617,7 @@ END-IF</code></pre>
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Relative files</h4>
+						<h3>Relative files</h3>
 					</div>
 					<div class="section-content">
 						<h4 class="center-block">Disadvantages</h4>
@@ -785,7 +785,7 @@ END-IF</code></pre>
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Indexed files</h4>
+						<h3>Indexed files</h3>
 					</div>
 					<div class="section-content">
 						<h4 class="center-block">Disadvantages</h4>
@@ -870,7 +870,7 @@ END-IF</code></pre>
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Summary</h4>
+						<h3>Summary</h3>
 					</div>
 					<div class="section-content">
 						<p>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -59,7 +59,7 @@
 					<h2 id="intro">Introduction</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Aims</h4>
+					<h3>Aims</h3>
 				</div>
 				<div class="section-content">
 					<div>
@@ -132,7 +132,7 @@
 					</div>
 				</div>
 				<div class="section-sidebar">
-					<h4>Objectives</h4>
+					<h3>Objectives</h3>
 				</div>
 				<div class="section-content">
 					<p>By the end of this unit you should -</p>
@@ -160,7 +160,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Prerequisites</h4>
+					<h3>Prerequisites</h3>
 				</div>
 				<div class="section-content">
 					<ul>
@@ -180,7 +180,7 @@
 					<h2 id="part1">PERFORM..Proc</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<div>
@@ -231,7 +231,7 @@
 					</div>
 				</div>
 				<div class="section-sidebar">
-					<h4>PERFORM format 1 syntax</h4>
+					<h3>PERFORM format 1 syntax</h3>
 					<aside>
 						<p class="center-block">
 							<img height="44" src="Resources/pics/i-LightBulbTip.gif" width="42" alt="" />
@@ -275,7 +275,7 @@
 					</div>
 				</div>
 				<div class="section-sidebar">
-					<h4>How this format works</h4>
+					<h3>How this format works</h3>
 					<aside>
 						<p class="center-block">
 							<img height="62" src="Resources/pics/i-BugAlert.gif" width="56" alt="" />
@@ -365,7 +365,7 @@
 					</div>
 				</div>
 				<div class="section-sidebar">
-					<h4>Why use this format?</h4>
+					<h3>Why use this format?</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -385,7 +385,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>PERFORM..PROC example</h4>
+					<h3>PERFORM..PROC example</h3>
 					<p class="center-block"><img height="44" src="Resources/pics/program.gif" width="42" alt="" /></p>
 				</div>
 				<div class="section-content">
@@ -417,7 +417,7 @@ ThreeLevelsDown.
 </code></pre>
 				</div>
 				<div class="section-sidebar">
-					<h4>Self Assessment Questions</h4>
+					<h3>Self Assessment Questions</h3>
 					<p class="center-block"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
 				</div>
 				<div class="section-content">
@@ -536,7 +536,7 @@ ThreeLevelsDown.
 					<h2 id="part2">Using the PERFORM..THRU</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -549,7 +549,7 @@ ThreeLevelsDown.
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Coping with errors</h4>
+					<h3>Coping with errors</h3>
 					<p class="center-block"><img height="44" src="Resources/pics/program-fragment.svg" width="48" alt="Program fragment" /></p>
 				</div>
 				<div class="section-content">
@@ -584,7 +584,7 @@ SumSales.
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Using the PERFORM..THRU</h4>
+					<h3>Using the PERFORM..THRU</h3>
 					<aside>
 						<p class="center-block">
 							<span class="i-detail" aria-hidden="true">🔍</span><br />
@@ -644,7 +644,7 @@ SumSalesExit.
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>PERFORM..THRU restrictions</h4>
+					<h3>PERFORM..THRU restrictions</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -667,7 +667,7 @@ SumSalesExit.
 					<h2 id="part3">PERFORM..TIMES</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -678,7 +678,7 @@ SumSalesExit.
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>PERFORM..TIMES Syntax</h4>
+					<h3>PERFORM..TIMES Syntax</h3>
 				</div>
 				<div class="section-content">
 					<p><img height="105" src="Resources/pics/Perform2.gif" width="406" alt="PERFORM..TIMES syntax diagram" /></p>
@@ -694,7 +694,7 @@ SumSalesExit.
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>In-line vs Out-of-line</h4>
+					<h3>In-line vs Out-of-line</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -736,7 +736,7 @@ SumSalesExit.
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Example</h4>
+					<h3>Example</h3>
 				</div>
 				<div class="section-content">
 					<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
@@ -765,7 +765,7 @@ OutOfLineEG.
     DISPLAY "&gt;&gt;&gt;&gt; This is an out of line Perform".</code></pre>
 				</div>
 				<div class="section-sidebar">
-					<h4>Self Assessment Questions</h4>
+					<h3>Self Assessment Questions</h3>
 					<p class="center-block"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
 				</div>
 				<div class="section-content">
@@ -798,7 +798,7 @@ OutOfLineEG.
 					<h2 id="part4">PERFORM..UNTIL</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -809,7 +809,7 @@ OutOfLineEG.
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>PERFORM..UNTIL syntax</h4>
+					<h3>PERFORM..UNTIL syntax</h3>
 				</div>
 				<div class="section-content">
 					<p><img height="126" src="Resources/pics/Perform3.gif" width="502" alt="PERFORM..UNTIL syntax diagram" /></p>
@@ -830,7 +830,7 @@ OutOfLineEG.
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>How the PERFORM..UNTIL works</h4>
+					<h3>How the PERFORM..UNTIL works</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -862,7 +862,7 @@ OutOfLineEG.
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>TEST BEFORE Vs TEST AFTER</h4>
+					<h3>TEST BEFORE Vs TEST AFTER</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -886,7 +886,7 @@ OutOfLineEG.
 					</p>
 				</div>
 				<div class="section-sidebar">
-					<h4>The "read ahead" technique</h4>
+					<h3>The "read ahead" technique</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -936,7 +936,7 @@ END-PERFORM</code></pre>
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>PERFORM..UNTIL comment</h4>
+					<h3>PERFORM..UNTIL comment</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -958,7 +958,7 @@ END-PERFORM</code></pre>
 					<h2 id="part5">PERFORM..VARYING</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -973,7 +973,7 @@ END-PERFORM</code></pre>
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>PERFORM..VARYING syntax</h4>
+					<h3>PERFORM..VARYING syntax</h3>
 				</div>
 				<div class="section-content">
 					<p><img height="234" src="Resources/pics/Perform4.gif" width="502" alt="PERFORM..VARYING syntax diagram" /></p>
@@ -1011,7 +1011,7 @@ END-PERFORM</code></pre>
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>PERFORM..VARYING using one counter Example</h4>
+					<h3>PERFORM..VARYING using one counter Example</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1028,7 +1028,7 @@ END-PERFORM</code></pre>
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>PERFORM..VARYING using two counter Example</h4>
+					<h3>PERFORM..VARYING using two counter Example</h3>
 				</div>
 				<div class="section-content">
 					<p>This example animation demonstrates how a PERFORM..VARYING, with two counters, works.</p>
@@ -1051,7 +1051,7 @@ END-PERFORM</code></pre>
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>PERFORM..VARYING Example Program</h4>
+					<h3>PERFORM..VARYING Example Program</h3>
 					<p class="center-block"><img height="44" src="Resources/pics/program.gif" width="42" alt="" /></p>
 					<p class="center-block"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
 				</div>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -59,7 +59,7 @@
 					<h2 id="intro">Introduction</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Aims</h4>
+					<h3>Aims</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -70,7 +70,7 @@
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>Objectives</h4>
+					<h3>Objectives</h3>
 				</div>
 				<div class="section-content">
 					<p>By the end of this unit you should:</p>
@@ -83,7 +83,7 @@
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>Prerequisites</h4>
+					<h3>Prerequisites</h3>
 				</div>
 				<div class="section-content">
 					<p>You should be familiar with the material covered in the unit;</p>
@@ -109,7 +109,7 @@
 					<h2 id="part1">Reference Modification</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Definition &amp; Syntax</h4>
+					<h3>Definition &amp; Syntax</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -140,7 +140,7 @@
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>Examples</h4>
+					<h3>Examples</h3>
 				</div>
 				<div class="section-content">
 					<pre class="language-cobol"><code class="language-cobol">WORKING-STORAGE SECTION.
@@ -166,7 +166,7 @@
 					<h2 id="part2">Intrinsic Functions</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -180,7 +180,7 @@
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>Using Intrinsic Functions</h4>
+					<h3>Using Intrinsic Functions</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -198,7 +198,7 @@
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>Intrinsic Function Notes</h4>
+					<h3>Intrinsic Function Notes</h3>
 				</div>
 				<div class="section-content">
 					<ul>
@@ -225,7 +225,7 @@
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>Intrinsic Function Template</h4>
+					<h3>Intrinsic Function Template</h3>
 				</div>
 				<div class="section-content">
 					<p>An Intrinsic Function consists of three parts;</p>
@@ -258,7 +258,7 @@
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>Intrinsic Function Notation</h4>
+					<h3>Intrinsic Function Notation</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -302,7 +302,7 @@ MOVE FUNCTION ORD-MAX(IntElement(ALL)) TO OrdPos             </code></pre>
 					<h2 id="part3">String Functions</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Definitions</h4>
+					<h3>Definitions</h3>
 				</div>
 				<div class="section-content">
 					<div class="table-scroll">
@@ -418,7 +418,7 @@ MOVE FUNCTION ORD-MAX(IntElement(ALL)) TO OrdPos             </code></pre>
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>Examples</h4>
+					<h3>Examples</h3>
 				</div>
 				<div class="section-content">
 					<p>The statements in the following examples produce the results shown below.</p>
@@ -492,7 +492,7 @@ Begin.
 					<h2 id="part4">Date Functions</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Definitions</h4>
+					<h3>Definitions</h3>
 				</div>
 				<div class="section-content">
 					<div class="table-scroll">
@@ -595,7 +595,7 @@ Begin.
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>Examples</h4>
+					<h3>Examples</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -697,7 +697,7 @@ Begin.
 					<h2 id="part5">Miscellaneous Functions</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Other Functions</h4>
+					<h3>Other Functions</h3>
 				</div>
 				<div class="section-content">
 					<div class="table-scroll">
@@ -1030,7 +1030,7 @@ Begin.
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>General Examples</h4>
+					<h3>General Examples</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1100,7 +1100,7 @@ Begin.
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>Lotto Example</h4>
+					<h3>Lotto Example</h3>
 				</div>
 				<div class="section-content">
 					<p>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -49,7 +49,7 @@
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>Aims</h4>
+					<h3>Aims</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -65,7 +65,7 @@
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>Objectives</h4>
+					<h3>Objectives</h3>
 				</div>
 				<div class="section-content">
 					<p>By the end of this unit you should:</p>
@@ -88,7 +88,7 @@
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>Prerequisites</h4>
+					<h3>Prerequisites</h3>
 				</div>
 				<div class="section-content">
 					<p>You should be familiar with the material covered in the unit;</p>
@@ -106,7 +106,7 @@
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>Example program - Creating a Relative file</h4>
+					<h3>Example program - Creating a Relative file</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -138,7 +138,7 @@
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>Example program - Reading a Relative file</h4>
+					<h3>Example program - Reading a Relative file</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -189,7 +189,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -202,7 +202,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>Select and Assign clause syntax</h4>
+					<h3>Select and Assign clause syntax</h3>
 				</div>
 				<div class="section-content">
 					<p><img height="189" src="Resources/pics/I-DFrel1.gif" width="507" alt="" /></p>
@@ -210,7 +210,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>The Optional phrase</h4>
+					<h3>The Optional phrase</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -221,7 +221,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>The Access Mode</h4>
+					<h3>The Access Mode</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -234,7 +234,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>The Record Key phrase</h4>
+					<h3>The Record Key phrase</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -248,7 +248,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>The File Status</h4>
+					<h3>The File Status</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -281,7 +281,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -299,7 +299,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>The Invalid Key clause</h4>
+					<h3>The Invalid Key clause</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -316,7 +316,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>OPEN/CLOSE verbs</h4>
+					<h3>OPEN/CLOSE verbs</h3>
 				</div>
 				<div class="section-content">
 					<p>The syntax for the CLOSE is the same for all file organizations.</p>
@@ -345,7 +345,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>The READ verb</h4>
+					<h3>The READ verb</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -357,7 +357,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>Reading using a key</h4>
+					<h3>Reading using a key</h3>
 				</div>
 				<div class="section-content">
 					<p><img src="Resources/pics/I-DFrel3.gif" alt="" /></p>
@@ -394,7 +394,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>Reading Sequentially</h4>
+					<h3>Reading Sequentially</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -421,7 +421,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>The WRITE verb</h4>
+					<h3>The WRITE verb</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -453,7 +453,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>The REWRITE verb</h4>
+					<h3>The REWRITE verb</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -487,7 +487,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>The DELETE verb</h4>
+					<h3>The DELETE verb</h3>
 				</div>
 				<div class="section-content">
 					<p><img src="Resources/pics/I-DFrel7.gif" alt="" /></p>
@@ -520,7 +520,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>The START verb</h4>
+					<h3>The START verb</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -570,7 +570,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -582,7 +582,7 @@ Enter supplier key (2 digits)-&gt; 05
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>The Declaratives template</h4>
+					<h3>The Declaratives template</h3>
 				</div>
 				<div class="section-content">
 					<div class="declaratives-layout">
@@ -636,7 +636,7 @@ Begin.</code></pre>
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4>The Use phrase</h4>
+					<h3>The Use phrase</h3>
 				</div>
 				<div class="section-content">
 					<p><img src="Resources/pics/I-DFrel9.gif" alt="" /></p>
@@ -665,7 +665,7 @@ Begin.</code></pre>
 			</div>
 			<div class="section-grid">
 				<div class="section-sidebar">
-					<h4 class="center-block">Example program - fragment</h4>
+					<h3 class="center-block">Example program - fragment</h3>
 				</div>
 				<pre class="language-cobol"><code class="language-cobol"> PROCEDURE DIVISION.
  DECLARATIVES.

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -59,7 +59,7 @@
 					</div>
 
 					<div class="section-sidebar">
-						<h4>Aims</h4>
+						<h3>Aims</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -87,7 +87,7 @@
 					</div>
 
 					<div class="section-sidebar">
-						<h4>Objectives</h4>
+						<h3>Objectives</h3>
 					</div>
 					<div class="section-content">
 						<p>By the end of this unit you should -</p>
@@ -112,7 +112,7 @@
 					</div>
 
 					<div class="section-sidebar">
-						<h4>Prerequisites</h4>
+						<h3>Prerequisites</h3>
 					</div>
 					<div class="section-content">
 						<p>You should be familiar with the material covered in the unit;</p>
@@ -139,7 +139,7 @@
 					</div>
 
 					<div class="section-sidebar">
-						<h4>Introduction</h4>
+						<h3>Introduction</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -158,7 +158,7 @@
 					</div>
 
 					<div class="section-sidebar">
-						<h4 class="center-block">An example report - with animated commentary.</h4>
+						<h3 class="center-block">An example report - with animated commentary.</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -182,7 +182,7 @@
 					</div>
 
 					<div class="section-sidebar">
-						<h4 class="center-block">The Procedure Division that produces the sales report</h4>
+						<h3 class="center-block">The Procedure Division that produces the sales report</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -216,7 +216,7 @@ PrintSalaryReport.
 					</div>
 
 					<div class="section-sidebar">
-						<h4 class="center-block">So much work, so little Procedure Division code</h4>
+						<h3 class="center-block">So much work, so little Procedure Division code</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -248,7 +248,7 @@ PrintSalaryReport.
 					</div>
 
 					<div class="section-sidebar">
-						<h4>Report Groups</h4>
+						<h3>Report Groups</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -334,7 +334,7 @@ PrintSalaryReport.
 					</div>
 
 					<div class="section-sidebar">
-						<h4 class="center-block">Report writing made easy</h4>
+						<h3 class="center-block">Report writing made easy</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -369,7 +369,7 @@ PrintSalaryReport.
 					</div>
 
 					<div class="section-sidebar">
-						<h4>Introduction</h4>
+						<h3>Introduction</h3>
 					</div>
 					<div class="section-content">
 						<p>Let's write a Report Writer program!</p>
@@ -385,7 +385,7 @@ PrintSalaryReport.
 					</div>
 
 					<div class="section-sidebar">
-						<h4>Report Specification</h4>
+						<h3>Report Specification</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -410,7 +410,7 @@ PrintSalaryReport.
 					</div>
 
 					<div class="section-sidebar">
-						<h4>A simple report</h4>
+						<h3>A simple report</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -458,7 +458,7 @@ Programmer - Michael Coughlan               Page :  1</code></pre>
 				</div>
 
 					<div class="section-sidebar">
-						<h4>Code &amp; Commentary</h4>
+						<h3>Code &amp; Commentary</h3>
 					</div>
 					<div class="section-content">
 						<div class="iframe-wrapper">
@@ -477,7 +477,7 @@ Programmer - Michael Coughlan               Page :  1</code></pre>
 					</div>
 
 					<div class="section-sidebar">
-						<h4>Adding a city and a final total</h4>
+						<h3>Adding a city and a final total</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -493,7 +493,7 @@ Programmer - Michael Coughlan               Page :  1</code></pre>
 					</div>
 
 					<div class="section-sidebar">
-						<h4>Printing the city total</h4>
+						<h3>Printing the city total</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -519,7 +519,7 @@ Programmer - Michael Coughlan               Page :  1</code></pre>
 					</div>
 
 					<div class="section-sidebar">
-						<h4>Printing a Final Total</h4>
+						<h3>Printing a Final Total</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -539,7 +539,7 @@ Programmer - Michael Coughlan               Page :  1</code></pre>
 					</div>
 
 					<div class="section-sidebar">
-						<h4>REPORT SECTION changes</h4>
+						<h3>REPORT SECTION changes</h3>
 					</div>
 					<div class="section-content">
 						<hr />
@@ -615,7 +615,7 @@ RD  SalesReport
 					</div>
 
 					<div class="section-sidebar">
-						<h4>Changes to the Procedure Division</h4>
+						<h3>Changes to the Procedure Division</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -632,7 +632,7 @@ RD  SalesReport
 					</div>
 
 					<div class="section-sidebar">
-						<h4>Introduction</h4>
+						<h3>Introduction</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -655,7 +655,7 @@ RD  SalesReport
 					</div>
 
 					<div class="section-sidebar">
-						<h4>Calculating the salesperson's commission and salary</h4>
+						<h3>Calculating the salesperson's commission and salary</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -688,7 +688,7 @@ RD  SalesReport
 					</div>
 
 					<div class="section-sidebar">
-						<h4>Values of control break items</h4>
+						<h3>Values of control break items</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -719,7 +719,7 @@ RD  SalesReport
 					</div>
 
 					<div class="section-sidebar">
-						<h4>The full program and the report it produces</h4>
+						<h3>The full program and the report it produces</h3>
 					</div>
 					<div class="section-content">
 						<p>Changes from the simple version are shown in red.</p>
@@ -969,7 +969,7 @@ Programmer - Michael Coughlan               Page :  1 </code></pre>
 					</div>
 
 					<div class="section-sidebar">
-						<h4>Summary of control break item reference</h4>
+						<h3>Summary of control break item reference</h3>
 					</div>
 					<div class="section-content">
 						<p>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -76,7 +76,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Aims</h4>
+						<h3>Aims</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -88,7 +88,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Objectives</h4>
+						<h3>Objectives</h3>
 					</div>
 					<div class="section-content">
 						<p>By the end of this unit you should -</p>
@@ -115,7 +115,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Prerequisites</h4>
+						<h3>Prerequisites</h3>
 					</div>
 					<div class="section-content">
 						<p>You should be familiar with the material covered in the units;</p>
@@ -137,7 +137,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4><code class="language-cobol">ENVIRONMENT DIVISION</code> entries</h4>
+						<h3><code class="language-cobol">ENVIRONMENT DIVISION</code> entries</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -193,7 +193,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>File Section entries</h4>
+						<h3>File Section entries</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -227,7 +227,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Introduction</h4>
+						<h3>Introduction</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -252,7 +252,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>The Report Description (RD) entries - Syntax</h4>
+						<h3>The Report Description (RD) entries - Syntax</h3>
 					</div>
 					<div class="section-content">
 						<p>The syntax for the Report Description (RD) entries is shown below -</p>
@@ -262,7 +262,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>The Report Description (RD) entries - Semantics</h4>
+						<h3>The Report Description (RD) entries - Semantics</h3>
 					</div>
 					<div class="section-content">
 						<p class="center-block"><b>RD Rules</b></p>
@@ -336,7 +336,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Introduction</h4>
+						<h3>Introduction</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -353,7 +353,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Defining a Report Group Record - Syntax</h4>
+						<h3>Defining a Report Group Record - Syntax</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -365,7 +365,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4><i>ReportGroupName</i> Rules</h4>
+						<h3><i>ReportGroupName</i> Rules</h3>
 					</div>
 					<div class="section-content">
 						<p>The <i>ReportGroupName</i> is required only when the group -</p>
@@ -386,7 +386,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>The <code class="language-cobol">LINE NUMBER</code> clause</h4>
+						<h3>The <code class="language-cobol">LINE NUMBER</code> clause</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -433,7 +433,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>The NEXT GROUP clause</h4>
+						<h3>The NEXT GROUP clause</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -470,7 +470,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>The TYPE clause</h4>
+						<h3>The TYPE clause</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -520,7 +520,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Introduction</h4>
+						<h3>Introduction</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -534,7 +534,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Defining Report Lines</h4>
+						<h3>Defining Report Lines</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -552,7 +552,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Defining Elementary print items in a report group</h4>
+						<h3>Defining Elementary print items in a report group</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -577,7 +577,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>The COLUMN NUMBER clause</h4>
+						<h3>The COLUMN NUMBER clause</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -595,7 +595,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>The GROUP INDICATE clause</h4>
+						<h3>The GROUP INDICATE clause</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -623,7 +623,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>The <code class="language-cobol">SOURCE</code> clause</h4>
+						<h3>The <code class="language-cobol">SOURCE</code> clause</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -638,7 +638,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>The <code class="language-cobol">SUM</code> clause</h4>
+						<h3>The <code class="language-cobol">SUM</code> clause</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -735,7 +735,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>The RESET ON clause</h4>
+						<h3>The RESET ON clause</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -757,7 +757,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Introduction</h4>
+						<h3>Introduction</h3>
 					</div>
 					<div class="section-content">
 						
@@ -775,7 +775,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>The <code class="language-cobol">LINE-COUNTER</code> register</h4>
+						<h3>The <code class="language-cobol">LINE-COUNTER</code> register</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -802,7 +802,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>The <code class="language-cobol">PAGE-COUNTER</code> register</h4>
+						<h3>The <code class="language-cobol">PAGE-COUNTER</code> register</h3>
 					</div>
 					<div class="section-content">
 						
@@ -836,7 +836,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Introduction</h4>
+						<h3>Introduction</h3>
 					</div>
 					<div class="section-content">
 						
@@ -866,7 +866,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Syntax</h4>
+						<h3>Syntax</h3>
 					</div>
 					<div class="section-content">
 						<p><img height="144" src="Resources/pics/rwVerbs.gif" width="238" alt="Report Writer Procedure Division verbs syntax diagram (INITIATE, GENERATE, TERMINATE, SUPPRESS PRINTING)" /></p>
@@ -875,7 +875,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4><code class="language-cobol">INITIATE</code></h4>
+						<h3><code class="language-cobol">INITIATE</code></h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -902,7 +902,7 @@ RD  SalesReport
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4><code class="language-cobol">GENERATE</code></h4>
+						<h3><code class="language-cobol">GENERATE</code></h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -991,7 +991,7 @@ Programmer - Michael Coughlan               Page :  1</code></pre>
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4><code class="language-cobol">TERMINATE</code></h4>
+						<h3><code class="language-cobol">TERMINATE</code></h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -1014,7 +1014,7 @@ Programmer - Michael Coughlan               Page :  1</code></pre>
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Introduction</h4>
+						<h3>Introduction</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -1041,7 +1041,7 @@ Programmer - Michael Coughlan               Page :  1</code></pre>
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Using Declaratives with the Report Writer</h4>
+						<h3>Using Declaratives with the Report Writer</h3>
 					</div>
 					<div class="section-content">
 						<p>When Declaratives are used they must appear as the first item in the Procedure Division.</p>
@@ -1077,7 +1077,7 @@ Programmer - Michael Coughlan               Page :  1</code></pre>
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Declaratives Example</h4>
+						<h3>Declaratives Example</h3>
 					</div>
 					<div class="section-content">
 						
@@ -1103,7 +1103,7 @@ Begin.
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>The <code class="language-cobol">SUPPRESS PRINTING</code> statement</h4>
+						<h3>The <code class="language-cobol">SUPPRESS PRINTING</code> statement</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -1137,7 +1137,7 @@ END DECLARATIVES.</code></pre>
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Control Break Registers</h4>
+						<h3>Control Break Registers</h3>
 					</div>
 					<div class="section-content">
 						

--- a/course/Search.html
+++ b/course/Search.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -60,7 +60,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Aims</h4>
+						<h3>Aims</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -93,7 +93,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Objectives</h4>
+						<h3>Objectives</h3>
 					</div>
 					<div class="section-content">
 						<p>By the end of this unit you should -</p>
@@ -120,7 +120,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Prerequisites</h4>
+						<h3>Prerequisites</h3>
 					</div>
 					<div class="section-content">
 						<ul>
@@ -147,7 +147,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Introduction</h4>
+						<h3>Introduction</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -168,7 +168,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Full OCCURS clause syntax</h4>
+						<h3>Full OCCURS clause syntax</h3>
 					</div>
 					<div class="section-content">
 						<p><img height="122" src="Resources/pics/Search1.gif" width="331" alt="Full OCCURS clause syntax diagram showing INDEXED BY and KEY IS extensions" /></p>
@@ -176,7 +176,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>INDEXED BY phrase - notes</h4>
+						<h3>INDEXED BY phrase - notes</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -218,7 +218,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>KEY IS phrase - notes</h4>
+						<h3>KEY IS phrase - notes</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -245,7 +245,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Introduction</h4>
+						<h3>Introduction</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -257,7 +257,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>SEARCH syntax</h4>
+						<h3>SEARCH syntax</h3>
 					</div>
 					<div class="section-content">
 						<p><img height="152" src="Resources/pics/Search2.gif" width="374" alt="SEARCH verb syntax diagram" /></p>
@@ -324,7 +324,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>The SET verb syntax</h4>
+						<h3>The SET verb syntax</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -352,7 +352,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>SEARCH example 1</h4>
+						<h3>SEARCH example 1</h3>
 						<p class="center-block"><img height="44" src="Resources/pics/program.gif" width="42" alt="" /></p>
 					</div>
 					<div class="section-content">
@@ -424,7 +424,7 @@ Begin.
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Example program 2</h4>
+						<h3>Example program 2</h3>
 						<p class="center-block"><img height="44" src="Resources/pics/program.gif" width="42" alt="" /></p>
 					</div>
 					<div class="section-content">
@@ -553,7 +553,7 @@ DisplayCountyTaxes.
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Introduction</h4>
+						<h3>Introduction</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -681,7 +681,7 @@ LoadTable.
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>The Race Results Example program</h4>
+						<h3>The Race Results Example program</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -810,7 +810,7 @@ END-SEARCH</code></pre>
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Introduction</h4>
+						<h3>Introduction</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -826,7 +826,7 @@ END-SEARCH</code></pre>
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>SEARCH ALL syntax</h4>
+						<h3>SEARCH ALL syntax</h3>
 					</div>
 					<div class="section-content">
 						<p><img height="302" src="Resources/pics/Search3.gif" width="492" alt="SEARCH ALL verb syntax diagram" /></p>
@@ -876,7 +876,7 @@ END-SEARCH</code></pre>
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>How a binary search works</h4>
+						<h3>How a binary search works</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -982,7 +982,7 @@ Begin.
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h4>Example program</h4>
+						<h3>Example program</h3>
 						<p class="center-block"><img height="44" src="Resources/pics/program.gif" width="42" alt="" /></p>
 					</div>
 					<div class="section-content">

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -67,7 +67,7 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Aims</h4>
+					<h3>Aims</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -84,7 +84,7 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Objectives</h4>
+					<h3>Objectives</h3>
 				</div>
 				<div class="section-content">
 					<p>By the end of this unit you should -</p>
@@ -111,7 +111,7 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Prerequisites</h4>
+					<h3>Prerequisites</h3>
 				</div>
 				<div class="section-content">
 					<ul>
@@ -136,7 +136,7 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -155,7 +155,7 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4>IF syntax</h4>
+					<h3>IF syntax</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -175,7 +175,7 @@
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Using the END-IF delimiter</h4>
+					<h3>Using the END-IF delimiter</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -225,7 +225,7 @@ Statement6.</code></pre>
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Condition Types</h4>
+					<h3>Condition Types</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -259,7 +259,7 @@ Statement6.</code></pre>
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Relation Conditions</h4>
+					<h3>Relation Conditions</h3>
 				</div>
 				<div class="section-content">
 					<div>
@@ -293,7 +293,7 @@ Statement6.</code></pre>
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Class Conditions</h4>
+					<h3>Class Conditions</h3>
 					<aside>
 						<p class="center-block">
 							<img height="44" src="Resources/pics/i-LightBulbTip.gif" width="42" alt="" />
@@ -352,7 +352,7 @@ END-IF</code></pre>
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Sign Condition</h4>
+					<h3>Sign Condition</h3>
 				</div>
 				<div class="section-content">
 					<p><img height="76" src="Resources/pics/Select4.gif" width="313" alt="Sign Condition syntax diagram" /></p>
@@ -364,7 +364,7 @@ END-IF</code></pre>
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Complex Conditions</h4>
+					<h3>Complex Conditions</h3>
 					<aside>
 						<p class="center-block">
 							<img height="44" src="Resources/pics/i-LightBulbTip.gif" width="42" alt="" />
@@ -573,7 +573,7 @@ END-IF
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Implied Subjects</h4>
+					<h3>Implied Subjects</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -619,7 +619,7 @@ END-IF
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Nested Ifs</h4>
+					<h3>Nested Ifs</h3>
 					<p class="center-block"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
 				</div>
 				<div class="section-content">
@@ -729,7 +729,7 @@ END-IF
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -751,7 +751,7 @@ END-IF
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Condition Name Syntax</h4>
+					<h3>Condition Name Syntax</h3>
 				</div>
 				<div class="section-content">
 					<p><img height="76" src="Resources/pics/Select6.gif" width="501" alt="Condition Name syntax diagram" /></p>
@@ -825,7 +825,7 @@ END-IF
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Condition Names examples</h4>
+					<h3>Condition Names examples</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -845,7 +845,7 @@ END-IF
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Using Condition Names correctly</h4>
+					<h3>Using Condition Names correctly</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -909,7 +909,7 @@ END-IF
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -925,7 +925,7 @@ END-IF
 				</div>
 
 				<div class="section-sidebar">
-					<h4>SET syntax</h4>
+					<h3>SET syntax</h3>
 				</div>
 				<div class="section-content">
 					<p>SET {ConditionName} ... TO TRUE</p>
@@ -950,7 +950,7 @@ END-IF
 				</div>
 
 				<div class="section-sidebar">
-					<h4>SET verb example</h4>
+					<h3>SET verb example</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -971,7 +971,7 @@ END-IF
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Using the SET verb with Sequential Files</h4>
+					<h3>Using the SET verb with Sequential Files</h3>
 					<p class="center-block"><img height="44" src="Resources/pics/program-fragment.svg" width="48" alt="Program fragment" /></p>
 				</div>
 				<div class="section-content">
@@ -1045,7 +1045,7 @@ Begin.
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1062,7 +1062,7 @@ Begin.
 				</div>
 
 				<div class="section-sidebar">
-					<h4>Evaluate syntax</h4>
+					<h3>Evaluate syntax</h3>
 				</div>
 				<div class="section-content">
 					<p><img height="453" src="Resources/pics/Select7.gif" width="523" alt="EVALUATE statement syntax diagram" /></p>
@@ -1102,7 +1102,7 @@ Begin.
 				</div>
 
 				<div class="section-sidebar">
-					<h4>EVALUATE example1</h4>
+					<h3>EVALUATE example1</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1172,7 +1172,7 @@ END-EVALUATE
 				</div>
 
 				<div class="section-sidebar">
-					<h4>EVALUATE example2</h4>
+					<h3>EVALUATE example2</h3>
 				</div>
 				<div class="section-content">
 					<p>

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -49,7 +49,7 @@
 					<h2 id="intro">Introduction</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Aims</h4>
+					<h3>Aims</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -81,7 +81,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Objectives</h4>
+					<h3>Objectives</h3>
 				</div>
 				<div class="section-content">
 					<p>By the end of this unit you should -</p>
@@ -98,7 +98,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Prerequisites</h4>
+					<h3>Prerequisites</h3>
 				</div>
 				<div class="section-content">
 					<ul>
@@ -122,7 +122,7 @@
 					<h2 id="part1">Introduction to record-based files</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -135,7 +135,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Files, Records, Fields</h4>
+					<h3>Files, Records, Fields</h3>
 				</div>
 				<div class="section-content">
 					<p>In record-based files;</p>
@@ -156,7 +156,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Record instance vs Record type</h4>
+					<h3>Record instance vs Record type</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -178,7 +178,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>The record buffer</h4>
+					<h3>The record buffer</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -207,7 +207,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Some implications of "buffers"</h4>
+					<h3>Some implications of "buffers"</h3>
 					<p class="center-block"><img height="44" src="Resources/pics/program.gif" width="42" alt="" /></p>
 				</div>
 				<div class="section-content">
@@ -241,7 +241,7 @@
 					<h2 id="part2">Declaring Records and Files</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 					<aside>
 						<p class="center-block">
 							<span class="i-detail" aria-hidden="true">🔍</span><br />
@@ -271,7 +271,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Creating a record</h4>
+					<h3>Creating a record</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -329,7 +329,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Declaring a record buffer in your program</h4>
+					<h3>Declaring a record buffer in your program</h3>
 					<p class="center-block"><img height="44" src="Resources/pics/program-fragment.svg" width="48" alt="Program fragment" /></p>
 				</div>
 				<div class="section-content">
@@ -363,7 +363,7 @@ FD StudentFile.
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>The SELECT and ASSIGN clause</h4>
+					<h3>The SELECT and ASSIGN clause</h3>
 					<p class="center-block"><img height="44" src="Resources/pics/program-fragment.svg" width="48" alt="Program fragment" /></p>
 				</div>
 				<div class="section-content">
@@ -403,7 +403,7 @@ FD StudentFile.
    02 Gender            PIC X.</code></pre>
 				</div>
 				<div class="section-sidebar">
-					<h4>SELECT and ASSIGN syntax for Sequential files</h4>
+					<h3>SELECT and ASSIGN syntax for Sequential files</h3>
 					<aside>
 						<p class="center-block">
 							<span class="i-detail" aria-hidden="true">🔍</span><br />
@@ -457,7 +457,7 @@ SELECT StudentFile
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>What is the purpose of the SELECT and ASSIGN clause?</h4>
+					<h3>What is the purpose of the SELECT and ASSIGN clause?</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -483,7 +483,7 @@ SELECT StudentFile
 					<h2 id="part3">COBOL file handling verbs</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -500,7 +500,7 @@ SELECT StudentFile
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>The OPEN verb</h4>
+					<h3>The OPEN verb</h3>
 					<aside>
 						<p class="center-block">
 							<img height="44" src="Resources/pics/i-LightBulbTip.gif" width="42" alt="" /><br />
@@ -547,7 +547,7 @@ SELECT StudentFile
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>The CLOSE verb</h4>
+					<h3>The CLOSE verb</h3>
 				</div>
 				<div class="section-content">
 					<p><code class="language-cobol">CLOSE</code> InternalFileName...</p>
@@ -559,7 +559,7 @@ SELECT StudentFile
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>The READ verb</h4>
+					<h3>The READ verb</h3>
 				</div>
 				<div class="section-content">
 					<p><img height="101" src="Resources/pics/FileSeq5.gif" width="288" alt="READ verb syntax diagram for Sequential files" /></p>
@@ -588,7 +588,7 @@ SELECT StudentFile
 					</p>
 				</div>
 				<div class="section-sidebar">
-					<h4>How the READ works</h4>
+					<h3>How the READ works</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -615,7 +615,7 @@ SELECT StudentFile
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>The WRITE verb</h4>
+					<h3>The WRITE verb</h3>
 					<aside>
 						<p class="center-block">
 							<span class="i-detail" aria-hidden="true">🔍</span><br />
@@ -650,7 +650,7 @@ SELECT StudentFile
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Read a file, Write a record</h4>
+					<h3>Read a file, Write a record</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -676,7 +676,7 @@ SELECT StudentFile
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Example Program</h4>
+					<h3>Example Program</h3>
 					<p class="center-block"><img height="44" src="Resources/pics/program.gif" width="42" alt="" /></p>
 				</div>
 				<div class="section-content">

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -50,7 +50,7 @@
 					<h2 id="intro">Introduction</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Aims</h4>
+					<h3>Aims</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -66,7 +66,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Objectives</h4>
+					<h3>Objectives</h3>
 				</div>
 				<div class="section-content">
 					<p>By the end of this unit you should -</p>
@@ -78,7 +78,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Prerequisites</h4>
+					<h3>Prerequisites</h3>
 				</div>
 				<div class="section-content">
 					<ul>
@@ -103,7 +103,7 @@
 					<h2 id="part1">Organization and Access</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -128,7 +128,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Sequential Organization</h4>
+					<h3>Sequential Organization</h3>
 				</div>
 				<div class="section-content">
 					<p>Sequential organization is simplest file organization in COBOL.</p>
@@ -146,7 +146,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Ordered and Unordered files</h4>
+					<h3>Ordered and Unordered files</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -198,7 +198,7 @@
 					<h2 id="part2">Processing unordered Sequential Files</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -212,7 +212,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Adding records to an unordered Sequential File</h4>
+					<h3>Adding records to an unordered Sequential File</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -235,7 +235,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Problems with unordered Sequential files</h4>
+					<h3>Problems with unordered Sequential files</h3>
 					<aside>
 						<p class="center-block">
 							<span class="i-detail" aria-hidden="true">🔍</span><br />
@@ -259,7 +259,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Record matching</h4>
+					<h3>Record matching</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -290,7 +290,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Attempting to batch delete records in an unordered file.</h4>
+					<h3>Attempting to batch delete records in an unordered file.</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -323,7 +323,7 @@
 					<h2 id="part3">Processing Ordered Sequential Files</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -335,7 +335,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Inserting records into an ordered Sequential file.</h4>
+					<h3>Inserting records into an ordered Sequential file.</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -359,7 +359,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Self Assessment questions</h4>
+					<h3>Self Assessment questions</h3>
 					<p class="center-block"><img height="44" src="Resources/pics/program-fragment.svg" width="48" alt="Program fragment" /></p>
 					<p class="center-block"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
 				</div>
@@ -451,7 +451,7 @@ END-PERFORM
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Deleting records from an ordered Sequential file.</h4>
+					<h3>Deleting records from an ordered Sequential file.</h3>
 				</div>
 				<div class="section-content">
 					<p>The animation below demonstrates how to delete records from an ordered Sequential file.</p>
@@ -463,7 +463,7 @@ END-PERFORM
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Updating records in an ordered Sequential file.</h4>
+					<h3>Updating records in an ordered Sequential file.</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -480,7 +480,7 @@ END-PERFORM
 					</p>
 				</div>
 				<div class="section-sidebar">
-					<h4>Multiple record type transaction files</h4>
+					<h3>Multiple record type transaction files</h3>
 				</div>
 				<div class="section-content">
 					<p>

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -50,7 +50,7 @@
 					<h2 id="intro">Introduction</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Aims</h4>
+					<h3>Aims</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -60,7 +60,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Objectives</h4>
+					<h3>Objectives</h3>
 				</div>
 				<div class="section-content">
 					<p>By the end of this unit you should -</p>
@@ -88,7 +88,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Prerequisites</h4>
+					<h3>Prerequisites</h3>
 				</div>
 				<div class="section-content">
 					<ul>
@@ -114,7 +114,7 @@
 					<h2 id="part1">Multiple record-type files</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -131,7 +131,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Implications of multiple record types</h4>
+					<h3>Implications of multiple record types</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -146,7 +146,7 @@
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Declaring a multiple record-type file</h4>
+					<h3>Declaring a multiple record-type file</h3>
 					<p class="center-block"><img height="44" src="Resources/pics/program-fragment.svg" width="48" alt="Program fragment" /></p>
 				</div>
 				<div class="section-content">
@@ -199,7 +199,7 @@ FD TransFile.
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Multiple record-types - one record buffer</h4>
+					<h3>Multiple record-types - one record buffer</h3>
 					<p class="center-block">
 						<img height="62" src="Resources/pics/i-Animation.gif" width="62" alt="" />
 					</p>
@@ -226,7 +226,7 @@ FD TransFile.
 					</p>
 				</div>
 				<div class="section-sidebar">
-					<h4>Implications of record mappings</h4>
+					<h3>Implications of record mappings</h3>
 					<aside>
 						<p class="center-block">
 							<span class="i-detail" aria-hidden="true">🔍</span><br />
@@ -256,7 +256,7 @@ FD TransFile.
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>The type-code.</h4>
+					<h3>The type-code.</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -276,10 +276,10 @@ FD TransFile.
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>The revised record descriptions.</h4>
-					<h4 class="center-block">
+					<h3>The revised record descriptions.</h3>
+					<h3 class="center-block">
 						<img height="44" src="Resources/pics/program-fragment.svg" width="48" alt="Program fragment" />
-					</h4>
+					</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -351,10 +351,10 @@ FD TransFile.
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Using FILLER in the transaction records.</h4>
-					<h4 class="center-block">
+					<h3>Using FILLER in the transaction records.</h3>
+					<h3 class="center-block">
 						<img height="44" src="Resources/pics/program-fragment.svg" width="48" alt="Program fragment" />
-					</h4>
+					</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -413,7 +413,7 @@ FD TransFile.
 					<h2 id="part2">COBOL print files</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -426,7 +426,7 @@ FD TransFile.
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Setting up a print file</h4>
+					<h3>Setting up a print file</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -441,7 +441,7 @@ FD TransFile.
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Declaring print lines</h4>
+					<h3>Declaring print lines</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -496,7 +496,7 @@ FD TransFile.
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Problems multiple print records.</h4>
+					<h3>Problems multiple print records.</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -519,7 +519,7 @@ FD TransFile.
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Setting up a print file</h4>
+					<h3>Setting up a print file</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -537,7 +537,7 @@ FD TransFile.
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>The WRITE format revisited.</h4>
+					<h3>The WRITE format revisited.</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -574,7 +574,7 @@ FD TransFile.
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Bringing it all together.</h4>
+					<h3>Bringing it all together.</h3>
 					<p class="center-block"><img height="44" src="Resources/pics/program.gif" width="42" alt="" /></p>
 				</div>
 				<div class="section-content">
@@ -701,7 +701,7 @@ PrintPageHeadings.
 					<h2 id="part3">Variable length records</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -717,7 +717,7 @@ PrintPageHeadings.
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>FD entries for variable length records</h4>
+					<h3>FD entries for variable length records</h3>
 					<aside>
 						<p class="center-block">
 							<span class="i-detail" aria-hidden="true">🔍</span><br />
@@ -765,7 +765,7 @@ FD Stringfile
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>How variable-length records, declared with the DEPENDING ON phrase, work.</h4>
+					<h3>How variable-length records, declared with the DEPENDING ON phrase, work.</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -783,7 +783,7 @@ FD Stringfile
 					<hr width="50%" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Example program</h4>
+					<h3>Example program</h3>
 				</div>
 				<div class="section-content">
 					<p>The example program below introduces and number of new techniques and concepts;</p>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -58,7 +58,7 @@
 					<h2 id="intro">Introduction</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Aims</h4>
+					<h3>Aims</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -84,7 +84,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Objectives</h4>
+					<h3>Objectives</h3>
 				</div>
 				<div class="section-content">
 					<p>By the end of this unit you should -</p>
@@ -121,7 +121,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Prerequisites</h4>
+					<h3>Prerequisites</h3>
 				</div>
 				<div class="section-content">
 					<ul>
@@ -146,7 +146,7 @@
 					<h2 id="part1">Simple Sorting</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -169,7 +169,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Why sort the file?</h4>
+					<h3>Why sort the file?</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -214,7 +214,7 @@ Total value =  999,999,999.99</code></pre>
 					</div>
 				</div>
 				<div class="section-sidebar">
-					<h4>Solving the problem without sorting the file?</h4>
+					<h3>Solving the problem without sorting the file?</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -266,7 +266,7 @@ END-IF</code></pre>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Syntax of a simplified SORT</h4>
+					<h3>Syntax of a simplified SORT</h3>
 					<aside>
 						<p class="center-block">
 							<span class="i-detail" aria-hidden="true">🔍</span><br />
@@ -416,7 +416,7 @@ Begin.
         etc.</code></pre>
 				</div>
 				<div class="section-sidebar">
-					<h4>How a simple SORT works</h4>
+					<h3>How a simple SORT works</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -440,7 +440,7 @@ Begin.
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Using multiple keys.</h4>
+					<h3>Using multiple keys.</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -593,7 +593,7 @@ etc.</code></pre>
 					<h2 id="part2">SORTing with an INPUT PROCEDURE</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -610,7 +610,7 @@ etc.</code></pre>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>SORT syntax with INPUT PROCEDURE</h4>
+					<h3>SORT syntax with INPUT PROCEDURE</h3>
 				</div>
 				<div class="section-content">
 					<p><img height="274" src="Resources/pics/Sort3.gif" width="486" alt="SORT verb syntax diagram with INPUT PROCEDURE" /></p>
@@ -672,7 +672,7 @@ SORT WorkFile ON ASCENDING CountryNameWF, CustomerNameWF
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>How a SORT with and INPUT PROCEDURE works.</h4>
+					<h3>How a SORT with and INPUT PROCEDURE works.</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -714,7 +714,7 @@ SORT WorkFile ON ASCENDING CountryNameWF, CustomerNameWF
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Creating an INPUT PROCEDURE</h4>
+					<h3>Creating an INPUT PROCEDURE</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -755,7 +755,7 @@ CLOSE InFileName</code></pre>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>The Foreign Guests Report - example program</h4>
+					<h3>The Foreign Guests Report - example program</h3>
 					<aside>
 						<p class="center-block">
 							<span class="i-detail" aria-hidden="true">🔍</span><br />
@@ -910,7 +910,7 @@ PrintReportBody.
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Feeding the SORT from the keyboard - example program</h4>
+					<h3>Feeding the SORT from the keyboard - example program</h3>
 					<p class="center-block"><img height="44" src="Resources/pics/program.gif" width="42" alt="" /></p>
 				</div>
 				<div class="section-content">
@@ -1001,7 +1001,7 @@ GetStudentDetails.
 					<h2 id="part3">Sorting with an OUTPUT PROCEDURE</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1033,7 +1033,7 @@ GetStudentDetails.
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>SORT syntax with OUTPUT PROCEDURE</h4>
+					<h3>SORT syntax with OUTPUT PROCEDURE</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1074,7 +1074,7 @@ SORT WorkFile ON ASCENDING KEY SalespersonNumWF
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>How the OUTPUT PROCEDURE works</h4>
+					<h3>How the OUTPUT PROCEDURE works</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1108,7 +1108,7 @@ SORT WorkFile ON ASCENDING KEY SalespersonNumWF
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Creating an OUTPUT PROCEDURE</h4>
+					<h3>Creating an OUTPUT PROCEDURE</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1153,7 +1153,7 @@ CLOSE OutFile
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Sales summary file - example program</h4>
+					<h3>Sales summary file - example program</h3>
 					<p class="center-block"><img height="44" src="Resources/pics/program.gif" width="42" alt="" /></p>
 				</div>
 				<div class="section-content">
@@ -1225,7 +1225,7 @@ SummariseSales.
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Revised Foreign Guests Report - example program</h4>
+					<h3>Revised Foreign Guests Report - example program</h3>
 					<p class="center-block"><img height="44" src="Resources/pics/program.gif" width="42" alt="" /></p>
 				</div>
 				<div class="section-content">
@@ -1358,7 +1358,7 @@ PrintReportBody.
 					<h2 id="part4">MERGEing files</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1378,7 +1378,7 @@ PrintReportBody.
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>MERGE syntax</h4>
+					<h3>MERGE syntax</h3>
 				</div>
 				<div class="section-content">
 					<p><img height="229" src="Resources/pics/Sort8.gif" width="494" alt="MERGE verb syntax diagram" /></p>
@@ -1441,7 +1441,7 @@ PrintReportBody.
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>MERGE example</h4>
+					<h3>MERGE example</h3>
 				</div>
 				<div class="section-content">
 					<p>

--- a/course/String.html
+++ b/course/String.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -39,7 +39,7 @@
 					<h2 id="intro">Introduction</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Aims</h4>
+					<h3>Aims</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -48,7 +48,7 @@
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>Objectives</h4>
+					<h3>Objectives</h3>
 				</div>
 				<div class="section-content">
 					<p>By the end of this unit you should:</p>
@@ -59,7 +59,7 @@
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>Prerequisites</h4>
+					<h3>Prerequisites</h3>
 				</div>
 				<div class="section-content">
 					<p>You should be familiar with the material covered in the unit;</p>
@@ -82,7 +82,7 @@
 					<h2 id="verb">The STRING verb</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -115,7 +115,7 @@ END-STRING.</code></pre>
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>STRING syntax</h4>
+					<h3>STRING syntax</h3>
 				</div>
 				<div class="section-content">
 					<p><img src="Resources/pics/I-String.gif" alt="" /></p>
@@ -137,7 +137,7 @@ END-STRING.</code></pre>
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>How the STRING works</h4>
+					<h3>How the STRING works</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -168,7 +168,7 @@ END-STRING.</code></pre>
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>Data movement termination</h4>
+					<h3>Data movement termination</h3>
 				</div>
 				<div class="section-content">
 					<p>Data movement from a particular source string ends when either;</p>
@@ -180,7 +180,7 @@ END-STRING.</code></pre>
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>STRING termination</h4>
+					<h3>STRING termination</h3>
 				</div>
 				<div class="section-content">
 					<p>The STRING statement ends when either;</p>
@@ -192,7 +192,7 @@ END-STRING.</code></pre>
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>STRING rules</h4>
+					<h3>STRING rules</h3>
 				</div>
 				<div class="section-content">
 					<ol>
@@ -218,7 +218,7 @@ END-STRING.</code></pre>
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>STRING clauses</h4>
+					<h3>STRING clauses</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -257,7 +257,7 @@ END-STRING.</code></pre>
 					<h2 id="examples">STRING examples</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -267,10 +267,10 @@ END-STRING.</code></pre>
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>
+					<h3>
 						Example 1<br />
 						(animation)
-					</h4>
+					</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -293,10 +293,10 @@ END-STRING.</code></pre>
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>
+					<h3>
 						Example 2<br />
 						(animation)
-					</h4>
+					</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -328,7 +328,7 @@ END-STRING.</code></pre>
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>Self assessment questions/examples</h4>
+					<h3>Self assessment questions/examples</h3>
 				</div>
 				<div class="section-content">
 					<p>The examples below consist of data delarations and a number of STRING statements.</p>
@@ -391,7 +391,7 @@ END-STRING.</code></pre>
    DISPLAY Field2. </code></pre>
 				</div>
 				<div class="section-sidebar">
-					<h4>Answers to SAQs</h4>
+					<h3>Answers to SAQs</h3>
 				</div>
 				<div class="section-content">
 					<iframe

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -43,7 +43,7 @@
 					<h2 id="intro">Introduction</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Aims</h4>
+					<h3>Aims</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -75,7 +75,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Objectives</h4>
+					<h3>Objectives</h3>
 				</div>
 				<div class="section-content">
 					<p>By the end of this unit you should -</p>
@@ -110,7 +110,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Prerequisites</h4>
+					<h3>Prerequisites</h3>
 				</div>
 				<div class="section-content">
 					<ul>
@@ -145,9 +145,9 @@
 					<h2 id="part1">The CALL verb</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>
+					<h3>
 						<b>Introduction</b>
-					</h4>
+					</h3>
 					<aside>
 						<p class="center-block">
 							<span class="i-detail" aria-hidden="true">🔍</span><br />
@@ -184,9 +184,9 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>
+					<h3>
 						<b>CALL verb semantics</b>
-					</h4>
+					</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -590,9 +590,9 @@ Begin.
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>
+					<h3>
 						<b>State memory and the CANCEL verb</b>
-					</h4>
+					</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -619,9 +619,9 @@ CALL "Fickle" USING BY CONTENT IncValue.</code></pre>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>
+					<h3>
 						<b>Subprogram clauses and verbs</b>
-					</h4>
+					</h3>
 				</div>
 				<div class="section-content">
 					<p>COBOL subprograms. are identical to standard COBOL programs with the following exceptions:</p>
@@ -673,7 +673,7 @@ CALL "Fickle" USING BY CONTENT IncValue.</code></pre>
 					<h2 id="part2">Contained Subprograms</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -730,9 +730,9 @@ CALL "Fickle" USING BY CONTENT IncValue.</code></pre>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>
+					<h3>
 						<b>The IS GLOBAL clause</b>
-					</h4>
+					</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -789,7 +789,7 @@ END-PROGRAM ContainerProgram.</code></pre>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Information Hiding using the IS GLOBAL clause and contained subprograms</h4>
+					<h3>Information Hiding using the IS GLOBAL clause and contained subprograms</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -861,12 +861,12 @@ END-PROGRAM ContainerProgram.</code></pre>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>
+					<h3>
 						<b
 							>Example program using contained subprograms. and the IS COMMON PROGRAM and IS GLOBAL
 							clauses</b
 						>
-					</h4>
+					</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -914,7 +914,7 @@ END PROGRAM MainProgram.
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Example program using the IS INITIAL and IS COMMON clauses and the CANCEL command.</h4>
+					<h3>Example program using the IS INITIAL and IS COMMON clauses and the CANCEL command.</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1052,7 +1052,7 @@ Value - 0</code></pre>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>The IS EXTERNAL clause</h4>
+					<h3>The IS EXTERNAL clause</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1098,7 +1098,7 @@ Value - 0</code></pre>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Designing a modular system</h4>
+					<h3>Designing a modular system</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1124,9 +1124,9 @@ Value - 0</code></pre>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>
+					<h3>
 						<b>Criteria for module goodness</b>
-					</h4>
+					</h3>
 				</div>
 				<div class="section-content">
 					<p>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -52,7 +52,7 @@
 					<h2 id="intro">Introduction</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Aims</h4>
+					<h3>Aims</h3>
 				</div>
 				<div class="section-content">
 					
@@ -68,7 +68,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Objectives</h4>
+					<h3>Objectives</h3>
 				</div>
 				<div class="section-content">
 					<p>By the end of this unit you should -</p>
@@ -86,7 +86,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Prerequisites</h4>
+					<h3>Prerequisites</h3>
 				</div>
 				<div class="section-content">
 					<ul>
@@ -115,7 +115,7 @@
 					<h2 id="part1">Why use tables?</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 					<p class="center-block"><img height="44" src="Resources/pics/program-fragment.svg" width="48" alt="Program fragment" /></p>
 				</div>
 				<div class="section-content">
@@ -164,7 +164,7 @@ Begin.
 				
 				</div>
 				<div class="section-sidebar">
-					<h4>Exploring the problem</h4>
+					<h3>Exploring the problem</h3>
 				</div>
 				<div class="section-content">
 					
@@ -258,7 +258,7 @@ DISPLAY "County 3 total is ", County3TaxTotal
 					<h2 id="part2">Using a CountyTax table</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -284,7 +284,7 @@ DISPLAY "County 3 total is ", County3TaxTotal
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Declaring the CountyTax table</h4>
+					<h3>Declaring the CountyTax table</h3>
 					<p class="center-block">
 						<a href="Resources/ppz/TC-Tables1.html"
 							><img height="62" src="Resources/pics/i-Animation.gif" width="62" alt="Click for animation: CountyTax table declaration and usage"
@@ -323,7 +323,7 @@ ADD TaxPaid TO CountyTax(CountyCode - 2)</code></pre>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>The County Tax Report program</h4>
+					<h3>The County Tax Report program</h3>
 					<p class="center-block"><img height="44" src="Resources/pics/program-fragment.svg" width="48" alt="Program fragment" /></p>
 				</div>
 				<div class="section-content">
@@ -374,7 +374,7 @@ Begin.
 					<h2 id="part3">Displaying the County Name</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					
@@ -389,7 +389,7 @@ Begin.
 				
 				</div>
 				<div class="section-sidebar">
-					<h4>A table-based solution</h4>
+					<h3>A table-based solution</h3>
 					<p class="center-block"><img height="44" src="Resources/pics/program-fragment.svg" width="48" alt="Program fragment" /></p>
 				</div>
 				<div class="section-content">
@@ -437,7 +437,7 @@ Begin.
    STOP RUN.</code></pre>
 				</div>
 				<div class="section-sidebar">
-					<h4>A diagrammatic representation of the CountyName table</h4>
+					<h3>A diagrammatic representation of the CountyName table</h3>
 				</div>
 				<div class="section-content">
 					
@@ -471,7 +471,7 @@ Begin.
 					<h2 id="part4">Using one table to index into another</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -497,7 +497,7 @@ Begin.
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>An EVALUATE based solution</h4>
+					<h3>An EVALUATE based solution</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -521,7 +521,7 @@ ADD TaxPaid TO CountyTax(CountyNum)</code></pre>
 					</p>
 				</div>
 				<div class="section-sidebar">
-					<h4>Using the subscript from one table as the index into another</h4>
+					<h3>Using the subscript from one table as the index into another</h3>
 					<p class="center-block"><img height="44" src="Resources/pics/program-fragment.svg" width="48" alt="Program fragment" /></p>
 				</div>
 				<div class="section-content">

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -91,7 +91,7 @@
 					<h2 id="intro">Introduction</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Aims</h4>
+					<h3>Aims</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -106,7 +106,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Objectives</h4>
+					<h3>Objectives</h3>
 				</div>
 				<div class="section-content">
 					<p>By the end of this unit you should -</p>
@@ -133,7 +133,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Prerequisites</h4>
+					<h3>Prerequisites</h3>
 				</div>
 				<div class="section-content">
 					<ul>
@@ -160,7 +160,7 @@
 					<h2 id="part1">Declaring a single dimension table</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -174,7 +174,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Tables - general notes</h4>
+					<h3>Tables - general notes</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -207,7 +207,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Using the <code class="language-cobol">OCCURS</code> clause to declare a table</h4>
+					<h3>Using the <code class="language-cobol">OCCURS</code> clause to declare a table</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -254,7 +254,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>OCCURS clause syntax and rules</h4>
+					<h3>OCCURS clause syntax and rules</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -312,7 +312,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Table examples and some SAQ's</h4>
+					<h3>Table examples and some SAQ's</h3>
 					<p class="center-block"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
 				</div>
 				<div class="section-content">
@@ -407,7 +407,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Declaring a variable length table.</h4>
+					<h3>Declaring a variable length table.</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -450,7 +450,7 @@
 					<h2 id="part2">Group items as elements</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -459,7 +459,7 @@
 					</p>
 				</div>
 				<div class="section-sidebar">
-					<h4>Setting up a combined table</h4>
+					<h3>Setting up a combined table</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -502,7 +502,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Self Assessment Questions and animated example</h4>
+					<h3>Self Assessment Questions and animated example</h3>
 					<p class="center-block"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
 				</div>
 				<div class="section-content">
@@ -549,7 +549,7 @@ MOVE ZEROS TO CountyTaxTable</code></pre>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Example program</h4>
+					<h3>Example program</h3>
 					<p class="center-block"><img height="44" src="Resources/pics/program.gif" width="42" alt="" /></p>
 				</div>
 				<div class="section-content">
@@ -647,7 +647,7 @@ DisplayCountyTaxes.
 					<h2 id="part3">Declaring multi-dimension tables</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -713,7 +713,7 @@ DisplayCountyTaxes.
 					</p>
 				</div>
 				<div class="section-sidebar">
-					<h4>Problem discussion</h4>
+					<h3>Problem discussion</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -770,7 +770,7 @@ END-EVALUATE.
 					</p>
 				</div>
 				<div class="section-sidebar">
-					<h4>A two dimension table</h4>
+					<h3>A two dimension table</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -804,7 +804,7 @@ END-EVALUATE.
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Self Assessment Questions and examples</h4>
+					<h3>Self Assessment Questions and examples</h3>
 					<p class="center-block"><img height="46" src="Resources/pics/i-SAQ2.gif" width="32" alt="" /></p>
 				</div>
 				<div class="section-content">
@@ -826,7 +826,7 @@ MOVE ZEROS TO Age(3)</code></pre>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Displaying the population report for each county</h4>
+					<h3>Displaying the population report for each county</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -860,7 +860,7 @@ MOVE ZEROS TO Age(3)</code></pre>
 					</p>
 				</div>
 				<div class="section-sidebar">
-					<h4>Creating a three dimension table</h4>
+					<h3>Creating a three dimension table</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -880,7 +880,7 @@ MOVE ZEROS TO Age(3)</code></pre>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Self Assessment Questions and examples</h4>
+					<h3>Self Assessment Questions and examples</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -902,7 +902,7 @@ MOVE ZEROS TO PopulationTable</code></pre>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>One last tweak to the problem specification.</h4>
+					<h3>One last tweak to the problem specification.</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -989,7 +989,7 @@ ADD 56 TO PopTotal(12,3,2)</code></pre>
 					<h2 id="part4">Creating pre-filled tables with the REDEFINES clause</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1015,7 +1015,7 @@ ADD 56 TO PopTotal(12,3,2)</code></pre>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Non-tables uses for the REDEFINES clause - some examples</h4>
+					<h3>Non-tables uses for the REDEFINES clause - some examples</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1116,7 +1116,7 @@ END-EVALUATE </code></pre>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>REDEFINES syntax and rules</h4>
+					<h3>REDEFINES syntax and rules</h3>
 				</div>
 				<div class="section-content">
 					<p><img height="48" src="Resources/pics/Redefines.gif" width="358" alt="REDEFINES clause syntax diagram" /></p>
@@ -1154,7 +1154,7 @@ END-EVALUATE </code></pre>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Using the REDEFINES clause to create a pre-filled table.</h4>
+					<h3>Using the REDEFINES clause to create a pre-filled table.</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1196,7 +1196,7 @@ END-EVALUATE </code></pre>
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Example program</h4>
+					<h3>Example program</h3>
 					<p class="center-block"><img height="44" src="Resources/pics/program.gif" width="42" alt="" /></p>
 				</div>
 				<div class="section-content">
@@ -1308,7 +1308,7 @@ DisplayCountyTaxes.
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Creating pre-filled tables without using the REDEFINES clause.</h4>
+					<h3>Creating pre-filled tables without using the REDEFINES clause.</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -1336,7 +1336,7 @@ DisplayCountyTaxes.
 					</div>
 				</div>
 				<div class="section-sidebar">
-					<h4>COBOL'85 table initialisation changes</h4>
+					<h3>COBOL'85 table initialisation changes</h3>
 				</div>
 				<div class="section-content">
 					<p>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -46,7 +46,7 @@
 					<h2 id="intro">Introduction</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Aims</h4>
+					<h3>Aims</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -56,7 +56,7 @@
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>Objectives</h4>
+					<h3>Objectives</h3>
 				</div>
 				<div class="section-content">
 					<p>By the end of this unit you should:</p>
@@ -67,7 +67,7 @@
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>Prerequisites</h4>
+					<h3>Prerequisites</h3>
 				</div>
 				<div class="section-content">
 					<p>You should be familiar with the material covered in the unit;</p>
@@ -91,7 +91,7 @@
 					<h2 id="verb">The UNSTRING verb</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>The UNSTRING is used to divide a string into sub-strings.</p>
@@ -122,7 +122,7 @@ END-UNSTRING.</code></pre>
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>UNSTRING syntax</h4>
+					<h3>UNSTRING syntax</h3>
 				</div>
 				<div class="section-content">
 					<p><img src="Resources/pics/I-UnString.gif" alt="" /></p>
@@ -166,7 +166,7 @@ END-UNSTRING.</code></pre>
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>How the UNSTRING works</h4>
+					<h3>How the UNSTRING works</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -185,7 +185,7 @@ END-UNSTRING.</code></pre>
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>Data movement termination</h4>
+					<h3>Data movement termination</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -207,7 +207,7 @@ END-UNSTRING.</code></pre>
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>UNSTRING termination</h4>
+					<h3>UNSTRING termination</h3>
 				</div>
 				<div class="section-content">
 					<p>The UNSTRING statement terminates when either;</p>
@@ -222,7 +222,7 @@ END-UNSTRING.</code></pre>
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>UNSTRING rules</h4>
+					<h3>UNSTRING rules</h3>
 				</div>
 				<div class="section-content">
 					<ol>
@@ -251,7 +251,7 @@ END-UNSTRING.</code></pre>
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>UNSTRING clauses</h4>
+					<h3>UNSTRING clauses</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -335,7 +335,7 @@ END-UNSTRING.</code></pre>
 					<h2 id="examples">UNSTRING examples</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>This section starts with 6 short examples exploring various aspects the UNSTRING.</p>
@@ -344,10 +344,10 @@ END-UNSTRING.</code></pre>
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>
+					<h3>
 						Examples 1 - 6<br />
 						(animation)
-					</h4>
+					</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -370,10 +370,10 @@ END-UNSTRING.</code></pre>
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>
+					<h3>
 						Example 7<br />
 						(animation)
-					</h4>
+					</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -396,7 +396,7 @@ END-UNSTRING.</code></pre>
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>Example program</h4>
+					<h3>Example program</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -488,7 +488,7 @@ Begin.
 					<h2 id="combined">Combined example</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Introduction</h4>
+					<h3>Introduction</h3>
 				</div>
 				<div class="section-content">
 					<p>
@@ -499,7 +499,7 @@ Begin.
 					<p>For example "Michael John Tim James Ryan" becomes "M.J.T.J. Ryan".</p>
 				</div>
 				<div class="section-sidebar">
-					<h4>Data items used in the example</h4>
+					<h3>Data items used in the example</h3>
 				</div>
 				<div class="section-content">
 					<pre class="language-cobol"><code class="language-cobol">01 OldName  PIC X(80).
@@ -517,7 +517,7 @@ Begin.
 					<hr />
 				</div>
 				<div class="section-sidebar">
-					<h4>Animation</h4>
+					<h3>Animation</h3>
 				</div>
 				<div class="section-content">
 					<iframe

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -39,7 +39,7 @@
 					<h2 id="intro">Introduction</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4>Aims</h4>
+					<h3>Aims</h3>
 				</div>
 				<div class="section-content">
 <p>
@@ -64,7 +64,7 @@
 <hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Objectives</h4>
+					<h3>Objectives</h3>
 				</div>
 				<div class="section-content">
 					<p>By the end of this unit you should -</p>
@@ -90,7 +90,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4>Prerequisites</h4>
+					<h3>Prerequisites</h3>
 				</div>
 				<div class="section-content">
 					<ul>
@@ -113,7 +113,7 @@
 					<h2 id="part1">The USAGE clause</h2>
 				</div>
 				<div class="section-sidebar">
-					<h4><b>Introduction</b></h4>
+					<h3><b>Introduction</b></h3>
 <span class="i-detail" aria-hidden="true">🔍</span>
 <p>
 	<br />
@@ -158,7 +158,7 @@
 					<hr size="1" />
 				</div>
 				<div class="section-sidebar">
-					<h4><b>Problems with USAGE IS DISPLAY</b></h4>
+					<h3><b>Problems with USAGE IS DISPLAY</b></h3>
 					<p class="center-block">
 						<img height="44" src="Resources/pics/program-fragment.svg" width="48" alt="Program fragment" />
 					</p>


### PR DESCRIPTION
## Summary

Phase 1 of #222. The course pages use \`<h2>\` for section headers and \`<h4>\` for sidebar labels (\"Aims\", \"Objectives\", \"Prerequisites\"), skipping \`<h3>\`. Screen readers expose the document outline via heading level — skipping a level breaks WCAG 1.3.1 (Info and Relationships).

This PR fixes the most common pattern: every \`<h4>\` that's a direct child of \`<div class="section-sidebar">\` becomes \`<h3>\`. **565 substitutions across 25 \`course/*.html\` files.**

CSS already had matching \`.section-sidebar h3\` selectors in \`course/Resources/css/course.css\` (lines 310–311 and 333–334), so visual rendering is identical for both old and new markup — no CSS changes needed for this phase.

**Phase 2** (separate follow-up — #222 stays open):
- Other heading-level skips (e.g. \`<h4>\` inside \`.section-full\` or bare grid cells in \`Inspect.html\`, \`Intro2DirectAccess.html\`).
- Then re-enable \`heading-level\` in \`.htmlvalidate.json\` (currently \`"off"\`).

References #222 (does not close).

## Test plan

- [x] \`npm run validate\` passes
- [ ] Visual: open \`course/COBOLcommands.html\` and \`course/DataDeclaration.html\` — sidebar labels (Aims/Objectives/Prerequisites) render identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)