### PR TITLE
Add descriptive alt text to content-bearing diagram images (#261)

### DIFF
--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -341,7 +341,12 @@
 								record areas labeled "free", have not yet had record values written to them.
 							</p>
 							<figure class="img-figure">
-								<img height="348" src="Resources/pics/I-DFIntroFig1.gif" width="267" alt="Schematic of a relative file with 328 allocated record slots on disk; occupied slots hold records while slots labeled 'free' show unwritten positions." />
+								<img
+									height="348"
+									src="Resources/pics/I-DFIntroFig1.gif"
+									width="267"
+									alt="Schematic of a relative file with 328 allocated record slots on disk; occupied slots hold records while slots labeled 'free' show unwritten positions."
+								/>
 								<figcaption>
 									Relative File - Organization<br />
 									Figure 1

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -341,7 +341,7 @@
 								record areas labeled "free", have not yet had record values written to them.
 							</p>
 							<figure class="img-figure">
-								<img height="348" src="Resources/pics/I-DFIntroFig1.gif" width="267" alt="" />
+								<img height="348" src="Resources/pics/I-DFIntroFig1.gif" width="267" alt="Schematic of a relative file with 328 allocated record slots on disk; occupied slots hold records while slots labeled 'free' show unwritten positions." />
 								<figcaption>
 									Relative File - Organization<br />
 									Figure 1

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -211,7 +211,14 @@ Enter supplier key (2 digits)-&gt; 05
 						<h3>Select and Assign clause syntax</h3>
 					</div>
 					<div class="section-content">
-						<p><img height="189" src="Resources/pics/I-DFrel1.gif" width="507" alt="Syntax diagram for the SELECT and ASSIGN clause used to declare a relative file in COBOL." /></p>
+						<p>
+							<img
+								height="189"
+								src="Resources/pics/I-DFrel1.gif"
+								width="507"
+								alt="Syntax diagram for the SELECT and ASSIGN clause used to declare a relative file in COBOL."
+							/>
+						</p>
 					</div>
 				</div>
 				<div class="section-grid">
@@ -332,7 +339,12 @@ Enter supplier key (2 digits)-&gt; 05
 							The full syntax for the OPEN verbs is shown below. Note the new I-O entry. This is used with
 							direct access files when we intend to update or both read and write to the file.
 						</p>
-						<p><img src="Resources/pics/I-DFrel2.gif" alt="Syntax diagram for the OPEN verb applied to relative files, showing INPUT, OUTPUT, I-O, and EXTEND modes." /></p>
+						<p>
+							<img
+								src="Resources/pics/I-DFrel2.gif"
+								alt="Syntax diagram for the OPEN verb applied to relative files, showing INPUT, OUTPUT, I-O, and EXTEND modes."
+							/>
+						</p>
 						<p>
 							<b>Notes<br /></b> If the file is opened for input then only READ and START will be allowed.
 						</p>
@@ -369,7 +381,12 @@ Enter supplier key (2 digits)-&gt; 05
 						<h3>Reading using a key</h3>
 					</div>
 					<div class="section-content">
-						<p><img src="Resources/pics/I-DFrel3.gif" alt="Syntax diagram for the READ verb used to read a record directly from a relative file by key value." /></p>
+						<p>
+							<img
+								src="Resources/pics/I-DFrel3.gif"
+								alt="Syntax diagram for the READ verb used to read a record directly from a relative file by key value."
+							/>
+						</p>
 						<p>
 							<b>Operation<br /></b> To read a record directly from a Relative file
 						</p>
@@ -412,7 +429,12 @@ Enter supplier key (2 digits)-&gt; 05
 							format of the ordinary sequential READ except that in this format the NEXT RECORD phrase is
 							used.
 						</p>
-						<p><img src="Resources/pics/I-DFrel4.gif" alt="Syntax diagram for the sequential READ NEXT format used with relative files when ACCESS MODE is DYNAMIC." /></p>
+						<p>
+							<img
+								src="Resources/pics/I-DFrel4.gif"
+								alt="Syntax diagram for the sequential READ NEXT format used with relative files when ACCESS MODE is DYNAMIC."
+							/>
+						</p>
 						<p>
 							<b>Notes<br /></b> This format is used to access a Relative file sequentially when the
 							ACCESS MODE has been declared as DYNAMIC and the file has been opened for INPUT or I-O.
@@ -440,7 +462,12 @@ Enter supplier key (2 digits)-&gt; 05
 							to a Sequential file, but to write directly to a Relative file a key must be used and this
 							requires a different WRITE format.
 						</p>
-						<p><img src="Resources/pics/I-DFrel5.gif" alt="Syntax diagram for the WRITE verb used to write a record directly to a relative file using a key value." /></p>
+						<p>
+							<img
+								src="Resources/pics/I-DFrel5.gif"
+								alt="Syntax diagram for the WRITE verb used to write a record directly to a relative file using a key value."
+							/>
+						</p>
 						<p>
 							<b>Operation<br /></b> To write a record directly to a Relative file
 						</p>
@@ -471,7 +498,12 @@ Enter supplier key (2 digits)-&gt; 05
 							The REWRITE is used to update a record in situ by overwriting it. The format of the REWRITE
 							verb is shown below.
 						</p>
-						<p><img src="Resources/pics/I-DFrel6.gif" alt="Syntax diagram for the REWRITE verb used to update an existing record in place in a relative file." /></p>
+						<p>
+							<img
+								src="Resources/pics/I-DFrel6.gif"
+								alt="Syntax diagram for the REWRITE verb used to update an existing record in place in a relative file."
+							/>
+						</p>
 						<p>
 							<b>Operation<br /></b> The REWRITE is normally used in the following way;
 						</p>
@@ -501,7 +533,12 @@ Enter supplier key (2 digits)-&gt; 05
 						<h3>The DELETE verb</h3>
 					</div>
 					<div class="section-content">
-						<p><img src="Resources/pics/I-DFrel7.gif" alt="Syntax diagram for the DELETE verb used to remove a record from a relative file by its relative record number." /></p>
+						<p>
+							<img
+								src="Resources/pics/I-DFrel7.gif"
+								alt="Syntax diagram for the DELETE verb used to remove a record from a relative file by its relative record number."
+							/>
+						</p>
 						<p>
 							<b>Operation<br /></b> To delete a record
 						</p>
@@ -539,7 +576,12 @@ Enter supplier key (2 digits)-&gt; 05
 							of the next record pointer. Where the START verb appears in a program it is usually followed
 							by a sequential READ or WRITE .
 						</p>
-						<p><img src="Resources/pics/I-DFrel8.gif" alt="Syntax diagram for the START verb used to position the next-record pointer in a relative file." /></p>
+						<p>
+							<img
+								src="Resources/pics/I-DFrel8.gif"
+								alt="Syntax diagram for the START verb used to position the next-record pointer in a relative file."
+							/>
+						</p>
 						<p>
 							<b>Operation<br /></b> To position the Next Record Pointer at a particular record
 						</p>
@@ -651,7 +693,12 @@ Begin.</code></pre>
 						<h3>The Use phrase</h3>
 					</div>
 					<div class="section-content">
-						<p><img src="Resources/pics/I-DFrel9.gif" alt="Syntax diagram for the USE phrase in COBOL Declaratives, specifying error-handling procedures for file I-O conditions." /></p>
+						<p>
+							<img
+								src="Resources/pics/I-DFrel9.gif"
+								alt="Syntax diagram for the USE phrase in COBOL Declaratives, specifying error-handling procedures for file I-O conditions."
+							/>
+						</p>
 						<p><b>Notes</b></p>
 						<p>
 							A USE statement can be used only in a sentence immediately after a section header in the

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -211,7 +211,7 @@ Enter supplier key (2 digits)-&gt; 05
 						<h3>Select and Assign clause syntax</h3>
 					</div>
 					<div class="section-content">
-						<p><img height="189" src="Resources/pics/I-DFrel1.gif" width="507" alt="" /></p>
+						<p><img height="189" src="Resources/pics/I-DFrel1.gif" width="507" alt="Syntax diagram for the SELECT and ASSIGN clause used to declare a relative file in COBOL." /></p>
 					</div>
 				</div>
 				<div class="section-grid">
@@ -332,7 +332,7 @@ Enter supplier key (2 digits)-&gt; 05
 							The full syntax for the OPEN verbs is shown below. Note the new I-O entry. This is used with
 							direct access files when we intend to update or both read and write to the file.
 						</p>
-						<p><img src="Resources/pics/I-DFrel2.gif" alt="" /></p>
+						<p><img src="Resources/pics/I-DFrel2.gif" alt="Syntax diagram for the OPEN verb applied to relative files, showing INPUT, OUTPUT, I-O, and EXTEND modes." /></p>
 						<p>
 							<b>Notes<br /></b> If the file is opened for input then only READ and START will be allowed.
 						</p>
@@ -369,7 +369,7 @@ Enter supplier key (2 digits)-&gt; 05
 						<h3>Reading using a key</h3>
 					</div>
 					<div class="section-content">
-						<p><img src="Resources/pics/I-DFrel3.gif" alt="" /></p>
+						<p><img src="Resources/pics/I-DFrel3.gif" alt="Syntax diagram for the READ verb used to read a record directly from a relative file by key value." /></p>
 						<p>
 							<b>Operation<br /></b> To read a record directly from a Relative file
 						</p>
@@ -412,7 +412,7 @@ Enter supplier key (2 digits)-&gt; 05
 							format of the ordinary sequential READ except that in this format the NEXT RECORD phrase is
 							used.
 						</p>
-						<p><img src="Resources/pics/I-DFrel4.gif" alt="" /></p>
+						<p><img src="Resources/pics/I-DFrel4.gif" alt="Syntax diagram for the sequential READ NEXT format used with relative files when ACCESS MODE is DYNAMIC." /></p>
 						<p>
 							<b>Notes<br /></b> This format is used to access a Relative file sequentially when the
 							ACCESS MODE has been declared as DYNAMIC and the file has been opened for INPUT or I-O.
@@ -440,7 +440,7 @@ Enter supplier key (2 digits)-&gt; 05
 							to a Sequential file, but to write directly to a Relative file a key must be used and this
 							requires a different WRITE format.
 						</p>
-						<p><img src="Resources/pics/I-DFrel5.gif" alt="" /></p>
+						<p><img src="Resources/pics/I-DFrel5.gif" alt="Syntax diagram for the WRITE verb used to write a record directly to a relative file using a key value." /></p>
 						<p>
 							<b>Operation<br /></b> To write a record directly to a Relative file
 						</p>
@@ -471,7 +471,7 @@ Enter supplier key (2 digits)-&gt; 05
 							The REWRITE is used to update a record in situ by overwriting it. The format of the REWRITE
 							verb is shown below.
 						</p>
-						<p><img src="Resources/pics/I-DFrel6.gif" alt="" /></p>
+						<p><img src="Resources/pics/I-DFrel6.gif" alt="Syntax diagram for the REWRITE verb used to update an existing record in place in a relative file." /></p>
 						<p>
 							<b>Operation<br /></b> The REWRITE is normally used in the following way;
 						</p>
@@ -501,7 +501,7 @@ Enter supplier key (2 digits)-&gt; 05
 						<h3>The DELETE verb</h3>
 					</div>
 					<div class="section-content">
-						<p><img src="Resources/pics/I-DFrel7.gif" alt="" /></p>
+						<p><img src="Resources/pics/I-DFrel7.gif" alt="Syntax diagram for the DELETE verb used to remove a record from a relative file by its relative record number." /></p>
 						<p>
 							<b>Operation<br /></b> To delete a record
 						</p>
@@ -539,7 +539,7 @@ Enter supplier key (2 digits)-&gt; 05
 							of the next record pointer. Where the START verb appears in a program it is usually followed
 							by a sequential READ or WRITE .
 						</p>
-						<p><img src="Resources/pics/I-DFrel8.gif" alt="" /></p>
+						<p><img src="Resources/pics/I-DFrel8.gif" alt="Syntax diagram for the START verb used to position the next-record pointer in a relative file." /></p>
 						<p>
 							<b>Operation<br /></b> To position the Next Record Pointer at a particular record
 						</p>
@@ -651,7 +651,7 @@ Begin.</code></pre>
 						<h3>The Use phrase</h3>
 					</div>
 					<div class="section-content">
-						<p><img src="Resources/pics/I-DFrel9.gif" alt="" /></p>
+						<p><img src="Resources/pics/I-DFrel9.gif" alt="Syntax diagram for the USE phrase in COBOL Declaratives, specifying error-handling procedures for file I-O conditions." /></p>
 						<p><b>Notes</b></p>
 						<p>
 							A USE statement can be used only in a sentence immediately after a section header in the

--- a/course/String.html
+++ b/course/String.html
@@ -125,7 +125,7 @@ END-STRING.</code></pre>
 						<h3>STRING syntax</h3>
 					</div>
 					<div class="section-content">
-						<p><img src="Resources/pics/I-String.gif" alt="" /></p>
+						<p><img src="Resources/pics/I-String.gif" alt="Syntax diagram for the COBOL STRING statement showing source identifiers, DELIMITED BY clause, INTO destination string, and optional WITH POINTER phrase." /></p>
 						<table bgcolor="#DDFFDD" class="data-table" cellpadding="5" width="77%" style="margin: 0 auto">
 							<tr>
 								<td width="21%">Delim$il</td>

--- a/course/String.html
+++ b/course/String.html
@@ -125,7 +125,12 @@ END-STRING.</code></pre>
 						<h3>STRING syntax</h3>
 					</div>
 					<div class="section-content">
-						<p><img src="Resources/pics/I-String.gif" alt="Syntax diagram for the COBOL STRING statement showing source identifiers, DELIMITED BY clause, INTO destination string, and optional WITH POINTER phrase." /></p>
+						<p>
+							<img
+								src="Resources/pics/I-String.gif"
+								alt="Syntax diagram for the COBOL STRING statement showing source identifiers, DELIMITED BY clause, INTO destination string, and optional WITH POINTER phrase."
+							/>
+						</p>
 						<table bgcolor="#DDFFDD" class="data-table" cellpadding="5" width="77%" style="margin: 0 auto">
 							<tr>
 								<td width="21%">Delim$il</td>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -133,7 +133,7 @@ END-UNSTRING.</code></pre>
 						<h3>UNSTRING syntax</h3>
 					</div>
 					<div class="section-content">
-						<p><img src="Resources/pics/I-UnString.gif" alt="" /></p>
+						<p><img src="Resources/pics/I-UnString.gif" alt="Syntax diagram for the COBOL UNSTRING statement showing source string, DELIMITED BY clause, INTO destination identifiers, and optional TALLYING and POINTER phrases." /></p>
 						<table bgcolor="#DDFFDD" class="data-table" cellpadding="5" width="77%" style="margin: 0 auto">
 							<tr>
 								<td width="21%">Delim$il</td>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -133,7 +133,12 @@ END-UNSTRING.</code></pre>
 						<h3>UNSTRING syntax</h3>
 					</div>
 					<div class="section-content">
-						<p><img src="Resources/pics/I-UnString.gif" alt="Syntax diagram for the COBOL UNSTRING statement showing source string, DELIMITED BY clause, INTO destination identifiers, and optional TALLYING and POINTER phrases." /></p>
+						<p>
+							<img
+								src="Resources/pics/I-UnString.gif"
+								alt="Syntax diagram for the COBOL UNSTRING statement showing source string, DELIMITED BY clause, INTO destination identifiers, and optional TALLYING and POINTER phrases."
+							/>
+						</p>
 						<table bgcolor="#DDFFDD" class="data-table" cellpadding="5" width="77%" style="margin: 0 auto">
 							<tr>
 								<td width="21%">Delim$il</td>

--- a/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html
+++ b/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html
@@ -450,7 +450,12 @@
 					</p>
 					<div style="text-align: center">
 						<a href="BestSellers.gif"
-							><img height="199" src="SBestSellers.gif" width="344" style="border: 1px solid" alt="Thumbnail of the print layout specification for the Best Sellers Report, showing column headings and sample rows for book title, author name, and sales figures." /></a
+							><img
+								height="199"
+								src="SBestSellers.gif"
+								width="344"
+								style="border: 1px solid"
+								alt="Thumbnail of the print layout specification for the Best Sellers Report, showing column headings and sample rows for book title, author name, and sales figures." /></a
 						><br />
 						Click for full size version
 					</div>

--- a/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html
+++ b/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html
@@ -450,7 +450,7 @@
 					</p>
 					<div style="text-align: center">
 						<a href="BestSellers.gif"
-							><img height="199" src="SBestSellers.gif" width="344" style="border: 1px solid" /></a
+							><img height="199" src="SBestSellers.gif" width="344" style="border: 1px solid" alt="Thumbnail of the print layout specification for the Best Sellers Report, showing column headings and sample rows for book title, author name, and sales figures." /></a
 						><br />
 						Click for full size version
 					</div>

--- a/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html
+++ b/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html
@@ -484,7 +484,7 @@
 					<p style="text-align: center">
 						<br />
 						<a href="DueSubsRpt.gif"
-							><img height="242" src="SDueSubsRpt.gif" width="346" style="border: 1px solid" /></a
+							><img height="242" src="SDueSubsRpt.gif" width="346" style="border: 1px solid" alt="Thumbnail of the print layout specification for the Due Subscriptions Report, showing customer rows with country subtotals and final totals." /></a
 						><br />
 						Click to view full version
 					</p>

--- a/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html
+++ b/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html
@@ -484,7 +484,12 @@
 					<p style="text-align: center">
 						<br />
 						<a href="DueSubsRpt.gif"
-							><img height="242" src="SDueSubsRpt.gif" width="346" style="border: 1px solid" alt="Thumbnail of the print layout specification for the Due Subscriptions Report, showing customer rows with country subtotals and final totals." /></a
+							><img
+								height="242"
+								src="SDueSubsRpt.gif"
+								width="346"
+								style="border: 1px solid"
+								alt="Thumbnail of the print layout specification for the Due Subscriptions Report, showing customer rows with country subtotals and final totals." /></a
 						><br />
 						Click to view full version
 					</p>

--- a/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html
+++ b/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html
@@ -534,7 +534,7 @@
 					<p><b>Notes</b>:&nbsp; There is no need to allow for page breaks.&nbsp;</p>
 					<div style="text-align: center">
 						<a href="LibRoyaltyRpt.gif"
-							><img height="225" src="SLibRoyaltyRpt.gif" width="359" style="border: 1px solid" /></a
+							><img height="225" src="SLibRoyaltyRpt.gif" width="359" style="border: 1px solid" alt="Thumbnail of the print layout specification for the Library Royalty Report, showing author royalty rows grouped by agent with agent-payment subtotals." /></a
 						><br />
 						Click for full size version
 					</div>

--- a/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html
+++ b/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html
@@ -534,7 +534,12 @@
 					<p><b>Notes</b>:&nbsp; There is no need to allow for page breaks.&nbsp;</p>
 					<div style="text-align: center">
 						<a href="LibRoyaltyRpt.gif"
-							><img height="225" src="SLibRoyaltyRpt.gif" width="359" style="border: 1px solid" alt="Thumbnail of the print layout specification for the Library Royalty Report, showing author royalty rows grouped by agent with agent-payment subtotals." /></a
+							><img
+								height="225"
+								src="SLibRoyaltyRpt.gif"
+								width="359"
+								style="border: 1px solid"
+								alt="Thumbnail of the print layout specification for the Library Royalty Report, showing author royalty rows grouped by agent with agent-payment subtotals." /></a
 						><br />
 						Click for full size version
 					</div>

--- a/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html
+++ b/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html
@@ -496,7 +496,12 @@
 					</p>
 					<p style="text-align: center">
 						<a href="TopSupplierRpt.gif"
-							><img height="146" src="sTopSupplierRpt.gif" width="387" style="border: 1px solid" alt="Thumbnail of the print layout specification for the Top Supplier Report, showing the top three suppliers with total video earnings and most popular title." /></a
+							><img
+								height="146"
+								src="sTopSupplierRpt.gif"
+								width="387"
+								style="border: 1px solid"
+								alt="Thumbnail of the print layout specification for the Top Supplier Report, showing the top three suppliers with total video earnings and most popular title." /></a
 						><br />
 						Click to see the full size version
 					</p>

--- a/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html
+++ b/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html
@@ -496,7 +496,7 @@
 					</p>
 					<p style="text-align: center">
 						<a href="TopSupplierRpt.gif"
-							><img height="146" src="sTopSupplierRpt.gif" width="387" style="border: 1px solid" /></a
+							><img height="146" src="sTopSupplierRpt.gif" width="387" style="border: 1px solid" alt="Thumbnail of the print layout specification for the Top Supplier Report, showing the top three suppliers with total video earnings and most popular title." /></a
 						><br />
 						Click to see the full size version
 					</p>

--- a/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html
+++ b/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html
@@ -714,7 +714,7 @@
 					</div>
 					<p style="text-align: center">
 						<a href="Ussrship.gif"
-							><img height="274" src="sUssrship.gif" width="317" style="border: 1px solid" /></a
+							><img height="274" src="sUssrship.gif" width="317" style="border: 1px solid" alt="Thumbnail of the print layout specification for the USSR Ship Report, showing vessel type, function, tonnage, crew count, and monthly cost columns." /></a
 						><br />
 						Click to view full version
 					</p>

--- a/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html
+++ b/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html
@@ -714,7 +714,12 @@
 					</div>
 					<p style="text-align: center">
 						<a href="Ussrship.gif"
-							><img height="274" src="sUssrship.gif" width="317" style="border: 1px solid" alt="Thumbnail of the print layout specification for the USSR Ship Report, showing vessel type, function, tonnage, crew count, and monthly cost columns." /></a
+							><img
+								height="274"
+								src="sUssrship.gif"
+								width="317"
+								style="border: 1px solid"
+								alt="Thumbnail of the print layout specification for the USSR Ship Report, showing vessel type, function, tonnage, crew count, and monthly cost columns." /></a
 						><br />
 						Click to view full version
 					</p>

--- a/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html
+++ b/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html
@@ -293,7 +293,7 @@
 					</div>
 					<p class="h15" style="text-align: center">
 						<a href="Prj-MunsterSurnamesFreqRpt.gif"
-							><img height="333" src="sPrj-MunsterSurnamesFreqRpt.gif" width="248" /></a
+							><img height="333" src="sPrj-MunsterSurnamesFreqRpt.gif" width="248" alt="Thumbnail of the print layout specification for the Munster Surnames Frequency Report, showing surname frequency rows and a programmer name and ID footer." /></a
 						><br />
 						Click for the full size version
 					</p>

--- a/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html
+++ b/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html
@@ -293,7 +293,11 @@
 					</div>
 					<p class="h15" style="text-align: center">
 						<a href="Prj-MunsterSurnamesFreqRpt.gif"
-							><img height="333" src="sPrj-MunsterSurnamesFreqRpt.gif" width="248" alt="Thumbnail of the print layout specification for the Munster Surnames Frequency Report, showing surname frequency rows and a programmer name and ID footer." /></a
+							><img
+								height="333"
+								src="sPrj-MunsterSurnamesFreqRpt.gif"
+								width="248"
+								alt="Thumbnail of the print layout specification for the Munster Surnames Frequency Report, showing surname frequency rows and a programmer name and ID footer." /></a
 						><br />
 						Click for the full size version
 					</p>

--- a/lectures/ReportWriterSSWeb.html
+++ b/lectures/ReportWriterSSWeb.html
@@ -344,7 +344,14 @@ REPORT SECTION.
 							print files, in the File Section the normal file description is replaced by phrase which
 							points to the Report Description (RD) in the Report Section. The syntax of the phrase is -
 						</p>
-						<p style="text-align: center"><img height="48" src="rwReportIS.gif" width="222" alt="Syntax for the REPORT IS phrase used in the File Section to link a print file to its named Report Description." /></p>
+						<p style="text-align: center">
+							<img
+								height="48"
+								src="rwReportIS.gif"
+								width="222"
+								alt="Syntax for the REPORT IS phrase used in the File Section to link a print file to its named Report Description."
+							/>
+						</p>
 						<p>
 							The <i>ReportName</i> must be the same as the <i>ReportName</i> used in the Report
 							Description (RD) entry.
@@ -396,7 +403,14 @@ REPORT SECTION.
 					</div>
 					<div class="section-content">
 						<p>The syntax for the Report Description (RD) entries is shown below -</p>
-						<p style="text-align: center"><img height="277" src="rwRD.gif" width="360" alt="Syntax diagram for the Report Description (RD) entry, showing PAGE LIMIT, HEADING, FIRST DETAIL, LAST DETAIL, FOOTING, and CONTROL clauses." /></p>
+						<p style="text-align: center">
+							<img
+								height="277"
+								src="rwRD.gif"
+								width="360"
+								alt="Syntax diagram for the Report Description (RD) entry, showing PAGE LIMIT, HEADING, FIRST DETAIL, LAST DETAIL, FOOTING, and CONTROL clauses."
+							/>
+						</p>
 						<hr />
 					</div>
 				</div>
@@ -495,7 +509,14 @@ REPORT SECTION.
 						<p>
 							<b>Report Group Definition</b>
 						</p>
-						<p><img height="512" src="rwGroupType.gif" width="405" alt="Syntax diagram for the Report Group Definition at level 01, showing TYPE clause options: REPORT HEADING, PAGE HEADING, CONTROL HEADING, DETAIL, CONTROL FOOTING, PAGE FOOTING, and REPORT FOOTING." /></p>
+						<p>
+							<img
+								height="512"
+								src="rwGroupType.gif"
+								width="405"
+								alt="Syntax diagram for the Report Group Definition at level 01, showing TYPE clause options: REPORT HEADING, PAGE HEADING, CONTROL HEADING, DETAIL, CONTROL FOOTING, PAGE FOOTING, and REPORT FOOTING."
+							/>
+						</p>
 						<hr />
 					</div>
 				</div>
@@ -682,7 +703,14 @@ REPORT SECTION.
 						<p>
 							If the <i>ReportLineName</i> is used its only purpose is to qualify a sum counter reference.
 						</p>
-						<p><img height="74" src="rwGroupDesc1.gif" width="364" alt="Syntax diagram for defining a print line within a report group, showing level number, optional ReportLineName, and LINE NUMBER clause." /></p>
+						<p>
+							<img
+								height="74"
+								src="rwGroupDesc1.gif"
+								width="364"
+								alt="Syntax diagram for defining a print line within a report group, showing level number, optional ReportLineName, and LINE NUMBER clause."
+							/>
+						</p>
 						<hr />
 					</div>
 				</div>
@@ -707,7 +735,14 @@ REPORT SECTION.
 							The <i>PrintItemName</i> can only be referenced if the entry uses the
 							<code class="language-cobol">SUM</code> clause to define a sum counter.
 						</p>
-						<p><img height="456" src="rwGroupDesc2.gif" width="413" alt="Syntax diagram for defining an elementary print item within a report group line, showing COLUMN NUMBER, SOURCE, SUM, PIC, GROUP INDICATE, and other available clauses." /></p>
+						<p>
+							<img
+								height="456"
+								src="rwGroupDesc2.gif"
+								width="413"
+								alt="Syntax diagram for defining an elementary print item within a report group line, showing COLUMN NUMBER, SOURCE, SUM, PIC, GROUP INDICATE, and other available clauses."
+							/>
+						</p>
 						<hr />
 					</div>
 				</div>
@@ -1001,7 +1036,14 @@ REPORT SECTION.
 						<h3>Syntax</h3>
 					</div>
 					<div class="section-content">
-						<p><img height="144" src="rwVerbs.gif" width="238" alt="Syntax diagram showing the four Report Writer Procedure Division verbs: INITIATE, GENERATE, TERMINATE, and SUPPRESS PRINTING." /></p>
+						<p>
+							<img
+								height="144"
+								src="rwVerbs.gif"
+								width="238"
+								alt="Syntax diagram showing the four Report Writer Procedure Division verbs: INITIATE, GENERATE, TERMINATE, and SUPPRESS PRINTING."
+							/>
+						</p>
 						<hr />
 					</div>
 				</div>
@@ -1187,7 +1229,14 @@ Programmer - Michael Coughlan               Page :  1
 							Declaratives may also be used to handle file operation errors. In this case the USE clause
 							should use the following syntax -
 						</p>
-						<p style="text-align: center"><img height="173" src="rwUSE1.gif" width="495" alt="Syntax diagram for the USE clause in Declaratives specifying error-handling procedures for file I-O operations." /></p>
+						<p style="text-align: center">
+							<img
+								height="173"
+								src="rwUSE1.gif"
+								width="495"
+								alt="Syntax diagram for the USE clause in Declaratives specifying error-handling procedures for file I-O operations."
+							/>
+						</p>
 						<hr />
 					</div>
 				</div>
@@ -1203,7 +1252,14 @@ Programmer - Michael Coughlan               Page :  1
 						</p>
 						<p>The USE statement governs when a particular declarative section is executed.</p>
 						<p>When Declaratives are used with the Report Writer the USE syntax shown below must be used</p>
-						<p style="text-align: center"><img height="22" src="rwUSE2.gif" width="402" alt="Syntax diagram for USE BEFORE REPORTING, specifying that a declarative section executes before a named report group is printed." /></p>
+						<p style="text-align: center">
+							<img
+								height="22"
+								src="rwUSE2.gif"
+								width="402"
+								alt="Syntax diagram for USE BEFORE REPORTING, specifying that a declarative section executes before a named report group is printed."
+							/>
+						</p>
 						<p style="text-align: left"><b>Rules:</b></p>
 						<p style="text-align: left">
 							The ReportGroupName must not appear in more than one USE statement.

--- a/lectures/ReportWriterSSWeb.html
+++ b/lectures/ReportWriterSSWeb.html
@@ -344,7 +344,7 @@ REPORT SECTION.
 							print files, in the File Section the normal file description is replaced by phrase which
 							points to the Report Description (RD) in the Report Section. The syntax of the phrase is -
 						</p>
-						<p style="text-align: center"><img height="48" src="rwReportIS.gif" width="222" /></p>
+						<p style="text-align: center"><img height="48" src="rwReportIS.gif" width="222" alt="Syntax for the REPORT IS phrase used in the File Section to link a print file to its named Report Description." /></p>
 						<p>
 							The <i>ReportName</i> must be the same as the <i>ReportName</i> used in the Report
 							Description (RD) entry.
@@ -396,7 +396,7 @@ REPORT SECTION.
 					</div>
 					<div class="section-content">
 						<p>The syntax for the Report Description (RD) entries is shown below -</p>
-						<p style="text-align: center"><img height="277" src="rwRD.gif" width="360" /></p>
+						<p style="text-align: center"><img height="277" src="rwRD.gif" width="360" alt="Syntax diagram for the Report Description (RD) entry, showing PAGE LIMIT, HEADING, FIRST DETAIL, LAST DETAIL, FOOTING, and CONTROL clauses." /></p>
 						<hr />
 					</div>
 				</div>
@@ -495,7 +495,7 @@ REPORT SECTION.
 						<p>
 							<b>Report Group Definition</b>
 						</p>
-						<p><img height="512" src="rwGroupType.gif" width="405" /></p>
+						<p><img height="512" src="rwGroupType.gif" width="405" alt="Syntax diagram for the Report Group Definition at level 01, showing TYPE clause options: REPORT HEADING, PAGE HEADING, CONTROL HEADING, DETAIL, CONTROL FOOTING, PAGE FOOTING, and REPORT FOOTING." /></p>
 						<hr />
 					</div>
 				</div>
@@ -682,7 +682,7 @@ REPORT SECTION.
 						<p>
 							If the <i>ReportLineName</i> is used its only purpose is to qualify a sum counter reference.
 						</p>
-						<p><img height="74" src="rwGroupDesc1.gif" width="364" /></p>
+						<p><img height="74" src="rwGroupDesc1.gif" width="364" alt="Syntax diagram for defining a print line within a report group, showing level number, optional ReportLineName, and LINE NUMBER clause." /></p>
 						<hr />
 					</div>
 				</div>
@@ -707,7 +707,7 @@ REPORT SECTION.
 							The <i>PrintItemName</i> can only be referenced if the entry uses the
 							<code class="language-cobol">SUM</code> clause to define a sum counter.
 						</p>
-						<p><img height="456" src="rwGroupDesc2.gif" width="413" /></p>
+						<p><img height="456" src="rwGroupDesc2.gif" width="413" alt="Syntax diagram for defining an elementary print item within a report group line, showing COLUMN NUMBER, SOURCE, SUM, PIC, GROUP INDICATE, and other available clauses." /></p>
 						<hr />
 					</div>
 				</div>
@@ -1001,7 +1001,7 @@ REPORT SECTION.
 						<h3>Syntax</h3>
 					</div>
 					<div class="section-content">
-						<p><img height="144" src="rwVerbs.gif" width="238" /></p>
+						<p><img height="144" src="rwVerbs.gif" width="238" alt="Syntax diagram showing the four Report Writer Procedure Division verbs: INITIATE, GENERATE, TERMINATE, and SUPPRESS PRINTING." /></p>
 						<hr />
 					</div>
 				</div>
@@ -1187,7 +1187,7 @@ Programmer - Michael Coughlan               Page :  1
 							Declaratives may also be used to handle file operation errors. In this case the USE clause
 							should use the following syntax -
 						</p>
-						<p style="text-align: center"><img height="173" src="rwUSE1.gif" width="495" /></p>
+						<p style="text-align: center"><img height="173" src="rwUSE1.gif" width="495" alt="Syntax diagram for the USE clause in Declaratives specifying error-handling procedures for file I-O operations." /></p>
 						<hr />
 					</div>
 				</div>
@@ -1203,7 +1203,7 @@ Programmer - Michael Coughlan               Page :  1
 						</p>
 						<p>The USE statement governs when a particular declarative section is executed.</p>
 						<p>When Declaratives are used with the Report Writer the USE syntax shown below must be used</p>
-						<p style="text-align: center"><img height="22" src="rwUSE2.gif" width="402" /></p>
+						<p style="text-align: center"><img height="22" src="rwUSE2.gif" width="402" alt="Syntax diagram for USE BEFORE REPORTING, specifying that a declarative section executes before a named report group is printed." /></p>
 						<p style="text-align: left"><b>Rules:</b></p>
 						<p style="text-align: left">
 							The ReportGroupName must not appear in more than one USE statement.


### PR DESCRIPTION
## Summary

- 26 technical diagram images across `course/`, `exercises/`, and `lectures/` had `alt=""` despite carrying information not available in surrounding prose
- Screen-reader users received nothing where sighted users got syntax diagrams, file-structure schematics, and print layout charts
- Decorative `i-*` icon images are unchanged — `alt=""` remains correct for those

## What changed

| Directory | Files touched | Images updated |
|---|---|---|
| `course/` | `Intro2DirectAccess.html`, `RelativeFiles.html`, `String.html`, `Unstring.html` | 12 |
| `exercises/` | 6 exercise/project specification pages | 6 |
| `lectures/` | `ReportWriterSSWeb.html` | 8 |

**Alt text strategy:**
- **Syntax diagrams** (`I-DFrel1.gif`–`I-DFrel9.gif`, `I-String.gif`, `I-UnString.gif`, `rwRD.gif`, `rwGroupType.gif`, etc.) — describe the COBOL verb or clause shown and its key sub-clauses, drawn from the surrounding prose
- **Figure 1 schematic** (`I-DFIntroFig1.gif`) — describes the allocated-vs-free slot layout of a relative file as explained in the lesson text
- **Exercise thumbnails** (`SBestSellers.gif`, `SDueSubsRpt.gif`, etc.) — identify them as print layout specification thumbnails and summarise the report's content/columns

## Reviewer checklist

- [ ] Read a few alt strings and confirm they match the intent of the surrounding prose
- [ ] Confirm no `i-*` icon image was touched
- [ ] `pa11y-ci` passes (no new violations from long-alt warnings)

Closes #261