### PR TITLE
Fix typos in COBOLIntro.html: "souces" → "sources" and "all to easily" → "all too easily"

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -381,14 +381,14 @@
 					</div>
 					<div class="section-content">
 						<p>
-							In this semi-formal document I have not been fastidious in referencing all the sources I have
-							used. Because of that I would like to acknowledge that most of factual material and some of
-							the commentary was gleaned from the following sources. These may also serve as further
-							reading.
+							In this semi-formal document I have not been fastidious in referencing all the sources I
+							have used. Because of that I would like to acknowledge that most of factual material and
+							some of the commentary was gleaned from the following sources. These may also serve as
+							further reading.
 						</p>
 						<p>
-							Most of this material is available on the web but as the web is dynamic and links are all too
-							easily broken I won't give the URL's here. You will have to search for them.
+							Most of this material is available on the web but as the web is dynamic and links are all
+							too easily broken I won't give the URL's here. You will have to search for them.
 						</p>
 						<h3 class="center-block">Resources</h3>
 						<p>

--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -381,13 +381,13 @@
 					</div>
 					<div class="section-content">
 						<p>
-							In this semi-formal document I have not been fastidious in referencing all the souces I have
+							In this semi-formal document I have not been fastidious in referencing all the sources I have
 							used. Because of that I would like to acknowledge that most of factual material and some of
 							the commentary was gleaned from the following sources. These may also serve as further
 							reading.
 						</p>
 						<p>
-							Most of this material is available on the web but as the web is dynamic and links are all to
+							Most of this material is available on the web but as the web is dynamic and links are all too
 							easily broken I won't give the URL's here. You will have to search for them.
 						</p>
 						<h3 class="center-block">Resources</h3>


### PR DESCRIPTION
## Summary

- Corrects `souces` → `sources` (line 384)
- Corrects `all to easily` → `all too easily` (line 390) — restores the idiomatic "all *too* easily"

## Test plan

- [x] `npm run validate` passes (HTML validation clean)

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)