### PR TITLE
Phase 2 of #220: roll out <related-content> to all course pages

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -39,6 +39,7 @@
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
+		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 	</head>
 
@@ -1245,6 +1246,11 @@ DisplayGreeting.
    STOP RUN.</code></pre>
 					</div>
 					<div class="page-footer">
+						<related-content
+							lectures="../lectures/cobintro.html|Introduction to COBOL Lecture, ../lectures/GenIntro.html|General Introduction Lecture"
+							examples="../examples/Accept/ACCEPT.html|ACCEPT and DISPLAY Example, ../examples/Accept/Shortest.html|Shortest COBOL Program"
+							exercises="../exercises/GettingStarted.html|Getting Started with VISOC"
+						></related-content>
 						<hr />
 						<lesson-nav></lesson-nav>
 						<back-to-top></back-to-top>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -14,6 +14,7 @@
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
+		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 	</head>
 
@@ -1022,6 +1023,11 @@ The time is 14:41
 						</p>
 					</div>
 					<div class="page-footer">
+						<related-content
+							lectures="../lectures/basics1.html|Basic Procedure Division Lecture, ../lectures/arithmetic.html|Arithmetic Lecture"
+							examples="../examples/Accept/ACCEPT.html|ACCEPT and DISPLAY Example, ../examples/Accept/Multiplier.html|ACCEPT, DISPLAY and MULTIPLY Example"
+							exercises="../exercises/GettingStarted.html|Getting Started with VISOC"
+						></related-content>
 						<hr />
 						<lesson-nav></lesson-nav>
 						<back-to-top></back-to-top>

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -26,6 +26,7 @@
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
+		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 	</head>
 
@@ -1007,6 +1008,7 @@ COPY CopyFile7 REPLACING N1 BY Num1
 				</div>
 				<!-- Footer -->
 				<div class="page-footer">
+					<related-content lectures="../lectures/COPY.html|COPY Libraries Lecture"></related-content>
 					<hr />
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -14,6 +14,7 @@
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
+		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 	</head>
 	<body>
@@ -727,6 +728,10 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 						</div>
 					</div>
 					<div class="page-footer">
+						<related-content
+							lectures="../lectures/Basics2.html|Data Declaration Lecture, ../lectures/dsr1.html|Data Structures Lecture"
+							examples="../examples/Accept/ACCEPT.html|ACCEPT and DISPLAY Example"
+						></related-content>
 						<hr />
 						<lesson-nav></lesson-nav>
 						<back-to-top></back-to-top>

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -14,6 +14,7 @@
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
+		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 	</head>
 
@@ -1419,6 +1420,10 @@ B 0 / , + - CR DB 9</code></pre>
 				</div>
 
 				<div class="page-footer">
+					<related-content
+						lectures="../lectures/Basics2.html|Data Declaration Lecture"
+						examples="../examples/Accept/Multiplier.html|ACCEPT, DISPLAY and MULTIPLY Example"
+					></related-content>
 					<hr />
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -20,6 +20,7 @@
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
+		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 	</head>
 	<body>
@@ -1100,6 +1101,10 @@ ProcessOneBook.
 					</div>
 				</div>
 				<div class="page-footer">
+					<related-content
+						lectures="../lectures/indexed.html|Indexed Files Lecture"
+						examples="../examples/Indexed/Seq2Index.html|Creating an Indexed File from Sequential, ../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly by Key"
+					></related-content>
 					<hr />
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -14,6 +14,7 @@
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
+		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 	</head>
 	<body>
@@ -597,6 +598,7 @@ END-PERFORM</code></pre>
 					</div>
 				</div>
 				<div class="page-footer">
+					<related-content lectures="../lectures/inspect.html|INSPECT Verb Lecture"></related-content>
 					<hr />
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -14,6 +14,7 @@
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
+		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 	</head>
 	<body>
@@ -924,6 +925,10 @@ END-IF</code></pre>
 				</div>
 
 				<div class="page-footer">
+					<related-content
+						lectures="../lectures/direct1.html|Direct Access Files Lecture"
+						examples="../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly by Key, ../examples/Indexed/Seq2Index.html|Creating an Indexed File from Sequential"
+					></related-content>
 					<hr />
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -14,6 +14,7 @@
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
+		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 	</head>
 	<body>
@@ -1172,6 +1173,10 @@ Begin.
 					</div>
 				</div>
 				<div class="page-footer">
+					<related-content
+						lectures="../lectures/inspect.html|INSPECT Verb Lecture"
+						examples="../examples/Strings/RefMod.html|Reference Modification Examples"
+					></related-content>
 					<hr />
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -14,6 +14,7 @@
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
+		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 	</head>
 	<body>
@@ -693,6 +694,10 @@ Begin.</code></pre>
  Begin.</code></pre>
 				</div>
 				<div class="page-footer">
+					<related-content
+						lectures="../lectures/relative.html|Relative Files Lecture"
+						examples="../examples/Relative/Seq2Rel.html|Creating a Relative File from Sequential, ../examples/Relative/ReadRel.html|Reading a Relative File Directly"
+					></related-content>
 					<hr />
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -14,6 +14,7 @@
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
+		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 	</head>
 
@@ -1003,6 +1004,10 @@ Programmer - Michael Coughlan               Page :  1 </code></pre>
 						</div>
 
 						<div class="page-footer">
+							<related-content
+								lectures="../lectures/ReportWriterWeb.html|COBOL Report Writer Lecture"
+								examples="../examples/ReportWriter/RepWriteFull.html|Full Report Writer Program, ../examples/ReportWriter/RepWriteA.html|Report Writer – One Control Break"
+							></related-content>
 							<hr />
 							<lesson-nav></lesson-nav>
 							<back-to-top></back-to-top>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -14,6 +14,7 @@
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
+		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 	</head>
 
@@ -1236,6 +1237,10 @@ END DECLARATIVES.</code></pre>
 					</div>
 				</div>
 				<div class="page-footer">
+					<related-content
+						lectures="../lectures/ReportWriterSSWeb.html|Report Writer – Syntax and Semantics Lecture"
+						examples="../examples/ReportWriter/RepWriteFull.html|Full Report Writer Program, ../examples/ReportWriter/RepWriteSumm.html|Report Writer Summary Version"
+					></related-content>
 					<hr />
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>

--- a/course/Search.html
+++ b/course/Search.html
@@ -14,6 +14,7 @@
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
+		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 	</head>
 
@@ -1174,6 +1175,10 @@ DisplayCountyTaxes.
 					</div>
 				</div>
 				<div class="page-footer">
+					<related-content
+						lectures="../lectures/search.html|SEARCH and SEARCH ALL Lecture"
+						examples="../examples/Tables/MonthTable.html|Month Table – Counting with a Table"
+					></related-content>
 					<hr />
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -14,6 +14,7 @@
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
+		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 	</head>
 
@@ -814,6 +815,11 @@ GetStudentRecord.
 					</div>
 				</div>
 				<div class="page-footer">
+					<related-content
+						lectures="../lectures/seqfile1.html|Sequential Files 1 Lecture"
+						examples="../examples/SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../examples/SeqRead/SEQREAD.html|Reading a Sequential File"
+						exercises="../exercises/SeqWrite.html|Writing Records to a Sequential File"
+					></related-content>
 					<hr />
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -14,6 +14,7 @@
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
+		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 	</head>
 
@@ -538,6 +539,11 @@ END-PERFORM
 					</div>
 				</div>
 				<div class="page-footer">
+					<related-content
+						lectures="../lectures/seqfile2.html|Sequential Files 2 Lecture"
+						examples="../examples/SeqRead/SEQREAD.html|Reading a Sequential File, ../examples/SeqRpt/SEQRPT.html|Sequential Student Number Report"
+						exercises="../exercises/SeqRead.html|Reading Sequential Files, ../exercises/SeqReadIf.html|Counting Records in a Sequential File"
+					></related-content>
 					<hr />
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -14,6 +14,7 @@
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
+		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 	</head>
 
@@ -977,6 +978,11 @@ DisplayTransactions.
    END-READ.</code></pre>
 					</div>
 					<div class="page-footer">
+						<related-content
+							lectures="../lectures/SeqFile3.html|Sequential Files 3 Lecture"
+							examples="../examples/SeqIns/SEQINSERT.html|Inserting Records in a Sequential File, ../examples/SeqRpt/SEQRPT.html|Sequential Student Number Report"
+							exercises="../exercises/SeqInsert.html|Inserting Records in a Sequential File, ../exercises/SeqUpdate.html|Updating a Sequential File"
+						></related-content>
 						<hr />
 						<lesson-nav></lesson-nav>
 						<back-to-top></back-to-top>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -14,6 +14,7 @@
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
+		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 	</head>
 
@@ -1583,6 +1584,11 @@ Begin.
 					</div>
 				</div>
 				<div class="page-footer">
+					<related-content
+						lectures="../lectures/sort.html|SORT and MERGE Lecture"
+						examples="../examples/Sort/InputSort.html|SORT with Input Procedure, ../examples/Sort/MaleSort.html|SORT with Output Procedure, ../examples/Merge/Merge.html|Merging Files Example"
+						exercises="../exercises/SortIP.html|Sorting a Sequential File"
+					></related-content>
 					<hr />
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>

--- a/course/String.html
+++ b/course/String.html
@@ -14,6 +14,7 @@
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
+		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 	</head>
 	<body>
@@ -415,6 +416,10 @@ END-STRING.</code></pre>
 					</div>
 				</div>
 				<div class="page-footer">
+					<related-content
+						lectures="../lectures/string.html|STRING Verb Lecture"
+						examples="../examples/Strings/RefMod.html|Reference Modification Examples"
+					></related-content>
 					<hr />
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -14,6 +14,7 @@
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
+		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 	</head>
 
@@ -1231,6 +1232,10 @@ Value - 0</code></pre>
 					</div>
 				</div>
 				<div class="page-footer">
+					<related-content
+						lectures="../lectures/call.html|Subprograms and CALL Lecture"
+						examples="../examples/SubProg/Multiply/DriverProg.html|Driver for Subprogram Examples, ../examples/SubProg/DateValid/DateDriver.html|Date Validation Subprogram"
+					></related-content>
 					<hr />
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -14,6 +14,7 @@
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
+		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 	</head>
 
@@ -608,6 +609,11 @@ Begin.
 				</div>
 
 				<div class="page-footer">
+					<related-content
+						lectures="../lectures/tables1.html|Tables 1 Lecture"
+						examples="../examples/Tables/MonthTable.html|Month Table – Counting with a Table"
+						exercises="../exercises/MonthTable.html|Using Tables Exercise"
+					></related-content>
 					<hr />
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -50,6 +50,7 @@
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
+		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 	</head>
 
@@ -1465,6 +1466,11 @@ DisplayCountyTaxes.
       03 CountyName PIC X(12) VALUE SPACES.</code></pre>
 					</div>
 					<div class="page-footer">
+						<related-content
+							lectures="../lectures/tables2.html|Tables 2 Lecture"
+							examples="../examples/Tables/MonthTable.html|Month Table – Counting with a Table"
+							exercises="../exercises/MonthTable.html|Using Tables Exercise"
+						></related-content>
 						<hr />
 						<lesson-nav></lesson-nav>
 						<back-to-top></back-to-top>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -14,6 +14,7 @@
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
+		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 	</head>
 	<body>
@@ -547,6 +548,10 @@ Begin.
 					</div>
 				</div>
 				<div class="page-footer">
+					<related-content
+						lectures="../lectures/Unstring.html|UNSTRING Verb Lecture"
+						examples="../examples/Strings/UnstringFileEg.html|Unpacking Comma-Separated Records"
+					></related-content>
 					<hr />
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -14,6 +14,7 @@
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
+		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 	</head>
 
@@ -2376,6 +2377,7 @@ Begin.
 					</div>
 				</div>
 				<div class="page-footer">
+					<related-content lectures="../lectures/Usage.html|USAGE Clause Lecture"></related-content>
 					<hr />
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>


### PR DESCRIPTION
## Summary

Completes the cross-linking rollout started in #235. The `<related-content>` Light-DOM custom element (introduced in Phase 1) is now applied to every course page, giving learners direct links from each tutorial to the matching lecture decks, example programs, and exercises.

**23 course pages updated.** Each file received:
1. `<script src="../components/related-content.js" defer></script>` in `<head>` after `copyright-notice.js`.
2. A `<related-content>` element inside `<div class="page-footer">` just before the `<hr />`.

## Mapping table

| Course page | Lectures | Examples | Exercises |
|---|---|---|---|
| COBOLIntro | cobintro, GenIntro | ACCEPT, Shortest | GettingStarted |
| COBOLcommands | basics1, arithmetic | ACCEPT, Multiplier | GettingStarted |
| DataDeclaration | Basics2, dsr1 | ACCEPT | — |
| SequentialFiles1 | seqfile1 | SEQWRITE, SEQREAD | SeqWrite |
| SequentialFiles2 | seqfile2 | SEQREAD, SEQRPT | SeqRead, SeqReadIf |
| SequentialFiles3 | SeqFile3 | SEQINSERT, SEQRPT | SeqInsert, SeqUpdate |
| EditedPics | Basics2 | Multiplier | — |
| Usage | Usage | — | — |
| Copy | COPY | — | — |
| Tables1 | tables1 | MonthTable | MonthTable |
| Tables2 | tables2 | MonthTable | MonthTable |
| Search | search | MonthTable | — |
| IndexedFiles | indexed | Seq2Index, SeqReadIdx, DirectReadIdx | — |
| RelativeFiles | relative | Seq2Rel, ReadRel | — |
| Intro2DirectAccess | direct1 | DirectReadIdx, Seq2Index | — |
| SortMerge | sort | InputSort, MaleSort, Merge | SortIP |
| ReportWriter | ReportWriterWeb | RepWriteFull, RepWriteA | — |
| ReportWriterSS | ReportWriterSSWeb | RepWriteFull, RepWriteSumm | — |
| Inspect | inspect | — | — |
| String | string | RefMod | — |
| Unstring | Unstring | UnstringFileEg | — |
| RefMod | inspect | RefMod | — |
| Subprograms | call | DriverProg, DateDriver | — |

(Phase 1 already covered Iteration and Selection.)

Closes #220.

## Test plan

- [x] `npm run validate` passes
- [x] `npm run check:assets` passes (no broken hrefs in the new links)
- [x] `prettier --write .` applied so formatting matches master
- [ ] Visual: open a representative few (e.g. Tables1, SortMerge, ReportWriter) — "Related" block renders at the bottom with categorized links

🤖 Generated with [Claude Code](https://claude.com/claude-code)