### PR TITLE
feat: add per-page SEO metadata to all 165 leaf content pages

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -11,6 +11,27 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Introduction to COBOL</title>
+		<meta
+			name="description"
+			content="To provide a brief introduction to the programming language COBOL. To provide a context in which its uses might be understood. To introduce the"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/COBOLIntro.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/COBOLIntro.html" />
+		<meta property="og:title" content="Introduction to COBOL" />
+		<meta
+			property="og:description"
+			content="To provide a brief introduction to the programming language COBOL. To provide a context in which its uses might be understood. To introduce the"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Introduction to COBOL" />
+		<meta
+			name="twitter:description"
+			content="To provide a brief introduction to the programming language COBOL. To provide a context in which its uses might be understood. To introduce the"
+		/>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -11,6 +11,27 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Basic Procedure Division commands</title>
+		<meta
+			name="description"
+			content="The PROCEDURE DIVISION contains the code used to manipulate the data described in the DATA DIVISION . This tutorial examines some of the basic COBOL"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/COBOLcommands.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/COBOLcommands.html" />
+		<meta property="og:title" content="Basic Procedure Division commands" />
+		<meta
+			property="og:description"
+			content="The PROCEDURE DIVISION contains the code used to manipulate the data described in the DATA DIVISION . This tutorial examines some of the basic COBOL"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Basic Procedure Division commands" />
+		<meta
+			name="twitter:description"
+			content="The PROCEDURE DIVISION contains the code used to manipulate the data described in the DATA DIVISION . This tutorial examines some of the basic COBOL"
+		/>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -11,6 +11,18 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>The COPY verb</title>
+		<meta name="description" content="COBOL programming lesson on The COPY verb." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Copy.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/Copy.html" />
+		<meta property="og:title" content="The COPY verb" />
+		<meta property="og:description" content="COBOL programming lesson on The COPY verb." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="The COPY verb" />
+		<meta name="twitter:description" content="COBOL programming lesson on The COPY verb." />
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -11,6 +11,27 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Declaring Data in COBOL</title>
+		<meta
+			name="description"
+			content="The aim of this unit is to give you an understanding of the different categories of data used in a COBOL program and to demonstrate how items of each"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/DataDeclaration.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/DataDeclaration.html" />
+		<meta property="og:title" content="Declaring Data in COBOL" />
+		<meta
+			property="og:description"
+			content="The aim of this unit is to give you an understanding of the different categories of data used in a COBOL program and to demonstrate how items of each"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Declaring Data in COBOL" />
+		<meta
+			name="twitter:description"
+			content="The aim of this unit is to give you an understanding of the different categories of data used in a COBOL program and to demonstrate how items of each"
+		/>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -11,6 +11,27 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Edited Pictures</title>
+		<meta
+			name="description"
+			content="In a business-programming environment, the ability to print reports is an important property for a programming language. COBOL allows programmers to write"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/EditedPics.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/EditedPics.html" />
+		<meta property="og:title" content="Edited Pictures" />
+		<meta
+			property="og:description"
+			content="In a business-programming environment, the ability to print reports is an important property for a programming language. COBOL allows programmers to write"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Edited Pictures" />
+		<meta
+			name="twitter:description"
+			content="In a business-programming environment, the ability to print reports is an important property for a programming language. COBOL allows programmers to write"
+		/>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -11,6 +11,27 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Indexed Files</title>
+		<meta
+			name="description"
+			content="The aim of this unit is to provide you with a solid understanding of; the organization of Indexed files, the declarations required for them and the"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/IndexedFiles.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/IndexedFiles.html" />
+		<meta property="og:title" content="Indexed Files" />
+		<meta
+			property="og:description"
+			content="The aim of this unit is to provide you with a solid understanding of; the organization of Indexed files, the declarations required for them and the"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Indexed Files" />
+		<meta
+			name="twitter:description"
+			content="The aim of this unit is to provide you with a solid understanding of; the organization of Indexed files, the declarations required for them and the"
+		/>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -11,6 +11,27 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>The INSPECT verb</title>
+		<meta
+			name="description"
+			content="Many programming languages rely on library functions for string handling. COBOL too, uses Intrinsic Functions for some tasks but most string manipulation"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Inspect.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/Inspect.html" />
+		<meta property="og:title" content="The INSPECT verb" />
+		<meta
+			property="og:description"
+			content="Many programming languages rely on library functions for string handling. COBOL too, uses Intrinsic Functions for some tasks but most string manipulation"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="The INSPECT verb" />
+		<meta
+			name="twitter:description"
+			content="Many programming languages rely on library functions for string handling. COBOL too, uses Intrinsic Functions for some tasks but most string manipulation"
+		/>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -11,6 +11,30 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Introduction to Direct Access Files</title>
+		<meta
+			name="description"
+			content="The aim of this unit is to provide a gentle introduction to COBOL's direct access file organizations and to equip you with a knowledge of the advantages"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Intro2DirectAccess.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Intro2DirectAccess.html"
+		/>
+		<meta property="og:title" content="Introduction to Direct Access Files" />
+		<meta
+			property="og:description"
+			content="The aim of this unit is to provide a gentle introduction to COBOL's direct access file organizations and to equip you with a knowledge of the advantages"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Introduction to Direct Access Files" />
+		<meta
+			name="twitter:description"
+			content="The aim of this unit is to provide a gentle introduction to COBOL's direct access file organizations and to equip you with a knowledge of the advantages"
+		/>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -26,6 +26,27 @@
 			}
 		</script>
 		<title>COBOL Iteration Constructs</title>
+		<meta
+			name="description"
+			content="In almost every programming job, there is some task that needs to be done over and over again. For example: The job of processing a file of records is an"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Iteration.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/Iteration.html" />
+		<meta property="og:title" content="COBOL Iteration Constructs" />
+		<meta
+			property="og:description"
+			content="In almost every programming job, there is some task that needs to be done over and over again. For example: The job of processing a file of records is an"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="COBOL Iteration Constructs" />
+		<meta
+			name="twitter:description"
+			content="In almost every programming job, there is some task that needs to be done over and over again. For example: The job of processing a file of records is an"
+		/>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -11,6 +11,27 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Reference Modification</title>
+		<meta
+			name="description"
+			content="The aim of this unit is to provide to provide you with a solid understanding of string manipulation using Reference Modification. It will also introduce"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/RefMod.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/RefMod.html" />
+		<meta property="og:title" content="Reference Modification" />
+		<meta
+			property="og:description"
+			content="The aim of this unit is to provide to provide you with a solid understanding of string manipulation using Reference Modification. It will also introduce"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Reference Modification" />
+		<meta
+			name="twitter:description"
+			content="The aim of this unit is to provide to provide you with a solid understanding of string manipulation using Reference Modification. It will also introduce"
+		/>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -11,6 +11,27 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Relative Files</title>
+		<meta
+			name="description"
+			content="The aim of this unit is to provide you with a solid understanding of declarations required for Relative files and the Procedure Division verbs used to"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/RelativeFiles.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/RelativeFiles.html" />
+		<meta property="og:title" content="Relative Files" />
+		<meta
+			property="og:description"
+			content="The aim of this unit is to provide you with a solid understanding of declarations required for Relative files and the Procedure Division verbs used to"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Relative Files" />
+		<meta
+			name="twitter:description"
+			content="The aim of this unit is to provide you with a solid understanding of declarations required for Relative files and the Procedure Division verbs used to"
+		/>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -11,6 +11,27 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>COBOL Report Writer</title>
+		<meta
+			name="description"
+			content="The aim of this unit is to provide you with a solid understanding of COBOL Report Writer. This unit introduces the report writer by -"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/ReportWriter.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/ReportWriter.html" />
+		<meta property="og:title" content="COBOL Report Writer" />
+		<meta
+			property="og:description"
+			content="The aim of this unit is to provide you with a solid understanding of COBOL Report Writer. This unit introduces the report writer by -"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="COBOL Report Writer" />
+		<meta
+			name="twitter:description"
+			content="The aim of this unit is to provide you with a solid understanding of COBOL Report Writer. This unit introduces the report writer by -"
+		/>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -11,6 +11,27 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>COBOL Report Writer - Syntax and Semantics</title>
+		<meta
+			name="description"
+			content="The unit provides a Report Writer reference. The syntax elements of the Report Writer are presented and the semantics of their operation discussed."
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/ReportWriterSS.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/ReportWriterSS.html" />
+		<meta property="og:title" content="COBOL Report Writer - Syntax and Semantics" />
+		<meta
+			property="og:description"
+			content="The unit provides a Report Writer reference. The syntax elements of the Report Writer are presented and the semantics of their operation discussed."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="COBOL Report Writer - Syntax and Semantics" />
+		<meta
+			name="twitter:description"
+			content="The unit provides a Report Writer reference. The syntax elements of the Report Writer are presented and the semantics of their operation discussed."
+		/>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/Resources/pdf-viewer.html
+++ b/course/Resources/pdf-viewer.html
@@ -4,6 +4,21 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta charset="utf-8" />
 		<title>PDF slide viewer</title>
+		<meta name="description" content="COBOL programming lesson on PDF slide viewer." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Resources/pdf-viewer.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/pdf-viewer.html"
+		/>
+		<meta property="og:title" content="PDF slide viewer" />
+		<meta property="og:description" content="COBOL programming lesson on PDF slide viewer." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="PDF slide viewer" />
+		<meta name="twitter:description" content="COBOL programming lesson on PDF slide viewer." />
 
 		<style>
 			html,

--- a/course/Resources/ppz/TC-Call.html
+++ b/course/Resources/ppz/TC-Call.html
@@ -3,6 +3,21 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-Call - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-Call." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Call.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Call.html"
+		/>
+		<meta property="og:title" content="TC-Call - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-Call." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-Call - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-Call." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Resources/ppz/TC-CobIntro1.html
+++ b/course/Resources/ppz/TC-CobIntro1.html
@@ -3,6 +3,24 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-CobIntro1 - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-CobIntro1." />
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro1.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro1.html"
+		/>
+		<meta property="og:title" content="TC-CobIntro1 - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-CobIntro1." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-CobIntro1 - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-CobIntro1." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Resources/ppz/TC-CobIntro2.html
+++ b/course/Resources/ppz/TC-CobIntro2.html
@@ -3,6 +3,24 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-CobIntro2 - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-CobIntro2." />
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro2.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro2.html"
+		/>
+		<meta property="og:title" content="TC-CobIntro2 - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-CobIntro2." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-CobIntro2 - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-CobIntro2." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Resources/ppz/TC-CobIntro3.html
+++ b/course/Resources/ppz/TC-CobIntro3.html
@@ -3,6 +3,24 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-CobIntro3 - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-CobIntro3." />
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro3.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro3.html"
+		/>
+		<meta property="og:title" content="TC-CobIntro3 - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-CobIntro3." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-CobIntro3 - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-CobIntro3." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Resources/ppz/TC-CobIntro4.html
+++ b/course/Resources/ppz/TC-CobIntro4.html
@@ -3,6 +3,24 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-CobIntro4 - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-CobIntro4." />
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro4.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro4.html"
+		/>
+		<meta property="og:title" content="TC-CobIntro4 - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-CobIntro4." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-CobIntro4 - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-CobIntro4." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Resources/ppz/TC-CobIntro5.html
+++ b/course/Resources/ppz/TC-CobIntro5.html
@@ -3,6 +3,24 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-CobIntro5 - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-CobIntro5." />
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro5.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro5.html"
+		/>
+		<meta property="og:title" content="TC-CobIntro5 - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-CobIntro5." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-CobIntro5 - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-CobIntro5." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Resources/ppz/TC-CobIntro6.html
+++ b/course/Resources/ppz/TC-CobIntro6.html
@@ -3,6 +3,24 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-CobIntro6 - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-CobIntro6." />
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro6.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro6.html"
+		/>
+		<meta property="og:title" content="TC-CobIntro6 - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-CobIntro6." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-CobIntro6 - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-CobIntro6." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Resources/ppz/TC-Commands1.html
+++ b/course/Resources/ppz/TC-Commands1.html
@@ -3,6 +3,24 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-Commands1 - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-Commands1." />
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Commands1.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Commands1.html"
+		/>
+		<meta property="og:title" content="TC-Commands1 - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-Commands1." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-Commands1 - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-Commands1." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Resources/ppz/TC-Commands2.html
+++ b/course/Resources/ppz/TC-Commands2.html
@@ -3,6 +3,24 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-Commands2 - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-Commands2." />
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Commands2.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Commands2.html"
+		/>
+		<meta property="og:title" content="TC-Commands2 - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-Commands2." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-Commands2 - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-Commands2." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Resources/ppz/TC-Condition1.html
+++ b/course/Resources/ppz/TC-Condition1.html
@@ -3,6 +3,24 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-Condition1 - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-Condition1." />
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Condition1.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Condition1.html"
+		/>
+		<meta property="og:title" content="TC-Condition1 - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-Condition1." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-Condition1 - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-Condition1." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Resources/ppz/TC-Condition2.html
+++ b/course/Resources/ppz/TC-Condition2.html
@@ -3,6 +3,24 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-Condition2 - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-Condition2." />
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Condition2.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Condition2.html"
+		/>
+		<meta property="og:title" content="TC-Condition2 - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-Condition2." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-Condition2 - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-Condition2." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Resources/ppz/TC-Data1.html
+++ b/course/Resources/ppz/TC-Data1.html
@@ -3,6 +3,21 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-Data1 - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-Data1." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Data1.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Data1.html"
+		/>
+		<meta property="og:title" content="TC-Data1 - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-Data1." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-Data1 - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-Data1." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Resources/ppz/TC-Data2.html
+++ b/course/Resources/ppz/TC-Data2.html
@@ -3,6 +3,21 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-Data2 - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-Data2." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Data2.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Data2.html"
+		/>
+		<meta property="og:title" content="TC-Data2 - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-Data2." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-Data2 - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-Data2." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Resources/ppz/TC-Perform1.html
+++ b/course/Resources/ppz/TC-Perform1.html
@@ -3,6 +3,24 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-Perform1 - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-Perform1." />
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Perform1.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Perform1.html"
+		/>
+		<meta property="og:title" content="TC-Perform1 - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-Perform1." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-Perform1 - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-Perform1." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Resources/ppz/TC-Perform2.html
+++ b/course/Resources/ppz/TC-Perform2.html
@@ -3,6 +3,24 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-Perform2 - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-Perform2." />
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Perform2.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Perform2.html"
+		/>
+		<meta property="og:title" content="TC-Perform2 - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-Perform2." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-Perform2 - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-Perform2." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Resources/ppz/TC-Search2.html
+++ b/course/Resources/ppz/TC-Search2.html
@@ -3,6 +3,24 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-Search2 - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-Search2." />
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Search2.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Search2.html"
+		/>
+		<meta property="og:title" content="TC-Search2 - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-Search2." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-Search2 - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-Search2." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Resources/ppz/TC-SeqFile1.html
+++ b/course/Resources/ppz/TC-SeqFile1.html
@@ -3,6 +3,24 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-SeqFile1 - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-SeqFile1." />
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile1.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile1.html"
+		/>
+		<meta property="og:title" content="TC-SeqFile1 - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-SeqFile1." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-SeqFile1 - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-SeqFile1." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Resources/ppz/TC-SeqFile2a.html
+++ b/course/Resources/ppz/TC-SeqFile2a.html
@@ -3,6 +3,24 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-SeqFile2a - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-SeqFile2a." />
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2a.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2a.html"
+		/>
+		<meta property="og:title" content="TC-SeqFile2a - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-SeqFile2a." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-SeqFile2a - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-SeqFile2a." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Resources/ppz/TC-SeqFile2b.html
+++ b/course/Resources/ppz/TC-SeqFile2b.html
@@ -3,6 +3,24 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-SeqFile2b - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-SeqFile2b." />
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2b.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2b.html"
+		/>
+		<meta property="og:title" content="TC-SeqFile2b - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-SeqFile2b." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-SeqFile2b - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-SeqFile2b." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Resources/ppz/TC-SeqFile2c.html
+++ b/course/Resources/ppz/TC-SeqFile2c.html
@@ -3,6 +3,24 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-SeqFile2c - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-SeqFile2c." />
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2c.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2c.html"
+		/>
+		<meta property="og:title" content="TC-SeqFile2c - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-SeqFile2c." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-SeqFile2c - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-SeqFile2c." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Resources/ppz/TC-SeqFile2d.html
+++ b/course/Resources/ppz/TC-SeqFile2d.html
@@ -3,6 +3,24 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-SeqFile2d - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-SeqFile2d." />
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2d.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2d.html"
+		/>
+		<meta property="og:title" content="TC-SeqFile2d - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-SeqFile2d." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-SeqFile2d - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-SeqFile2d." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Resources/ppz/TC-SeqFile2e.html
+++ b/course/Resources/ppz/TC-SeqFile2e.html
@@ -3,6 +3,24 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-SeqFile2e - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-SeqFile2e." />
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2e.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2e.html"
+		/>
+		<meta property="og:title" content="TC-SeqFile2e - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-SeqFile2e." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-SeqFile2e - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-SeqFile2e." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Resources/ppz/TC-SeqFile3a.html
+++ b/course/Resources/ppz/TC-SeqFile3a.html
@@ -3,6 +3,24 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-SeqFile3a - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-SeqFile3a." />
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile3a.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile3a.html"
+		/>
+		<meta property="og:title" content="TC-SeqFile3a - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-SeqFile3a." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-SeqFile3a - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-SeqFile3a." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Resources/ppz/TC-Tables1.html
+++ b/course/Resources/ppz/TC-Tables1.html
@@ -3,6 +3,24 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-Tables1 - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-Tables1." />
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables1.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables1.html"
+		/>
+		<meta property="og:title" content="TC-Tables1 - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-Tables1." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-Tables1 - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-Tables1." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Resources/ppz/TC-Tables2.html
+++ b/course/Resources/ppz/TC-Tables2.html
@@ -3,6 +3,24 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-Tables2 - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-Tables2." />
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables2.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables2.html"
+		/>
+		<meta property="og:title" content="TC-Tables2 - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-Tables2." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-Tables2 - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-Tables2." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Resources/ppz/TC-Tables3.html
+++ b/course/Resources/ppz/TC-Tables3.html
@@ -3,6 +3,24 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-Tables3 - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-Tables3." />
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables3.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables3.html"
+		/>
+		<meta property="og:title" content="TC-Tables3 - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-Tables3." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-Tables3 - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-Tables3." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Resources/ppz/TC-Tables4.html
+++ b/course/Resources/ppz/TC-Tables4.html
@@ -3,6 +3,24 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-Tables4 - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-Tables4." />
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables4.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables4.html"
+		/>
+		<meta property="og:title" content="TC-Tables4 - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-Tables4." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-Tables4 - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-Tables4." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Resources/ppz/TC-Tables5.html
+++ b/course/Resources/ppz/TC-Tables5.html
@@ -3,6 +3,24 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-Tables5 - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-Tables5." />
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables5.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables5.html"
+		/>
+		<meta property="og:title" content="TC-Tables5 - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-Tables5." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-Tables5 - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-Tables5." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Resources/ppz/TC-Tables7.html
+++ b/course/Resources/ppz/TC-Tables7.html
@@ -3,6 +3,24 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-Tables7 - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-Tables7." />
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables7.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables7.html"
+		/>
+		<meta property="og:title" content="TC-Tables7 - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-Tables7." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-Tables7 - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-Tables7." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Resources/ppz/TC-Tables8.html
+++ b/course/Resources/ppz/TC-Tables8.html
@@ -3,6 +3,24 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>TC-Tables8 - COBOL Course Animation</title>
+		<meta name="description" content="COBOL programming lesson on TC-Tables8." />
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables8.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables8.html"
+		/>
+		<meta property="og:title" content="TC-Tables8 - COBOL Course Animation" />
+		<meta property="og:description" content="COBOL programming lesson on TC-Tables8." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TC-Tables8 - COBOL Course Animation" />
+		<meta name="twitter:description" content="COBOL programming lesson on TC-Tables8." />
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe

--- a/course/Search.html
+++ b/course/Search.html
@@ -11,6 +11,27 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Searching Tables</title>
+		<meta
+			name="description"
+			content="The task of searching a table to determine whether it contains a particular value is a common operation. The method used to search a table depends heavily"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Search.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/Search.html" />
+		<meta property="og:title" content="Searching Tables" />
+		<meta
+			property="og:description"
+			content="The task of searching a table to determine whether it contains a particular value is a common operation. The method used to search a table depends heavily"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Searching Tables" />
+		<meta
+			name="twitter:description"
+			content="The task of searching a table to determine whether it contains a particular value is a common operation. The method used to search a table depends heavily"
+		/>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -11,6 +11,27 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>COBOL Selection Constructs</title>
+		<meta
+			name="description"
+			content="In most procedural languages, If and Case/Switch are the only selection constructs supported. COBOL supports advanced versions of both of these constructs,"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Selection.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/Selection.html" />
+		<meta property="og:title" content="COBOL Selection Constructs" />
+		<meta
+			property="og:description"
+			content="In most procedural languages, If and Case/Switch are the only selection constructs supported. COBOL supports advanced versions of both of these constructs,"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="COBOL Selection Constructs" />
+		<meta
+			name="twitter:description"
+			content="In most procedural languages, If and Case/Switch are the only selection constructs supported. COBOL supports advanced versions of both of these constructs,"
+		/>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -11,6 +11,27 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Introduction to Sequential Files</title>
+		<meta
+			name="description"
+			content="Files are repositories of data that reside on backing storage (hard disk, magnetic tape or CD-ROM). Nowadays, files are used to store a variety of"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles1.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles1.html" />
+		<meta property="og:title" content="Introduction to Sequential Files" />
+		<meta
+			property="og:description"
+			content="Files are repositories of data that reside on backing storage (hard disk, magnetic tape or CD-ROM). Nowadays, files are used to store a variety of"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Introduction to Sequential Files" />
+		<meta
+			name="twitter:description"
+			content="Files are repositories of data that reside on backing storage (hard disk, magnetic tape or CD-ROM). Nowadays, files are used to store a variety of"
+		/>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -11,6 +11,27 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Processing Sequential Files</title>
+		<meta
+			name="description"
+			content="The records in a Sequential file are organized serially, one after another, but the records in the file may be ordered or unordered. The serial"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles2.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles2.html" />
+		<meta property="og:title" content="Processing Sequential Files" />
+		<meta
+			property="og:description"
+			content="The records in a Sequential file are organized serially, one after another, but the records in the file may be ordered or unordered. The serial"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Processing Sequential Files" />
+		<meta
+			name="twitter:description"
+			content="The records in a Sequential file are organized serially, one after another, but the records in the file may be ordered or unordered. The serial"
+		/>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -11,6 +11,27 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Print files and variable-length records</title>
+		<meta
+			name="description"
+			content="This tutorial covers a number of topics including; COBOL print files, multiple record-type files, variable length records, and run-time file name"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles3.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles3.html" />
+		<meta property="og:title" content="Print files and variable-length records" />
+		<meta
+			property="og:description"
+			content="This tutorial covers a number of topics including; COBOL print files, multiple record-type files, variable length records, and run-time file name"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Print files and variable-length records" />
+		<meta
+			name="twitter:description"
+			content="This tutorial covers a number of topics including; COBOL print files, multiple record-type files, variable length records, and run-time file name"
+		/>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -11,6 +11,27 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Sorting and Merging files</title>
+		<meta
+			name="description"
+			content="As we noted in the tutorial - Processing Sequential Files - it is possible to apply processing to an ordered sequential file that is difficult, or"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/SortMerge.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/SortMerge.html" />
+		<meta property="og:title" content="Sorting and Merging files" />
+		<meta
+			property="og:description"
+			content="As we noted in the tutorial - Processing Sequential Files - it is possible to apply processing to an ordered sequential file that is difficult, or"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Sorting and Merging files" />
+		<meta
+			name="twitter:description"
+			content="As we noted in the tutorial - Processing Sequential Files - it is possible to apply processing to an ordered sequential file that is difficult, or"
+		/>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/String.html
+++ b/course/String.html
@@ -11,6 +11,27 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>The STRING verb</title>
+		<meta
+			name="description"
+			content="The aim of this unit is to provide to provide you with a solid understanding of the STRING verb."
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/String.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/String.html" />
+		<meta property="og:title" content="The STRING verb" />
+		<meta
+			property="og:description"
+			content="The aim of this unit is to provide to provide you with a solid understanding of the STRING verb."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="The STRING verb" />
+		<meta
+			name="twitter:description"
+			content="The aim of this unit is to provide to provide you with a solid understanding of the STRING verb."
+		/>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -11,6 +11,27 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Contained and external sub-programs</title>
+		<meta
+			name="description"
+			content="To provide a brief introduction to building modular systems using separately compiled and/or contained subprograms."
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Subprograms.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/Subprograms.html" />
+		<meta property="og:title" content="Contained and external sub-programs" />
+		<meta
+			property="og:description"
+			content="To provide a brief introduction to building modular systems using separately compiled and/or contained subprograms."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Contained and external sub-programs" />
+		<meta
+			name="twitter:description"
+			content="To provide a brief introduction to building modular systems using separately compiled and/or contained subprograms."
+		/>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -11,6 +11,27 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Using Tables</title>
+		<meta
+			name="description"
+			content='In most programming languages the term "array" is used to describe repeated, or multiple- occurrence, data-items. COBOL uses the term - "table".'
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Tables1.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/Tables1.html" />
+		<meta property="og:title" content="Using Tables" />
+		<meta
+			property="og:description"
+			content='In most programming languages the term "array" is used to describe repeated, or multiple- occurrence, data-items. COBOL uses the term - "table".'
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Using Tables" />
+		<meta
+			name="twitter:description"
+			content='In most programming languages the term "array" is used to describe repeated, or multiple- occurrence, data-items. COBOL uses the term - "table".'
+		/>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -11,6 +11,27 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Creating tables - syntax and semantics</title>
+		<meta
+			name="description"
+			content='In the "Using Tables" tutorial we examined why we might want to use tables as part of the solution to a programming problem.'
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Tables2.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/Tables2.html" />
+		<meta property="og:title" content="Creating tables - syntax and semantics" />
+		<meta
+			property="og:description"
+			content='In the "Using Tables" tutorial we examined why we might want to use tables as part of the solution to a programming problem.'
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Creating tables - syntax and semantics" />
+		<meta
+			name="twitter:description"
+			content='In the "Using Tables" tutorial we examined why we might want to use tables as part of the solution to a programming problem.'
+		/>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -11,6 +11,27 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>The UNSTRING verb</title>
+		<meta
+			name="description"
+			content="The aim of this unit is to provide to provide you with a solid understanding of the UNSTRING verb."
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Unstring.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/Unstring.html" />
+		<meta property="og:title" content="The UNSTRING verb" />
+		<meta
+			property="og:description"
+			content="The aim of this unit is to provide to provide you with a solid understanding of the UNSTRING verb."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="The UNSTRING verb" />
+		<meta
+			name="twitter:description"
+			content="The aim of this unit is to provide to provide you with a solid understanding of the UNSTRING verb."
+		/>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -11,6 +11,27 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>The USAGE clause</title>
+		<meta
+			name="description"
+			content="The internal representation of data can be an important consideration for program efficiency. Unfortunately the default representation used by COBOL for"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Usage.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/Usage.html" />
+		<meta property="og:title" content="The USAGE clause" />
+		<meta
+			property="og:description"
+			content="The internal representation of data can be an important consideration for program efficiency. Unfortunately the default representation used by COBOL for"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="The USAGE clause" />
+		<meta
+			name="twitter:description"
+			content="The internal representation of data can be an important consideration for program efficiency. Unfortunately the default representation used by COBOL for"
+		/>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/examples/Accept/ACCEPT.html
+++ b/examples/Accept/ACCEPT.html
@@ -3,6 +3,27 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>ACCEPT and DISPLAY example program</title>
+		<meta
+			name="description"
+			content="The program accepts a simple student record from the user and displays the individual fields. Also shows how the ACCEPT may be used to get and DISPLAY the"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Accept/ACCEPT.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Accept/ACCEPT.html" />
+		<meta property="og:title" content="ACCEPT and DISPLAY example program" />
+		<meta
+			property="og:description"
+			content="The program accepts a simple student record from the user and displays the individual fields. Also shows how the ACCEPT may be used to get and DISPLAY the"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="ACCEPT and DISPLAY example program" />
+		<meta
+			name="twitter:description"
+			content="The program accepts a simple student record from the user and displays the individual fields. Also shows how the ACCEPT may be used to get and DISPLAY the"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/Accept/Multiplier.html
+++ b/examples/Accept/Multiplier.html
@@ -3,6 +3,30 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>ACCEPT, DISPLAY and MULTIPLY example program</title>
+		<meta
+			name="description"
+			content="Accepts two single digit numbers from the user, multiplies them together and displays the result."
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Accept/Multiplier.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/Accept/Multiplier.html"
+		/>
+		<meta property="og:title" content="ACCEPT, DISPLAY and MULTIPLY example program" />
+		<meta
+			property="og:description"
+			content="Accepts two single digit numbers from the user, multiplies them together and displays the result."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="ACCEPT, DISPLAY and MULTIPLY example program" />
+		<meta
+			name="twitter:description"
+			content="Accepts two single digit numbers from the user, multiplies them together and displays the result."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/Accept/Shortest.html
+++ b/examples/Accept/Shortest.html
@@ -3,6 +3,27 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>The Shortest COBOL program we can have</title>
+		<meta
+			name="description"
+			content="This example program is almost the shortest COBOL program we can have. We could make it shorter still by leaving out the STOP RUN."
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Accept/Shortest.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Accept/Shortest.html" />
+		<meta property="og:title" content="The Shortest COBOL program we can have" />
+		<meta
+			property="og:description"
+			content="This example program is almost the shortest COBOL program we can have. We could make it shorter still by leaving out the STOP RUN."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="The Shortest COBOL program we can have" />
+		<meta
+			name="twitter:description"
+			content="This example program is almost the shortest COBOL program we can have. We could make it shorter still by leaving out the STOP RUN."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/Conditn/Conditions.html
+++ b/examples/Conditn/Conditions.html
@@ -3,6 +3,21 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Condition Names (level 88) example program</title>
+		<meta name="description" content="COBOL example program: Condition Names (level 88) example program." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Conditn/Conditions.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/Conditn/Conditions.html"
+		/>
+		<meta property="og:title" content="Condition Names (level 88) example program" />
+		<meta property="og:description" content="COBOL example program: Condition Names (level 88) example program." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Condition Names (level 88) example program" />
+		<meta name="twitter:description" content="COBOL example program: Condition Names (level 88) example program." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/Conditn/IterIf.html
+++ b/examples/Conditn/IterIf.html
@@ -3,6 +3,18 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Condition Names (level 88) example program</title>
+		<meta name="description" content="COBOL example program: Condition Names (level 88) example program." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Conditn/IterIf.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Conditn/IterIf.html" />
+		<meta property="og:title" content="Condition Names (level 88) example program" />
+		<meta property="og:description" content="COBOL example program: Condition Names (level 88) example program." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Condition Names (level 88) example program" />
+		<meta name="twitter:description" content="COBOL example program: Condition Names (level 88) example program." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/Indexed/DirectReadIdx.html
+++ b/examples/Indexed/DirectReadIdx.html
@@ -3,6 +3,33 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Reading an Indexed file directly by key</title>
+		<meta
+			name="description"
+			content="Does a direct read on the Indexed file created by the previous example program. Allows the user to choose which of the keys to use for the direct read."
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/examples/Indexed/DirectReadIdx.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/Indexed/DirectReadIdx.html"
+		/>
+		<meta property="og:title" content="Reading an Indexed file directly by key" />
+		<meta
+			property="og:description"
+			content="Does a direct read on the Indexed file created by the previous example program. Allows the user to choose which of the keys to use for the direct read."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Reading an Indexed file directly by key" />
+		<meta
+			name="twitter:description"
+			content="Does a direct read on the Indexed file created by the previous example program. Allows the user to choose which of the keys to use for the direct read."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/Indexed/Seq2Index.html
+++ b/examples/Indexed/Seq2Index.html
@@ -3,6 +3,30 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Creating an Indexed file from a sequential file</title>
+		<meta
+			name="description"
+			content="Creates a direct access Indexed file from a Sequential file. Note that Microfocus Indexed files actually consist of two files - the data file and the index"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Indexed/Seq2Index.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/Indexed/Seq2Index.html"
+		/>
+		<meta property="og:title" content="Creating an Indexed file from a sequential file" />
+		<meta
+			property="og:description"
+			content="Creates a direct access Indexed file from a Sequential file. Note that Microfocus Indexed files actually consist of two files - the data file and the index"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Creating an Indexed file from a sequential file" />
+		<meta
+			name="twitter:description"
+			content="Creates a direct access Indexed file from a Sequential file. Note that Microfocus Indexed files actually consist of two files - the data file and the index"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/Indexed/SeqReadIdx.html
+++ b/examples/Indexed/SeqReadIdx.html
@@ -3,6 +3,30 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Reading an Indexed file sequentially on any of its keys</title>
+		<meta
+			name="description"
+			content="Reads the Indexed file sequentially on whichever key is chosen by the user. Displays all the records in the file."
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Indexed/SeqReadIdx.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/Indexed/SeqReadIdx.html"
+		/>
+		<meta property="og:title" content="Reading an Indexed file sequentially on any of its keys" />
+		<meta
+			property="og:description"
+			content="Reads the Indexed file sequentially on whichever key is chosen by the user. Displays all the records in the file."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Reading an Indexed file sequentially on any of its keys" />
+		<meta
+			name="twitter:description"
+			content="Reads the Indexed file sequentially on whichever key is chosen by the user. Displays all the records in the file."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/Merge/Merge.html
+++ b/examples/Merge/Merge.html
@@ -3,6 +3,27 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Merge Files - Example Program</title>
+		<meta
+			name="description"
+			content="Uses the MERGE to insert records from a transaction file into a sequential master file. . To test this program you will need to download Student Masterfile"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Merge/Merge.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Merge/Merge.html" />
+		<meta property="og:title" content="Merge Files - Example Program" />
+		<meta
+			property="og:description"
+			content="Uses the MERGE to insert records from a transaction file into a sequential master file. . To test this program you will need to download Student Masterfile"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Merge Files - Example Program" />
+		<meta
+			name="twitter:description"
+			content="Uses the MERGE to insert records from a transaction file into a sequential master file. . To test this program you will need to download Student Masterfile"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/Perform/MileageCount.html
+++ b/examples/Perform/MileageCount.html
@@ -3,6 +3,30 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Mileage counter simulation</title>
+		<meta
+			name="description"
+			content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used to simulate a mileage counter."
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Perform/MileageCount.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/Perform/MileageCount.html"
+		/>
+		<meta property="og:title" content="Mileage counter simulation" />
+		<meta
+			property="og:description"
+			content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used to simulate a mileage counter."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Mileage counter simulation" />
+		<meta
+			name="twitter:description"
+			content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used to simulate a mileage counter."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/Perform/Perform1.html
+++ b/examples/Perform/Perform1.html
@@ -3,6 +3,30 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Perform - Format 1 example program</title>
+		<meta
+			name="description"
+			content="An example program demonstrating how the first format of the PERFORM may be used to change the flow of control through a program."
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform1.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform1.html"
+		/>
+		<meta property="og:title" content="Perform - Format 1 example program" />
+		<meta
+			property="og:description"
+			content="An example program demonstrating how the first format of the PERFORM may be used to change the flow of control through a program."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Perform - Format 1 example program" />
+		<meta
+			name="twitter:description"
+			content="An example program demonstrating how the first format of the PERFORM may be used to change the flow of control through a program."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/Perform/Perform2.html
+++ b/examples/Perform/Perform2.html
@@ -3,6 +3,30 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Perform - Format 2 example program</title>
+		<meta
+			name="description"
+			content="Demonstrates the second format of the PERFORM. The PERFORM..TIMES may be used to execute a block of code x number of times."
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform2.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform2.html"
+		/>
+		<meta property="og:title" content="Perform - Format 2 example program" />
+		<meta
+			property="og:description"
+			content="Demonstrates the second format of the PERFORM. The PERFORM..TIMES may be used to execute a block of code x number of times."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Perform - Format 2 example program" />
+		<meta
+			name="twitter:description"
+			content="Demonstrates the second format of the PERFORM. The PERFORM..TIMES may be used to execute a block of code x number of times."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/Perform/Perform3.html
+++ b/examples/Perform/Perform3.html
@@ -3,6 +3,30 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Perform - Format 3 example program</title>
+		<meta
+			name="description"
+			content="Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values where the length of the stream cannot be determined in advance"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform3.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform3.html"
+		/>
+		<meta property="og:title" content="Perform - Format 3 example program" />
+		<meta
+			property="og:description"
+			content="Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values where the length of the stream cannot be determined in advance"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Perform - Format 3 example program" />
+		<meta
+			name="twitter:description"
+			content="Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values where the length of the stream cannot be determined in advance"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/Perform/Perform4.html
+++ b/examples/Perform/Perform4.html
@@ -3,6 +3,30 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Perform - Format 4 example program</title>
+		<meta
+			name="description"
+			content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used for counting iteration. Also introduces the WITH TEST"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform4.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform4.html"
+		/>
+		<meta property="og:title" content="Perform - Format 4 example program" />
+		<meta
+			property="og:description"
+			content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used for counting iteration. Also introduces the WITH TEST"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Perform - Format 4 example program" />
+		<meta
+			name="twitter:description"
+			content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used for counting iteration. Also introduces the WITH TEST"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/Relative/ReadRel.html
+++ b/examples/Relative/ReadRel.html
@@ -3,6 +3,30 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Inserting records in a Sequential File</title>
+		<meta
+			name="description"
+			content="Reads the Relative file - RELSUPP.DAT - created in the previous example program and displays the records. Allows the user to choose to read through and"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Relative/ReadRel.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/Relative/ReadRel.html"
+		/>
+		<meta property="og:title" content="Inserting records in a Sequential File" />
+		<meta
+			property="og:description"
+			content="Reads the Relative file - RELSUPP.DAT - created in the previous example program and displays the records. Allows the user to choose to read through and"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Inserting records in a Sequential File" />
+		<meta
+			name="twitter:description"
+			content="Reads the Relative file - RELSUPP.DAT - created in the previous example program and displays the records. Allows the user to choose to read through and"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/Relative/Seq2Rel.html
+++ b/examples/Relative/Seq2Rel.html
@@ -3,6 +3,30 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Inserting records in a Sequential File</title>
+		<meta
+			name="description"
+			content="Creates a direct access Relative file from a Sequential File. Note that Relative files are not standard ASCII files and so cannot be created with an editor"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Relative/Seq2Rel.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/Relative/Seq2Rel.html"
+		/>
+		<meta property="og:title" content="Inserting records in a Sequential File" />
+		<meta
+			property="og:description"
+			content="Creates a direct access Relative file from a Sequential File. Note that Relative files are not standard ASCII files and so cannot be created with an editor"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Inserting records in a Sequential File" />
+		<meta
+			name="twitter:description"
+			content="Creates a direct access Relative file from a Sequential File. Note that Relative files are not standard ASCII files and so cannot be created with an editor"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/ReportWriter/RepWriteA.html
+++ b/examples/ReportWriter/RepWriteA.html
@@ -3,6 +3,33 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>One control break version of full Report Writer example Program</title>
+		<meta
+			name="description"
+			content="A simplified version of RepWriteFull.cbl using only one control break. All four of these Report Writer programs use the GBsales.dat data file."
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteA.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteA.html"
+		/>
+		<meta property="og:title" content="One control break version of full Report Writer example Program" />
+		<meta
+			property="og:description"
+			content="A simplified version of RepWriteFull.cbl using only one control break. All four of these Report Writer programs use the GBsales.dat data file."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="One control break version of full Report Writer example Program" />
+		<meta
+			name="twitter:description"
+			content="A simplified version of RepWriteFull.cbl using only one control break. All four of these Report Writer programs use the GBsales.dat data file."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/ReportWriter/RepWriteB.html
+++ b/examples/ReportWriter/RepWriteB.html
@@ -3,6 +3,33 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>No Declaratives version of full Report Writer example program</title>
+		<meta
+			name="description"
+			content="A simplified version of RepWriteFull.cbl containing all the control breaks but not using Declaratives. All four of these Report Writer programs use the"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteB.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteB.html"
+		/>
+		<meta property="og:title" content="No Declaratives version of full Report Writer example program" />
+		<meta
+			property="og:description"
+			content="A simplified version of RepWriteFull.cbl containing all the control breaks but not using Declaratives. All four of these Report Writer programs use the"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="No Declaratives version of full Report Writer example program" />
+		<meta
+			name="twitter:description"
+			content="A simplified version of RepWriteFull.cbl containing all the control breaks but not using Declaratives. All four of these Report Writer programs use the"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/ReportWriter/RepWriteFull.html
+++ b/examples/ReportWriter/RepWriteFull.html
@@ -3,6 +3,33 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Full Report Writer example program - includes Declaratives</title>
+		<meta
+			name="description"
+			content="The full version of the report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission. All"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteFull.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteFull.html"
+		/>
+		<meta property="og:title" content="Full Report Writer example program - includes Declaratives" />
+		<meta
+			property="og:description"
+			content="The full version of the report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission. All"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Full Report Writer example program - includes Declaratives" />
+		<meta
+			name="twitter:description"
+			content="The full version of the report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission. All"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/ReportWriter/RepWriteSumm.html
+++ b/examples/ReportWriter/RepWriteSumm.html
@@ -3,6 +3,33 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Summary version of the full Report Writer program</title>
+		<meta
+			name="description"
+			content="The summary version of the full report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission."
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteSumm.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteSumm.html"
+		/>
+		<meta property="og:title" content="Summary version of the full Report Writer program" />
+		<meta
+			property="og:description"
+			content="The summary version of the full report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Summary version of the full Report Writer program" />
+		<meta
+			name="twitter:description"
+			content="The summary version of the full report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/SeqIns/SEQINSERT.html
+++ b/examples/SeqIns/SEQINSERT.html
@@ -3,6 +3,30 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Inserting records in a Sequential File</title>
+		<meta
+			name="description"
+			content="Demonstrates how to insert records into a sequential file from a file of transaction records. A new file is created which contains the inserted records. To"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SeqIns/SEQINSERT.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/SeqIns/SEQINSERT.html"
+		/>
+		<meta property="og:title" content="Inserting records in a Sequential File" />
+		<meta
+			property="og:description"
+			content="Demonstrates how to insert records into a sequential file from a file of transaction records. A new file is created which contains the inserted records. To"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Inserting records in a Sequential File" />
+		<meta
+			name="twitter:description"
+			content="Demonstrates how to insert records into a sequential file from a file of transaction records. A new file is created which contains the inserted records. To"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/SeqRead/SEQREAD.html
+++ b/examples/SeqRead/SEQREAD.html
@@ -3,6 +3,27 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Reading a Sequential File</title>
+		<meta
+			name="description"
+			content="An example program that reads a sequential file and displays the records. This is the correct version which uses the Condition Name (level 88)"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREAD.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREAD.html" />
+		<meta property="og:title" content="Reading a Sequential File" />
+		<meta
+			property="og:description"
+			content="An example program that reads a sequential file and displays the records. This is the correct version which uses the Condition Name (level 88)"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Reading a Sequential File" />
+		<meta
+			name="twitter:description"
+			content="An example program that reads a sequential file and displays the records. This is the correct version which uses the Condition Name (level 88)"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/SeqRead/SEQREADno88.html
+++ b/examples/SeqRead/SEQREADno88.html
@@ -3,6 +3,21 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Reading a Sequential File</title>
+		<meta name="description" content="COBOL example program: Reading a Sequential File." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREADno88.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREADno88.html"
+		/>
+		<meta property="og:title" content="Reading a Sequential File" />
+		<meta property="og:description" content="COBOL example program: Reading a Sequential File." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Reading a Sequential File" />
+		<meta name="twitter:description" content="COBOL example program: Reading a Sequential File." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/SeqRpt/SEQRPT.html
+++ b/examples/SeqRpt/SEQRPT.html
@@ -3,6 +3,27 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Sequential Student Number Report</title>
+		<meta
+			name="description"
+			content="This program reads records from the student file, counts the total number of student records in the file and the number records for females and males."
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SeqRpt/SEQRPT.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/SeqRpt/SEQRPT.html" />
+		<meta property="og:title" content="Sequential Student Number Report" />
+		<meta
+			property="og:description"
+			content="This program reads records from the student file, counts the total number of student records in the file and the number records for females and males."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Sequential Student Number Report" />
+		<meta
+			name="twitter:description"
+			content="This program reads records from the student file, counts the total number of student records in the file and the number records for females and males."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/SeqWrite/SEQWRITE.html
+++ b/examples/SeqWrite/SEQWRITE.html
@@ -3,6 +3,21 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Writing to a Sequential File</title>
+		<meta name="description" content="COBOL example program: Writing to a Sequential File." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SeqWrite/SEQWRITE.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/SeqWrite/SEQWRITE.html"
+		/>
+		<meta property="og:title" content="Writing to a Sequential File" />
+		<meta property="og:description" content="COBOL example program: Writing to a Sequential File." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Writing to a Sequential File" />
+		<meta name="twitter:description" content="COBOL example program: Writing to a Sequential File." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/Sort/InputSort.html
+++ b/examples/Sort/InputSort.html
@@ -3,6 +3,27 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>SORT with Input Procedure to get recs from user</title>
+		<meta
+			name="description"
+			content="Uses the SORT and an INPUT PROCEDURE to accept records from the user and sort them on ascending StudentId."
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Sort/InputSort.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Sort/InputSort.html" />
+		<meta property="og:title" content="SORT with Input Procedure to get recs from user" />
+		<meta
+			property="og:description"
+			content="Uses the SORT and an INPUT PROCEDURE to accept records from the user and sort them on ascending StudentId."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="SORT with Input Procedure to get recs from user" />
+		<meta
+			name="twitter:description"
+			content="Uses the SORT and an INPUT PROCEDURE to accept records from the user and sort them on ascending StudentId."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/Sort/MaleSort.html
+++ b/examples/Sort/MaleSort.html
@@ -3,6 +3,27 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>SORT file and select only male records</title>
+		<meta
+			name="description"
+			content="Sorts the student masterfile (sorted on ascending Student Id) and produces a new file, sorted on ascending student name, containing only the records of"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Sort/MaleSort.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Sort/MaleSort.html" />
+		<meta property="og:title" content="SORT file and select only male records" />
+		<meta
+			property="og:description"
+			content="Sorts the student masterfile (sorted on ascending Student Id) and produces a new file, sorted on ascending student name, containing only the records of"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="SORT file and select only male records" />
+		<meta
+			name="twitter:description"
+			content="Sorts the student masterfile (sorted on ascending Student Id) and produces a new file, sorted on ascending student name, containing only the records of"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/Strings/RefMod.html
+++ b/examples/Strings/RefMod.html
@@ -3,6 +3,27 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>String handling - Reference Modification examples</title>
+		<meta
+			name="description"
+			content="Solves a number of string handling tasks such as : - Extracting a substring from a string given the start position and length of the substring. Extracting"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Strings/RefMod.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Strings/RefMod.html" />
+		<meta property="og:title" content="String handling - Reference Modification examples" />
+		<meta
+			property="og:description"
+			content="Solves a number of string handling tasks such as : - Extracting a substring from a string given the start position and length of the substring. Extracting"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="String handling - Reference Modification examples" />
+		<meta
+			name="twitter:description"
+			content="Solves a number of string handling tasks such as : - Extracting a substring from a string given the start position and length of the substring. Extracting"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/Strings/UnstringFileEg.html
+++ b/examples/Strings/UnstringFileEg.html
@@ -3,6 +3,33 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>String handling - Unpacking and size-validating comma separated records</title>
+		<meta
+			name="description"
+			content="An example showing the unpacking of comma separated records and the size validation of the unpacked fields. To test this program use the data file"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/examples/Strings/UnstringFileEg.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/Strings/UnstringFileEg.html"
+		/>
+		<meta property="og:title" content="String handling - Unpacking and size-validating comma separated records" />
+		<meta
+			property="og:description"
+			content="An example showing the unpacking of comma separated records and the size validation of the unpacked fields. To test this program use the data file"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="String handling - Unpacking and size-validating comma separated records" />
+		<meta
+			name="twitter:description"
+			content="An example showing the unpacking of comma separated records and the size validation of the unpacked fields. To test this program use the data file"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/SubProg/DateValid/DateDriver.html
+++ b/examples/SubProg/DateValid/DateDriver.html
@@ -3,6 +3,33 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Driver program for date validation sub-program</title>
+		<meta
+			name="description"
+			content="A driver program for the date validation sub-program below. Accepts a date from the user, passes it to the date validation sub-program and interprets and"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/DateDriver.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/DateDriver.html"
+		/>
+		<meta property="og:title" content="Driver program for date validation sub-program" />
+		<meta
+			property="og:description"
+			content="A driver program for the date validation sub-program below. Accepts a date from the user, passes it to the date validation sub-program and interprets and"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Driver program for date validation sub-program" />
+		<meta
+			name="twitter:description"
+			content="A driver program for the date validation sub-program below. Accepts a date from the user, passes it to the date validation sub-program and interprets and"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/SubProg/DateValid/ValiDate.html
+++ b/examples/SubProg/DateValid/ValiDate.html
@@ -3,6 +3,33 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Date validation sub-program</title>
+		<meta
+			name="description"
+			content="A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a code indicating if the date was valid or not. If not valid, the"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/ValiDate.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/ValiDate.html"
+		/>
+		<meta property="og:title" content="Date validation sub-program" />
+		<meta
+			property="og:description"
+			content="A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a code indicating if the date was valid or not. If not valid, the"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Date validation sub-program" />
+		<meta
+			name="twitter:description"
+			content="A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a code indicating if the date was valid or not. If not valid, the"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/SubProg/DayDiff/DayDiffDriver.html
+++ b/examples/SubProg/DayDiff/DayDiffDriver.html
@@ -3,6 +3,33 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Get difference between dates driver program</title>
+		<meta
+			name="description"
+			content="A driver program that accepts two dates from the user and displays the difference in days between them. This program uses the ValiDate.cbl sub-program"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DayDiff/DayDiffDriver.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DayDiff/DayDiffDriver.html"
+		/>
+		<meta property="og:title" content="Get difference between dates driver program" />
+		<meta
+			property="og:description"
+			content="A driver program that accepts two dates from the user and displays the difference in days between them. This program uses the ValiDate.cbl sub-program"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Get difference between dates driver program" />
+		<meta
+			name="twitter:description"
+			content="A driver program that accepts two dates from the user and displays the difference in days between them. This program uses the ValiDate.cbl sub-program"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/SubProg/Multiply/DriverProg.html
+++ b/examples/SubProg/Multiply/DriverProg.html
@@ -3,6 +3,33 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>A driver for the MultiplyNums, Fickle and Steafast sub-programs</title>
+		<meta
+			name="description"
+			content='This program demonstrates the CALL verb by calling three external sub-programs. The "MultiplyNums" sub-program demonstrates flow of control - from caller'
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/DriverProg.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/DriverProg.html"
+		/>
+		<meta property="og:title" content="A driver for the MultiplyNums, Fickle and Steafast sub-programs" />
+		<meta
+			property="og:description"
+			content='This program demonstrates the CALL verb by calling three external sub-programs. The "MultiplyNums" sub-program demonstrates flow of control - from caller'
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="A driver for the MultiplyNums, Fickle and Steafast sub-programs" />
+		<meta
+			name="twitter:description"
+			content='This program demonstrates the CALL verb by calling three external sub-programs. The "MultiplyNums" sub-program demonstrates flow of control - from caller'
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/SubProg/Multiply/Fickle.html
+++ b/examples/SubProg/Multiply/Fickle.html
@@ -3,6 +3,33 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>The Fickle sub-program demonstrates State Memory</title>
+		<meta
+			name="description"
+			content="Fickle is a sub-program called from DriverProg.cbl above. Fickle is a program that demonstrates State Memory. Each time the program is called it remembers"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Fickle.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Fickle.html"
+		/>
+		<meta property="og:title" content="The Fickle sub-program demonstrates State Memory" />
+		<meta
+			property="og:description"
+			content="Fickle is a sub-program called from DriverProg.cbl above. Fickle is a program that demonstrates State Memory. Each time the program is called it remembers"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="The Fickle sub-program demonstrates State Memory" />
+		<meta
+			name="twitter:description"
+			content="Fickle is a sub-program called from DriverProg.cbl above. Fickle is a program that demonstrates State Memory. Each time the program is called it remembers"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/SubProg/Multiply/MultiplyNums.html
+++ b/examples/SubProg/Multiply/MultiplyNums.html
@@ -3,6 +3,33 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>The MultiplyNums sub-program</title>
+		<meta
+			name="description"
+			content='The "MultiplyNums" sub-program, called from the driver program above, demonstrates the flow of control from the driver program to the called sub-program'
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/MultiplyNums.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/MultiplyNums.html"
+		/>
+		<meta property="og:title" content="The MultiplyNums sub-program" />
+		<meta
+			property="og:description"
+			content='The "MultiplyNums" sub-program, called from the driver program above, demonstrates the flow of control from the driver program to the called sub-program'
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="The MultiplyNums sub-program" />
+		<meta
+			name="twitter:description"
+			content='The "MultiplyNums" sub-program, called from the driver program above, demonstrates the flow of control from the driver program to the called sub-program'
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/SubProg/Multiply/Steadfast.html
+++ b/examples/SubProg/Multiply/Steadfast.html
@@ -3,6 +3,33 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>The Steadfast sub-program demonstrates the IS INITIAL phrase</title>
+		<meta
+			name="description"
+			content="Steadfast is a sub-program called from DriverProg.cbl above. Steadfast is identical to Fickle except that it uses the IS INITIAL phrase to avoid State"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Steadfast.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Steadfast.html"
+		/>
+		<meta property="og:title" content="The Steadfast sub-program demonstrates the IS INITIAL phrase" />
+		<meta
+			property="og:description"
+			content="Steadfast is a sub-program called from DriverProg.cbl above. Steadfast is identical to Fickle except that it uses the IS INITIAL phrase to avoid State"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="The Steadfast sub-program demonstrates the IS INITIAL phrase" />
+		<meta
+			name="twitter:description"
+			content="Steadfast is a sub-program called from DriverProg.cbl above. Steadfast is identical to Fickle except that it uses the IS INITIAL phrase to avoid State"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/examples/Tables/MonthTable.html
+++ b/examples/Tables/MonthTable.html
@@ -3,6 +3,30 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Tables - Counts number of students born in each month</title>
+		<meta
+			name="description"
+			content="This program counts the number of students born in each month and displays the result. The program uses a pre-filled table of month names. This program is"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Tables/MonthTable.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/Tables/MonthTable.html"
+		/>
+		<meta property="og:title" content="Tables - Counts number of students born in each month" />
+		<meta
+			property="og:description"
+			content="This program counts the number of students born in each month and displays the result. The program uses a pre-filled table of month names. This program is"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Tables - Counts number of students born in each month" />
+		<meta
+			name="twitter:description"
+			content="This program counts the number of students born in each month and displays the result. The program uses a pre-filled table of month names. This program is"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>

--- a/exercises/COBOLExams/COBOLExams.html
+++ b/exercises/COBOLExams/COBOLExams.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>COBOL Programming Exams</title>
+		<meta
+			name="description"
+			content="The COBOL modules that I have taught at the University of Limerick have been examined by requiring students to write a single COBOL program. On this page,"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/COBOLExams/COBOLExams.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/COBOLExams/COBOLExams.html"
+		/>
+		<meta property="og:title" content="COBOL Programming Exams" />
+		<meta
+			property="og:description"
+			content="The COBOL modules that I have taught at the University of Limerick have been examined by requiring students to write a single COBOL program. On this page,"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="COBOL Programming Exams" />
+		<meta
+			name="twitter:description"
+			content="The COBOL modules that I have taught at the University of Limerick have been examined by requiring students to write a single COBOL program. On this page,"
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<script src="../../components/theme-toggle.js" defer></script>

--- a/exercises/CountDown.html
+++ b/exercises/CountDown.html
@@ -11,6 +11,18 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>The Calculator and Countdown exercises</title>
+		<meta name="description" content=" Read the tutorial: COBOL Iteration Constructs" />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/exercises/CountDown.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/exercises/CountDown.html" />
+		<meta property="og:title" content="The Calculator and Countdown exercises" />
+		<meta property="og:description" content=" Read the tutorial: COBOL Iteration Constructs" />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="The Calculator and Countdown exercises" />
+		<meta name="twitter:description" content=" Read the tutorial: COBOL Iteration Constructs" />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />
 		<script src="../components/theme-toggle.js" defer></script>

--- a/exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html
+++ b/exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>ACME Stock Reorder 1999 (Exam Paper)</title>
+		<meta
+			name="description"
+			content="Acme Manufacturing Plc. manufactures a range of cheap catering equipment for the European market. Some of the parts used are fabricated within the company,"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html"
+		/>
+		<meta property="og:title" content="ACME Stock Reorder 1999 (Exam Paper)" />
+		<meta
+			property="og:description"
+			content="Acme Manufacturing Plc. manufactures a range of cheap catering equipment for the European market. Some of the parts used are fabricated within the company,"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="ACME Stock Reorder 1999 (Exam Paper)" />
+		<meta
+			name="twitter:description"
+			content="Acme Manufacturing Plc. manufactures a range of cheap catering equipment for the European market. Some of the parts used are fabricated within the company,"
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<script src="../../components/theme-toggle.js" defer></script>

--- a/exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html
+++ b/exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>AcmeStockReorder – ACME Stock Reorder 1999 (COBOL source)</title>
+		<meta
+			name="description"
+			content="COBOL programming exercise: AcmeStockReorder – ACME Stock Reorder 1999 (COBOL source)."
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html"
+		/>
+		<meta property="og:title" content="AcmeStockReorder – ACME Stock Reorder 1999 (COBOL source)" />
+		<meta
+			property="og:description"
+			content="COBOL programming exercise: AcmeStockReorder – ACME Stock Reorder 1999 (COBOL source)."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="AcmeStockReorder – ACME Stock Reorder 1999 (COBOL source)" />
+		<meta
+			name="twitter:description"
+			content="COBOL programming exercise: AcmeStockReorder – ACME Stock Reorder 1999 (COBOL source)."
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html
+++ b/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>Aromamora Oil Stock Maintenance and Report (Exam Paper)</title>
+		<meta
+			name="description"
+			content="Aromamora PLC sells essential oils to Aromatherapists, Health Shops, Chemists and other retailers. Details of the oils sold are kept in two files:- the"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html"
+		/>
+		<meta property="og:title" content="Aromamora Oil Stock Maintenance and Report (Exam Paper)" />
+		<meta
+			property="og:description"
+			content="Aromamora PLC sells essential oils to Aromatherapists, Health Shops, Chemists and other retailers. Details of the oils sold are kept in two files:- the"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Aromamora Oil Stock Maintenance and Report (Exam Paper)" />
+		<meta
+			name="twitter:description"
+			content="Aromamora PLC sells essential oils to Aromatherapists, Health Shops, Chemists and other retailers. Details of the oils sold are kept in two files:- the"
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<script src="../../components/theme-toggle.js" defer></script>

--- a/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html
+++ b/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html
@@ -11,6 +11,39 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>AromaOilFileMainRpt – Aromamora Oil Stock Maintenance and Report (COBOL source)</title>
+		<meta
+			name="description"
+			content="COBOL programming exercise: AromaOilFileMainRpt – Aromamora Oil Stock Maintenance and Report (COBOL source)."
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html"
+		/>
+		<meta
+			property="og:title"
+			content="AromaOilFileMainRpt – Aromamora Oil Stock Maintenance and Report (COBOL source)"
+		/>
+		<meta
+			property="og:description"
+			content="COBOL programming exercise: AromaOilFileMainRpt – Aromamora Oil Stock Maintenance and Report (COBOL source)."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta
+			name="twitter:title"
+			content="AromaOilFileMainRpt – Aromamora Oil Stock Maintenance and Report (COBOL source)"
+		/>
+		<meta
+			name="twitter:description"
+			content="COBOL programming exercise: AromaOilFileMainRpt – Aromamora Oil Stock Maintenance and Report (COBOL source)."
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html
+++ b/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>Aromamora Summary Sales Report (Exam Paper)</title>
+		<meta
+			name="description"
+			content="Aromamora PLC is a company which sells essential oils to Aromatherapists, Health Shops, Chemists and other mass users of essential oils. Every month,"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html"
+		/>
+		<meta property="og:title" content="Aromamora Summary Sales Report (Exam Paper)" />
+		<meta
+			property="og:description"
+			content="Aromamora PLC is a company which sells essential oils to Aromatherapists, Health Shops, Chemists and other mass users of essential oils. Every month,"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Aromamora Summary Sales Report (Exam Paper)" />
+		<meta
+			name="twitter:description"
+			content="Aromamora PLC is a company which sells essential oils to Aromatherapists, Health Shops, Chemists and other mass users of essential oils. Every month,"
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<script src="../../components/theme-toggle.js" defer></script>

--- a/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html
+++ b/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>AromaSalesSummaryRpt – Aromamora Summary Sales Report (COBOL source)</title>
+		<meta
+			name="description"
+			content="COBOL programming exercise: AromaSalesSummaryRpt – Aromamora Summary Sales Report (COBOL source)."
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html"
+		/>
+		<meta property="og:title" content="AromaSalesSummaryRpt – Aromamora Summary Sales Report (COBOL source)" />
+		<meta
+			property="og:description"
+			content="COBOL programming exercise: AromaSalesSummaryRpt – Aromamora Summary Sales Report (COBOL source)."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="AromaSalesSummaryRpt – Aromamora Summary Sales Report (COBOL source)" />
+		<meta
+			name="twitter:description"
+			content="COBOL programming exercise: AromaSalesSummaryRpt – Aromamora Summary Sales Report (COBOL source)."
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html
+++ b/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>Folio Society - Best Sellers List Report Exam Paper)</title>
+		<meta
+			name="description"
+			content="The Folio Society is a Book Club that sells fine books to customers all over the world. Each time a book is sold the Book-Number, the Number-of-Copies and"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html"
+		/>
+		<meta property="og:title" content="Folio Society - Best Sellers List Report Exam Paper)" />
+		<meta
+			property="og:description"
+			content="The Folio Society is a Book Club that sells fine books to customers all over the world. Each time a book is sold the Book-Number, the Number-of-Copies and"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Folio Society - Best Sellers List Report Exam Paper)" />
+		<meta
+			name="twitter:description"
+			content="The Folio Society is a Book Club that sells fine books to customers all over the world. Each time a book is sold the Book-Number, the Number-of-Copies and"
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<script src="../../components/theme-toggle.js" defer></script>

--- a/exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html
+++ b/exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html
@@ -11,6 +11,39 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>FolioBestSellersRpt – Folio Society Best Sellers List Report (COBOL source)</title>
+		<meta
+			name="description"
+			content="COBOL programming exercise: FolioBestSellersRpt – Folio Society Best Sellers List Report (COBOL source)."
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html"
+		/>
+		<meta
+			property="og:title"
+			content="FolioBestSellersRpt – Folio Society Best Sellers List Report (COBOL source)"
+		/>
+		<meta
+			property="og:description"
+			content="COBOL programming exercise: FolioBestSellersRpt – Folio Society Best Sellers List Report (COBOL source)."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta
+			name="twitter:title"
+			content="FolioBestSellersRpt – Folio Society Best Sellers List Report (COBOL source)"
+		/>
+		<meta
+			name="twitter:description"
+			content="COBOL programming exercise: FolioBestSellersRpt – Folio Society Best Sellers List Report (COBOL source)."
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html
+++ b/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>Campus Bookshop Purchase Requirements Report (Exam Paper)</title>
+		<meta
+			name="description"
+			content="Two months before the beginning of each semester the Campus Bookshop produces a Purchase Requirements Report. This report details the books that have to be"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html"
+		/>
+		<meta property="og:title" content="Campus Bookshop Purchase Requirements Report (Exam Paper)" />
+		<meta
+			property="og:description"
+			content="Two months before the beginning of each semester the Campus Bookshop produces a Purchase Requirements Report. This report details the books that have to be"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Campus Bookshop Purchase Requirements Report (Exam Paper)" />
+		<meta
+			name="twitter:description"
+			content="Two months before the beginning of each semester the Campus Bookshop produces a Purchase Requirements Report. This report details the books that have to be"
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<script src="../../components/theme-toggle.js" defer></script>

--- a/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html
+++ b/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html
@@ -11,6 +11,39 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>BookshopLectReqRpt – Campus Bookshop Purchase Requirements Report (COBOL source)</title>
+		<meta
+			name="description"
+			content="COBOL programming exercise: BookshopLectReqRpt – Campus Bookshop Purchase Requirements Report (COBOL source)."
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html"
+		/>
+		<meta
+			property="og:title"
+			content="BookshopLectReqRpt – Campus Bookshop Purchase Requirements Report (COBOL source)"
+		/>
+		<meta
+			property="og:description"
+			content="COBOL programming exercise: BookshopLectReqRpt – Campus Bookshop Purchase Requirements Report (COBOL source)."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta
+			name="twitter:title"
+			content="BookshopLectReqRpt – Campus Bookshop Purchase Requirements Report (COBOL source)"
+		/>
+		<meta
+			name="twitter:description"
+			content="COBOL programming exercise: BookshopLectReqRpt – Campus Bookshop Purchase Requirements Report (COBOL source)."
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html
+++ b/exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>CSIS Web Site - Email Domain File (Exam Paper)</title>
+		<meta
+			name="description"
+			content="One purpose of the CSIS web site is to collect, and display, the current email addresses of all CSIS graduates. Graduates who visit the site are asked to"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html"
+		/>
+		<meta property="og:title" content="CSIS Web Site - Email Domain File (Exam Paper)" />
+		<meta
+			property="og:description"
+			content="One purpose of the CSIS web site is to collect, and display, the current email addresses of all CSIS graduates. Graduates who visit the site are asked to"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="CSIS Web Site - Email Domain File (Exam Paper)" />
+		<meta
+			name="twitter:description"
+			content="One purpose of the CSIS web site is to collect, and display, the current email addresses of all CSIS graduates. Graduates who visit the site are asked to"
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<script src="../../components/theme-toggle.js" defer></script>

--- a/exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html
+++ b/exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>CSISEmailDomain – CSIS Web Site Email Domain File (COBOL source)</title>
+		<meta
+			name="description"
+			content="COBOL programming exercise: CSISEmailDomain – CSIS Web Site Email Domain File (COBOL source)."
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html"
+		/>
+		<meta property="og:title" content="CSISEmailDomain – CSIS Web Site Email Domain File (COBOL source)" />
+		<meta
+			property="og:description"
+			content="COBOL programming exercise: CSISEmailDomain – CSIS Web Site Email Domain File (COBOL source)."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="CSISEmailDomain – CSIS Web Site Email Domain File (COBOL source)" />
+		<meta
+			name="twitter:description"
+			content="COBOL programming exercise: CSISEmailDomain – CSIS Web Site Email Domain File (COBOL source)."
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html
+++ b/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>NetNews - Due Subscriptions Report (Exam Paper)</title>
+		<meta
+			name="description"
+			content="NetNews is a company which runs an NNTP server carrying the complete USENET news feed with over 15,000 news groups. Access to this server is available to"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html"
+		/>
+		<meta property="og:title" content="NetNews - Due Subscriptions Report (Exam Paper)" />
+		<meta
+			property="og:description"
+			content="NetNews is a company which runs an NNTP server carrying the complete USENET news feed with over 15,000 news groups. Access to this server is available to"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="NetNews - Due Subscriptions Report (Exam Paper)" />
+		<meta
+			name="twitter:description"
+			content="NetNews is a company which runs an NNTP server carrying the complete USENET news feed with over 15,000 news groups. Access to this server is available to"
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<script src="../../components/theme-toggle.js" defer></script>

--- a/exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html
+++ b/exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>DueSubsRpt – NetNews Due Subscriptions Report (COBOL source)</title>
+		<meta
+			name="description"
+			content="COBOL programming exercise: DueSubsRpt – NetNews Due Subscriptions Report (COBOL source)."
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html"
+		/>
+		<meta property="og:title" content="DueSubsRpt – NetNews Due Subscriptions Report (COBOL source)" />
+		<meta
+			property="og:description"
+			content="COBOL programming exercise: DueSubsRpt – NetNews Due Subscriptions Report (COBOL source)."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="DueSubsRpt – NetNews Due Subscriptions Report (COBOL source)" />
+		<meta
+			name="twitter:description"
+			content="COBOL programming exercise: DueSubsRpt – NetNews Due Subscriptions Report (COBOL source)."
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/exercises/Exm-FileConversion/Exm-FileConversion.html
+++ b/exercises/Exm-FileConversion/Exm-FileConversion.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>File Conversion Program (Exam Paper)</title>
+		<meta
+			name="description"
+			content="A program is required to convert the unsorted Client-Names file of free-format, variable length, records into a sorted file of fixed length records. The"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FileConversion/Exm-FileConversion.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FileConversion/Exm-FileConversion.html"
+		/>
+		<meta property="og:title" content="File Conversion Program (Exam Paper)" />
+		<meta
+			property="og:description"
+			content="A program is required to convert the unsorted Client-Names file of free-format, variable length, records into a sorted file of fixed length records. The"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="File Conversion Program (Exam Paper)" />
+		<meta
+			name="twitter:description"
+			content="A program is required to convert the unsorted Client-Names file of free-format, variable length, records into a sorted file of fixed length records. The"
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<script src="../../components/theme-toggle.js" defer></script>

--- a/exercises/Exm-FileConversion/Prg-FileConversion.html
+++ b/exercises/Exm-FileConversion/Prg-FileConversion.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>FileConversion – File Conversion Program (COBOL source)</title>
+		<meta
+			name="description"
+			content="COBOL programming exercise: FileConversion – File Conversion Program (COBOL source)."
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FileConversion/Prg-FileConversion.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FileConversion/Prg-FileConversion.html"
+		/>
+		<meta property="og:title" content="FileConversion – File Conversion Program (COBOL source)" />
+		<meta
+			property="og:description"
+			content="COBOL programming exercise: FileConversion – File Conversion Program (COBOL source)."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="FileConversion – File Conversion Program (COBOL source)" />
+		<meta
+			name="twitter:description"
+			content="COBOL programming exercise: FileConversion – File Conversion Program (COBOL source)."
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html
+++ b/exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>FlyByNight Travel Agency Sorted Summary File (Exam Question)</title>
+		<meta
+			name="description"
+			content="The FlyByNight travel agency sends its customers all over the world. For each booking a record is created in the Booking Master file (BOOKING.DAT). Each"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html"
+		/>
+		<meta property="og:title" content="FlyByNight Travel Agency Sorted Summary File (Exam Question)" />
+		<meta
+			property="og:description"
+			content="The FlyByNight travel agency sends its customers all over the world. For each booking a record is created in the Booking Master file (BOOKING.DAT). Each"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="FlyByNight Travel Agency Sorted Summary File (Exam Question)" />
+		<meta
+			name="twitter:description"
+			content="The FlyByNight travel agency sends its customers all over the world. For each booking a record is created in the Booking Master file (BOOKING.DAT). Each"
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<script src="../../components/theme-toggle.js" defer></script>

--- a/exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html
+++ b/exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>FlyByNight – Travel Agency Sorted Summary File (COBOL source)</title>
+		<meta
+			name="description"
+			content="COBOL programming exercise: FlyByNight – Travel Agency Sorted Summary File (COBOL source)."
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html"
+		/>
+		<meta property="og:title" content="FlyByNight – Travel Agency Sorted Summary File (COBOL source)" />
+		<meta
+			property="og:description"
+			content="COBOL programming exercise: FlyByNight – Travel Agency Sorted Summary File (COBOL source)."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="FlyByNight – Travel Agency Sorted Summary File (COBOL source)" />
+		<meta
+			name="twitter:description"
+			content="COBOL programming exercise: FlyByNight – Travel Agency Sorted Summary File (COBOL source)."
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html
+++ b/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>Pascal Memorial Library - Royalty Payments Report Program (Exam Paper)</title>
+		<meta
+			name="description"
+			content='Each time a book is borrowed, the Pascal Memorial Library pays the author a small sum of money as royalty. Because the sum owed for each "borrowing" is'
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html"
+		/>
+		<meta property="og:title" content="Pascal Memorial Library - Royalty Payments Report Program (Exam Paper)" />
+		<meta
+			property="og:description"
+			content='Each time a book is borrowed, the Pascal Memorial Library pays the author a small sum of money as royalty. Because the sum owed for each "borrowing" is'
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Pascal Memorial Library - Royalty Payments Report Program (Exam Paper)" />
+		<meta
+			name="twitter:description"
+			content='Each time a book is borrowed, the Pascal Memorial Library pays the author a small sum of money as royalty. Because the sum owed for each "borrowing" is'
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<script src="../../components/theme-toggle.js" defer></script>

--- a/exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html
+++ b/exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>LibRoyaltyRpt – Library Royalty Payment Report (COBOL source)</title>
+		<meta
+			name="description"
+			content="COBOL programming exercise: LibRoyaltyRpt – Library Royalty Payment Report (COBOL source)."
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html"
+		/>
+		<meta property="og:title" content="LibRoyaltyRpt – Library Royalty Payment Report (COBOL source)" />
+		<meta
+			property="og:description"
+			content="COBOL programming exercise: LibRoyaltyRpt – Library Royalty Payment Report (COBOL source)."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="LibRoyaltyRpt – Library Royalty Payment Report (COBOL source)" />
+		<meta
+			name="twitter:description"
+			content="COBOL programming exercise: LibRoyaltyRpt – Library Royalty Payment Report (COBOL source)."
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/exercises/Exm-SFbyMail/Exm-SFbyMail.html
+++ b/exercises/Exm-SFbyMail/Exm-SFbyMail.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>Science Fiction by Mail - Order Processing Program (Exam Paper)</title>
+		<meta
+			name="description"
+			content="Science Fiction by Mail is a company which sells Science Fiction and Fantasy books through the Internet. Customers view the book catalogues and place"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-SFbyMail/Exm-SFbyMail.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-SFbyMail/Exm-SFbyMail.html"
+		/>
+		<meta property="og:title" content="Science Fiction by Mail - Order Processing Program (Exam Paper)" />
+		<meta
+			property="og:description"
+			content="Science Fiction by Mail is a company which sells Science Fiction and Fantasy books through the Internet. Customers view the book catalogues and place"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Science Fiction by Mail - Order Processing Program (Exam Paper)" />
+		<meta
+			name="twitter:description"
+			content="Science Fiction by Mail is a company which sells Science Fiction and Fantasy books through the Internet. Customers view the book catalogues and place"
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<script src="../../components/theme-toggle.js" defer></script>

--- a/exercises/Exm-SFbyMail/Prg-SFbyMail.html
+++ b/exercises/Exm-SFbyMail/Prg-SFbyMail.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>SFbyMail – Science Fiction by Mail Order Processing (COBOL source)</title>
+		<meta
+			name="description"
+			content="COBOL programming exercise: SFbyMail – Science Fiction by Mail Order Processing (COBOL source)."
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-SFbyMail/Prg-SFbyMail.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-SFbyMail/Prg-SFbyMail.html"
+		/>
+		<meta property="og:title" content="SFbyMail – Science Fiction by Mail Order Processing (COBOL source)" />
+		<meta
+			property="og:description"
+			content="COBOL programming exercise: SFbyMail – Science Fiction by Mail Order Processing (COBOL source)."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="SFbyMail – Science Fiction by Mail Order Processing (COBOL source)" />
+		<meta
+			name="twitter:description"
+			content="COBOL programming exercise: SFbyMail – Science Fiction by Mail Order Processing (COBOL source)."
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/exercises/Exm-StudFeesRpt/Exm-StudPay.html
+++ b/exercises/Exm-StudFeesRpt/Exm-StudPay.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>Student Fee Payment - Update and Report (Exam Question)</title>
+		<meta
+			name="description"
+			content="At the beginning of each term Student Services creates a report showing those students whose fees are still outstanding. Until now this report was created"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-StudFeesRpt/Exm-StudPay.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-StudFeesRpt/Exm-StudPay.html"
+		/>
+		<meta property="og:title" content="Student Fee Payment - Update and Report (Exam Question)" />
+		<meta
+			property="og:description"
+			content="At the beginning of each term Student Services creates a report showing those students whose fees are still outstanding. Until now this report was created"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Student Fee Payment - Update and Report (Exam Question)" />
+		<meta
+			name="twitter:description"
+			content="At the beginning of each term Student Services creates a report showing those students whose fees are still outstanding. Until now this report was created"
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<script src="../../components/theme-toggle.js" defer></script>

--- a/exercises/Exm-StudFeesRpt/Prg-StudPay.html
+++ b/exercises/Exm-StudFeesRpt/Prg-StudPay.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>StudPay – Student Fee Payment Update and Report (COBOL source)</title>
+		<meta
+			name="description"
+			content="COBOL programming exercise: StudPay – Student Fee Payment Update and Report (COBOL source)."
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-StudFeesRpt/Prg-StudPay.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-StudFeesRpt/Prg-StudPay.html"
+		/>
+		<meta property="og:title" content="StudPay – Student Fee Payment Update and Report (COBOL source)" />
+		<meta
+			property="og:description"
+			content="COBOL programming exercise: StudPay – Student Fee Payment Update and Report (COBOL source)."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="StudPay – Student Fee Payment Update and Report (COBOL source)" />
+		<meta
+			name="twitter:description"
+			content="COBOL programming exercise: StudPay – Student Fee Payment Update and Report (COBOL source)."
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html
+++ b/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>Top Vide Supplier Report (Exam Question)</title>
+		<meta
+			name="description"
+			content="The manager of Metropolis Videos was so pleased with your Video Stock File Maintenance and Report system that he has asked you to write the Top Suppliers"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html"
+		/>
+		<meta property="og:title" content="Top Vide Supplier Report (Exam Question)" />
+		<meta
+			property="og:description"
+			content="The manager of Metropolis Videos was so pleased with your Video Stock File Maintenance and Report system that he has asked you to write the Top Suppliers"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Top Vide Supplier Report (Exam Question)" />
+		<meta
+			name="twitter:description"
+			content="The manager of Metropolis Videos was so pleased with your Video Stock File Maintenance and Report system that he has asked you to write the Top Suppliers"
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<script src="../../components/theme-toggle.js" defer></script>

--- a/exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html
+++ b/exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>TopSupplierRpt – Top Video Supplier Report (COBOL source)</title>
+		<meta
+			name="description"
+			content="COBOL programming exercise: TopSupplierRpt – Top Video Supplier Report (COBOL source)."
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html"
+		/>
+		<meta property="og:title" content="TopSupplierRpt – Top Video Supplier Report (COBOL source)" />
+		<meta
+			property="og:description"
+			content="COBOL programming exercise: TopSupplierRpt – Top Video Supplier Report (COBOL source)."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="TopSupplierRpt – Top Video Supplier Report (COBOL source)" />
+		<meta
+			name="twitter:description"
+			content="COBOL programming exercise: TopSupplierRpt – Top Video Supplier Report (COBOL source)."
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html
+++ b/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>USSR Naval Vessel Inventory Report</title>
+		<meta
+			name="description"
+			content="The unsorted USSR Vessel Master File (UVMF) contains details of all the sea-going vessels of the SOVIET UNION. The following is the record description."
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html"
+		/>
+		<meta property="og:title" content="USSR Naval Vessel Inventory Report" />
+		<meta
+			property="og:description"
+			content="The unsorted USSR Vessel Master File (UVMF) contains details of all the sea-going vessels of the SOVIET UNION. The following is the record description."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="USSR Naval Vessel Inventory Report" />
+		<meta
+			name="twitter:description"
+			content="The unsorted USSR Vessel Master File (UVMF) contains details of all the sea-going vessels of the SOVIET UNION. The following is the record description."
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<script src="../../components/theme-toggle.js" defer></script>

--- a/exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html
+++ b/exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>USSRshipRpt – USSR Naval Vessel Inventory Report (COBOL source)</title>
+		<meta
+			name="description"
+			content="COBOL programming exercise: USSRshipRpt – USSR Naval Vessel Inventory Report (COBOL source)."
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html"
+		/>
+		<meta property="og:title" content="USSRshipRpt – USSR Naval Vessel Inventory Report (COBOL source)" />
+		<meta
+			property="og:description"
+			content="COBOL programming exercise: USSRshipRpt – USSR Naval Vessel Inventory Report (COBOL source)."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="USSRshipRpt – USSR Naval Vessel Inventory Report (COBOL source)" />
+		<meta
+			name="twitter:description"
+			content="COBOL programming exercise: USSRshipRpt – USSR Naval Vessel Inventory Report (COBOL source)."
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />

--- a/exercises/GettingStarted.html
+++ b/exercises/GettingStarted.html
@@ -11,6 +11,24 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Getting Started with the VISOC Environment</title>
+		<meta name="description" content="COBOL programming exercise: Getting Started with the VISOC Environment." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/exercises/GettingStarted.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/exercises/GettingStarted.html" />
+		<meta property="og:title" content="Getting Started with the VISOC Environment" />
+		<meta
+			property="og:description"
+			content="COBOL programming exercise: Getting Started with the VISOC Environment."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Getting Started with the VISOC Environment" />
+		<meta
+			name="twitter:description"
+			content="COBOL programming exercise: Getting Started with the VISOC Environment."
+		/>
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />
 		<script src="../components/theme-toggle.js" defer></script>

--- a/exercises/MonthTable.html
+++ b/exercises/MonthTable.html
@@ -11,6 +11,27 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Using Tables</title>
+		<meta
+			name="description"
+			content="A program is required which will process the Students File (Students.Dat) and will count the number students born on each month of the year and will"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/exercises/MonthTable.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/exercises/MonthTable.html" />
+		<meta property="og:title" content="Using Tables" />
+		<meta
+			property="og:description"
+			content="A program is required which will process the Students File (Students.Dat) and will count the number students born on each month of the year and will"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Using Tables" />
+		<meta
+			name="twitter:description"
+			content="A program is required which will process the Students File (Students.Dat) and will count the number students born on each month of the year and will"
+		/>
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />
 		<script src="../components/theme-toggle.js" defer></script>

--- a/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html
+++ b/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>Aromamora Essential Oils - Sales Report (25 hours)</title>
+		<meta
+			name="description"
+			content="A program is required that will examine the Aromamora Customer and Invoice files and from them produce a report showing the unpaid customer invoices. The"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html"
+		/>
+		<meta property="og:title" content="Aromamora Essential Oils - Sales Report (25 hours)" />
+		<meta
+			property="og:description"
+			content="A program is required that will examine the Aromamora Customer and Invoice files and from them produce a report showing the unpaid customer invoices. The"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Aromamora Essential Oils - Sales Report (25 hours)" />
+		<meta
+			name="twitter:description"
+			content="A program is required that will examine the Aromamora Customer and Invoice files and from them produce a report showing the unpaid customer invoices. The"
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<style>

--- a/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html
+++ b/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>Aromamora Essential Oils - Sales Report (25 hours)</title>
+		<meta
+			name="description"
+			content="Aromamora PLC is a company which sells essential oils to Aromatherapists, Health Shops, Chemists and other mass users of essential oils. Every month,"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html"
+		/>
+		<meta property="og:title" content="Aromamora Essential Oils - Sales Report (25 hours)" />
+		<meta
+			property="og:description"
+			content="Aromamora PLC is a company which sells essential oils to Aromatherapists, Health Shops, Chemists and other mass users of essential oils. Every month,"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Aromamora Essential Oils - Sales Report (25 hours)" />
+		<meta
+			name="twitter:description"
+			content="Aromamora PLC is a company which sells essential oils to Aromatherapists, Health Shops, Chemists and other mass users of essential oils. Every month,"
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<style>

--- a/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html
+++ b/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>UL CAO points calculator and Report</title>
+		<meta
+			name="description"
+			content="The Central Applications Office (CAO) provides a centralised applications mechanism to many of the third level institutions in Ireland. Students wishing to"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html"
+		/>
+		<meta property="og:title" content="UL CAO points calculator and Report" />
+		<meta
+			property="og:description"
+			content="The Central Applications Office (CAO) provides a centralised applications mechanism to many of the third level institutions in Ireland. Students wishing to"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="UL CAO points calculator and Report" />
+		<meta
+			name="twitter:description"
+			content="The Central Applications Office (CAO) provides a centralised applications mechanism to many of the third level institutions in Ireland. Students wishing to"
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<style>

--- a/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html
+++ b/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>Munster Surnames Frequency Report</title>
+		<meta
+			name="description"
+			content="The Genealogists Society of Ireland is trying to discover which Irish surnames occur most frequently in the counties of Munster. In order to obtain this"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html"
+		/>
+		<meta property="og:title" content="Munster Surnames Frequency Report" />
+		<meta
+			property="og:description"
+			content="The Genealogists Society of Ireland is trying to discover which Irish surnames occur most frequently in the counties of Munster. In order to obtain this"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Munster Surnames Frequency Report" />
+		<meta
+			name="twitter:description"
+			content="The Genealogists Society of Ireland is trying to discover which Irish surnames occur most frequently in the counties of Munster. In order to obtain this"
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<style>

--- a/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html
+++ b/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>Newtronics Plc. File Maintenance Program</title>
+		<meta
+			name="description"
+			content="Newtronics Plc. is a company which sells electronic parts (diodes, transistors, IC's, LED's thermostats etc.) and goods. Currently, the company is being"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html"
+		/>
+		<meta property="og:title" content="Newtronics Plc. File Maintenance Program" />
+		<meta
+			property="og:description"
+			content="Newtronics Plc. is a company which sells electronic parts (diodes, transistors, IC's, LED's thermostats etc.) and goods. Currently, the company is being"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Newtronics Plc. File Maintenance Program" />
+		<meta
+			name="twitter:description"
+			content="Newtronics Plc. is a company which sells electronic parts (diodes, transistors, IC's, LED's thermostats etc.) and goods. Currently, the company is being"
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<style>

--- a/exercises/Proj-CSISEvalform/CSISEvalForm.html
+++ b/exercises/Proj-CSISEvalform/CSISEvalForm.html
@@ -11,6 +11,33 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
 		<title>Zoom taxis DP291 Cobol project</title>
+		<meta
+			name="description"
+			content="Visitors to the CSIS web site are asked to fill in an evaluation form. The form requests the name of the visitor, his/her country of origin, his/her"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/exercises/Proj-CSISEvalform/CSISEvalForm.html"
+		/>
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/exercises/Proj-CSISEvalform/CSISEvalForm.html"
+		/>
+		<meta property="og:title" content="Zoom taxis DP291 Cobol project" />
+		<meta
+			property="og:description"
+			content="Visitors to the CSIS web site are asked to fill in an evaluation form. The form requests the name of the visitor, his/her country of origin, his/her"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Zoom taxis DP291 Cobol project" />
+		<meta
+			name="twitter:description"
+			content="Visitors to the CSIS web site are asked to fill in an evaluation form. The form requests the name of the visitor, his/her country of origin, his/her"
+		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<script src="../../components/theme-toggle.js" defer></script>

--- a/exercises/SeqInsert.html
+++ b/exercises/SeqInsert.html
@@ -11,6 +11,27 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Inserting records in a Sequential File</title>
+		<meta
+			name="description"
+			content="Using the SeqWrite.Cbl program as a starting point write a program called SeqInsert.Cbl to take a file of new student records (TransIns.Dat) and insert"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/exercises/SeqInsert.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/exercises/SeqInsert.html" />
+		<meta property="og:title" content="Inserting records in a Sequential File" />
+		<meta
+			property="og:description"
+			content="Using the SeqWrite.Cbl program as a starting point write a program called SeqInsert.Cbl to take a file of new student records (TransIns.Dat) and insert"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Inserting records in a Sequential File" />
+		<meta
+			name="twitter:description"
+			content="Using the SeqWrite.Cbl program as a starting point write a program called SeqInsert.Cbl to take a file of new student records (TransIns.Dat) and insert"
+		/>
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />
 		<script src="../components/theme-toggle.js" defer></script>

--- a/exercises/SeqRead.html
+++ b/exercises/SeqRead.html
@@ -11,6 +11,27 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Reading Sequential Files</title>
+		<meta
+			name="description"
+			content="The program SeqRead.Cbl reads a sequential file and displays the StudentId, StudentName and the CourseCode of each record in the file on the screen. In"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/exercises/SeqRead.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/exercises/SeqRead.html" />
+		<meta property="og:title" content="Reading Sequential Files" />
+		<meta
+			property="og:description"
+			content="The program SeqRead.Cbl reads a sequential file and displays the StudentId, StudentName and the CourseCode of each record in the file on the screen. In"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Reading Sequential Files" />
+		<meta
+			name="twitter:description"
+			content="The program SeqRead.Cbl reads a sequential file and displays the StudentId, StudentName and the CourseCode of each record in the file on the screen. In"
+		/>
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />
 		<script src="../components/theme-toggle.js" defer></script>

--- a/exercises/SeqReadIf.html
+++ b/exercises/SeqReadIf.html
@@ -11,6 +11,27 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Counting records in a sequential file</title>
+		<meta
+			name="description"
+			content="The program SeqRead.Cbl reads a sequential file and displays the StudentId, StudentName and the CourseCode of each record in the file on the screen. In"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/exercises/SeqReadIf.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/exercises/SeqReadIf.html" />
+		<meta property="og:title" content="Counting records in a sequential file" />
+		<meta
+			property="og:description"
+			content="The program SeqRead.Cbl reads a sequential file and displays the StudentId, StudentName and the CourseCode of each record in the file on the screen. In"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Counting records in a sequential file" />
+		<meta
+			name="twitter:description"
+			content="The program SeqRead.Cbl reads a sequential file and displays the StudentId, StudentName and the CourseCode of each record in the file on the screen. In"
+		/>
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />
 		<script src="../components/theme-toggle.js" defer></script>

--- a/exercises/SeqUpdate.html
+++ b/exercises/SeqUpdate.html
@@ -11,6 +11,27 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Updating a Sequential File</title>
+		<meta
+			name="description"
+			content="The transaction file (Transfer.Dat) contains records of students who have transferred from one University of Limerick (UL) course to another. The file is"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/exercises/SeqUpdate.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/exercises/SeqUpdate.html" />
+		<meta property="og:title" content="Updating a Sequential File" />
+		<meta
+			property="og:description"
+			content="The transaction file (Transfer.Dat) contains records of students who have transferred from one University of Limerick (UL) course to another. The file is"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Updating a Sequential File" />
+		<meta
+			name="twitter:description"
+			content="The transaction file (Transfer.Dat) contains records of students who have transferred from one University of Limerick (UL) course to another. The file is"
+		/>
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />
 		<script src="../components/theme-toggle.js" defer></script>

--- a/exercises/SeqWrite.html
+++ b/exercises/SeqWrite.html
@@ -11,6 +11,27 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Writing records to a Sequential File</title>
+		<meta
+			name="description"
+			content="Using Seqread.Cbl as a starting point, write a program called SeqWrite.Cbl to accept student records from the user and write them to a file"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/exercises/SeqWrite.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/exercises/SeqWrite.html" />
+		<meta property="og:title" content="Writing records to a Sequential File" />
+		<meta
+			property="og:description"
+			content="Using Seqread.Cbl as a starting point, write a program called SeqWrite.Cbl to accept student records from the user and write them to a file"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Writing records to a Sequential File" />
+		<meta
+			name="twitter:description"
+			content="Using Seqread.Cbl as a starting point, write a program called SeqWrite.Cbl to accept student records from the user and write them to a file"
+		/>
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />
 		<script src="../components/theme-toggle.js" defer></script>

--- a/exercises/SortIP.html
+++ b/exercises/SortIP.html
@@ -11,6 +11,27 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>Sorting a Sequential File</title>
+		<meta
+			name="description"
+			content="A program is required which will process the Students File (Students.Dat) and will count the number of males and females taking each course. The totals"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/exercises/SortIP.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/exercises/SortIP.html" />
+		<meta property="og:title" content="Sorting a Sequential File" />
+		<meta
+			property="og:description"
+			content="A program is required which will process the Students File (Students.Dat) and will count the number of males and females taking each course. The totals"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Sorting a Sequential File" />
+		<meta
+			name="twitter:description"
+			content="A program is required which will process the Students File (Students.Dat) and will count the number of males and females taking each course. The totals"
+		/>
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />
 		<script src="../components/theme-toggle.js" defer></script>

--- a/lectures/Basics2.html
+++ b/lectures/Basics2.html
@@ -3,6 +3,18 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>basics2 - COBOL Lecture</title>
+		<meta name="description" content="COBOL lecture slides covering basics2." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/Basics2.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/Basics2.html" />
+		<meta property="og:title" content="basics2 - COBOL Lecture" />
+		<meta property="og:description" content="COBOL lecture slides covering basics2." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="basics2 - COBOL Lecture" />
+		<meta name="twitter:description" content="COBOL lecture slides covering basics2." />
 		<style type="text/css">
 			img {
 				max-width: 100%;

--- a/lectures/COPY.html
+++ b/lectures/COPY.html
@@ -3,6 +3,18 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>COPY - COBOL Lecture</title>
+		<meta name="description" content="COBOL lecture slides covering COPY." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/COPY.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/COPY.html" />
+		<meta property="og:title" content="COPY - COBOL Lecture" />
+		<meta property="og:description" content="COBOL lecture slides covering COPY." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="COPY - COBOL Lecture" />
+		<meta name="twitter:description" content="COBOL lecture slides covering COPY." />
 		<style type="text/css">
 			img {
 				max-width: 100%;

--- a/lectures/CS4312Topics.html
+++ b/lectures/CS4312Topics.html
@@ -3,6 +3,18 @@
 	<head>
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<title>COBOL Course Outline</title>
+		<meta name="description" content="COBOL lecture slides covering COBOL Course Outline." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/CS4312Topics.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/CS4312Topics.html" />
+		<meta property="og:title" content="COBOL Course Outline" />
+		<meta property="og:description" content="COBOL lecture slides covering COBOL Course Outline." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="COBOL Course Outline" />
+		<meta name="twitter:description" content="COBOL lecture slides covering COBOL Course Outline." />
 		<style>
 			img {
 				max-width: 100%;

--- a/lectures/GenIntro.html
+++ b/lectures/GenIntro.html
@@ -3,6 +3,18 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>GenIntro - COBOL Lecture</title>
+		<meta name="description" content="COBOL lecture slides covering GenIntro." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/GenIntro.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/GenIntro.html" />
+		<meta property="og:title" content="GenIntro - COBOL Lecture" />
+		<meta property="og:description" content="COBOL lecture slides covering GenIntro." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="GenIntro - COBOL Lecture" />
+		<meta name="twitter:description" content="COBOL lecture slides covering GenIntro." />
 		<style type="text/css">
 			img {
 				max-width: 100%;

--- a/lectures/ReportWriterSSWeb.html
+++ b/lectures/ReportWriterSSWeb.html
@@ -4,6 +4,27 @@
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>COBOL Report Writer - Syntax and Semantics</title>
+		<meta name="description" content="COBOL lecture slides covering COBOL Report Writer - Syntax and Semantics." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/ReportWriterSSWeb.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/lectures/ReportWriterSSWeb.html"
+		/>
+		<meta property="og:title" content="COBOL Report Writer - Syntax and Semantics" />
+		<meta
+			property="og:description"
+			content="COBOL lecture slides covering COBOL Report Writer - Syntax and Semantics."
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="COBOL Report Writer - Syntax and Semantics" />
+		<meta
+			name="twitter:description"
+			content="COBOL lecture slides covering COBOL Report Writer - Syntax and Semantics."
+		/>
 		<style type="text/css">
 			ul.toc {
 				list-style-image: url(Ballgreeng.gif);

--- a/lectures/ReportWriterWeb.html
+++ b/lectures/ReportWriterWeb.html
@@ -4,6 +4,18 @@
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>COBOL Report Writer</title>
+		<meta name="description" content="COBOL lecture slides covering COBOL Report Writer." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/ReportWriterWeb.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/ReportWriterWeb.html" />
+		<meta property="og:title" content="COBOL Report Writer" />
+		<meta property="og:description" content="COBOL lecture slides covering COBOL Report Writer." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="COBOL Report Writer" />
+		<meta name="twitter:description" content="COBOL lecture slides covering COBOL Report Writer." />
 		<style type="text/css">
 			img {
 				max-width: 100%;

--- a/lectures/SeqFile3.html
+++ b/lectures/SeqFile3.html
@@ -3,6 +3,18 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>SeqFile3 - COBOL Lecture</title>
+		<meta name="description" content="COBOL lecture slides covering SeqFile3." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/SeqFile3.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/SeqFile3.html" />
+		<meta property="og:title" content="SeqFile3 - COBOL Lecture" />
+		<meta property="og:description" content="COBOL lecture slides covering SeqFile3." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="SeqFile3 - COBOL Lecture" />
+		<meta name="twitter:description" content="COBOL lecture slides covering SeqFile3." />
 		<style type="text/css">
 			img {
 				max-width: 100%;

--- a/lectures/Unstring.html
+++ b/lectures/Unstring.html
@@ -3,6 +3,18 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Unstring - COBOL Lecture</title>
+		<meta name="description" content="COBOL lecture slides covering Unstring." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/Unstring.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/Unstring.html" />
+		<meta property="og:title" content="Unstring - COBOL Lecture" />
+		<meta property="og:description" content="COBOL lecture slides covering Unstring." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Unstring - COBOL Lecture" />
+		<meta name="twitter:description" content="COBOL lecture slides covering Unstring." />
 		<style type="text/css">
 			img {
 				max-width: 100%;

--- a/lectures/Usage.html
+++ b/lectures/Usage.html
@@ -3,6 +3,18 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Usage - COBOL Lecture</title>
+		<meta name="description" content="COBOL lecture slides covering Usage." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/Usage.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/Usage.html" />
+		<meta property="og:title" content="Usage - COBOL Lecture" />
+		<meta property="og:description" content="COBOL lecture slides covering Usage." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Usage - COBOL Lecture" />
+		<meta name="twitter:description" content="COBOL lecture slides covering Usage." />
 		<style type="text/css">
 			img {
 				max-width: 100%;

--- a/lectures/arithmetic.html
+++ b/lectures/arithmetic.html
@@ -3,6 +3,18 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Arithmetic - COBOL Lecture</title>
+		<meta name="description" content="COBOL lecture slides covering Arithmetic." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/arithmetic.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/arithmetic.html" />
+		<meta property="og:title" content="Arithmetic - COBOL Lecture" />
+		<meta property="og:description" content="COBOL lecture slides covering Arithmetic." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Arithmetic - COBOL Lecture" />
+		<meta name="twitter:description" content="COBOL lecture slides covering Arithmetic." />
 		<style type="text/css">
 			img {
 				max-width: 100%;

--- a/lectures/basics1.html
+++ b/lectures/basics1.html
@@ -3,6 +3,18 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Basics1 - COBOL Lecture</title>
+		<meta name="description" content="COBOL lecture slides covering Basics1." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/basics1.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/basics1.html" />
+		<meta property="og:title" content="Basics1 - COBOL Lecture" />
+		<meta property="og:description" content="COBOL lecture slides covering Basics1." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Basics1 - COBOL Lecture" />
+		<meta name="twitter:description" content="COBOL lecture slides covering Basics1." />
 		<style type="text/css">
 			img {
 				max-width: 100%;

--- a/lectures/call.html
+++ b/lectures/call.html
@@ -3,6 +3,18 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>call - COBOL Lecture</title>
+		<meta name="description" content="COBOL lecture slides covering call." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/call.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/call.html" />
+		<meta property="og:title" content="call - COBOL Lecture" />
+		<meta property="og:description" content="COBOL lecture slides covering call." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="call - COBOL Lecture" />
+		<meta name="twitter:description" content="COBOL lecture slides covering call." />
 		<style type="text/css">
 			img {
 				max-width: 100%;

--- a/lectures/cobintro.html
+++ b/lectures/cobintro.html
@@ -3,6 +3,18 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>cobintro - COBOL Lecture</title>
+		<meta name="description" content="COBOL lecture slides covering cobintro." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/cobintro.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/cobintro.html" />
+		<meta property="og:title" content="cobintro - COBOL Lecture" />
+		<meta property="og:description" content="COBOL lecture slides covering cobintro." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="cobintro - COBOL Lecture" />
+		<meta name="twitter:description" content="COBOL lecture slides covering cobintro." />
 		<style type="text/css">
 			img {
 				max-width: 100%;

--- a/lectures/conditions.html
+++ b/lectures/conditions.html
@@ -3,6 +3,18 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Conditions - COBOL Lecture</title>
+		<meta name="description" content="COBOL lecture slides covering Conditions." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/conditions.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/conditions.html" />
+		<meta property="og:title" content="Conditions - COBOL Lecture" />
+		<meta property="og:description" content="COBOL lecture slides covering Conditions." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Conditions - COBOL Lecture" />
+		<meta name="twitter:description" content="COBOL lecture slides covering Conditions." />
 		<style type="text/css">
 			img {
 				max-width: 100%;

--- a/lectures/design.html
+++ b/lectures/design.html
@@ -3,6 +3,18 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>design - COBOL Lecture</title>
+		<meta name="description" content="COBOL lecture slides covering design." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/design.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/design.html" />
+		<meta property="og:title" content="design - COBOL Lecture" />
+		<meta property="og:description" content="COBOL lecture slides covering design." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="design - COBOL Lecture" />
+		<meta name="twitter:description" content="COBOL lecture slides covering design." />
 		<style type="text/css">
 			img {
 				max-width: 100%;

--- a/lectures/direct1.html
+++ b/lectures/direct1.html
@@ -3,6 +3,18 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>direct1 - COBOL Lecture</title>
+		<meta name="description" content="COBOL lecture slides covering direct1." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/direct1.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/direct1.html" />
+		<meta property="og:title" content="direct1 - COBOL Lecture" />
+		<meta property="og:description" content="COBOL lecture slides covering direct1." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="direct1 - COBOL Lecture" />
+		<meta name="twitter:description" content="COBOL lecture slides covering direct1." />
 		<style type="text/css">
 			img {
 				max-width: 100%;

--- a/lectures/dsr1.html
+++ b/lectures/dsr1.html
@@ -3,6 +3,18 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>dsr1 - COBOL Lecture</title>
+		<meta name="description" content="COBOL lecture slides covering dsr1." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/dsr1.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/dsr1.html" />
+		<meta property="og:title" content="dsr1 - COBOL Lecture" />
+		<meta property="og:description" content="COBOL lecture slides covering dsr1." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="dsr1 - COBOL Lecture" />
+		<meta name="twitter:description" content="COBOL lecture slides covering dsr1." />
 		<style type="text/css">
 			img {
 				max-width: 100%;

--- a/lectures/indexed.html
+++ b/lectures/indexed.html
@@ -3,6 +3,18 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Indexed - COBOL Lecture</title>
+		<meta name="description" content="COBOL lecture slides covering Indexed." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/indexed.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/indexed.html" />
+		<meta property="og:title" content="Indexed - COBOL Lecture" />
+		<meta property="og:description" content="COBOL lecture slides covering Indexed." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Indexed - COBOL Lecture" />
+		<meta name="twitter:description" content="COBOL lecture slides covering Indexed." />
 		<style type="text/css">
 			img {
 				max-width: 100%;

--- a/lectures/inspect.html
+++ b/lectures/inspect.html
@@ -3,6 +3,18 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Inspect - COBOL Lecture</title>
+		<meta name="description" content="COBOL lecture slides covering Inspect." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/inspect.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/inspect.html" />
+		<meta property="og:title" content="Inspect - COBOL Lecture" />
+		<meta property="og:description" content="COBOL lecture slides covering Inspect." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Inspect - COBOL Lecture" />
+		<meta name="twitter:description" content="COBOL lecture slides covering Inspect." />
 		<style type="text/css">
 			img {
 				max-width: 100%;

--- a/lectures/perform.html
+++ b/lectures/perform.html
@@ -3,6 +3,18 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>perform - COBOL Lecture</title>
+		<meta name="description" content="COBOL lecture slides covering perform." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/perform.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/perform.html" />
+		<meta property="og:title" content="perform - COBOL Lecture" />
+		<meta property="og:description" content="COBOL lecture slides covering perform." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="perform - COBOL Lecture" />
+		<meta name="twitter:description" content="COBOL lecture slides covering perform." />
 		<style type="text/css">
 			img {
 				max-width: 100%;

--- a/lectures/relative.html
+++ b/lectures/relative.html
@@ -3,6 +3,18 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Relative - COBOL Lecture</title>
+		<meta name="description" content="COBOL lecture slides covering Relative." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/relative.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/relative.html" />
+		<meta property="og:title" content="Relative - COBOL Lecture" />
+		<meta property="og:description" content="COBOL lecture slides covering Relative." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Relative - COBOL Lecture" />
+		<meta name="twitter:description" content="COBOL lecture slides covering Relative." />
 		<style type="text/css">
 			img {
 				max-width: 100%;

--- a/lectures/search.html
+++ b/lectures/search.html
@@ -3,6 +3,18 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Search - COBOL Lecture</title>
+		<meta name="description" content="COBOL lecture slides covering Search." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/search.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/search.html" />
+		<meta property="og:title" content="Search - COBOL Lecture" />
+		<meta property="og:description" content="COBOL lecture slides covering Search." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Search - COBOL Lecture" />
+		<meta name="twitter:description" content="COBOL lecture slides covering Search." />
 		<style type="text/css">
 			img {
 				max-width: 100%;

--- a/lectures/seqfile1.html
+++ b/lectures/seqfile1.html
@@ -3,6 +3,18 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>SeqFile1 - COBOL Lecture</title>
+		<meta name="description" content="COBOL lecture slides covering SeqFile1." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/seqfile1.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/seqfile1.html" />
+		<meta property="og:title" content="SeqFile1 - COBOL Lecture" />
+		<meta property="og:description" content="COBOL lecture slides covering SeqFile1." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="SeqFile1 - COBOL Lecture" />
+		<meta name="twitter:description" content="COBOL lecture slides covering SeqFile1." />
 		<style type="text/css">
 			img {
 				max-width: 100%;

--- a/lectures/seqfile2.html
+++ b/lectures/seqfile2.html
@@ -3,6 +3,18 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>SeqFile2 - COBOL Lecture</title>
+		<meta name="description" content="COBOL lecture slides covering SeqFile2." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/seqfile2.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/seqfile2.html" />
+		<meta property="og:title" content="SeqFile2 - COBOL Lecture" />
+		<meta property="og:description" content="COBOL lecture slides covering SeqFile2." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="SeqFile2 - COBOL Lecture" />
+		<meta name="twitter:description" content="COBOL lecture slides covering SeqFile2." />
 		<style type="text/css">
 			img {
 				max-width: 100%;

--- a/lectures/sort.html
+++ b/lectures/sort.html
@@ -3,6 +3,18 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>SORT - COBOL Lecture</title>
+		<meta name="description" content="COBOL lecture slides covering SORT." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/sort.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/sort.html" />
+		<meta property="og:title" content="SORT - COBOL Lecture" />
+		<meta property="og:description" content="COBOL lecture slides covering SORT." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="SORT - COBOL Lecture" />
+		<meta name="twitter:description" content="COBOL lecture slides covering SORT." />
 		<style type="text/css">
 			img {
 				max-width: 100%;

--- a/lectures/string.html
+++ b/lectures/string.html
@@ -3,6 +3,18 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>String - COBOL Lecture</title>
+		<meta name="description" content="COBOL lecture slides covering String." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/string.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/string.html" />
+		<meta property="og:title" content="String - COBOL Lecture" />
+		<meta property="og:description" content="COBOL lecture slides covering String." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="String - COBOL Lecture" />
+		<meta name="twitter:description" content="COBOL lecture slides covering String." />
 		<style type="text/css">
 			img {
 				max-width: 100%;

--- a/lectures/tables1.html
+++ b/lectures/tables1.html
@@ -3,6 +3,18 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Tables1 - COBOL Lecture</title>
+		<meta name="description" content="COBOL lecture slides covering Tables1." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/tables1.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/tables1.html" />
+		<meta property="og:title" content="Tables1 - COBOL Lecture" />
+		<meta property="og:description" content="COBOL lecture slides covering Tables1." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Tables1 - COBOL Lecture" />
+		<meta name="twitter:description" content="COBOL lecture slides covering Tables1." />
 		<style type="text/css">
 			img {
 				max-width: 100%;

--- a/lectures/tables2.html
+++ b/lectures/tables2.html
@@ -3,6 +3,18 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Tables2 - COBOL Lecture</title>
+		<meta name="description" content="COBOL lecture slides covering Tables2." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/tables2.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/tables2.html" />
+		<meta property="og:title" content="Tables2 - COBOL Lecture" />
+		<meta property="og:description" content="COBOL lecture slides covering Tables2." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Tables2 - COBOL Lecture" />
+		<meta name="twitter:description" content="COBOL lecture slides covering Tables2." />
 		<style type="text/css">
 			img {
 				max-width: 100%;

--- a/scripts/add-page-meta.js
+++ b/scripts/add-page-meta.js
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+/**
+ * add-page-meta.js
+ * Injects missing SEO metadata (description, canonical URL, Open Graph, Twitter Card)
+ * into every leaf HTML page under course/, exercises/, examples/, lectures/.
+ *
+ * Pages that already have a <meta name="description"> are skipped (idempotent).
+ *
+ * To override an auto-extracted description, add an entry to scripts/page-descriptions.json
+ * keyed by the repo-root-relative path, e.g.:
+ *   { "course/Arithmetic.html": "Custom description here." }
+ *
+ * Run: node scripts/add-page-meta.js
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const BASE_URL = "https://bushidocodes.github.io/limerick-cobol/";
+const OG_IMAGE = "https://bushidocodes.github.io/limerick-cobol/favicon.svg";
+const REPO_ROOT = path.resolve(__dirname, "..");
+const CONTENT_DIRS = ["course", "exercises", "examples", "lectures"];
+const SKIP_NAMES = new Set(["index.html", "default.html"]);
+
+// ── Optional manual override map ──────────────────────────────────────────────
+const OVERRIDES_PATH = path.join(__dirname, "page-descriptions.json");
+const OVERRIDES = fs.existsSync(OVERRIDES_PATH) ? JSON.parse(fs.readFileSync(OVERRIDES_PATH, "utf8")) : {};
+
+// ── Text utilities ─────────────────────────────────────────────────────────────
+function stripTags(html) {
+	return html.replace(/<[^>]+>/g, " ");
+}
+
+function decodeEntities(str) {
+	return str
+		.replace(/&amp;/g, "&")
+		.replace(/&lt;/g, "<")
+		.replace(/&gt;/g, ">")
+		.replace(/&quot;/g, '"')
+		.replace(/&apos;/g, "'")
+		.replace(/&nbsp;/g, " ")
+		.replace(/&#(\d+);/g, (_, n) => String.fromCharCode(parseInt(n, 10)));
+}
+
+function cleanText(html) {
+	return decodeEntities(stripTags(html)).replace(/\s+/g, " ").trim();
+}
+
+function truncate(text, max = 155) {
+	if (text.length <= max) return text;
+	const cut = text.lastIndexOf(" ", max);
+	return (cut > 80 ? text.slice(0, cut) : text.slice(0, max)).trimEnd();
+}
+
+function escapeAttr(str) {
+	return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+// ── HTML parsing helpers ───────────────────────────────────────────────────────
+function extractTitle(html) {
+	const m = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+	return m ? cleanText(m[1]) : "";
+}
+
+/** Detect the whitespace prefix used on the <title> line so injected tags match. */
+function detectIndent(html) {
+	const m = html.match(/^([ \t]*)<title/m);
+	return m ? m[1] : "\t";
+}
+
+function alreadyTagged(html) {
+	return /<meta\s[^>]*name=["']description["']/i.test(html);
+}
+
+// ── Description extractors ─────────────────────────────────────────────────────
+
+/** Course pages: lift the paragraph from the "Aims" sidebar section. */
+function fromCourse(html) {
+	const m = html.match(/<h3>\s*Aims\s*<\/h3>[\s\S]*?class="section-content"[^>]*>[\s\S]*?<p>([\s\S]*?)<\/p>/i);
+	if (m) {
+		const t = truncate(cleanText(m[1]));
+		if (t.length > 20) return t;
+	}
+	return null;
+}
+
+/** Exercise pages: lift the first paragraph from the Introduction section. */
+function fromExercise(html) {
+	const m = html.match(/<h2>\s*Introduction\s*<\/h2>[\s\S]*?<p>([\s\S]*?)<\/p>/i);
+	if (m) {
+		const t = truncate(cleanText(m[1]));
+		if (t.length > 20) return t;
+	}
+	return null;
+}
+
+/**
+ * Build a map of { lowercased-view-path → description } from examples/default.html.
+ * Each data row contains a description td (width=298) and a View link in the actions td.
+ */
+function buildExampleMap(defaultHtml) {
+	const map = {};
+	// Match complete <tr>...</tr> blocks, then inspect each for a View link + description td.
+	const rowRe = /<tr(?:\s[^>]*)?>[\s\S]*?<\/tr>/gi;
+	let rowMatch;
+	while ((rowMatch = rowRe.exec(defaultHtml)) !== null) {
+		const row = rowMatch[0];
+		const viewMatch = row.match(/href="([^"]+\.html)">\s*View\s*<\/a>/i);
+		const descMatch = row.match(/<td\s+width=["']298["'][^>]*>([\s\S]*?)<\/td>/i);
+		if (viewMatch && descMatch) {
+			const desc = truncate(cleanText(descMatch[1]));
+			if (desc.length > 15) {
+				map[viewMatch[1].toLowerCase()] = desc;
+			}
+		}
+	}
+	return map;
+}
+
+function fromExampleMap(exampleMap, filePath) {
+	const relToExamples = path.relative(path.join(REPO_ROOT, "examples"), filePath).replace(/\\/g, "/");
+	return exampleMap[relToExamples.toLowerCase()] || null;
+}
+
+/** Fallback for example pages: first long paragraph in the page. */
+function fromExamplePage(html) {
+	const paras = html.match(/<p[^>]*>([\s\S]*?)<\/p>/gi) || [];
+	for (const p of paras) {
+		const t = cleanText(p);
+		if (t.length > 40) return truncate(t);
+	}
+	return null;
+}
+
+/** Lecture pages: derive description from the page title. */
+function fromLecture(title) {
+	const topic = title.replace(/\s*[-–]\s*COBOL\s*(Lecture|Course)?\s*$/i, "").trim();
+	return `COBOL lecture slides covering ${topic}.`;
+}
+
+function fallback(type, title) {
+	const clean = title.replace(/\s*[-–]\s*COBOL.*$/i, "").trim() || title;
+	const templates = {
+		course: `COBOL programming lesson on ${clean}.`,
+		exercises: `COBOL programming exercise: ${clean}.`,
+		examples: `COBOL example program: ${clean}.`,
+		lectures: `COBOL lecture on ${clean}.`,
+	};
+	return templates[type] || `${clean} — COBOL programming resource.`;
+}
+
+// ── Metadata block builder ─────────────────────────────────────────────────────
+function buildMetaBlock(title, description, canonical, ogType, indent) {
+	const d = escapeAttr(description);
+	const t = escapeAttr(title);
+	const c = escapeAttr(canonical);
+	const lines = [
+		`<meta name="description" content="${d}" />`,
+		`<link rel="canonical" href="${c}" />`,
+		`<!-- Open Graph -->`,
+		`<meta property="og:type" content="${ogType}" />`,
+		`<meta property="og:url" content="${c}" />`,
+		`<meta property="og:title" content="${t}" />`,
+		`<meta property="og:description" content="${d}" />`,
+		`<meta property="og:image" content="${OG_IMAGE}" />`,
+		`<!-- Twitter Card -->`,
+		`<meta name="twitter:card" content="summary" />`,
+		`<meta name="twitter:title" content="${t}" />`,
+		`<meta name="twitter:description" content="${d}" />`,
+	];
+	return lines.map((line) => indent + line).join("\n");
+}
+
+// ── File collection ────────────────────────────────────────────────────────────
+function collectLeafHtmlFiles(dir) {
+	const results = [];
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			results.push(...collectLeafHtmlFiles(full));
+		} else if (entry.isFile() && entry.name.endsWith(".html") && !SKIP_NAMES.has(entry.name)) {
+			results.push(full);
+		}
+	}
+	return results;
+}
+
+// ── Per-file processing ────────────────────────────────────────────────────────
+function processFile(filePath, exampleMap) {
+	const html = fs.readFileSync(filePath, "utf8");
+	if (alreadyTagged(html)) return null;
+
+	const relPath = path.relative(REPO_ROOT, filePath).replace(/\\/g, "/");
+	const pageType = relPath.split("/")[0];
+	const title = extractTitle(html);
+	const canonical = BASE_URL + relPath;
+	const ogType = pageType === "course" ? "article" : "website";
+	const indent = detectIndent(html);
+
+	const description =
+		OVERRIDES[relPath] ||
+		(pageType === "course" && fromCourse(html)) ||
+		(pageType === "exercises" && fromExercise(html)) ||
+		(pageType === "examples" && (fromExampleMap(exampleMap, filePath) || fromExamplePage(html))) ||
+		(pageType === "lectures" && fromLecture(title)) ||
+		fallback(pageType, title);
+
+	const metaBlock = buildMetaBlock(title, description, canonical, ogType, indent);
+	const updated = html.replace(/(<\/title>)/, "$1\n" + metaBlock);
+	fs.writeFileSync(filePath, updated, "utf8");
+	return { relPath, description };
+}
+
+// ── Entry point ────────────────────────────────────────────────────────────────
+function main() {
+	const defaultHtmlPath = path.join(REPO_ROOT, "examples", "default.html");
+	const exampleMap = fs.existsSync(defaultHtmlPath) ? buildExampleMap(fs.readFileSync(defaultHtmlPath, "utf8")) : {};
+
+	let updated = 0,
+		skipped = 0,
+		errors = 0;
+
+	for (const dir of CONTENT_DIRS) {
+		const dirPath = path.join(REPO_ROOT, dir);
+		if (!fs.existsSync(dirPath)) continue;
+
+		for (const file of collectLeafHtmlFiles(dirPath)) {
+			try {
+				const result = processFile(file, exampleMap);
+				if (!result) {
+					skipped++;
+				} else {
+					updated++;
+					console.log(`✓ ${result.relPath}`);
+					console.log(`  "${result.description}"`);
+				}
+			} catch (err) {
+				errors++;
+				console.error(`✗ ${path.relative(REPO_ROOT, file)}: ${err.message}`);
+			}
+		}
+	}
+
+	console.log(`\nDone: ${updated} updated, ${skipped} skipped, ${errors} errors.`);
+}
+
+main();

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,682 +2,682 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/COBOLIntro.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/COBOLcommands.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Copy.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/DataDeclaration.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/EditedPics.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/IndexedFiles.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Inspect.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Intro2DirectAccess.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Iteration.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/RefMod.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/RelativeFiles.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/ReportWriter.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/ReportWriterSS.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/pdf-viewer.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Call.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro1.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro2.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro3.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro4.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro5.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro6.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Commands1.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Commands2.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Condition1.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Condition2.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Data1.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Data2.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Perform1.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Perform2.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Search2.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile1.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2a.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2b.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2c.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2d.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2e.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile3a.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables1.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables2.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables3.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables4.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables5.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables7.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables8.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Search.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Selection.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles1.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles2.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles3.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SortMerge.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/String.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Subprograms.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Tables1.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Tables2.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Unstring.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Usage.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/index.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Accept/ACCEPT.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Accept/Multiplier.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Accept/Shortest.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Conditn/Conditions.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Conditn/IterIf.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Indexed/DirectReadIdx.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Indexed/Seq2Index.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Indexed/SeqReadIdx.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Merge/Merge.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/MileageCount.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform1.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform2.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform3.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform4.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Relative/ReadRel.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Relative/Seq2Rel.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteA.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteB.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteFull.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteSumm.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqIns/SEQINSERT.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREAD.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREADno88.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqRpt/SEQRPT.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqWrite/SEQWRITE.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Sort/InputSort.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Sort/MaleSort.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Strings/RefMod.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Strings/UnstringFileEg.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/DateDriver.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/ValiDate.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DayDiff/DayDiffDriver.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/DriverProg.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Fickle.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/MultiplyNums.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Steadfast.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Tables/MonthTable.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/default.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/COBOLExams/COBOLExams.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/CountDown.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FileConversion/Exm-FileConversion.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FileConversion/Prg-FileConversion.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-SFbyMail/Exm-SFbyMail.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-SFbyMail/Prg-SFbyMail.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-StudFeesRpt/Exm-StudPay.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-StudFeesRpt/Prg-StudPay.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/GettingStarted.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/MonthTable.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Proj-CSISEvalform/CSISEvalForm.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqInsert.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqRead.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqReadIf.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqUpdate.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqWrite.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SortIP.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/index.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/index.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/Basics2.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/COPY.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/CS4312Topics.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/GenIntro.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/ReportWriterSSWeb.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/ReportWriterWeb.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/SeqFile3.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/Unstring.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/Usage.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/arithmetic.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/basics1.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/call.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/cobintro.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/conditions.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/design.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/direct1.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/dsr1.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/index.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/indexed.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/inspect.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/perform.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/relative.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/search.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/seqfile1.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/seqfile2.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/sort.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/string.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/tables1.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/tables2.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
Closes #260. Phase 2 of #214.

## Summary

- Adds `<meta name="description">`, `<link rel="canonical">`, Open Graph, and Twitter Card tags to every leaf HTML page under `course/`, `exercises/`, `examples/`, and `lectures/` (165 pages total).
- Adds `scripts/add-page-meta.js`, a one-shot Node.js script that auto-extracts descriptions from page content and is idempotent on re-runs.

## Description extraction strategy

| Page type | Source |
|---|---|
| Course lessons | Aims section (`div.section-content > p` after `<h3>Aims</h3>`) |
| Exercises | First `<p>` in the Introduction section |
| Example programs | Description column from the table in `examples/default.html` |
| Lecture slides | Derived from the page `<title>` |

Manual overrides can be added to `scripts/page-descriptions.json` (keyed by repo-root-relative path) without touching the script.

## Test plan

- [x] `npm run validate` passes (exit 0, no html-validate errors)
- [x] `npm run format:write` applied; no format-check drift
- [x] Script is idempotent: second run reports `0 updated, 165 skipped, 0 errors`
- [x] Spot-checked `course/Selection.html`, `examples/Accept/ACCEPT.html`, `lectures/arithmetic.html` — canonical URLs, og:type (`article` vs `website`), and descriptions all correct

🤖 Generated with [Claude Code](https://claude.ai/claude-code)