### PR TITLE
refactor: remove duplicated CSS from index pages by linking shared course.css

### DIFF
--- a/course/index.html
+++ b/course/index.html
@@ -22,6 +22,8 @@
 			}
 		</script>
 		<title>COBOL Course</title>
+		<link rel="stylesheet" href="Resources/css/course.css" />
+		<link rel="stylesheet" href="Resources/css/course-components.css" />
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" charset="utf-8" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" charset="utf-8" defer></script>
@@ -58,28 +60,6 @@
 			content="On-line COBOL programming course - includes tutorials, example programs and exercises."
 		/>
 		<style type="text/css">
-			:root {
-				color-scheme: light dark;
-			}
-			body {
-				color: #000000;
-				background-color: #ffffff;
-			}
-			a:link {
-				color: #1d4ed8;
-			}
-			a:visited {
-				color: #6366cc;
-			}
-			a:active {
-				color: #0b1f5e;
-			}
-
-			h1 img {
-				max-width: 100%;
-				height: auto;
-			}
-
 			/* Header: flexbox replaces the 3-column layout table */
 			.course-header {
 				display: flex;
@@ -125,12 +105,12 @@
 			}
 
 			.topic-label {
-				background-color: #ffffcc;
+				background-color: var(--color-panel-bg);
 				padding: 4px;
 			}
 
 			.topic-links {
-				background-color: #ffffff;
+				background-color: var(--color-bg);
 				display: flex;
 				flex-direction: column;
 			}
@@ -152,81 +132,14 @@
 				background-color: #990033;
 			}
 
-			@media (max-width: 600px) {
-				body {
-					margin: 4px;
-					padding-bottom: 65px;
-				}
-
-				h1 font {
-					font-size: medium;
-				}
-
-				.course-header {
-					flex-wrap: wrap;
-				}
-
-				.course-header-title {
-					flex: 1 1 auto;
-				}
-
-				/* Legend wraps to its own row on narrow screens */
-				.course-header-legend {
-					flex: 0 0 100%;
-					margin-top: 8px;
-				}
-
-				/* Topic sections stack vertically on mobile */
-				.course-topics {
-					grid-template-columns: 1fr;
-				}
-			}
-
-			/* Preliminary dark mode. Token values mirror course.css so this page
-			   feels consistent with the rest of the dark-themed lessons. */
 			@media (prefers-color-scheme: dark) {
-				body {
-					color: #e6e6e6;
-					background-color: #1a1a1a;
-				}
-				a:link {
-					color: #93c5fd;
-				}
-				a:visited {
-					color: #a5b4fc;
-				}
-				a:active {
-					color: #bfdbfe;
-				}
-				.topic-label {
-					background-color: #3a3520;
-				}
-				.topic-links {
-					background-color: #1a1a1a;
-				}
-				.topic-divider {
+				:root:not([data-theme="light"]) .topic-divider {
 					background-color: #b3334d;
 				}
-				img {
-					filter: invert(0.92) hue-rotate(180deg);
-				}
-				img.no-invert,
-				img[src$=".jpg"],
-				img[src$=".jpeg"],
-				img[src$=".JPG"],
-				img[src$=".JPEG"] {
-					filter: none;
-				}
 			}
 
-			/* Department banner — replaces T-Dept.gif */
-			.dept-banner {
-				display: inline-block;
-				font-family: Arial, Helvetica, sans-serif;
-				font-size: 1.5rem;
-				font-weight: bold;
-				letter-spacing: 0.04em;
-				color: #993300;
+			:root[data-theme="dark"] .topic-divider {
+				background-color: #b3334d;
 			}
 
 			/* Decorative disc bullet — replaces BallRedG.gif (13×13 px) */
@@ -259,45 +172,42 @@
 				flex-shrink: 0;
 				margin: 4px 5px;
 			}
+
 			.icon-tut {
 				background-color: #1565c0;
 			}
+
 			.icon-exercise {
 				background-color: #2e7d32;
 			}
+
 			.icon-saq {
 				background-color: #e65100;
 			}
 
-			@media (prefers-color-scheme: dark) {
-				.dept-banner {
-					color: #ff9966;
+			@media (max-width: 600px) {
+				body {
+					padding-bottom: 65px;
 				}
-			}
 
-			/* Skip-to-content link */
-			.skip-link {
-				position: absolute;
-				left: -9999px;
-				top: auto;
-				width: 1px;
-				height: 1px;
-				overflow: hidden;
-			}
+				.course-header {
+					flex-wrap: wrap;
+				}
 
-			.skip-link:focus {
-				position: fixed;
-				top: 0;
-				left: 0;
-				width: auto;
-				height: auto;
-				overflow: visible;
-				padding: 0.5em 1em;
-				background-color: #993300;
-				color: #ffff00;
-				font-weight: bold;
-				z-index: 9999;
-				text-decoration: none;
+				.course-header-title {
+					flex: 1 1 auto;
+				}
+
+				/* Legend wraps to its own row on narrow screens */
+				.course-header-legend {
+					flex: 0 0 100%;
+					margin-top: 8px;
+				}
+
+				/* Topic sections stack vertically on mobile */
+				.course-topics {
+					grid-template-columns: 1fr;
+				}
 			}
 		</style>
 	</head>
@@ -320,7 +230,7 @@
 				</div>
 				<div class="course-header-legend">
 					<!-- Legend table: real tabular data (icon → meaning), kept as <table> -->
-					<table width="100%" class="data-table" height="100" cellpadding="2" cellspacing="0">
+					<table width="100%" height="100" cellpadding="2" cellspacing="0">
 						<tr>
 							<td colspan="2" height="29">
 								<div class="center-block">

--- a/index.html
+++ b/index.html
@@ -50,10 +50,7 @@
 				font-size: smaller;
 			}
 
-			ul.toc {
-				list-style-type: disc;
-			}
-
+			/* Blue ball marker — overrides the green from course.css */
 			ul.toc ::marker {
 				color: #0066cc;
 			}
@@ -73,35 +70,6 @@
 					margin-right: 12px;
 					padding-left: 1.5em;
 				}
-
-				h1 font {
-					font-size: medium;
-				}
-			}
-
-			/* Skip-to-content link */
-			.skip-link {
-				position: absolute;
-				left: -9999px;
-				top: auto;
-				width: 1px;
-				height: 1px;
-				overflow: hidden;
-			}
-
-			.skip-link:focus {
-				position: fixed;
-				top: 0;
-				left: 0;
-				width: auto;
-				height: auto;
-				overflow: visible;
-				padding: 0.5em 1em;
-				background-color: #993300;
-				color: #ffff00;
-				font-weight: bold;
-				z-index: 9999;
-				text-decoration: none;
 			}
 		</style>
 	</head>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,682 +2,682 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/COBOLIntro.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/COBOLcommands.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Copy.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/DataDeclaration.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/EditedPics.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/IndexedFiles.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Inspect.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Intro2DirectAccess.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Iteration.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/RefMod.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/RelativeFiles.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/ReportWriter.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/ReportWriterSS.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/pdf-viewer.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Call.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro1.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro2.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro3.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro4.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro5.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro6.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Commands1.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Commands2.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Condition1.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Condition2.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Data1.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Data2.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Perform1.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Perform2.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Search2.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile1.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2a.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2b.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2c.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2d.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2e.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile3a.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables1.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables2.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables3.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables4.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables5.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables7.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables8.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Search.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Selection.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles1.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles2.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles3.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SortMerge.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/String.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Subprograms.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Tables1.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Tables2.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Unstring.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Usage.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/index.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Accept/ACCEPT.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Accept/Multiplier.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Accept/Shortest.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Conditn/Conditions.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Conditn/IterIf.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Indexed/DirectReadIdx.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Indexed/Seq2Index.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Indexed/SeqReadIdx.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Merge/Merge.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/MileageCount.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform1.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform2.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform3.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform4.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Relative/ReadRel.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Relative/Seq2Rel.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteA.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteB.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteFull.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteSumm.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqIns/SEQINSERT.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREAD.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREADno88.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqRpt/SEQRPT.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqWrite/SEQWRITE.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Sort/InputSort.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Sort/MaleSort.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Strings/RefMod.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Strings/UnstringFileEg.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/DateDriver.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/ValiDate.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DayDiff/DayDiffDriver.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/DriverProg.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Fickle.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/MultiplyNums.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Steadfast.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Tables/MonthTable.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/default.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/COBOLExams/COBOLExams.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/CountDown.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FileConversion/Exm-FileConversion.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FileConversion/Prg-FileConversion.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-SFbyMail/Exm-SFbyMail.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-SFbyMail/Prg-SFbyMail.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-StudFeesRpt/Exm-StudPay.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-StudFeesRpt/Prg-StudPay.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/GettingStarted.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/MonthTable.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Proj-CSISEvalform/CSISEvalForm.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqInsert.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqRead.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqReadIf.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqUpdate.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqWrite.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SortIP.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/index.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/index.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/Basics2.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/COPY.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/CS4312Topics.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/GenIntro.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/ReportWriterSSWeb.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/ReportWriterWeb.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/SeqFile3.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/Unstring.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/Usage.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/arithmetic.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/basics1.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/call.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/cobintro.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/conditions.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/design.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/direct1.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/dsr1.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/index.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/indexed.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/inspect.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/perform.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/relative.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/search.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/seqfile1.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/seqfile2.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/sort.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/string.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/tables1.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/tables2.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
Closes #251

## Summary

- **`course/index.html`**: Added `<link>` tags for `course.css` and `course-components.css`. Replaced ~150-line inline `<style>` block (which duplicated the full token table, dark-mode block, `.skip-link`, `.dept-banner`, and every `a:link`/`body` rule) with ~60 lines of layout-only rules. Hard-coded `#ffffcc`/`#ffffff` colors in `.topic-label` and `.topic-links` replaced with `var(--color-panel-bg)` / `var(--color-bg)`. Also removed the erroneous `class="data-table"` from the legend layout table (it's not a data table; the class caused unwanted cell borders once `course-components.css` loaded).
- **`index.html`**: Dropped duplicate `.skip-link`/`.skip-link:focus` block (already in `course.css`), removed `ul.toc { list-style-type: disc }` (already in `course.css`), and removed the dead `h1 font` rule (no `<font>` tags remain after #217).

## Test plan

- [x] HTML validation passes (`npx html-validate`)
- [x] Asset references resolve (`npm run check:assets`)
- [x] Image dimensions present (`npm run check:img-dims`)
- [x] Prettier formatting clean (`npx prettier --check`)
- [x] Desktop (1280×900) before/after screenshots identical for both pages
- [x] Mobile (390×844) before/after screenshots identical for both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)