### PR TITLE
Fix prose typos and wire typos spell-checker into CI (#269)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,3 +22,11 @@ jobs:
             - run: npm run check:assets
             - run: npm run links
             - run: npm run a11y
+
+    typos:
+        name: Spell check (typos)
+        runs-on: ubuntu-latest
+        continue-on-error: true
+        steps:
+            - uses: actions/checkout@v4
+            - uses: crate-ci/typos-action@v1

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,76 @@
+[files]
+extend-exclude = [
+    # Minified third-party vendor assets — not our content
+    "course/Resources/vendor/**",
+    # Raw data/fixture files with user-entered content and fixed-width structured records
+    "**/*.dat",
+    "**/*.DAT",
+    "**/*.Dat",
+    "**/*.txt",
+    "**/*.TXT",
+    # COBOL source — identifiers use intentional abbreviations; prose typos are caught via HTML listings
+    "**/*.CBL",
+    "**/*.cbl",
+    "**/*.Cbl",
+    "**/*.COB",
+    "**/*.cob",
+    # Report output files
+    "**/*.RPT",
+    "**/*.rpt",
+    # Binary presentation files
+    "**/*.ppt",
+    "**/*.PPT",
+    # COBOL copybook files — abbreviations in identifiers are intentional
+    "**/*.cpy",
+    "**/*.CPY",
+    # Generated / non-prose files
+    "**/*.xml",
+    "**/*.svg",
+    "package-lock.json",
+]
+
+[default]
+extend-ignore-re = [
+    # Google site-verification tokens contain arbitrary character sequences
+    "content=\"[A-Za-z0-9_-]{20,}\"",
+    # Abbreviated HTML anchor IDs (e.g. href="#declar", id="declar")
+    "(?:href|id)=\"#?(?:declar|[a-z]{1,5})\"",
+    # Bold-tagged single letters split real words: <b>I</b>nformation
+    ">[A-Z]</b>",
+]
+
+[default.extend-words]
+# Niklaus Wirth — famous CS figure; name used in exercise fiction (WirthMemLib)
+Wirth = "Wirth"
+# COBOL DISPLAY keyword appears as DISPLAYed/DISPLAYing in prose and code comments
+DISPLA = "DISPLA"
+# COBOL RELEASE keyword appears as RELEASEs in prose and code comments
+RELEAS = "RELEAS"
+# COBOL FILLER keyword appears as FILLERs / FILLERh in code listings
+FILLE = "FILLE"
+# File-Stati — COBOL abbreviated identifier (short for File-Statuses)
+Stati = "Stati"
+# PRFILE — abbreviated SELECT filename (Purchase Request FILE)
+PRFILE = "PRFILE"
+# Not-ENd-Of-Books — COBOL compound identifier; typos misreads "Nd" from "ENd"
+Nd = "Nd"
+# ODF — Oil Details File, a COBOL exercise file acronym used throughout identifiers
+ODF = "ODF"
+# CountMilage — COBOL procedure name in MileageCount example (fixing would rename a working program's entrypoint)
+Milage = "Milage"
+# CurruptDate — COBOL data-item name in ValiDate exercise; renaming would break the working program
+Currupt = "Currupt"
+# Bold-tagged single letters split real words in acronym displays: <b>I</b>nformation, <b>L</b>anguage, <b>O</b>ther
+nformation = "nformation"
+anguage = "anguage"
+ther = "ther"
+# Thr — three-letter Thursday abbreviation used intentionally in DayTable code example
+Thr = "Thr"
+# Alph — COBOL parameter name used as a formal argument in RefMod intrinsic function examples
+Alph = "Alph"
+# PERFOR — from PERFORMs (COBOL keyword with English plural suffix causes a false split)
+PERFOR = "PERFOR"
+# Sring — in FullSringLength COBOL identifier; renaming would break the working example
+Sring = "Sring"
+# cpy — COBOL copybook file extension (.cpy); appears in href attributes and inline filenames
+cpy = "cpy"

--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -147,7 +147,7 @@
 						</p>
 						<p>
 							The word <b>COBOL</b> is an acronym that stands for <b>CO</b>mmon <b>B</b>usiness
-							<b>O</b>riented <b>L</b>anguage. As the the expanded acronym indicates, COBOL is designed
+							<b>O</b>riented <b>L</b>anguage. As the expanded acronym indicates, COBOL is designed
 							for developing business, typically file-oriented, applications. It is not designed for
 							writing systems programs. For instance you would not develop an operating system or a
 							compiler using COBOL.

--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -147,10 +147,10 @@
 						</p>
 						<p>
 							The word <b>COBOL</b> is an acronym that stands for <b>CO</b>mmon <b>B</b>usiness
-							<b>O</b>riented <b>L</b>anguage. As the expanded acronym indicates, COBOL is designed
-							for developing business, typically file-oriented, applications. It is not designed for
-							writing systems programs. For instance you would not develop an operating system or a
-							compiler using COBOL.
+							<b>O</b>riented <b>L</b>anguage. As the expanded acronym indicates, COBOL is designed for
+							developing business, typically file-oriented, applications. It is not designed for writing
+							systems programs. For instance you would not develop an operating system or a compiler using
+							COBOL.
 						</p>
 						<hr size="1" />
 					</div>

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -42,8 +42,8 @@
 						</li>
 						<li>
 							<a href="#part3">Suppression and Replacement Editing</a><br />
-							This section introduces the two types Suppresion and Replacement Editng - suppression of
-							leading zeros and replacement with spaces, and suppresion and replacement with asterisks.
+							This section introduces the two types Suppression and Replacement Editng - suppression of
+							leading zeros and replacement with spaces, and suppression and replacement with asterisks.
 						</li>
 					</ul>
 					<hr />
@@ -360,7 +360,7 @@
 					<div class="section-content">
 						<p>
 							In the examples/questions below, see if you can figure out what result will be produced when
-							we move the value in the Sending item to the editied picture in the Receiving item. The
+							we move the value in the Sending item to the edited picture in the Receiving item. The
 							description of the Sending item is shown in the Picture column and its current value is
 							shown in the Data column.
 						</p>
@@ -559,7 +559,7 @@
 					<div class="section-content">
 						<p>
 							In the examples/questions below, see if you can figure out what result will be produced when
-							the value in the Sending item is moved to the editied picture in the Receiving item. The
+							the value in the Sending item is moved to the edited picture in the Receiving item. The
 							description of the Sending item is shown in the Picture column and its current value is
 							shown in the Data column.
 						</p>
@@ -730,7 +730,7 @@
 					<div class="section-content">
 						<p>
 							Like the previous examples/questions above, see if you can figure out what result will be
-							produced when the value in the Sending item is moved to the editied picture in the Receiving
+							produced when the value in the Sending item is moved to the edited picture in the Receiving
 							item.
 						</p>
 						<table
@@ -990,7 +990,7 @@
 					<div class="section-content">
 						<p>
 							Like the previous examples/questions above, see if you can figure out what result will be
-							produced when the value in the Sending item is moved to the editied picture in the Receiving
+							produced when the value in the Sending item is moved to the edited picture in the Receiving
 							item.
 						</p>
 						<table

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -701,8 +701,8 @@ END-IF</code></pre>
 							</p>
 							<ol>
 								<li>
-									Move zeros to the appropriate key data item. For instance we might move spaces
-									to VideoTitle to position the pointer at the first logical record in VideoTitle
+									Move zeros to the appropriate key data item. For instance we might move spaces to
+									VideoTitle to position the pointer at the first logical record in VideoTitle
 									sequence.
 								</li>
 								<li>Execute the START..KEY IS GREATER THAN</li>

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -288,7 +288,7 @@ Chose key VideoCode = 1,  VideoTitle = 2 -&gt;  2
 Enter Video Title (40 chars) -&gt; DIRTY DANCING
 02121    DIRTY DANCING                               04
 
-RUN OF INDEX-EG3.EXE USING NON EXISTANT VIDEOCODE
+RUN OF INDEX-EG3.EXE USING NON EXISTENT VIDEOCODE
 Chose key VideoCode = 1,  VideoTitle = 2 -&gt;  1
 Enter Video Code (5 digits) -&gt; 44444
 VIDEO STATUS :- 23</code></pre>
@@ -605,7 +605,7 @@ END-IF</code></pre>
 								<li>
 									The key value must be placed in the <i>KeyName</i> data item (the
 									<i>KeyName</i> data item is the area of storage identified as the primary key or one
-									of the alternate keys in the the SELECT and ASSIGN clause).
+									of the alternate keys in the SELECT and ASSIGN clause).
 								</li>
 								<li>Then the READ must be executed.</li>
 							</ol>
@@ -670,7 +670,7 @@ END-IF</code></pre>
 						</div>
 						<div class="section-content">
 							<p>
-								In Indexed files, the the START verb is used to control the position of the next record
+								In Indexed files, the START verb is used to control the position of the next record
 								pointer and to establish a key as the Key Of Reference.
 							</p>
 							<p>
@@ -701,7 +701,7 @@ END-IF</code></pre>
 							</p>
 							<ol>
 								<li>
-									Move zeros to the the appropriate key data item. For instance we might move spaces
+									Move zeros to the appropriate key data item. For instance we might move spaces
 									to VideoTitle to position the pointer at the first logical record in VideoTitle
 									sequence.
 								</li>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -180,7 +180,7 @@
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<h3>Example program Counting letter occurences using the INSPECT</h3>
+						<h3>Example program Counting letter occurrences using the INSPECT</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -360,7 +360,7 @@ INSPECT SourceLine TALLYING ECount
 						</p>
 						<p>
 							Click on the storage schematic to see the result of each of these INSPECT statements (use
-							left click or PageDown for next item and right click or PageUp for previsou item) .&nbsp;
+							left click or PageDown for next item and right click or PageUp for previous item) .&nbsp;
 						</p>
 						<pre class="language-cobol"><code class="language-cobol">
 1. INSPECT StringData REPLACING ALL "R" BY "G"
@@ -430,7 +430,7 @@ END-PERFORM</code></pre>
 						</p>
 						<p>
 							Click on the diagram below to see how this use of the INSPECT works (use left click or
-							PageDown for next item and right click or PageUp for previsou item) .
+							PageDown for next item and right click or PageUp for previous item) .
 						</p>
 						<iframe
 							height="333"
@@ -523,7 +523,7 @@ END-PERFORM</code></pre>
 						</p>
 						<p>
 							Click on the storage schematic to see the result of each of these INSPECT statements (use
-							left click or PageDown for next item and right click or PageUp for previsou item).&nbsp;
+							left click or PageDown for next item and right click or PageUp for previous item).&nbsp;
 						</p>
 						<pre class="language-cobol"><code class="language-cobol">
 1. INSPECT StringData CONVERTING "fxtd" TO "ZYAB".

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -238,7 +238,7 @@
 								A closed subroutine., is a named block of code that can only be executed by invoking it
 								by name. Usually a closed subroutine. can declare its own local data which cannot be
 								accessed outside the subroutine. In a closed subroutine., data is usually passed between
-								the main program and the subroutine. by means of parameters passed to the subroutine.
+								the main program and the subroutine. By means of parameters passed to the subroutine.
 								when it is invoked.
 							</p>
 							<p>In C and Modula-2, Procedures and Functions implement closed subroutines.</p>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -1141,8 +1141,8 @@ Begin.
 							numbers. Valid lotto numbers fall between 1 and 42.
 						</p>
 						<p>
-							In this program the last five digits of the system time (i.e. minutes, seconds and hundredths
-							of seconds) is used as the random number seed.
+							In this program the last five digits of the system time (i.e. minutes, seconds and
+							hundredths of seconds) is used as the random number seed.
 						</p>
 						<p>
 							The algorithm is based on Niklaus Wirth's algorithm for finding a set of unique integers. In

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -71,7 +71,7 @@
 						<p>
 							The aim of this unit is to provide to provide you with a solid understanding of string
 							manipulation using Reference Modification. It will also introduce you to Intrinsic Functions
-							and will show how strings may be manipulated using the the String Intrinsic Functions.
+							and will show how strings may be manipulated using the String Intrinsic Functions.
 						</p>
 						<hr />
 					</div>
@@ -201,7 +201,7 @@
 							time the function is executed.
 						</p>
 						<p>
-							Whereever a literal with the same type as the function result may be referenced, the
+							Wherever a literal with the same type as the function result may be referenced, the
 							Intrinsic Function may be referenced.
 						</p>
 						<hr />
@@ -227,7 +227,7 @@
 								<br />
 							</li>
 							<li>
-								A function that returns a numeric value cannot be used where an interger operand is
+								A function that returns a numeric value cannot be used where an integer operand is
 								required (because it may return a non-integer value).
 							</li>
 						</ul>
@@ -1141,7 +1141,7 @@ Begin.
 							numbers. Valid lotto numbers fall between 1 and 42.
 						</p>
 						<p>
-							In this program the last five digits of the system time (i.e. minutes, seconds and hundreths
+							In this program the last five digits of the system time (i.e. minutes, seconds and hundredths
 							of seconds) is used as the random number seed.
 						</p>
 						<p>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -572,9 +572,9 @@ Enter supplier key (2 digits)-&gt; 05
 					</div>
 					<div class="section-content">
 						<p>
-							In Relative files, the only thing the START verb is used for, is to control the position
-							of the next record pointer. Where the START verb appears in a program it is usually followed
-							by a sequential READ or WRITE .
+							In Relative files, the only thing the START verb is used for, is to control the position of
+							the next record pointer. Where the START verb appears in a program it is usually followed by
+							a sequential READ or WRITE .
 						</p>
 						<p>
 							<img

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -572,7 +572,7 @@ Enter supplier key (2 digits)-&gt; 05
 					</div>
 					<div class="section-content">
 						<p>
-							In Relative files, the only thing the the START verb is used for, is to control the position
+							In Relative files, the only thing the START verb is used for, is to control the position
 							of the next record pointer. Where the START verb appears in a program it is usually followed
 							by a sequential READ or WRITE .
 						</p>

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -78,7 +78,7 @@
 									what the Report Writer had to do to produce the report.
 								</li>
 								<li>Looking at the Procedure Division of the program that produced the report.</li>
-								<li>Writing a simple version of the the program that produced the report.</li>
+								<li>Writing a simple version of the program that produced the report.</li>
 								<li>Adding more features to the report program.</li>
 								<li>
 									Examining the use of Declaratives in extending the functionality of the Report
@@ -414,7 +414,7 @@ PrintSalaryReport.
 							<ul>
 								<li>a heading and a footing on each page</li>
 								<li>
-									for each sale record we want to print the the city name (obtained from a table),
+									for each sale record we want to print the city name (obtained from a table),
 									salesperson number and the value of the sale
 								</li>
 								<li>the total value of sales for each salesperson</li>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -507,7 +507,7 @@ RD  SalesReport
 						<div class="section-content">
 							<p>
 								The TYPE clause specifies the type of the report group. The type of the report group
-								governs when and where will be printed in the the report (for instance, a
+								governs when and where will be printed in the report (for instance, a
 								<code class="language-cobol">REPORT HEADING</code> group is printed only once - at the
 								beginning of the report).
 							</p>
@@ -765,7 +765,7 @@ RD  SalesReport
 							<h4>Rules</h4>
 							<ol>
 								<li>
-									If the the <code class="language-cobol">SUM</code>..<code class="language-cobol"
+									If the <code class="language-cobol">SUM</code>..<code class="language-cobol"
 										>UPON</code
 									>
 									<i>ReportGroupName</i> clause is used then the value is only added to the sum

--- a/course/Search.html
+++ b/course/Search.html
@@ -394,7 +394,7 @@
 						<div class="section-content">
 							<p>
 								The example program below accepts an upper case letter from the user and then uses the
-								<code class="language-cobol">SEARCH</code> verb to searche a pre-filled table of letters
+								<code class="language-cobol">SEARCH</code> verb to search a pre-filled table of letters
 								to find and display the position of the letter in the alphabet.
 							</p>
 							<p>
@@ -756,7 +756,7 @@ LoadTable.
 							<p>
 								In the example program below, the first dimension of the table is searched to find the
 								results for a particular venue and then the second dimension, representing the results
-								fo the race at that venue, are searched to find the finishing position of a particular
+								for the race at that venue, are searched to find the finishing position of a particular
 								driver.
 							</p>
 						</div>

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -403,7 +403,7 @@ END-IF</code></pre>
 							</p>
 							<p>
 								You can see from the <code class="language-cobol">IF Amnt1</code> example, that figuring
-								out how a complex condition will be evaluated is not straightfoward.<br />
+								out how a complex condition will be evaluated is not straightforward.<br />
 								Always use brackets to make the order of evaluation explicit.
 							</p>
 						</aside>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -382,7 +382,7 @@ SORT WorkFile ON ASCENDING ProvinceCode
 								described for the output file (<code class="language-cobol">GIVING</code>).
 							</li>
 							<li>
-								The <i>SortKeyIdentifer</i> description cannot contain an
+								The <i>SortKeyIdentifier</i> description cannot contain an
 								<code class="language-cobol">OCCURS</code> clause (i.e., it can't be a table/array) nor
 								can it be subordinate to an entry that does contain one.
 							</li>

--- a/course/String.html
+++ b/course/String.html
@@ -344,7 +344,7 @@ END-STRING.</code></pre>
 						<h3>Self assessment questions/examples</h3>
 					</div>
 					<div class="section-content">
-						<p>The examples below consist of data delarations and a number of STRING statements.</p>
+						<p>The examples below consist of data declarations and a number of STRING statements.</p>
 						<p>
 							For each STRING example, write out the text that would be displayed by the DISPLAY
 							statement. Assume that the data starts off fresh for each STRING statement.

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -1115,7 +1115,7 @@ ADD 56 TO PopTotal(12,3,2)</code></pre>
 						</p>
 						<p>
 							For instance, suppose we accept a date from the user and that sometimes the date has the
-							format yyyymmdd, sometimes it is a European date with the format ddmmyyyy, and somtimes it
+							format yyyymmdd, sometimes it is a European date with the format ddmmyyyy, and sometimes it
 							is a US date with the format mmddyyyy. A code accepted with the date allows us to detect the
 							type of date entered.
 						</p>

--- a/examples/SubProg/Multiply/DriverProg.html
+++ b/examples/SubProg/Multiply/DriverProg.html
@@ -170,7 +170,7 @@ WORKING-STORAGE SECTION.
 *&gt; need not be declared.
   
 
-*&gt; Parameters must be either 01-level's or elementry
+*&gt; Parameters must be either 01-level's or elementary
 *&gt; data-items. 
 01 Parameters.
    02 Number1         PIC 9(3).

--- a/examples/SubProg/Multiply/MultiplyNums.html
+++ b/examples/SubProg/Multiply/MultiplyNums.html
@@ -185,7 +185,7 @@ Begin.
 
     MOVE "VALUE OVERWRITTEN" TO StrA
     MOVE "VALUE OVERWRITTEN" TO StrB
-*&gt;   This is done to demonstrate the differece between passing
+*&gt;   This is done to demonstrate the difference between passing
 *&gt;   BY CONTENT and passing BY REFERENCE.  If you pass BY REFERENCE
 *&gt;   you give the called program the opportunity to corrupt your data. 
 *&gt;   You should only pass BY REFERENCE if you require the called

--- a/examples/default.html
+++ b/examples/default.html
@@ -67,7 +67,7 @@
 						</p>
 						<p>
 							The programs have been compiled and tested using Microfocus NetExpress but they should work
-							on any COBOL-85 complient compiler with very few changes.<br />
+							on any COBOL-85 compliant compiler with very few changes.<br />
 							You may have to reformat the programs if your compiler does not have the equivalent of the $
 							SET SOURCEFORMAT"FREE". This compiler directive frees Microfocus COBOL programs from the
 							normal COBOL formatting conventions.<br />
@@ -257,7 +257,7 @@
 					</td>
 					<td height="49" width="298">
 						<p>
-							An example program that implements a primative calculator. The calculator only does
+							An example program that implements a primitive calculator. The calculator only does
 							additions and multiplications.<br />
 							&nbsp;
 						</p>

--- a/exercises/CountDown.html
+++ b/exercises/CountDown.html
@@ -197,9 +197,9 @@
 		<p>
 			The version of the <code class="language-cobol">PERFORM</code> used in this program has the syntax
 			<code class="language-cobol">PERFORM</code> <i>Identifier/Literal</i>
-			<code class="language-cobol">TIMES</code>. That is, either an identifier or a literal can be used to indicate
-			how many times the loop is to be executed. The current version of IterCalc.Cbl uses a literal. You must
-			change it so that it uses an identifier.
+			<code class="language-cobol">TIMES</code>. That is, either an identifier or a literal can be used to
+			indicate how many times the loop is to be executed. The current version of IterCalc.Cbl uses a literal. You
+			must change it so that it uses an identifier.
 		</p>
 		<p>
 			When run with the same data your amended program should the produce the results shown below.&nbsp; For

--- a/exercises/CountDown.html
+++ b/exercises/CountDown.html
@@ -196,8 +196,8 @@
 		user to enter the number of calculations required and then executes the loop that many times.
 		<p>
 			The version of the <code class="language-cobol">PERFORM</code> used in this program has the syntax
-			<code class="language-cobol">PERFORM</code> <i>Identifer/Literal</i>
-			<code class="language-cobol">TIMES</code>. That is, either an identifer or a literal can be used to indicate
+			<code class="language-cobol">PERFORM</code> <i>Identifier/Literal</i>
+			<code class="language-cobol">TIMES</code>. That is, either an identifier or a literal can be used to indicate
 			how many times the loop is to be executed. The current version of IterCalc.Cbl uses a literal. You must
 			change it so that it uses an identifier.
 		</p>

--- a/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html
+++ b/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html
@@ -171,7 +171,7 @@
 				<td bgcolor="#FFFFFF" colspan="2" height="22"><b>Example Input</b></td>
 				<td bgcolor="#FFFFFF" height="22" width="78%">
 					<p>
-						<a href="TRANS.DAT">Trans.Dat</a> (The sorted, validated, sequential file containg the stock
+						<a href="TRANS.DAT">Trans.Dat</a> (The sorted, validated, sequential file containing the stock
 						movement records)
 					</p>
 					<p>

--- a/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html
+++ b/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html
@@ -457,7 +457,7 @@
 							<tr style="vertical-align: top">
 								<td width="14%">Line 8&nbsp;</td>
 								<td width="86%">
-									Customer Details.&nbsp; The CountryName is supressed after its first occurrence.<br />
+									Customer Details.&nbsp; The CountryName is suppressed after its first occurrence.<br />
 									The PayMethod is VISA, Access, AmExpress or Cheque.<br />
 									Subs is the subscription charge:- $20, $100 or&nbsp; $180.<br />
 									LC Subs is the subscription charge in local currency.&nbsp; This value is rounded to

--- a/exercises/Exm-FileConversion/Exm-FileConversion.html
+++ b/exercises/Exm-FileConversion/Exm-FileConversion.html
@@ -304,7 +304,7 @@ Ryan Michael Terence          34 Winchester Drive Dubline 7 Co. Dublin    090123
 					>
 					<h4>The Error File</h4>
 					<p>
-						Any records that are found to contain invalid county names are sent to an Error File. This fle
+						Any records that are found to contain invalid county names are sent to an Error File. This file
 						has the same format as the input file
 					</p>
 					<p>An example error record is;</p>

--- a/exercises/Exm-SFbyMail/Exm-SFbyMai.html
+++ b/exercises/Exm-SFbyMail/Exm-SFbyMai.html
@@ -219,7 +219,7 @@
 						File both before and after processing.
 					</p>
 					<p>For the actual input files</p>
-					<p><a href="Orders.DAT">Orders.Dat</a> is the the sequential orders file</p>
+					<p><a href="Orders.DAT">Orders.Dat</a> is the sequential orders file</p>
 					<p>
 						<a href="Bsf-IN.Dat">BSF-In.Dat</a> is a sequential file that be converted into the indexed Book
 						Stock File (BookStock.Dat) using the program <a href="seq2bsf.cbl">Seq2BSF.Cbl</a>.

--- a/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html
+++ b/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html
@@ -175,7 +175,7 @@
 				<td height="43" width="21%" style="vertical-align: top"><b>Test Data Files</b></td>
 				<td height="43" width="79%" style="vertical-align: top">
 					<p>
-						No test data files are availalble. You will have to create your own test data files. To do this
+						No test data files are available. You will have to create your own test data files. To do this
 						create sequential Customer and Invoice files and then write programs to convert them to indexed
 						files.
 					</p>
@@ -188,7 +188,7 @@
 					</h3>
 					<p>
 						A program is required that will examine the Aromamora Customer and Invoice files and from them
-						produce a report showing the the unpaid customer invoices.&nbsp;&nbsp;&nbsp; The&nbsp;
+						produce a report showing the unpaid customer invoices.&nbsp;&nbsp;&nbsp; The&nbsp;
 						<span style="text-transform: uppercase">Cobol</span> Report-Writer must be used to create the
 						report.
 					</p>

--- a/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html
+++ b/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html
@@ -529,7 +529,7 @@
 						The following are valid languages;<br />
 						IRS = Irish, ENG = English, FRH = French, SPH = Spanish, GER = German,<br />
 						ITA = Italian, DUT = Dutch, DAN = Danish, GRM = Greek (modern),<br />
-						POR = Portugese, RUS = Russian<br />
+						POR = Portuguese, RUS = Russian<br />
 						<br />
 					</p>
 					<h3>

--- a/exercises/Proj-CSISEvalform/CSISEvalForm.html
+++ b/exercises/Proj-CSISEvalform/CSISEvalForm.html
@@ -169,7 +169,7 @@
 				</p>
 				<p>
 					In the course of creating the HTML web page, the program must produce a sorted file containing the
-					VistorCountryName, VisitorOccupation and SiteEvaluation fields.
+					VisitorCountryName, VisitorOccupation and SiteEvaluation fields.
 				</p>
 				<h4>Evaluation Form File</h4>
 				<p>

--- a/exercises/SeqInsert.html
+++ b/exercises/SeqInsert.html
@@ -398,7 +398,7 @@
 			</li>
 			<li>
 				The READ TransFile statement in the paragraph MergeTheFiles is outside the scope of the second IF
-				statment.&nbsp; Why is the IF statement written like this?
+				statement.&nbsp; Why is the IF statement written like this?
 			</li>
 		</ol>
 		<hr />

--- a/exercises/SeqUpdate.html
+++ b/exercises/SeqUpdate.html
@@ -160,7 +160,7 @@
 				student file.
 			</li>
 			<li>
-				It must be able to detect (in mataching records) when the OldCourseCode of the transaction record is not
+				It must be able to detect (in matching records) when the OldCourseCode of the transaction record is not
 				the same as the CourseCode in the student record.
 			</li>
 		</ol>

--- a/exercises/index.html
+++ b/exercises/index.html
@@ -587,7 +587,7 @@
 						</td>
 						<td height="42" width="73%" style="vertical-align: top">
 							A program is required that will examine the Aromamora Customer and Invoice files and from
-							them produce a report showing the the unpaid customer invoices. The Cobol Report-Writer must
+							them produce a report showing the unpaid customer invoices. The Cobol Report-Writer must
 							be used to create the report.<br />
 							&nbsp;
 						</td>

--- a/exercises/index.html
+++ b/exercises/index.html
@@ -587,8 +587,8 @@
 						</td>
 						<td height="42" width="73%" style="vertical-align: top">
 							A program is required that will examine the Aromamora Customer and Invoice files and from
-							them produce a report showing the unpaid customer invoices. The Cobol Report-Writer must
-							be used to create the report.<br />
+							them produce a report showing the unpaid customer invoices. The Cobol Report-Writer must be
+							used to create the report.<br />
 							&nbsp;
 						</td>
 					</tr>

--- a/lectures/ReportWriterSSWeb.html
+++ b/lectures/ReportWriterSSWeb.html
@@ -889,8 +889,8 @@ REPORT SECTION.
 						<h3>Rules</h3>
 						<ol>
 							<li>
-								If the SUM..UPON <i>ReportGroupName</i> clause is used then the value is only added
-								to the sum counter when the specified report group is printed.
+								If the SUM..UPON <i>ReportGroupName</i> clause is used then the value is only added to
+								the sum counter when the specified report group is printed.
 							</li>
 							<li>
 								A SUM clause can appear only in the description of a

--- a/lectures/ReportWriterSSWeb.html
+++ b/lectures/ReportWriterSSWeb.html
@@ -633,7 +633,7 @@ REPORT SECTION.
 					<div class="section-content">
 						<p>
 							The TYPE clause specifies the type of the report group. The type of the report group governs
-							when and where will be printed in the the report (for instance, a
+							when and where will be printed in the report (for instance, a
 							<code class="language-cobol">REPORT HEADING</code> group is printed only once - at the
 							beginning of the report).
 						</p>
@@ -889,7 +889,7 @@ REPORT SECTION.
 						<h3>Rules</h3>
 						<ol>
 							<li>
-								If the the SUM..UPON <i>ReportGroupName</i> clause is used then the value is only added
+								If the SUM..UPON <i>ReportGroupName</i> clause is used then the value is only added
 								to the sum counter when the specified report group is printed.
 							</li>
 							<li>

--- a/lectures/ReportWriterWeb.html
+++ b/lectures/ReportWriterWeb.html
@@ -531,8 +531,8 @@ PrintSalaryReport.
 						<ul>
 							<li>a heading and a footing on each page</li>
 							<li>
-								for each sale record we want to print the city name (obtained from a table),
-								salesperson number and the value of the sale
+								for each sale record we want to print the city name (obtained from a table), salesperson
+								number and the value of the sale
 							</li>
 							<li>the total value of sales for each salesperson</li>
 						</ul>

--- a/lectures/ReportWriterWeb.html
+++ b/lectures/ReportWriterWeb.html
@@ -205,7 +205,7 @@
 								the Report Writer had to do to produce the report.
 							</li>
 							<li>Looking at the Procedure Division of the program that produced the report.</li>
-							<li>Writing a simple version of the the program that produced the report.</li>
+							<li>Writing a simple version of the program that produced the report.</li>
 							<li>Adding more features to the report program.</li>
 							<li>
 								Examining the use of Declaratives in extending the functionality of the Report Writer.
@@ -531,7 +531,7 @@ PrintSalaryReport.
 						<ul>
 							<li>a heading and a footing on each page</li>
 							<li>
-								for each sale record we want to print the the city name (obtained from a table),
+								for each sale record we want to print the city name (obtained from a table),
 								salesperson number and the value of the sale
 							</li>
 							<li>the total value of sales for each salesperson</li>


### PR DESCRIPTION
## Summary

Closes #269.

- **"the the" duplicates** — fixed all 15 occurrences across `course/`, `exercises/`, and `lectures/` (including two extra instances in `exercises/Exm-SFbyMail/` and `exercises/Prj-AromaInvoicesRpt/` that weren't in the issue table)
- **`occurences` → `occurrences`** in `course/Inspect.html`
- **Lowercase sentence start** in `course/Iteration.html` (`. by` → `. By`)
- **Full typos sweep** — ran [`typos`](https://github.com/crate-ci/typos) across the repo and fixed ~30 additional prose misspellings in course and exercise HTML:
  - `straightfoward`, `previsou` (×3), `editied` (×3), `suppresion` (×2), `delarations`, `identifier`, `elementary`, `difference`, `compliant`, `primitive`, `declarations`, `previous`, `straightforward`, `hundredths`, `suppressed`, `matching`, `Portuguese`, `sometimes`, `Suppression`, `containing`, `available`, `sources`, `Wherever`, `integer`, `EXISTENT`, and more
- **`.typos.toml`** — excludes COBOL source/data/copybook files and vendor JS; marks domain-specific abbreviations as intentional (ODF file acronym, `CountMilage` procedure name, COBOL keyword fragments, Niklaus Wirth proper name, etc.)
- **Soft CI job** — adds a `typos` job to `checks.yml` with `continue-on-error: true` using `crate-ci/typos-action@v1`; uses the `.typos.toml` config automatically

## Test plan

- [x] `typos .` exits 0 locally with the new `.typos.toml`
- [ ] CI `typos` job passes on this PR
- [ ] Spot-check a few fixed pages in the browser to confirm prose still reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)