### PR TITLE
docs(vendor): add VERSIONS.md tracking Prism 1.29.0 and PDF.js 3.11.174

### DIFF
--- a/course/Resources/vendor/VERSIONS.md
+++ b/course/Resources/vendor/VERSIONS.md
@@ -1,0 +1,42 @@
+# Vendored third-party assets
+
+| Library               | Version  | Source                                                                          |
+| --------------------- | -------- | ------------------------------------------------------------------------------- |
+| Prism (core)          | 1.29.0   | https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js               |
+| Prism (COBOL grammar) | 1.29.0   | https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cobol.min.js |
+| Prism (default theme) | 1.29.0   | https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css       |
+| PDF.js (main)         | 3.11.174 | https://github.com/mozilla/pdf.js/releases/tag/v3.11.174                       |
+| PDF.js (worker)       | 3.11.174 | https://github.com/mozilla/pdf.js/releases/tag/v3.11.174                       |
+
+## Refresh procedure
+
+### Prism
+
+Download updated files from cdnjs (replace `1.29.0` with the new version):
+
+```sh
+curl -o prism/prism.min.js \
+  https://cdnjs.cloudflare.com/ajax/libs/prism/NEW_VERSION/prism.min.js
+
+curl -o prism/components/prism-cobol.min.js \
+  https://cdnjs.cloudflare.com/ajax/libs/prism/NEW_VERSION/components/prism-cobol.min.js
+
+curl -o prism/themes/prism.min.css \
+  https://cdnjs.cloudflare.com/ajax/libs/prism/NEW_VERSION/themes/prism.min.css
+```
+
+Verify the downloaded files against the SRI hashes published on
+https://cdnjs.com/libraries/prism/NEW_VERSION, then update the version
+in this table.
+
+### PDF.js
+
+1. Download the prebuilt release zip from
+   https://github.com/mozilla/pdf.js/releases/tag/vNEW_VERSION
+   (asset named `pdfjs-NEW_VERSION-dist.zip`).
+2. Extract `build/pdf.min.js` → `pdfjs/pdf.min.js`
+3. Extract `build/pdf.worker.min.js` → `pdfjs/pdf.worker.min.js`
+4. Update the version in this table.
+
+The versions of `pdf.min.js` and `pdf.worker.min.js` **must match** —
+mixing releases will cause runtime errors.


### PR DESCRIPTION
Closes #266 (items 1 and 2).

## Summary

- Creates `course/Resources/vendor/VERSIONS.md` listing each vendored library with its pinned version and source URL.
- Versions confirmed from commit messages: **Prism 1.29.0** (commit f0f9c23) and **PDF.js 3.11.174** (commit 3f1bb43).
- Documents `curl`-based refresh procedure for Prism (with SRI hash verification against cdnjs) and a zip-extract procedure for PDF.js.

## Test plan

- [ ] Verify `VERSIONS.md` renders correctly on GitHub.
- [ ] Confirm version numbers match the commit messages that originally vendored the files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)