### PR TITLE
Add manual Light/Auto/Dark theme toggle

### DIFF
--- a/components/page-hero.js
+++ b/components/page-hero.js
@@ -12,6 +12,7 @@ class PageHero extends HTMLElement {
 			<div class="hero">
 				<p id="top" class="page-hero-eyebrow">COBOL Tutorial</p>
 				<h1></h1>
+				<theme-toggle></theme-toggle>
 			</div>
 		`;
 		this.querySelector("h1").textContent = title;

--- a/components/theme-toggle.js
+++ b/components/theme-toggle.js
@@ -1,0 +1,40 @@
+// Light-DOM custom element. Renders a three-button group (Light | Auto | Dark)
+// that overrides the OS color-scheme preference and persists the choice to
+// localStorage under the key 'lc-theme'.
+//
+// An inline <script> in each page's <head> reads the same key before first
+// paint and sets data-theme on <html>, preventing a flash of wrong theme.
+// This component handles the interactive UI only — the initial application is
+// already done by the time connectedCallback fires.
+class ThemeToggle extends HTMLElement {
+	static #KEY = "lc-theme";
+
+	connectedCallback() {
+		this.#render();
+	}
+
+	#render() {
+		const current = localStorage.getItem(ThemeToggle.#KEY) || "auto";
+		this.innerHTML = `
+			<div class="theme-toggle" role="group" aria-label="Color theme">
+				<button class="theme-toggle__btn${current === "light" ? " theme-toggle__btn--active" : ""}" data-theme-value="light" aria-pressed="${current === "light"}" type="button">Light</button><button class="theme-toggle__btn${current === "auto" ? " theme-toggle__btn--active" : ""}" data-theme-value="auto" aria-pressed="${current === "auto"}" type="button">Auto</button><button class="theme-toggle__btn${current === "dark" ? " theme-toggle__btn--active" : ""}" data-theme-value="dark" aria-pressed="${current === "dark"}" type="button">Dark</button>
+			</div>
+		`;
+		this.querySelectorAll("[data-theme-value]").forEach((btn) => {
+			btn.addEventListener("click", () => this.#set(btn.dataset.themeValue));
+		});
+	}
+
+	#set(value) {
+		if (value === "auto") {
+			localStorage.removeItem(ThemeToggle.#KEY);
+			document.documentElement.removeAttribute("data-theme");
+		} else {
+			localStorage.setItem(ThemeToggle.#KEY, value);
+			document.documentElement.setAttribute("data-theme", value);
+		}
+		this.#render();
+	}
+}
+
+customElements.define("theme-toggle", ThemeToggle);

--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Introduction to COBOL</title>
@@ -35,6 +36,7 @@
 				}
 			}
 		</style>
+		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>

--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -2,7 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Introduction to COBOL</title>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -2,7 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Basic Procedure Division commands</title>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Basic Procedure Division commands</title>
@@ -10,6 +11,7 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>The COPY verb</title>
@@ -22,6 +23,7 @@
 				}
 			}
 		</style>
+		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -2,7 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>The COPY verb</title>

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Declaring Data in COBOL</title>
@@ -10,6 +11,7 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -2,7 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Declaring Data in COBOL</title>

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -2,7 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Edited Pictures</title>

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Edited Pictures</title>
@@ -10,6 +11,7 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Indexed Files</title>
@@ -16,6 +17,7 @@
 				box-sizing: border-box;
 			}
 		</style>
+		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -2,7 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Indexed Files</title>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>The INSPECT verb</title>
@@ -10,6 +11,7 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -2,7 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>The INSPECT verb</title>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -2,7 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Introduction to Direct Access Files</title>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Introduction to Direct Access Files</title>
@@ -10,6 +11,7 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<script type="application/ld+json">
@@ -25,6 +26,7 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -2,7 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<script type="application/ld+json">

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Reference Modification</title>
@@ -10,6 +11,7 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -2,7 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Reference Modification</title>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Relative Files</title>
@@ -10,6 +11,7 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -2,7 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Relative Files</title>

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -2,7 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>COBOL Report Writer</title>

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>COBOL Report Writer</title>
@@ -10,6 +11,7 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -2,7 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>COBOL Report Writer - Syntax and Semantics</title>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>COBOL Report Writer - Syntax and Semantics</title>
@@ -10,6 +11,7 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>

--- a/course/Resources/css/course-components.css
+++ b/course/Resources/css/course-components.css
@@ -21,9 +21,13 @@
 }
 
 @media (prefers-color-scheme: dark) {
-	.page-hero-eyebrow {
+	:root:not([data-theme="light"]) .page-hero-eyebrow {
 		color: #ff9966;
 	}
+}
+
+:root[data-theme="dark"] .page-hero-eyebrow {
+	color: #ff9966;
 }
 
 /* Decorative disc bullet — replaces BallBlueG.gif (13×13 px) used inline
@@ -120,9 +124,13 @@
 }
 
 @media (prefers-color-scheme: dark) {
-	.lesson-nav {
+	:root:not([data-theme="light"]) .lesson-nav {
 		border-top-color: var(--color-border-soft, #444);
 	}
+}
+
+:root[data-theme="dark"] .lesson-nav {
+	border-top-color: var(--color-border-soft, #444);
 }
 
 /* ============================================================================
@@ -526,10 +534,66 @@ body pre[class*="language-"] {
 }
 
 @media (prefers-color-scheme: dark) {
-	.copy-button {
+	:root:not([data-theme="light"]) .copy-button {
 		background-color: #2e2e2e;
 		color: #ddd;
 		border-color: #555;
+	}
+}
+
+:root[data-theme="dark"] .copy-button {
+	background-color: #2e2e2e;
+	color: #ddd;
+	border-color: #555;
+}
+
+/* ============================================================================
+   Theme-toggle button group (components/theme-toggle.js)
+   Three side-by-side buttons: Light | Auto | Dark. The active button uses a
+   filled style derived from the site's header palette so it's distinct without
+   needing a separate accent color.
+   ============================================================================ */
+
+.theme-toggle {
+	display: inline-flex;
+	border: 1px solid var(--color-border-mute);
+	border-radius: 4px;
+	overflow: hidden;
+	margin-top: 0.5em;
+}
+
+.theme-toggle__btn {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 0.7em;
+	font-weight: bold;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	padding: 0.3em 0.7em;
+	background: transparent;
+	color: inherit;
+	border: none;
+	border-right: 1px solid var(--color-border-mute);
+	cursor: pointer;
+	line-height: 1.4;
+}
+
+.theme-toggle__btn:last-child {
+	border-right: none;
+}
+
+.theme-toggle__btn:focus-visible {
+	outline: 2px solid currentColor;
+	outline-offset: -2px;
+}
+
+.theme-toggle__btn--active {
+	background-color: var(--color-header-bg);
+	color: var(--color-header-text);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.theme-toggle__btn {
+		transition: background-color 0.15s, color 0.15s;
 	}
 }
 

--- a/course/Resources/css/course-components.css
+++ b/course/Resources/css/course-components.css
@@ -593,7 +593,9 @@ body pre[class*="language-"] {
 
 @media (prefers-reduced-motion: no-preference) {
 	.theme-toggle__btn {
-		transition: background-color 0.15s, color 0.15s;
+		transition:
+			background-color 0.15s,
+			color 0.15s;
 	}
 }
 

--- a/course/Resources/css/course.css
+++ b/course/Resources/css/course.css
@@ -22,8 +22,14 @@
 	--color-border-mute: #999999;
 }
 
+/* Tighten color-scheme when the user has explicitly chosen a theme so the
+   browser's built-in UI (scrollbars, form controls) follows the override. */
+:root[data-theme="light"] { color-scheme: light; }
+:root[data-theme="dark"] { color-scheme: dark; }
+
 @media (prefers-color-scheme: dark) {
-	:root {
+	/* :not([data-theme="light"]) lets a manual Light override beat the OS. */
+	:root:not([data-theme="light"]) {
 		--color-bg: #1a1a1a;
 		--color-text: #e6e6e6;
 
@@ -43,6 +49,28 @@
 		--color-border-soft: #444444;
 		--color-border-mute: #666666;
 	}
+}
+
+/* Manual dark override — same tokens, applied regardless of OS preference. */
+:root[data-theme="dark"] {
+	--color-bg: #1a1a1a;
+	--color-text: #e6e6e6;
+
+	--color-link: #6ea8ff;
+	--color-link-visited: #ff8a8a;
+	--color-link-active: #6ee06e;
+
+	--color-header-bg: #6b2400;
+	--color-header-text: #ffe066;
+	--color-panel-bg: #3a3520;
+	--color-panel-text: #ffb3b3;
+	--color-code-bg: #1f2e1f;
+	--color-results-bg: #1a2e2e;
+	--color-cell-label-bg: #2d2d2d;
+	--color-emphasis: #8aa8ff;
+
+	--color-border-soft: #444444;
+	--color-border-mute: #666666;
 }
 
 body {
@@ -390,66 +418,70 @@ td[bgcolor="#ffffcc"] h4 {
    the vendor stylesheet), light-background images that need inversion, and
    inline `style="color: #..."` highlights baked into legacy code samples.
    ============================================================================ */
+/* Dark-mode non-token overrides shared between system-dark and manual-dark.
+   Defined as a ruleset that is applied under both conditions below. */
 @media (prefers-color-scheme: dark) {
+	/* :not([data-theme="light"]) lets a manual Light override beat the OS. */
+
 	/* Prism syntax highlighting — re-color the vendor light theme. The `body`
 	   prefix lifts specificity to (0,1,2) so these win against prism.min.css's
 	   (0,1,1) selectors despite the vendor sheet loading after course.css. */
-	body pre[class*="language-"],
-	body code[class*="language-"] {
+	:root:not([data-theme="light"]) body pre[class*="language-"],
+	:root:not([data-theme="light"]) body code[class*="language-"] {
 		background: #1f1f1f;
 		color: #e6e6e6;
 		text-shadow: none;
 	}
 
-	body :not(pre) > code[class*="language-"] {
+	:root:not([data-theme="light"]) body :not(pre) > code[class*="language-"] {
 		background: #1f1f1f;
 	}
 
-	body .token.comment,
-	body .token.prolog,
-	body .token.doctype,
-	body .token.cdata {
+	:root:not([data-theme="light"]) body .token.comment,
+	:root:not([data-theme="light"]) body .token.prolog,
+	:root:not([data-theme="light"]) body .token.doctype,
+	:root:not([data-theme="light"]) body .token.cdata {
 		color: #8a8a8a;
 	}
 
-	body .token.punctuation {
+	:root:not([data-theme="light"]) body .token.punctuation {
 		color: #c8c8c8;
 	}
 
-	body .token.keyword,
-	body .token.tag,
-	body .token.selector,
-	body .token.atrule {
+	:root:not([data-theme="light"]) body .token.keyword,
+	:root:not([data-theme="light"]) body .token.tag,
+	:root:not([data-theme="light"]) body .token.selector,
+	:root:not([data-theme="light"]) body .token.atrule {
 		color: #ff9d6e;
 	}
 
-	body .token.string,
-	body .token.attr-value,
-	body .token.char,
-	body .token.builtin,
-	body .token.inserted {
+	:root:not([data-theme="light"]) body .token.string,
+	:root:not([data-theme="light"]) body .token.attr-value,
+	:root:not([data-theme="light"]) body .token.char,
+	:root:not([data-theme="light"]) body .token.builtin,
+	:root:not([data-theme="light"]) body .token.inserted {
 		color: #b5e8a3;
 	}
 
-	body .token.number,
-	body .token.boolean,
-	body .token.constant,
-	body .token.symbol,
-	body .token.deleted {
+	:root:not([data-theme="light"]) body .token.number,
+	:root:not([data-theme="light"]) body .token.boolean,
+	:root:not([data-theme="light"]) body .token.constant,
+	:root:not([data-theme="light"]) body .token.symbol,
+	:root:not([data-theme="light"]) body .token.deleted {
 		color: #f8d57e;
 	}
 
-	body .token.function,
-	body .token.class-name {
+	:root:not([data-theme="light"]) body .token.function,
+	:root:not([data-theme="light"]) body .token.class-name {
 		color: #90c8ff;
 	}
 
-	body .token.operator,
-	body .token.entity,
-	body .token.url,
-	body .token.variable,
-	body .language-css .token.string,
-	body .style .token.string {
+	:root:not([data-theme="light"]) body .token.operator,
+	:root:not([data-theme="light"]) body .token.entity,
+	:root:not([data-theme="light"]) body .token.url,
+	:root:not([data-theme="light"]) body .token.variable,
+	:root:not([data-theme="light"]) body .language-css .token.string,
+	:root:not([data-theme="light"]) body .style .token.string {
 		color: #d8a0ff;
 		background: transparent;
 	}
@@ -458,73 +490,196 @@ td[bgcolor="#ffffcc"] h4 {
 	   `0.92` keeps blacks just shy of pure white so they merge into the page;
 	   `hue-rotate(180deg)` recovers reds/greens. Photos opt out by extension
 	   or by adding `class="no-invert"` to the <img>. */
-	img {
+	:root:not([data-theme="light"]) img {
 		filter: invert(0.92) hue-rotate(180deg);
 	}
 
-	img.no-invert,
-	img[src$=".jpg"],
-	img[src$=".jpeg"],
-	img[src$=".JPG"],
-	img[src$=".JPEG"] {
+	:root:not([data-theme="light"]) img.no-invert,
+	:root:not([data-theme="light"]) img[src$=".jpg"],
+	:root:not([data-theme="light"]) img[src$=".jpeg"],
+	:root:not([data-theme="light"]) img[src$=".JPG"],
+	:root:not([data-theme="light"]) img[src$=".JPEG"] {
 		filter: none;
 	}
 
 	/* Override inline `style="color: #..."` spans baked into legacy code
 	   samples. These attribute selectors target the raw inline value, so
 	   `!important` is required to beat the inline declaration. */
-	[style*="color:#0000ff"],
-	[style*="color: #0000ff"],
-	[style*="color:#0000FF"],
-	[style*="color: #0000FF"] {
+	:root:not([data-theme="light"]) [style*="color:#0000ff"],
+	:root:not([data-theme="light"]) [style*="color: #0000ff"],
+	:root:not([data-theme="light"]) [style*="color:#0000FF"],
+	:root:not([data-theme="light"]) [style*="color: #0000FF"] {
 		color: var(--color-link) !important;
 	}
 
-	[style*="color:#993300"],
-	[style*="color: #993300"] {
+	:root:not([data-theme="light"]) [style*="color:#993300"],
+	:root:not([data-theme="light"]) [style*="color: #993300"] {
 		color: #ff9966 !important;
 	}
 
-	[style*="color:#000099"],
-	[style*="color: #000099"] {
+	:root:not([data-theme="light"]) [style*="color:#000099"],
+	:root:not([data-theme="light"]) [style*="color: #000099"] {
 		color: var(--color-emphasis) !important;
 	}
 
-	[style*="color:#800000"],
-	[style*="color: #800000"] {
+	:root:not([data-theme="light"]) [style*="color:#800000"],
+	:root:not([data-theme="light"]) [style*="color: #800000"] {
 		color: var(--color-panel-text) !important;
 	}
 
-	[style*="color:#ff0000"],
-	[style*="color: #ff0000"],
-	[style*="color:#FF0000"],
-	[style*="color: #FF0000"] {
+	:root:not([data-theme="light"]) [style*="color:#ff0000"],
+	:root:not([data-theme="light"]) [style*="color: #ff0000"],
+	:root:not([data-theme="light"]) [style*="color:#FF0000"],
+	:root:not([data-theme="light"]) [style*="color: #FF0000"] {
 		color: #ff8a8a !important;
 	}
 
-	[style*="color:#006600"],
-	[style*="color: #006600"] {
+	:root:not([data-theme="light"]) [style*="color:#006600"],
+	:root:not([data-theme="light"]) [style*="color: #006600"] {
 		color: #7ec47e !important;
 	}
 
-	[style*="color:#cccccc"],
-	[style*="color: #cccccc"],
-	[style*="color:#CCCCCC"],
-	[style*="color: #CCCCCC"] {
+	:root:not([data-theme="light"]) [style*="color:#cccccc"],
+	:root:not([data-theme="light"]) [style*="color: #cccccc"],
+	:root:not([data-theme="light"]) [style*="color:#CCCCCC"],
+	:root:not([data-theme="light"]) [style*="color: #CCCCCC"] {
 		color: #888888 !important;
 	}
 
 	/* #CCCCCC has no matching light-mode token (only used as decorative
 	   spacer cells), so it's remapped only in dark mode. Uses the same
 	   --color-cell-label-bg as #E8E8E8 since both are gray. */
-	table[bgcolor="#CCCCCC"],
-	table[bgcolor="#cccccc"],
-	tr[bgcolor="#CCCCCC"],
-	tr[bgcolor="#cccccc"],
-	td[bgcolor="#CCCCCC"],
-	td[bgcolor="#cccccc"] {
+	:root:not([data-theme="light"]) table[bgcolor="#CCCCCC"],
+	:root:not([data-theme="light"]) table[bgcolor="#cccccc"],
+	:root:not([data-theme="light"]) tr[bgcolor="#CCCCCC"],
+	:root:not([data-theme="light"]) tr[bgcolor="#cccccc"],
+	:root:not([data-theme="light"]) td[bgcolor="#CCCCCC"],
+	:root:not([data-theme="light"]) td[bgcolor="#cccccc"] {
 		background-color: var(--color-cell-label-bg);
 	}
+}
+
+/* Manual dark override — same non-token rules, applied regardless of OS. */
+:root[data-theme="dark"] body pre[class*="language-"],
+:root[data-theme="dark"] body code[class*="language-"] {
+	background: #1f1f1f;
+	color: #e6e6e6;
+	text-shadow: none;
+}
+
+:root[data-theme="dark"] body :not(pre) > code[class*="language-"] {
+	background: #1f1f1f;
+}
+
+:root[data-theme="dark"] body .token.comment,
+:root[data-theme="dark"] body .token.prolog,
+:root[data-theme="dark"] body .token.doctype,
+:root[data-theme="dark"] body .token.cdata {
+	color: #8a8a8a;
+}
+
+:root[data-theme="dark"] body .token.punctuation {
+	color: #c8c8c8;
+}
+
+:root[data-theme="dark"] body .token.keyword,
+:root[data-theme="dark"] body .token.tag,
+:root[data-theme="dark"] body .token.selector,
+:root[data-theme="dark"] body .token.atrule {
+	color: #ff9d6e;
+}
+
+:root[data-theme="dark"] body .token.string,
+:root[data-theme="dark"] body .token.attr-value,
+:root[data-theme="dark"] body .token.char,
+:root[data-theme="dark"] body .token.builtin,
+:root[data-theme="dark"] body .token.inserted {
+	color: #b5e8a3;
+}
+
+:root[data-theme="dark"] body .token.number,
+:root[data-theme="dark"] body .token.boolean,
+:root[data-theme="dark"] body .token.constant,
+:root[data-theme="dark"] body .token.symbol,
+:root[data-theme="dark"] body .token.deleted {
+	color: #f8d57e;
+}
+
+:root[data-theme="dark"] body .token.function,
+:root[data-theme="dark"] body .token.class-name {
+	color: #90c8ff;
+}
+
+:root[data-theme="dark"] body .token.operator,
+:root[data-theme="dark"] body .token.entity,
+:root[data-theme="dark"] body .token.url,
+:root[data-theme="dark"] body .token.variable,
+:root[data-theme="dark"] body .language-css .token.string,
+:root[data-theme="dark"] body .style .token.string {
+	color: #d8a0ff;
+	background: transparent;
+}
+
+:root[data-theme="dark"] img {
+	filter: invert(0.92) hue-rotate(180deg);
+}
+
+:root[data-theme="dark"] img.no-invert,
+:root[data-theme="dark"] img[src$=".jpg"],
+:root[data-theme="dark"] img[src$=".jpeg"],
+:root[data-theme="dark"] img[src$=".JPG"],
+:root[data-theme="dark"] img[src$=".JPEG"] {
+	filter: none;
+}
+
+:root[data-theme="dark"] [style*="color:#0000ff"],
+:root[data-theme="dark"] [style*="color: #0000ff"],
+:root[data-theme="dark"] [style*="color:#0000FF"],
+:root[data-theme="dark"] [style*="color: #0000FF"] {
+	color: var(--color-link) !important;
+}
+
+:root[data-theme="dark"] [style*="color:#993300"],
+:root[data-theme="dark"] [style*="color: #993300"] {
+	color: #ff9966 !important;
+}
+
+:root[data-theme="dark"] [style*="color:#000099"],
+:root[data-theme="dark"] [style*="color: #000099"] {
+	color: var(--color-emphasis) !important;
+}
+
+:root[data-theme="dark"] [style*="color:#800000"],
+:root[data-theme="dark"] [style*="color: #800000"] {
+	color: var(--color-panel-text) !important;
+}
+
+:root[data-theme="dark"] [style*="color:#ff0000"],
+:root[data-theme="dark"] [style*="color: #ff0000"],
+:root[data-theme="dark"] [style*="color:#FF0000"],
+:root[data-theme="dark"] [style*="color: #FF0000"] {
+	color: #ff8a8a !important;
+}
+
+:root[data-theme="dark"] [style*="color:#006600"],
+:root[data-theme="dark"] [style*="color: #006600"] {
+	color: #7ec47e !important;
+}
+
+:root[data-theme="dark"] [style*="color:#cccccc"],
+:root[data-theme="dark"] [style*="color: #cccccc"],
+:root[data-theme="dark"] [style*="color:#CCCCCC"],
+:root[data-theme="dark"] [style*="color: #CCCCCC"] {
+	color: #888888 !important;
+}
+
+:root[data-theme="dark"] table[bgcolor="#CCCCCC"],
+:root[data-theme="dark"] table[bgcolor="#cccccc"],
+:root[data-theme="dark"] tr[bgcolor="#CCCCCC"],
+:root[data-theme="dark"] tr[bgcolor="#cccccc"],
+:root[data-theme="dark"] td[bgcolor="#CCCCCC"],
+:root[data-theme="dark"] td[bgcolor="#cccccc"] {
+	background-color: var(--color-cell-label-bg);
 }
 
 /* ============================================================================
@@ -564,6 +719,7 @@ td[bgcolor="#ffffcc"] h4 {
 	.hero img,
 	.back-to-top,
 	.skip-link,
+	theme-toggle,
 	ul.toc {
 		display: none !important;
 	}

--- a/course/Resources/css/course.css
+++ b/course/Resources/css/course.css
@@ -24,8 +24,12 @@
 
 /* Tighten color-scheme when the user has explicitly chosen a theme so the
    browser's built-in UI (scrollbars, form controls) follows the override. */
-:root[data-theme="light"] { color-scheme: light; }
-:root[data-theme="dark"] { color-scheme: dark; }
+:root[data-theme="light"] {
+	color-scheme: light;
+}
+:root[data-theme="dark"] {
+	color-scheme: dark;
+}
 
 @media (prefers-color-scheme: dark) {
 	/* :not([data-theme="light"]) lets a manual Light override beat the OS. */

--- a/course/Search.html
+++ b/course/Search.html
@@ -2,7 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Searching Tables</title>

--- a/course/Search.html
+++ b/course/Search.html
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Searching Tables</title>
@@ -10,6 +11,7 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -2,7 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>COBOL Selection Constructs</title>

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>COBOL Selection Constructs</title>
@@ -22,6 +23,7 @@
 				}
 			}
 		</style>
+		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Introduction to Sequential Files</title>
@@ -10,6 +11,7 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -2,7 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Introduction to Sequential Files</title>

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -2,7 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Processing Sequential Files</title>

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Processing Sequential Files</title>
@@ -10,6 +11,7 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Print files and variable-length records</title>
@@ -10,6 +11,7 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -2,7 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Print files and variable-length records</title>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -2,7 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Sorting and Merging files</title>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Sorting and Merging files</title>
@@ -10,6 +11,7 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>

--- a/course/String.html
+++ b/course/String.html
@@ -2,7 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>The STRING verb</title>

--- a/course/String.html
+++ b/course/String.html
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>The STRING verb</title>
@@ -10,6 +11,7 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -2,7 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Contained and external sub-programs</title>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Contained and external sub-programs</title>
@@ -10,6 +11,7 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -2,7 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Using Tables</title>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Using Tables</title>
@@ -10,6 +11,7 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Creating tables - syntax and semantics</title>
@@ -46,6 +47,7 @@
 				}
 			}
 		</style>
+		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -2,7 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Creating tables - syntax and semantics</title>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -2,7 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>The UNSTRING verb</title>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>The UNSTRING verb</title>
@@ -10,6 +11,7 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>The USAGE clause</title>
@@ -10,6 +11,7 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -2,7 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<script>(function(){var t=localStorage.getItem('lc-theme');if(t==='dark'||t==='light')document.documentElement.setAttribute('data-theme',t);}());</script>
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>The USAGE clause</title>


### PR DESCRIPTION
Closes #249.

## What changed

- **`components/theme-toggle.js`** (new) — Light-DOM custom element rendering a `[ Light | Auto | Dark ]` button group. Reads/writes `localStorage` key `lc-theme`; sets `data-theme` on `<html>` to `"light"` or `"dark"`, or removes the attribute for Auto.

- **`components/page-hero.js`** — adds `<theme-toggle>` inside the `.hero` div so the toggle appears on every page that uses `<page-hero>` without touching each page's HTML structure.

- **`course/Resources/css/course.css`** — all dark-mode selectors updated to the dual-condition pattern:
  - System dark: `@media (prefers-color-scheme: dark) { :root:not([data-theme="light"]) … }` (manual Light beats the OS)
  - Manual dark: `[data-theme="dark"]` block duplicating every rule (CSS variables, Prism tokens, image inversion, inline-style overrides, bgcolor attributes)
  - `color-scheme` property narrows to `light` or `dark` on `:root` when an explicit override is active (scrollbars/form controls follow the choice)
  - `theme-toggle` added to the print-hidden list

- **`course/Resources/css/course-components.css`** — same dual-condition treatment for `.page-hero-eyebrow`, `.lesson-nav` border, and `.copy-button`; new `.theme-toggle` / `.theme-toggle__btn` styles using the site's maroon/yellow header palette for the active state; `prefers-reduced-motion`-gated 0.15 s transition.

- **All 25 course HTML files** (every page that loads `course.css` and uses `<page-hero>`) each received two additions:
  1. Anti-FOUC inline `<script>` immediately after `<meta name="viewport">` — reads `localStorage` synchronously before CSS is processed so the correct `data-theme` is already on `<html>` at first paint.
  2. `<script src="../components/theme-toggle.js" defer>` loaded before `page-hero.js`.

## Pages excluded (per spec)

- `course/Resources/pdf-viewer.html` — intentional dark chrome, no toggle.
- `course/index.html` — uses its own inline CSS, not `course.css`; no `<page-hero>`.
- `course/Resources/ppz/*.html` — PDF iframe wrappers, no `course.css`.

## Test plan

- [ ] Load any course page; toggle renders in the page hero (Light | Auto | Dark).
- [ ] Click **Light** on a dark-OS machine — page switches to light theme instantly, active button highlights.
- [ ] Click **Dark** on a light-OS machine — page switches to dark, Prism tokens re-color, images invert.
- [ ] Click **Auto** — theme follows OS preference, `data-theme` removed from `<html>`.
- [ ] Navigate to a different course page — previously chosen theme persists (no FOUC, correct active button).
- [ ] Hard reload with a saved preference — page renders in the correct theme before JS runs.
- [ ] Print / save as PDF — toggle is hidden, page prints in light theme regardless of chosen mode.
- [ ] `pa11y-ci` passes — buttons have accessible name via text content and `aria-pressed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)