### PR TITLE
Migrate SAQ reveal widgets from <select> to <details>/<summary>

### DIFF
--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -390,10 +390,10 @@
 								<td headers="ep-t1-ri ep-t1-rp" width="24%">PIC 999,999</td>
 								<td headers="ep-t1-ri ep-t1-rr" width="41%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 123,456</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											Ans = 123,456
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -405,10 +405,10 @@
 								<td headers="ep-t1-ri ep-t1-rp" width="24%">PIC 9(3),9(3)</td>
 								<td headers="ep-t1-ri ep-t1-rr" width="41%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select2">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 000,078</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											Ans = 000,078
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -420,17 +420,14 @@
 								<td headers="ep-t1-ri ep-t1-rp" width="24%">PIC ZZZ,ZZZ</td>
 								<td headers="ep-t1-ri ep-t1-rr" width="41%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select3">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = sssss78</option>
-											<option>s - indicates a space.</option>
-											<option>The Z suppresses</option>
-											<option>leading zeros, replacing</option>
-											<option>them with spaces. Since</option>
-											<option>there are only zeros to</option>
-											<option>the left of the comma, it</option>
-											<option>is replaced by a space.</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											<p>
+												Ans = sssss78 s - indicates a space. The Z suppresses leading zeros,
+												replacing them with spaces. Since there are only zeros to the left of
+												the comma, it is replaced by a space.
+											</p>
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -442,14 +439,13 @@
 								<td headers="ep-t1-ri ep-t1-rp" width="24%">PIC ***,***</td>
 								<td headers="ep-t1-ri ep-t1-rr" width="41%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select4">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = ****178</option>
-											<option>Since only zeros are</option>
-											<option>to the left of the comma</option>
-											<option>it is replaced by the</option>
-											<option>replacement symbol *.</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											<p>
+												Ans = ****178 Since only zeros are to the left of the comma it is
+												replaced by the replacement symbol *.
+											</p>
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -461,10 +457,10 @@
 								<td headers="ep-t1-ri ep-t1-rp" width="24%">PIC ***,***</td>
 								<td headers="ep-t1-ri ep-t1-rr" width="41%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select8">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = **2,178</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											Ans = **2,178
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -476,11 +472,10 @@
 								<td headers="ep-t1-ri ep-t1-rp" width="24%">PIC 99B99B99</td>
 								<td headers="ep-t1-ri ep-t1-rr" width="41%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select9">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 12s01s83</option>
-											<option>s - indicates a space</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											<p>Ans = 12s01s83 s - indicates a space</p>
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -492,13 +487,12 @@
 								<td headers="ep-t1-ri ep-t1-rp" width="24%">PIC 99/99/99</td>
 								<td headers="ep-t1-ri ep-t1-rr" width="41%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select10">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 12/01/83</option>
-											<option>As in this case,</option>
-											<option>the slash is often</option>
-											<option>used to edit dates.</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											<p>
+												Ans = 12/01/83 As in this case, the slash is often used to edit dates.
+											</p>
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -510,18 +504,14 @@
 								<td headers="ep-t1-ri ep-t1-rp" height="2" width="24%">PIC 990099</td>
 								<td headers="ep-t1-ri ep-t1-rr" height="2" width="41%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select11">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 120045</option>
-											<option>Decimal point alignment</option>
-											<option>means that 45 will be</option>
-											<option>placed in the rightmost</option>
-											<option>two digits, then the zeros</option>
-											<option>will be inserted and then</option>
-											<option>the 12 will be placed in</option>
-											<option>the last two positions.</option>
-											<option>The 3 will be truncated.</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											<p>
+												Ans = 120045 Decimal point alignment means that 45 will be placed in the
+												rightmost two digits, then the zeros will be inserted and then the 12
+												will be placed in the last two positions. The 3 will be truncated.
+											</p>
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -590,16 +580,13 @@
 								<td headers="ep-t2-ri ep-t2-rp" height="13" width="22%">PIC 999.99</td>
 								<td headers="ep-t2-ri ep-t2-rr" height="13" width="44%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select12" size="1">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 123.45</option>
-											<option>The assumed decimal</option>
-											<option>point (V) aligns with the</option>
-											<option>actual decimal point (.)</option>
-											<option>so 45 goes after the</option>
-											<option>decimal point and 123</option>
-											<option>before it.</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											<p>
+												Ans = 123.45 The assumed decimal point (V) aligns with the actual
+												decimal point (.) so 45 goes after the decimal point and 123 before it.
+											</p>
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -611,15 +598,13 @@
 								<td headers="ep-t2-ri ep-t2-rp" height="16" width="22%">PIC 999.9</td>
 								<td headers="ep-t2-ri ep-t2-rr" height="16" width="44%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select12b" size="1">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 023.4</option>
-											<option>The receiving field only</option>
-											<option>allows one digit after the</option>
-											<option>decimal point so after</option>
-											<option>decimal point alignment</option>
-											<option>the 5 will be lost.</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											<p>
+												Ans = 023.4 The receiving field only allows one digit after the decimal
+												point so after decimal point alignment the 5 will be lost.
+											</p>
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -631,14 +616,13 @@
 								<td headers="ep-t2-ri ep-t2-rp" height="16" width="22%">PIC 99.99</td>
 								<td headers="ep-t2-ri ep-t2-rr" height="16" width="44%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select12c" size="1">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 12.34</option>
-											<option>In this case decimal</option>
-											<option>point alignment causes</option>
-											<option>most significant digit (7) to</option>
-											<option>be lost.</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											<p>
+												Ans = 12.34 In this case decimal point alignment causes most significant
+												digit (7) to be lost.
+											</p>
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -650,16 +634,14 @@
 								<td headers="ep-t2-ri ep-t2-rp" width="22%">PIC 999.99</td>
 								<td headers="ep-t2-ri ep-t2-rr" width="44%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select12d" size="1">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 456.00</option>
-											<option>Decimal point alignment</option>
-											<option>means that, the most</option>
-											<option>significant digit (2) will be</option>
-											<option>lost, and the positions</option>
-											<option>after the decimal point</option>
-											<option>will be filled with zeros</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											<p>
+												Ans = 456.00 Decimal point alignment means that, the most significant
+												digit (2) will be lost, and the positions after the decimal point will
+												be filled with zeros
+											</p>
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -759,10 +741,10 @@
 								<td headers="ep-t3-ri ep-t3-rp" height="15" width="20%">PIC -999</td>
 								<td headers="ep-t3-ri ep-t3-rr" height="15" width="46%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select13">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = -123</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											Ans = -123
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -774,10 +756,10 @@
 								<td headers="ep-t3-ri ep-t3-rp" height="16" width="20%">PIC 999-</td>
 								<td headers="ep-t3-ri ep-t3-rr" height="16" width="46%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select13b">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 123-</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											Ans = 123-
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -789,17 +771,14 @@
 								<td headers="ep-t3-ri ep-t3-rp" height="16" width="20%">PIC -999</td>
 								<td headers="ep-t3-ri ep-t3-rr" height="16" width="46%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select14">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = s123</option>
-											<option>s - indicates a space</option>
-											<option>The - symbol only</option>
-											<option>highlights negative</option>
-											<option>values. If the value is</option>
-											<option>positive, a space is</option>
-											<option>printed instead of the</option>
-											<option>sign.</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											<p>
+												Ans = s123 s - indicates a space The - symbol only highlights negative
+												values. If the value is positive, a space is printed instead of the
+												sign.
+											</p>
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -811,10 +790,10 @@
 								<td headers="ep-t3-ri ep-t3-rp" height="16" width="20%">PIC +9(5)</td>
 								<td headers="ep-t3-ri ep-t3-rr" height="16" width="46%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select15">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = +12345</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											Ans = +12345
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -826,14 +805,13 @@
 								<td headers="ep-t3-ri ep-t3-rp" height="16" width="20%">PIC +9(3)</td>
 								<td headers="ep-t3-ri ep-t3-rr" height="16" width="46%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select16">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = -123</option>
-											<option>If a + symbol is used, a +</option>
-											<option>is printed if the value is</option>
-											<option>positive and a - is printed</option>
-											<option>if the value is negative.</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											<p>
+												Ans = -123 If a + symbol is used, a + is printed if the value is
+												positive and a - is printed if the value is negative.
+											</p>
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -845,14 +823,13 @@
 								<td headers="ep-t3-ri ep-t3-rp" height="16" width="20%">PIC 999+</td>
 								<td headers="ep-t3-ri ep-t3-rr" height="16" width="46%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select13c">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 123-</option>
-											<option>In this case decimal</option>
-											<option>point alignment causes</option>
-											<option>most significant digit (7)</option>
-											<option>to be lost.</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											<p>
+												Ans = 123- In this case decimal point alignment causes most significant
+												digit (7) to be lost.
+											</p>
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -864,11 +841,10 @@
 								<td headers="ep-t3-ri ep-t3-rp" height="16" width="20%">PIC 9(4)CR</td>
 								<td headers="ep-t3-ri ep-t3-rr" height="16" width="46%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select17">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 1234ss</option>
-											<option>s- indicates a space</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											<p>Ans = 1234ss s- indicates a space</p>
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -880,10 +856,10 @@
 								<td headers="ep-t3-ri ep-t3-rp" height="16" width="20%">PIC 9(4)CR</td>
 								<td headers="ep-t3-ri ep-t3-rr" height="16" width="46%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select18">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 1234CR</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											Ans = 1234CR
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -895,11 +871,10 @@
 								<td headers="ep-t3-ri ep-t3-rp" height="16" width="20%">PIC 9(4)DB</td>
 								<td headers="ep-t3-ri ep-t3-rr" height="16" width="46%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select19">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 1223ss</option>
-											<option>s - indicates a space</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											<p>Ans = 1223ss s - indicates a space</p>
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -911,10 +886,10 @@
 								<td headers="ep-t3-ri ep-t3-rp" height="16" width="20%">PIC 9(4)DB</td>
 								<td headers="ep-t3-ri ep-t3-rr" height="16" width="46%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select20">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = 1234DB</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											Ans = 1234DB
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -926,10 +901,10 @@
 								<td headers="ep-t3-ri ep-t3-rp" height="16" width="20%">PIC $99999</td>
 								<td headers="ep-t3-ri ep-t3-rr" height="16" width="46%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select21">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = $01234</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											Ans = $01234
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -941,11 +916,10 @@
 								<td headers="ep-t3-ri ep-t3-rp" height="16" width="20%">PIC $ZZZZZ</td>
 								<td headers="ep-t3-ri ep-t3-rr" height="16" width="46%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select22">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = $sssss</option>
-											<option>s - indicates a space</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											<p>Ans = $sssss s - indicates a space</p>
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -1019,11 +993,10 @@
 								<td headers="ep-t4-ri ep-t4-rp" height="15" width="23%">PIC $$,$$9.99</td>
 								<td headers="ep-t4-ri ep-t4-rr" height="15" width="43%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select5">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = ssss$0.00</option>
-											<option>s - indicates a space</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											<p>Ans = ssss$0.00 s - indicates a space</p>
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -1035,13 +1008,13 @@
 								<td headers="ep-t4-ri ep-t4-rp" height="16" width="23%">PIC $$,$$9.00</td>
 								<td headers="ep-t4-ri ep-t4-rr" height="16" width="43%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select5b">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = sss$80.00</option>
-											<option>s - indicates a space</option>
-											<option>The fixed insertion zeros</option>
-											<option>are added to the end.</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											<p>
+												Ans = sss$80.00 s - indicates a space The fixed insertion zeros are
+												added to the end.
+											</p>
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -1053,11 +1026,10 @@
 								<td headers="ep-t4-ri ep-t4-rp" height="16" width="23%">PIC $$,$$9.99</td>
 								<td headers="ep-t4-ri ep-t4-rr" height="16" width="43%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select5c">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = ss$128.00</option>
-											<option>s - indicates a space</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											<p>Ans = ss$128.00 s - indicates a space</p>
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -1069,19 +1041,14 @@
 								<td headers="ep-t4-ri ep-t4-rp" height="16" width="23%">PIC $$,$$9</td>
 								<td headers="ep-t4-ri ep-t4-rr" height="16" width="43%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select5d">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = $7,397</option>
-											<option>Although the receiving</option>
-											<option>field appears to have</option>
-											<option>enough room for the</option>
-											<option>value, the programmer</option>
-											<option>forgot that the left-most</option>
-											<option>floating symbol cannot</option>
-											<option>be replaced by a digit.</option>
-											<option>This causes the digit (5)</option>
-											<option>to be lost.</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											<p>
+												Ans = $7,397 Although the receiving field appears to have enough room
+												for the value, the programmer forgot that the left-most floating symbol
+												cannot be replaced by a digit. This causes the digit (5) to be lost.
+											</p>
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -1093,11 +1060,10 @@
 								<td headers="ep-t4-ri ep-t4-rp" height="16" width="23%">PIC ++++9</td>
 								<td headers="ep-t4-ri ep-t4-rr" height="16" width="43%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select5e">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = sss-5</option>
-											<option>s - indicates a space</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											<p>Ans = sss-5 s - indicates a space</p>
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -1109,11 +1075,10 @@
 								<td headers="ep-t4-ri ep-t4-rp" height="16" width="23%">PIC ++++9</td>
 								<td headers="ep-t4-ri ep-t4-rr" height="16" width="43%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select5f">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = sss+80</option>
-											<option>s - indicates a space</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											<p>Ans = sss+80 s - indicates a space</p>
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -1127,11 +1092,10 @@
 								<td headers="ep-t4-ri ep-t4-rp" height="20" width="23%">PIC - - - - 9</td>
 								<td headers="ep-t4-ri ep-t4-rr" height="20" width="43%" style="vertical-align: top">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select5g">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = sss-80</option>
-											<option>s- indicates a space</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											<p>Ans = sss-80 s- indicates a space</p>
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -1143,15 +1107,13 @@
 								<td headers="ep-t4-ri ep-t4-rp" height="16" width="23%">PIC - - - - 9</td>
 								<td headers="ep-t4-ri ep-t4-rr" height="16" width="43%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select5h">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = s1234</option>
-											<option>s- indicates a space</option>
-											<option>The left-most sign cannot</option>
-											<option>be replaced by a digit,</option>
-											<option>so the most significant</option>
-											<option>digit (7) is truncated.</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											<p>
+												Ans = s1234 s- indicates a space The left-most sign cannot be replaced
+												by a digit, so the most significant digit (7) is truncated.
+											</p>
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -1234,10 +1196,10 @@
 								<td headers="ep-t5-ri ep-t5-rp" height="15" width="25%">PIC ZZ,999</td>
 								<td headers="ep-t5-ri ep-t5-rr" height="15" width="41%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select27">
-											<option selected value="none">Click arrow for the answer</option>
-											<option value="none">Ans = 12,345</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											Ans = 12,345
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -1249,11 +1211,10 @@
 								<td headers="ep-t5-ri ep-t5-rp" height="16" width="25%">PIC ZZ,999</td>
 								<td headers="ep-t5-ri ep-t5-rr" height="16" width="41%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select23" size="1">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = s1,234</option>
-											<option>s - indicates a space</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											<p>Ans = s1,234 s - indicates a space</p>
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -1265,16 +1226,13 @@
 								<td headers="ep-t5-ri ep-t5-rp" height="16" width="25%">PIC ZZ,999</td>
 								<td headers="ep-t5-ri ep-t5-rr" height="16" width="41%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select23b">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = sss123</option>
-											<option>s - indicates a space</option>
-											<option>Because there are only</option>
-											<option>zeros to the left of the</option>
-											<option>comma, it is replaced by</option>
-											<option>the replacement symbol</option>
-											<option>space.</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											<p>
+												Ans = sss123 s - indicates a space Because there are only zeros to the
+												left of the comma, it is replaced by the replacement symbol space.
+											</p>
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -1286,11 +1244,10 @@
 								<td headers="ep-t5-ri ep-t5-rp" height="16" width="25%">PIC ZZ,999</td>
 								<td headers="ep-t5-ri ep-t5-rr" height="16" width="41%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select23c">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = sss012</option>
-											<option>s - indicates a space</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											<p>Ans = sss012 s - indicates a space</p>
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -1302,10 +1259,10 @@
 								<td headers="ep-t5-ri ep-t5-rp" height="16" width="25%">PIC **,**9</td>
 								<td headers="ep-t5-ri ep-t5-rr" height="16" width="41%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select23d">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = *5,678</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											Ans = *5,678
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -1317,10 +1274,10 @@
 								<td headers="ep-t5-ri ep-t5-rp" height="16" width="25%">PIC **,**9</td>
 								<td headers="ep-t5-ri ep-t5-rr" height="16" width="41%">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select23e">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = ***567</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											Ans = ***567
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -1332,11 +1289,10 @@
 								<td headers="ep-t5-ri ep-t5-rp" height="20" width="25%">PIC **,***</td>
 								<td headers="ep-t5-ri ep-t5-rr" height="20" width="41%" style="vertical-align: top">
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select25">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = ******</option>
-											<option>s- indicates a space</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											<p>Ans = ****** s- indicates a space</p>
+										</details>
 									</div>
 								</td>
 							</tr>
@@ -1356,12 +1312,10 @@
 									style="vertical-align: top"
 								>
 									<div class="center-block">
-										<select aria-label="Click for answer" name="select26">
-											<option selected>Click arrow for the answer</option>
-											<option>Ans = $****43.45</option>
-											<option>Helps to prevent fraud</option>
-											<option>when printing cheques.</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click arrow for the answer</summary>
+											<p>Ans = $****43.45 Helps to prevent fraud when printing cheques.</p>
+										</details>
 									</div>
 								</td>
 							</tr>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -469,18 +469,17 @@ ThreeLevelsDown.
 										Write out what the example program above will display on the screen.
 									</div>
 									<div class="saq-answer">
-										<select aria-label="Click for answer" name="select5" size="1">
-											<option selected>Click the arrow for the answer</option>
-											<option>In TopLevel. Starting to run program</option>
-											<option>&gt;&gt;&gt;&gt; Now in OneLevelDown</option>
-											<option>&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Now in TwoLevelsDown.</option>
-											<option>
-												&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Now in ThreeLevelsDown
-											</option>
-											<option>&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Back in TwoLevelsDown.</option>
-											<option>&gt;&gt;&gt;&gt; Back in OneLevelDown</option>
-											<option>Back in TopLevel.</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click the arrow for the answer</summary>
+											<!-- prettier-ignore -->
+											<pre>In TopLevel. Starting to run program
+&gt;&gt;&gt;&gt; Now in OneLevelDown
+&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Now in TwoLevelsDown.
+&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Now in ThreeLevelsDown
+&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Back in TwoLevelsDown.
+&gt;&gt;&gt;&gt; Back in OneLevelDown
+Back in TopLevel.</pre>
+										</details>
 									</div>
 								</div>
 								<div class="saq-row">
@@ -490,36 +489,28 @@ ThreeLevelsDown.
 										the <code class="language-cobol">STOP RUN</code> is missing.
 									</div>
 									<div class="saq-answer">
-										<select aria-label="Click for answer" name="select6" size="1">
-											<option selected>Click the arrow for the answer</option>
-											<option>With the STOP RUN missing control falls</option>
-											<option>through the paragraphs</option>
-											<option>-------------------------------------------</option>
-											<option>In TopLevel. Starting to run program</option>
-											<option>&gt;&gt;&gt;&gt; Now in OneLevelDown</option>
-											<option>&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Now in TwoLevelsDown.</option>
-											<option>
-												&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Now in ThreeLevelsDown
-											</option>
-											<option>&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Back in TwoLevelsDown.</option>
-											<option>&gt;&gt;&gt;&gt; Back in OneLevelDown</option>
-											<option>Back in TopLevel.</option>
-											<option>&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Now in TwoLevelsDown.</option>
-											<option>
-												&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Now in ThreeLevelsDown
-											</option>
-											<option>&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Back in TwoLevelsDown.</option>
-											<option>&gt;&gt;&gt;&gt; Now in OneLevelDown</option>
-											<option>&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Now in TwoLevelsDown.</option>
-											<option>
-												&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Now in ThreeLevelsDown
-											</option>
-											<option>&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Back in TwoLevelsDown.</option>
-											<option>&gt;&gt;&gt;&gt; Back in OneLevelDown</option>
-											<option>
-												&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Now in ThreeLevelsDown
-											</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click the arrow for the answer</summary>
+											<!-- prettier-ignore -->
+											<pre>With the STOP RUN missing control falls
+through the paragraphs
+In TopLevel. Starting to run program
+&gt;&gt;&gt;&gt; Now in OneLevelDown
+&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Now in TwoLevelsDown.
+&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Now in ThreeLevelsDown
+&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Back in TwoLevelsDown.
+&gt;&gt;&gt;&gt; Back in OneLevelDown
+Back in TopLevel.
+&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Now in TwoLevelsDown.
+&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Now in ThreeLevelsDown
+&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Back in TwoLevelsDown.
+&gt;&gt;&gt;&gt; Now in OneLevelDown
+&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Now in TwoLevelsDown.
+&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Now in ThreeLevelsDown
+&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Back in TwoLevelsDown.
+&gt;&gt;&gt;&gt; Back in OneLevelDown
+&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Now in ThreeLevelsDown</pre>
+										</details>
 									</div>
 								</div>
 								<div class="saq-row">
@@ -530,16 +521,15 @@ ThreeLevelsDown.
 										<i>ThreeLevelsDown</i> into the paragraph ThreeLevelsDown?
 									</div>
 									<div class="saq-answer">
-										<select aria-label="Click for answer" name="select7" size="1">
-											<option selected>Click the arrow for the answer</option>
-											<option>No! This is not valid in standard COBOL.</option>
-											<option>This is recursion.</option>
-											<option>In standard COBOL, if ThreeLevelsDown</option>
-											<option>is performed from another paragraph</option>
-											<option>the recursive perform will cause it to lose</option>
-											<option>the return address that paragraph</option>
-											<option>and control will not be able to return to it.</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click the arrow for the answer</summary>
+											<p>
+												No! This is not valid in standard COBOL. This is recursion. In standard
+												COBOL, if ThreeLevelsDown is performed from another paragraph the
+												recursive perform will cause it to lose the return address that
+												paragraph and control will not be able to return to it.
+											</p>
+										</details>
 									</div>
 								</div>
 								<div class="saq-row">
@@ -550,12 +540,13 @@ ThreeLevelsDown.
 										paragraph ThreeLevelsDown?
 									</div>
 									<div class="saq-answer">
-										<select aria-label="Click for answer" name="select8" size="1">
-											<option selected>Click the arrow for the answer</option>
-											<option>No. This is indirect recursion since</option>
-											<option>TwoLevelsDown contains the statement</option>
-											<option>PERFORM ThreeLevelsDown.</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click the arrow for the answer</summary>
+											<p>
+												No. This is indirect recursion since TwoLevelsDown contains the
+												statement PERFORM ThreeLevelsDown.
+											</p>
+										</details>
 									</div>
 								</div>
 							</div>
@@ -831,21 +822,21 @@ OutOfLineEG.
 					<div class="section-content">
 						<p>Examine the program above and write out what it will display on the screen.</p>
 						<div>
-							<select aria-label="Click for answer" name="select">
-								<option selected>Click the arrow for the answer</option>
-								<option>--------------------------------------------</option>
-								<option>Starting to run program</option>
-								<option>&gt;&gt;&gt;&gt;This is an in line Perform</option>
-								<option>&gt;&gt;&gt;&gt;This is an in line Perform</option>
-								<option>&gt;&gt;&gt;&gt;This is an in line Perform</option>
-								<option>Finished in line Perform</option>
-								<option>&gt;&gt;&gt;&gt; This is an out of line Perform</option>
-								<option>&gt;&gt;&gt;&gt; This is an out of line Perform</option>
-								<option>&gt;&gt;&gt;&gt; This is an out of line Perform</option>
-								<option>&gt;&gt;&gt;&gt; This is an out of line Perform</option>
-								<option>&gt;&gt;&gt;&gt; This is an out of line Perform</option>
-								<option>Back in Begin. About to stop</option>
-							</select>
+							<details class="saq-reveal">
+								<summary>Click the arrow for the answer</summary>
+								<!-- prettier-ignore -->
+								<pre>Starting to run program
+&gt;&gt;&gt;&gt;This is an in line Perform
+&gt;&gt;&gt;&gt;This is an in line Perform
+&gt;&gt;&gt;&gt;This is an in line Perform
+Finished in line Perform
+&gt;&gt;&gt;&gt; This is an out of line Perform
+&gt;&gt;&gt;&gt; This is an out of line Perform
+&gt;&gt;&gt;&gt; This is an out of line Perform
+&gt;&gt;&gt;&gt; This is an out of line Perform
+&gt;&gt;&gt;&gt; This is an out of line Perform
+Back in Begin. About to stop</pre>
+							</details>
 						</div>
 					</div>
 					<div class="section-full">
@@ -1207,15 +1198,13 @@ CountMileage.
 								<div class="saq-label">Q1</div>
 								<div class="saq-question">Why is &gt; 9 used in all the terminating conditions?.</div>
 								<div class="saq-answer">
-									<select aria-label="Click for answer" name="select2" size="1">
-										<option selected>Click the arrow for the answer</option>
-										<option>--------------------------------------------------------</option>
-										<option>If = 9 were used, control would</option>
-										<option>never enter the loop body to</option>
-										<option>display any 9's because the</option>
-										<option>condition is tested before the</option>
-										<option>loop body is entered.</option>
-									</select>
+									<details class="saq-reveal">
+										<summary>Click the arrow for the answer</summary>
+										<p>
+											If = 9 were used, control would never enter the loop body to display any 9's
+											because the condition is tested before the loop body is entered.
+										</p>
+									</details>
 								</div>
 							</div>
 							<div class="saq-row">
@@ -1225,23 +1214,17 @@ CountMileage.
 									Surely the size of each counter should only be one digit?
 								</div>
 								<div class="saq-answer">
-									<select aria-label="Click for answer" name="select2" size="1">
-										<option selected>Click the arrow for the answer</option>
-										<option>--------------------------------------------------------</option>
-										<option>Consider what happens just after</option>
-										<option>UnitsCnt displays the value 9 in</option>
-										<option>the loop body. As control exits</option>
-										<option>the loop the counter is incremented</option>
-										<option>making it =10. If UnitsCnt had been</option>
-										<option>been defined as PIC 9, there would</option>
-										<option>not be enough room for the 2 digits</option>
-										<option>in 10 and the most significant digit</option>
-										<option>would be truncated, leaving the 0.</option>
-										<option>When UnitsCnt was tested by the</option>
-										<option>condition it would be found to</option>
-										<option>contain a 0 and the program</option>
-										<option>would continue to loop interminably.</option>
-									</select>
+									<details class="saq-reveal">
+										<summary>Click the arrow for the answer</summary>
+										<p>
+											Consider what happens just after UnitsCnt displays the value 9 in the loop
+											body. As control exits the loop the counter is incremented making it =10. If
+											UnitsCnt had been been defined as PIC 9, there would not be enough room for
+											the 2 digits in 10 and the most significant digit would be truncated,
+											leaving the 0. When UnitsCnt was tested by the condition it would be found
+											to contain a 0 and the program would continue to loop interminably.
+										</p>
+									</details>
 								</div>
 							</div>
 							<div class="saq-row">
@@ -1251,15 +1234,14 @@ CountMileage.
 									separate Performs?
 								</div>
 								<div class="saq-answer">
-									<select aria-label="Click for answer" name="select2" size="1">
-										<option selected>Click the arrow for the answer</option>
-										<option>--------------------------------------------------------</option>
-										<option>The AFTER phrase can not be</option>
-										<option>used in an in-line PERFORM.</option>
-										<option>So we have to use nested Performs</option>
-										<option>to increment the other counters just</option>
-										<option>as you would in C or Modula-2.</option>
-									</select>
+									<details class="saq-reveal">
+										<summary>Click the arrow for the answer</summary>
+										<p>
+											The AFTER phrase can not be used in an in-line PERFORM. So we have to use
+											nested Performs to increment the other counters just as you would in C or
+											Modula-2.
+										</p>
+									</details>
 								</div>
 							</div>
 						</div>

--- a/course/Resources/css/course-components.css
+++ b/course/Resources/css/course-components.css
@@ -305,6 +305,34 @@ ol.spaced > li + li {
 	vertical-align: top;
 }
 
+.saq-reveal {
+	border: 1px solid var(--color-border-soft);
+	border-radius: 3px;
+	background-color: var(--color-code-bg);
+}
+
+.saq-reveal summary {
+	cursor: pointer;
+	padding: 3px 6px;
+	font-style: italic;
+	list-style: none;
+}
+
+.saq-reveal summary::before {
+	content: "▶ ";
+	font-style: normal;
+	font-size: 0.7em;
+}
+
+details[open].saq-reveal summary::before {
+	content: "▼ ";
+}
+
+.saq-reveal > :not(summary) {
+	padding: 4px 8px;
+	margin: 0;
+}
+
 /* RefMod.html */
 
 .table-scroll {
@@ -453,12 +481,6 @@ ol.spaced > li + li {
 	overflow: hidden;
 }
 
-.qa-form .qa-answer select {
-	max-width: 100%;
-	width: 100%;
-	box-sizing: border-box;
-}
-
 /* SortMerge.html */
 
 .spec-block {
@@ -562,12 +584,6 @@ body pre[class*="language-"] {
 
 	.saq-question {
 		border-right: none;
-	}
-
-	.saq-answer select {
-		max-width: 100%;
-		width: 100%;
-		box-sizing: border-box;
 	}
 
 	.processing-template {

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -731,10 +731,10 @@ END-IF
 								<td width="13%" style="text-align: center">15</td>
 								<td width="12%" style="text-align: center">14</td>
 								<td bgcolor="#E1FFE1" width="49%" style="text-align: center">
-									<select aria-label="Click for answer" name="select">
-										<option selected>Click arrow for answer</option>
-										<option>First is displayed</option>
-									</select>
+									<details class="saq-reveal">
+										<summary>Click arrow for answer</summary>
+										First is displayed
+									</details>
 								</td>
 							</tr>
 							<tr>
@@ -743,10 +743,10 @@ END-IF
 								<td width="13%" style="text-align: center">15</td>
 								<td width="12%" style="text-align: center">15</td>
 								<td bgcolor="#E1FFE1" width="49%" style="text-align: center">
-									<select aria-label="Click for answer" name="select2">
-										<option selected>Click arrow for answer</option>
-										<option>Second is displayed</option>
-									</select>
+									<details class="saq-reveal">
+										<summary>Click arrow for answer</summary>
+										Second is displayed
+									</details>
 								</td>
 							</tr>
 							<tr>
@@ -755,10 +755,10 @@ END-IF
 								<td width="13%" style="text-align: center">3</td>
 								<td width="12%" style="text-align: center">14</td>
 								<td bgcolor="#E1FFE1" width="49%" style="text-align: center">
-									<select aria-label="Click for answer" name="select3">
-										<option selected>Click arrow for answer</option>
-										<option>Third is displayed</option>
-									</select>
+									<details class="saq-reveal">
+										<summary>Click arrow for answer</summary>
+										Third is displayed
+									</details>
 								</td>
 							</tr>
 							<tr>
@@ -767,10 +767,10 @@ END-IF
 								<td width="13%" style="text-align: center">15</td>
 								<td width="12%" style="text-align: center">14</td>
 								<td bgcolor="#E1FFE1" width="49%" style="text-align: center">
-									<select aria-label="Click for answer" name="select4">
-										<option selected>Click arrow for answer</option>
-										<option>Third is displayed</option>
-									</select>
+									<details class="saq-reveal">
+										<summary>Click arrow for answer</summary>
+										Third is displayed
+									</details>
 								</td>
 							</tr>
 						</table>

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -416,18 +416,15 @@ END-PERFORM
 									would it mean if the keys were equal?
 								</div>
 								<div class="qa-answer">
-									<select aria-label="Click for answer" name="select" size="1">
-										<option selected>Click the arrow for the answer</option>
-										<option>---------------------------------------------------------------</option>
-										<option>Since the key field is supposed to</option>
-										<option>be unique this would be a transaction</option>
-										<option>error. It would mean that we were trying</option>
-										<option>to insert a record when a record with</option>
-										<option>that key already exists.</option>
-										<option>Of course, transaction errors do occur</option>
-										<option>so you might want to include code</option>
-										<option>to handle these errors.</option>
-									</select>
+									<details class="saq-reveal">
+										<summary>Click the arrow for the answer</summary>
+										<p>
+											Since the key field is supposed to be unique this would be a transaction
+											error. It would mean that we were trying to insert a record when a record
+											with that key already exists. Of course, transaction errors do occur so you
+											might want to include code to handle these errors.
+										</p>
+									</details>
 								</div>
 							</div>
 							<div class="qa-row">
@@ -437,14 +434,13 @@ END-PERFORM
 									to terminate the loop?
 								</div>
 								<div class="qa-answer">
-									<select aria-label="Click for answer" name="select" size="1">
-										<option selected>Click the arrow for the answer</option>
-										<option>---------------------------------------------------------------</option>
-										<option>Since we don't know which file is going</option>
-										<option>to be exhausted first we have to use</option>
-										<option>a condition which says - keep going</option>
-										<option>until the end of both files is reached.</option>
-									</select>
+									<details class="saq-reveal">
+										<summary>Click the arrow for the answer</summary>
+										<p>
+											Since we don't know which file is going to be exhausted first we have to use
+											a condition which says - keep going until the end of both files is reached.
+										</p>
+									</details>
 								</div>
 							</div>
 							<div class="qa-row">
@@ -454,23 +450,18 @@ END-PERFORM
 									one file ends before the other. Can the code above be correct?
 								</div>
 								<div class="qa-answer">
-									<select aria-label="Click for answer" name="select" size="1">
-										<option selected>Click the arrow for the answer</option>
-										<option>---------------------------------------------------------------</option>
-										<option>Yes the code is correct!!!</option>
-										<option>It takes advantage of the fact that</option>
-										<option>when either condition name is set to</option>
-										<option>true, the corresponding record</option>
-										<option>(including its key field) is filled with</option>
-										<option>HIGH-VALUES. Since the key field of</option>
-										<option>the ended file contains the highest</option>
-										<option>possible value, all the keys in the</option>
-										<option>other file will be less than it and so</option>
-										<option>all the remaining records in that file will</option>
-										<option>automatically be written to the new file.</option>
-										<option>I told you using HIGH-VALUES would</option>
-										<option>come in handy.</option>
-									</select>
+									<details class="saq-reveal">
+										<summary>Click the arrow for the answer</summary>
+										<p>
+											Yes the code is correct!!! It takes advantage of the fact that when either
+											condition name is set to true, the corresponding record (including its key
+											field) is filled with HIGH-VALUES. Since the key field of the ended file
+											contains the highest possible value, all the keys in the other file will be
+											less than it and so all the remaining records in that file will
+											automatically be written to the new file. I told you using HIGH-VALUES would
+											come in handy.
+										</p>
+									</details>
 								</div>
 							</div>
 						</div>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -360,14 +360,10 @@
 										executed?
 									</td>
 									<td width="30%" style="vertical-align: top">
-										<select aria-label="Click for answer" name="select5" size="1">
-											<option selected>Click the arrow for the answer</option>
-											<option>
-												-----------------------------------------------------------------
-											</option>
-											<option>Every element of the table is filled with</option>
-											<option>zeros.</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click the arrow for the answer</summary>
+											<p>Every element of the table is filled with zeros.</p>
+										</details>
 									</td>
 								</tr>
 								<tr>
@@ -378,14 +374,10 @@
 										executed?
 									</td>
 									<td width="30%" style="vertical-align: top">
-										<select aria-label="Click for answer" name="select6" size="1">
-											<option selected>Click the arrow for the answer</option>
-											<option>
-												-----------------------------------------------------------------
-											</option>
-											<option>The value 456 is moved into the fifth</option>
-											<option>element of the DeptTotalsTable</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click the arrow for the answer</summary>
+											<p>The value 456 is moved into the fifth element of the DeptTotalsTable</p>
+										</details>
 									</td>
 								</tr>
 								<tr>
@@ -395,29 +387,23 @@
 										VATRateTable?
 									</td>
 									<td width="30%" style="vertical-align: top">
-										<select aria-label="Click for answer" name="select7" size="1">
-											<option selected>Click the arrow for the answer</option>
-											<option>
-												-----------------------------------------------------------------
-											</option>
-											<option>DISPLAY VATRate(2)</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click the arrow for the answer</summary>
+											DISPLAY VATRate(2)
+										</details>
 									</td>
 								</tr>
 								<tr>
 									<td bgcolor="#FFFFCC" width="8%">Q4</td>
 									<td width="62%">What is the purpose of the level 88 attached to the RatesTable?</td>
 									<td width="30%" style="vertical-align: top">
-										<select aria-label="Click for answer" name="select8" size="1">
-											<option selected>Click the arrow for the answer</option>
-											<option>
-												-----------------------------------------------------------------
-											</option>
-											<option>The TableNotPrimed condition name is</option>
-											<option>true is the whole table contains zeros i.e.</option>
-											<option>has not yet been filled with the exchange</option>
-											<option>rates.</option>
-										</select>
+										<details class="saq-reveal">
+											<summary>Click the arrow for the answer</summary>
+											<p>
+												The TableNotPrimed condition name is true is the whole table contains
+												zeros i.e. has not yet been filled with the exchange rates.
+											</p>
+										</details>
 									</td>
 								</tr>
 							</table>
@@ -565,17 +551,15 @@ MOVE ZEROS TO CountyTaxTable</code></pre>
       03 PayerCount  PIC 9(7)OCCURS 26 TIMES.
 </code></pre>
 						<div class="center-block">
-							<select aria-label="Click for answer" name="select" size="1">
-								<option selected>Click the arrow for the answer</option>
-								<option>
-									------------------------------------------------------------------------------------------------------------------------
-								</option>
-								<option>CountyTaxTable1 is a table where each element is a group item that is</option>
-								<option>divided into the items CountyTax and PayerCount.</option>
-								<option>In CountyTaxTable2, CountyTax and PayerCount are two separate tables.</option>
-								<option>CountyTaxDetails and CountTaxTable2 are group items that contain</option>
-								<option>these two tables.</option>
-							</select>
+							<details class="saq-reveal">
+								<summary>Click the arrow for the answer</summary>
+								<p>
+									CountyTaxTable1 is a table where each element is a group item that is divided into
+									the items CountyTax and PayerCount. In CountyTaxTable2, CountyTax and PayerCount are
+									two separate tables. CountyTaxDetails and CountTaxTable2 are group items that
+									contain these two tables.
+								</p>
+							</details>
 						</div>
 						<hr size="1" />
 					</div>

--- a/scripts/convert-saq-selects.js
+++ b/scripts/convert-saq-selects.js
@@ -16,8 +16,7 @@ const FILES = [
 
 // Match a <select aria-label="Click for answer" ...> ... </select> block,
 // preceded by optional whitespace on the same line (to recover indentation).
-const SELECT_RE =
-	/([ \t]*)(<select\s+aria-label="Click for answer"[^>]*>([\s\S]*?)<\/select>)/g;
+const SELECT_RE = /([ \t]*)(<select\s+aria-label="Click for answer"[^>]*>([\s\S]*?)<\/select>)/g;
 
 // Match individual <option> elements (content may span lines).
 const OPTION_RE = /<option([^>]*)>([\s\S]*?)<\/option>/g;

--- a/scripts/convert-saq-selects.js
+++ b/scripts/convert-saq-selects.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// Converts SAQ <select aria-label="Click for answer"> widgets to <details>/<summary>.
+// Run once from the repo root: node scripts/convert-saq-selects.js
+
+"use strict";
+
+const fs = require("fs");
+
+const FILES = [
+	"course/EditedPics.html",
+	"course/Iteration.html",
+	"course/Selection.html",
+	"course/Tables2.html",
+	"course/SequentialFiles2.html",
+];
+
+// Match a <select aria-label="Click for answer" ...> ... </select> block,
+// preceded by optional whitespace on the same line (to recover indentation).
+const SELECT_RE =
+	/([ \t]*)(<select\s+aria-label="Click for answer"[^>]*>([\s\S]*?)<\/select>)/g;
+
+// Match individual <option> elements (content may span lines).
+const OPTION_RE = /<option([^>]*)>([\s\S]*?)<\/option>/g;
+
+// Lines that are purely decorative separators ("-" repeated, possibly with spaces).
+const SEPARATOR_RE = /^[-\s]+$/;
+
+function convertFile(filePath) {
+	const original = fs.readFileSync(filePath, "utf8");
+	let count = 0;
+
+	const converted = original.replace(SELECT_RE, (match, indent, _full, optionsHtml) => {
+		const options = [];
+		let m;
+		OPTION_RE.lastIndex = 0;
+		while ((m = OPTION_RE.exec(optionsHtml)) !== null) {
+			const attrs = m[1];
+			const text = m[2].trim();
+			options.push({ selected: /selected/.test(attrs), text });
+		}
+		if (options.length === 0) return match;
+
+		const prompt = (options.find((o) => o.selected) ?? options[0]).text;
+
+		const answerLines = options
+			.filter((o) => !o.selected)
+			.map((o) => o.text)
+			.filter((t) => !SEPARATOR_RE.test(t));
+
+		if (answerLines.length === 0) return match;
+
+		// Detect COBOL output-trace content (lines starting with &gt; entities).
+		const isTrace = answerLines.some((l) => l.startsWith("&gt;"));
+
+		let answerContent;
+		if (isTrace) {
+			// prettier-ignore comments prevent prettier from adding a leading newline
+			// inside the <pre> tag, which would render as a blank first line.
+			answerContent = `<!-- prettier-ignore --><pre>${answerLines.join("\n")}</pre>`;
+		} else if (answerLines.length === 1) {
+			answerContent = answerLines[0];
+		} else {
+			// Prose that was word-wrapped across options — join into one paragraph.
+			answerContent = `<p>${answerLines.join(" ")}</p>`;
+		}
+
+		count++;
+		const i = `${indent}\t`;
+		return `${indent}<details class="saq-reveal">\n${i}<summary>${prompt}</summary>\n${i}${answerContent}\n${indent}</details>`;
+	});
+
+	if (count > 0) {
+		fs.writeFileSync(filePath, converted, "utf8");
+		console.log(`  ${filePath}: converted ${count} SAQ widget(s)`);
+	} else {
+		console.log(`  ${filePath}: no SAQ widgets found`);
+	}
+}
+
+console.log("Converting SAQ <select> widgets to <details>/<summary>…");
+for (const f of FILES) convertFile(f);
+console.log("Done.");


### PR DESCRIPTION
Closes #262.

## What changed

Replaced all 60 SAQ `<select aria-label="Click for answer">` hide/reveal widgets across five lesson files with semantic `<details>`/`<summary>` elements:

| File | Count |
|---|---|
| `course/EditedPics.html` | 40 |
| `course/Iteration.html` | 8 |
| `course/Selection.html` | 4 |
| `course/Tables2.html` | 5 |
| `course/SequentialFiles2.html` | 3 |

**Answer rendering strategy:**
- Single-line answers → plain text inside `<details>`
- Multi-option prose answers (text was split across options to fit the narrow select) → joined into `<p>`
- COBOL output traces (options containing `>>>>` markers) → `<pre>` with `<!-- prettier-ignore -->` to prevent a leading blank line from prettier's formatting

**CSS (`course-components.css`):**
- Added `.saq-reveal` styles: chevron (`▶`/`▼`) on `<summary>`, themed border (`var(--color-border-soft)`), `var(--color-code-bg)` background, padding on the revealed content
- Removed the now-dead `.qa-form .qa-answer select` and `.saq-answer select` rules

**`scripts/convert-saq-selects.js`:** one-shot Node script included for auditability. Not wired into any npm script.

## Verification

- `html-validate` — clean on all five converted files
- `pa11y-ci` — 29/29 URLs passed (WCAG2AA)
- Visual spot-check: open/closed chevron states, prose `<p>` flow, `<pre>` trace indentation, single-line table-cell answers all confirmed rendering correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)