### PR TITLE
feat: add <nav> landmarks to all index page navigation lists (closes #271)

### DIFF
--- a/course/index.html
+++ b/course/index.html
@@ -263,304 +263,306 @@
 
 			<!-- Main content: CSS grid replaces nested layout tables -->
 			<nav aria-label="Course topics">
-			<div class="course-content">
-				<div class="course-topics">
-					<!-- Introduction to COBOL -->
-					<div class="topic-label">
-						<span class="ball-red" aria-hidden="true"></span><b>Introduction to COBOL</b>
-					</div>
-					<div class="topic-links">
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
-							>
-							<a href="COBOLIntro.html">The structure of COBOL programs</a>
+				<div class="course-content">
+					<div class="course-topics">
+						<!-- Introduction to COBOL -->
+						<div class="topic-label">
+							<span class="ball-red" aria-hidden="true"></span><b>Introduction to COBOL</b>
 						</div>
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
-							>
-							<a href="DataDeclaration.html">Declaring data in COBOL</a>
+						<div class="topic-links">
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
+								>
+								<a href="COBOLIntro.html">The structure of COBOL programs</a>
+							</div>
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
+								>
+								<a href="DataDeclaration.html">Declaring data in COBOL</a>
+							</div>
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
+								>
+								<a href="COBOLcommands.html">Basic Procedure Division commands</a>
+							</div>
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-exercise" aria-hidden="true">E</span></span
+								>
+								<a href="../exercises/GettingStarted.html">Getting Started</a>
+							</div>
+							<div class="course-link">
+								<span class="course-link-icon"><span class="icon-saq" aria-hidden="true">?</span></span>
+								<a href="../exercises/GettingStarted.html">These will be self assessment questions</a>
+							</div>
 						</div>
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
-							>
-							<a href="COBOLcommands.html">Basic Procedure Division commands</a>
-						</div>
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-exercise" aria-hidden="true">E</span></span
-							>
-							<a href="../exercises/GettingStarted.html">Getting Started</a>
-						</div>
-						<div class="course-link">
-							<span class="course-link-icon"><span class="icon-saq" aria-hidden="true">?</span></span>
-							<a href="../exercises/GettingStarted.html">These will be self assessment questions</a>
-						</div>
-					</div>
-					<div class="topic-divider"></div>
+						<div class="topic-divider"></div>
 
-					<!-- COBOL Control structures -->
-					<div class="topic-label">
-						<span class="ball-red" aria-hidden="true"></span><b>COBOL Control structures</b>
-					</div>
-					<div class="topic-links">
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
-							>
-							<a href="Selection.html">Selection in COBOL</a>
+						<!-- COBOL Control structures -->
+						<div class="topic-label">
+							<span class="ball-red" aria-hidden="true"></span><b>COBOL Control structures</b>
 						</div>
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
-							>
-							<a href="Iteration.html">Iteration in COBOL</a>
+						<div class="topic-links">
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
+								>
+								<a href="Selection.html">Selection in COBOL</a>
+							</div>
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
+								>
+								<a href="Iteration.html">Iteration in COBOL</a>
+							</div>
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-exercise" aria-hidden="true">E</span></span
+								>
+								<a href="../exercises/CountDown.html">The Calculator and Countdown exercise</a>
+							</div>
+							<div class="course-link">
+								<span class="course-link-icon"><span class="icon-saq" aria-hidden="true">?</span></span>
+								<a href="../exercises/GettingStarted.html">These will be self assessment questions</a>
+							</div>
 						</div>
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-exercise" aria-hidden="true">E</span></span
-							>
-							<a href="../exercises/CountDown.html">The Calculator and Countdown exercise</a>
-						</div>
-						<div class="course-link">
-							<span class="course-link-icon"><span class="icon-saq" aria-hidden="true">?</span></span>
-							<a href="../exercises/GettingStarted.html">These will be self assessment questions</a>
-						</div>
-					</div>
-					<div class="topic-divider"></div>
+						<div class="topic-divider"></div>
 
-					<!-- Simple Sequential Files -->
-					<div class="topic-label">
-						<span class="ball-red" aria-hidden="true"></span><b>Simple Sequential Files</b>
-					</div>
-					<div class="topic-links">
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
-							>
-							<a href="SequentialFiles1.html">Introduction to Sequential files</a>
+						<!-- Simple Sequential Files -->
+						<div class="topic-label">
+							<span class="ball-red" aria-hidden="true"></span><b>Simple Sequential Files</b>
 						</div>
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
-							>
-							<a href="SequentialFiles2.html">Processing Sequential files</a>
+						<div class="topic-links">
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
+								>
+								<a href="SequentialFiles1.html">Introduction to Sequential files</a>
+							</div>
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
+								>
+								<a href="SequentialFiles2.html">Processing Sequential files</a>
+							</div>
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-exercise" aria-hidden="true">E</span></span
+								>
+								<a href="../exercises/SeqRead.html">Reading Sequential Files</a>
+							</div>
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-exercise" aria-hidden="true">E</span></span
+								>
+								<a href="../exercises/SeqReadIf.html">Counting records in a Sequential File</a>
+							</div>
 						</div>
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-exercise" aria-hidden="true">E</span></span
-							>
-							<a href="../exercises/SeqRead.html">Reading Sequential Files</a>
-						</div>
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-exercise" aria-hidden="true">E</span></span
-							>
-							<a href="../exercises/SeqReadIf.html">Counting records in a Sequential File</a>
-						</div>
-					</div>
-					<div class="topic-divider"></div>
+						<div class="topic-divider"></div>
 
-					<!-- Advanced data declaration -->
-					<div class="topic-label">
-						<span class="ball-red" aria-hidden="true"></span><b>Advanced data declaration</b>
-					</div>
-					<div class="topic-links">
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
-							>
-							<a href="EditedPics.html">Edited Pictures</a>
+						<!-- Advanced data declaration -->
+						<div class="topic-label">
+							<span class="ball-red" aria-hidden="true"></span><b>Advanced data declaration</b>
 						</div>
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
-							>
-							<a href="Usage.html">The USAGE clause</a>
+						<div class="topic-links">
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
+								>
+								<a href="EditedPics.html">Edited Pictures</a>
+							</div>
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
+								>
+								<a href="Usage.html">The USAGE clause</a>
+							</div>
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-exercise" aria-hidden="true">E</span></span
+								>
+								<a href="../exercises/SeqWrite.html">Writing records to a Sequential File</a>
+							</div>
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-exercise" aria-hidden="true">E</span></span
+								>
+								<a href="../exercises/SeqInsert.html">Inserting records in a Sequential File</a>
+							</div>
 						</div>
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-exercise" aria-hidden="true">E</span></span
-							>
-							<a href="../exercises/SeqWrite.html">Writing records to a Sequential File</a>
-						</div>
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-exercise" aria-hidden="true">E</span></span
-							>
-							<a href="../exercises/SeqInsert.html">Inserting records in a Sequential File</a>
-						</div>
-					</div>
-					<div class="topic-divider"></div>
+						<div class="topic-divider"></div>
 
-					<!-- Advanced Sequential Files -->
-					<div class="topic-label">
-						<span class="ball-red" aria-hidden="true"></span><b>Advanced Sequential Files</b>
-					</div>
-					<div class="topic-links">
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
-							>
-							<a href="SequentialFiles3.html">COBOL print files and variable-length records</a>
+						<!-- Advanced Sequential Files -->
+						<div class="topic-label">
+							<span class="ball-red" aria-hidden="true"></span><b>Advanced Sequential Files</b>
 						</div>
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
-							>
-							<a href="SortMerge.html">Sorting and Merging</a>
+						<div class="topic-links">
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
+								>
+								<a href="SequentialFiles3.html">COBOL print files and variable-length records</a>
+							</div>
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
+								>
+								<a href="SortMerge.html">Sorting and Merging</a>
+							</div>
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
+								>
+								<a href="COBOLcommands.html">Basic Procedure Division commands</a>
+							</div>
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-exercise" aria-hidden="true">E</span></span
+								>
+								<a href="../exercises/SeqUpdate.html">Updating a Sequential File</a>
+							</div>
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-exercise" aria-hidden="true">E</span></span
+								>
+								<a href="../exercises/SortIP.html">Sorting a Sequential File</a>
+							</div>
 						</div>
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
-							>
-							<a href="COBOLcommands.html">Basic Procedure Division commands</a>
-						</div>
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-exercise" aria-hidden="true">E</span></span
-							>
-							<a href="../exercises/SeqUpdate.html">Updating a Sequential File</a>
-						</div>
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-exercise" aria-hidden="true">E</span></span
-							>
-							<a href="../exercises/SortIP.html">Sorting a Sequential File</a>
-						</div>
-					</div>
-					<div class="topic-divider"></div>
+						<div class="topic-divider"></div>
 
-					<!-- Direct access files -->
-					<div class="topic-label">
-						<span class="ball-red" aria-hidden="true"></span><b>Direct access files</b>
-					</div>
-					<div class="topic-links">
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
-							>
-							<a href="Intro2DirectAccess.html">Introduction to direct access files</a>
+						<!-- Direct access files -->
+						<div class="topic-label">
+							<span class="ball-red" aria-hidden="true"></span><b>Direct access files</b>
 						</div>
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
-							>
-							<a href="RelativeFiles.html">Relative Files</a>
+						<div class="topic-links">
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
+								>
+								<a href="Intro2DirectAccess.html">Introduction to direct access files</a>
+							</div>
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
+								>
+								<a href="RelativeFiles.html">Relative Files</a>
+							</div>
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
+								>
+								<a href="IndexedFiles.html">Indexed Files</a>
+							</div>
 						</div>
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
-							>
-							<a href="IndexedFiles.html">Indexed Files</a>
-						</div>
-					</div>
-					<div class="topic-divider"></div>
+						<div class="topic-divider"></div>
 
-					<!-- COBOL tables -->
-					<div class="topic-label"><span class="ball-red" aria-hidden="true"></span><b>COBOL tables</b></div>
-					<div class="topic-links">
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
-							>
-							<a href="Tables1.html">Using tables</a>
+						<!-- COBOL tables -->
+						<div class="topic-label">
+							<span class="ball-red" aria-hidden="true"></span><b>COBOL tables</b>
 						</div>
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
-							>
-							<a href="Tables2.html">Creating tables - syntax and semantics</a>
+						<div class="topic-links">
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
+								>
+								<a href="Tables1.html">Using tables</a>
+							</div>
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
+								>
+								<a href="Tables2.html">Creating tables - syntax and semantics</a>
+							</div>
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
+								>
+								<a href="Search.html">Searching tables</a>
+							</div>
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-exercise" aria-hidden="true">E</span></span
+								>
+								<a href="../exercises/MonthTable.html">Using Tables</a>
+							</div>
 						</div>
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
-							>
-							<a href="Search.html">Searching tables</a>
-						</div>
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-exercise" aria-hidden="true">E</span></span
-							>
-							<a href="../exercises/MonthTable.html">Using Tables</a>
-						</div>
-					</div>
-					<div class="topic-divider"></div>
+						<div class="topic-divider"></div>
 
-					<!-- Constructing large systems -->
-					<div class="topic-label">
-						<span class="ball-red" aria-hidden="true"></span><b>Constructing large systems</b>
-					</div>
-					<div class="topic-links">
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
-							>
-							<a href="Subprograms.html">Contained and external sub-programs</a>
+						<!-- Constructing large systems -->
+						<div class="topic-label">
+							<span class="ball-red" aria-hidden="true"></span><b>Constructing large systems</b>
 						</div>
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
-							>
-							<a href="Copy.html">The COPY verb</a>
+						<div class="topic-links">
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
+								>
+								<a href="Subprograms.html">Contained and external sub-programs</a>
+							</div>
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
+								>
+								<a href="Copy.html">The COPY verb</a>
+							</div>
 						</div>
-					</div>
-					<div class="topic-divider"></div>
+						<div class="topic-divider"></div>
 
-					<!-- COBOL string handling -->
-					<div class="topic-label">
-						<span class="ball-red" aria-hidden="true"></span><b>COBOL string handling</b>
-					</div>
-					<div class="topic-links">
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
-							>
-							<a href="Inspect.html">Inspect</a>
+						<!-- COBOL string handling -->
+						<div class="topic-label">
+							<span class="ball-red" aria-hidden="true"></span><b>COBOL string handling</b>
 						</div>
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
-							>
-							<a href="String.html">String</a>
+						<div class="topic-links">
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
+								>
+								<a href="Inspect.html">Inspect</a>
+							</div>
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
+								>
+								<a href="String.html">String</a>
+							</div>
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
+								>
+								<a href="Unstring.html">Unstring</a>
+							</div>
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
+								>
+								<a href="RefMod.html">Reference modification and Intrinsic Functions</a>
+							</div>
 						</div>
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
-							>
-							<a href="Unstring.html">Unstring</a>
-						</div>
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
-							>
-							<a href="RefMod.html">Reference modification and Intrinsic Functions</a>
-						</div>
-					</div>
-					<div class="topic-divider"></div>
+						<div class="topic-divider"></div>
 
-					<!-- The COBOL Report Writer -->
-					<div class="topic-label">
-						<span class="ball-red" aria-hidden="true"></span><b>The COBOL Report Writer</b>
-					</div>
-					<div class="topic-links">
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
-							>
-							<a href="ReportWriter.html">Report Writer by example</a>
+						<!-- The COBOL Report Writer -->
+						<div class="topic-label">
+							<span class="ball-red" aria-hidden="true"></span><b>The COBOL Report Writer</b>
 						</div>
-						<div class="course-link">
-							<span class="course-link-icon"
-								><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
-							>
-							<a href="ReportWriterSS.html">Report Writer syntax and semantics</a>
+						<div class="topic-links">
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
+								>
+								<a href="ReportWriter.html">Report Writer by example</a>
+							</div>
+							<div class="course-link">
+								<span class="course-link-icon"
+									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
+								>
+								<a href="ReportWriterSS.html">Report Writer syntax and semantics</a>
+							</div>
 						</div>
 					</div>
 				</div>
-			</div>
 			</nav>
 		</main>
 	</body>

--- a/course/index.html
+++ b/course/index.html
@@ -262,6 +262,7 @@
 			<hr class="course-hr" />
 
 			<!-- Main content: CSS grid replaces nested layout tables -->
+			<nav aria-label="Course topics">
 			<div class="course-content">
 				<div class="course-topics">
 					<!-- Introduction to COBOL -->
@@ -560,6 +561,7 @@
 					</div>
 				</div>
 			</div>
+			</nav>
 		</main>
 	</body>
 </html>

--- a/examples/default.html
+++ b/examples/default.html
@@ -77,6 +77,7 @@
 			</table>
 			<hr />
 			<a id="pagetop"></a>
+			<nav aria-label="Example programs contents">
 			<ul class="toc">
 				<li>
 					<a href="#SimplePrograms">Beginners Programs</a> - Simple programs using
@@ -115,6 +116,7 @@
 				</li>
 				<li><a href="#Tables">COBOL Tables</a> - Example programs using tables.</li>
 			</ul>
+			</nav>
 			<table bordercolordark="#000000" bordercolorlight="#FFFFFF" width="725">
 				<tr bgcolor="#990000" style="vertical-align: top">
 					<td colspan="4">

--- a/examples/default.html
+++ b/examples/default.html
@@ -78,44 +78,46 @@
 			<hr />
 			<a id="pagetop"></a>
 			<nav aria-label="Example programs contents">
-			<ul class="toc">
-				<li>
-					<a href="#SimplePrograms">Beginners Programs</a> - Simple programs using
-					<code class="language-cobol">ACCEPT</code>, <code class="language-cobol">DISPLAY</code> and some
-					arithmetic verbs.
-				</li>
-				<li>
-					<a href="#Selection">Selection and Iteration</a>
-					- Selection (<code class="language-cobol">IF</code>, <code class="language-cobol">EVALUATE</code>)
-					and Iteration (<code class="language-cobol">PERFORM</code>) example programs.
-				</li>
-				<li>
-					<a href="#SequentialFiles">Sequential Files</a>&nbsp; - Programs that demonstrate how to process
-					sequential files.
-				</li>
-				<li>
-					<a href="#Sort">Sorting and Merging</a> - Examples that use
-					<code class="language-cobol">INPUT PROCEDURE</code>'s and the
-					<code class="language-cobol">SORT</code> and <code class="language-cobol">MERGE</code> verbs
-				</li>
-				<li>
-					<a href="#Direct">Direct Access Files</a> - Example programs that show how to process Indexed and
-					Relative files.
-				</li>
-				<li>
-					<a href="#Call">CALLing sub-programs</a> - Example programs that Demonstrate contained, and
-					external, sub-programs.
-				</li>
-				<li>
-					<a href="#Strings">String handling</a> - Example programs that show how to use Reference
-					Modification, <code class="language-cobol">INSPECT</code> and
-					<code class="language-cobol">UNSTRING</code>.
-				</li>
-				<li>
-					<a href="#Reports">The COBOL Report Writer</a> - Example programs using the COBOL Report Writer.
-				</li>
-				<li><a href="#Tables">COBOL Tables</a> - Example programs using tables.</li>
-			</ul>
+				<ul class="toc">
+					<li>
+						<a href="#SimplePrograms">Beginners Programs</a> - Simple programs using
+						<code class="language-cobol">ACCEPT</code>, <code class="language-cobol">DISPLAY</code> and some
+						arithmetic verbs.
+					</li>
+					<li>
+						<a href="#Selection">Selection and Iteration</a>
+						- Selection (<code class="language-cobol">IF</code>,
+						<code class="language-cobol">EVALUATE</code>) and Iteration (<code class="language-cobol"
+							>PERFORM</code
+						>) example programs.
+					</li>
+					<li>
+						<a href="#SequentialFiles">Sequential Files</a>&nbsp; - Programs that demonstrate how to process
+						sequential files.
+					</li>
+					<li>
+						<a href="#Sort">Sorting and Merging</a> - Examples that use
+						<code class="language-cobol">INPUT PROCEDURE</code>'s and the
+						<code class="language-cobol">SORT</code> and <code class="language-cobol">MERGE</code> verbs
+					</li>
+					<li>
+						<a href="#Direct">Direct Access Files</a> - Example programs that show how to process Indexed
+						and Relative files.
+					</li>
+					<li>
+						<a href="#Call">CALLing sub-programs</a> - Example programs that Demonstrate contained, and
+						external, sub-programs.
+					</li>
+					<li>
+						<a href="#Strings">String handling</a> - Example programs that show how to use Reference
+						Modification, <code class="language-cobol">INSPECT</code> and
+						<code class="language-cobol">UNSTRING</code>.
+					</li>
+					<li>
+						<a href="#Reports">The COBOL Report Writer</a> - Example programs using the COBOL Report Writer.
+					</li>
+					<li><a href="#Tables">COBOL Tables</a> - Example programs using tables.</li>
+				</ul>
 			</nav>
 			<table bordercolordark="#000000" bordercolorlight="#FFFFFF" width="725">
 				<tr bgcolor="#990000" style="vertical-align: top">

--- a/exercises/index.html
+++ b/exercises/index.html
@@ -136,53 +136,53 @@
 			</div>
 			<hr width="800" />
 			<nav aria-label="Simple programming exercises">
-			<h3>Simple Programming Exercises</h3>
-			<ul class="toc">
-				<li>
-					<a href="GettingStarted.html">Getting Started</a> - Exercise to load, compile, run and alter an
-					existing program.
-				</li>
-				<li>
-					<a href="CountDown.html">CountDown</a> - Exercise using the
-					<code class="language-cobol">ACCEPT</code>, <code class="language-cobol">DISPLAY</code>,
-					<code class="language-cobol">PERFORM</code> ... <code class="language-cobol">TIMES</code>,
-					<code class="language-cobol">COMPUTE</code> and <code class="language-cobol">IF</code> .
-				</li>
-				<li>
-					<a href="SeqRead.html">Reading Sequential Files</a>&nbsp; -
-					<code class="language-cobol">READ</code>, <code class="language-cobol">PERFORM.. UNTIL</code>,
-					<code class="language-cobol">DISPLAY</code>
-				</li>
-				<li>
-					<a href="SeqReadIf.html">Counting records in a Sequential File</a> -
-					<code class="language-cobol">READ</code>, <code class="language-cobol">PERFORM..UNTIL</code>,
-					<code class="language-cobol">DISPLAY</code>, <code class="language-cobol">IF</code>,
-					<code class="language-cobol">COMPUTE</code>
-				</li>
-				<li>
-					<a href="SeqWrite.html">Writing to a Sequential File</a> -
-					<code class="language-cobol">ACCEPT</code>, <code class="language-cobol">DISPLAY</code>,
-					<code class="language-cobol">WRITE</code>, <code class="language-cobol">PERFORM..UNTIL</code>,
-				</li>
-				<li>
-					<a href="SeqInsert.html">Inserting records into a Sequential File</a> -
-					<code class="language-cobol">READ</code>, <code class="language-cobol">WRITE</code>,
-					<code class="language-cobol">PERFORM.. UNTIL</code>.
-				</li>
-				<li>
-					<a href="SeqUpdate.html">Updating records in a Sequential File</a> -
-					<code class="language-cobol">READ</code>, <code class="language-cobol">WRITE</code>.
-				</li>
-				<li>
-					<a href="SortIP.html">Sorting a Sequential File</a> - <code class="language-cobol">SORT</code>,
-					<code class="language-cobol">READ</code>, <code class="language-cobol">RELEASE</code>, Input
-					Procedure.
-				</li>
-				<li>
-					<a href="MonthTable.html">Using Tables</a> - <code class="language-cobol">READ</code>, pre-defined
-					Tables, Tables.
-				</li>
-			</ul>
+				<h3>Simple Programming Exercises</h3>
+				<ul class="toc">
+					<li>
+						<a href="GettingStarted.html">Getting Started</a> - Exercise to load, compile, run and alter an
+						existing program.
+					</li>
+					<li>
+						<a href="CountDown.html">CountDown</a> - Exercise using the
+						<code class="language-cobol">ACCEPT</code>, <code class="language-cobol">DISPLAY</code>,
+						<code class="language-cobol">PERFORM</code> ... <code class="language-cobol">TIMES</code>,
+						<code class="language-cobol">COMPUTE</code> and <code class="language-cobol">IF</code> .
+					</li>
+					<li>
+						<a href="SeqRead.html">Reading Sequential Files</a>&nbsp; -
+						<code class="language-cobol">READ</code>, <code class="language-cobol">PERFORM.. UNTIL</code>,
+						<code class="language-cobol">DISPLAY</code>
+					</li>
+					<li>
+						<a href="SeqReadIf.html">Counting records in a Sequential File</a> -
+						<code class="language-cobol">READ</code>, <code class="language-cobol">PERFORM..UNTIL</code>,
+						<code class="language-cobol">DISPLAY</code>, <code class="language-cobol">IF</code>,
+						<code class="language-cobol">COMPUTE</code>
+					</li>
+					<li>
+						<a href="SeqWrite.html">Writing to a Sequential File</a> -
+						<code class="language-cobol">ACCEPT</code>, <code class="language-cobol">DISPLAY</code>,
+						<code class="language-cobol">WRITE</code>, <code class="language-cobol">PERFORM..UNTIL</code>,
+					</li>
+					<li>
+						<a href="SeqInsert.html">Inserting records into a Sequential File</a> -
+						<code class="language-cobol">READ</code>, <code class="language-cobol">WRITE</code>,
+						<code class="language-cobol">PERFORM.. UNTIL</code>.
+					</li>
+					<li>
+						<a href="SeqUpdate.html">Updating records in a Sequential File</a> -
+						<code class="language-cobol">READ</code>, <code class="language-cobol">WRITE</code>.
+					</li>
+					<li>
+						<a href="SortIP.html">Sorting a Sequential File</a> - <code class="language-cobol">SORT</code>,
+						<code class="language-cobol">READ</code>, <code class="language-cobol">RELEASE</code>, Input
+						Procedure.
+					</li>
+					<li>
+						<a href="MonthTable.html">Using Tables</a> - <code class="language-cobol">READ</code>,
+						pre-defined Tables, Tables.
+					</li>
+				</ul>
 			</nav>
 			<hr />
 			<h3>Programming Exam Specifications</h3>

--- a/exercises/index.html
+++ b/exercises/index.html
@@ -135,6 +135,7 @@
 				</table>
 			</div>
 			<hr width="800" />
+			<nav aria-label="Simple programming exercises">
 			<h3>Simple Programming Exercises</h3>
 			<ul class="toc">
 				<li>
@@ -182,6 +183,7 @@
 					Tables, Tables.
 				</li>
 			</ul>
+			</nav>
 			<hr />
 			<h3>Programming Exam Specifications</h3>
 			<blockquote>

--- a/index.html
+++ b/index.html
@@ -91,32 +91,34 @@
 				specifications with model answers, COBOL project specifications, and over 50 example COBOL programs.
 			</div>
 			<hr />
-			<ul class="toc">
-				<li>
-					<a href="course/index.html">COBOL programming course (comprehensive COBOL tutorials)</a>
-				</li>
-				<li>
-					<a href="lectures/CS4312Topics.html#ReportWriter1"
-						>Report Writer Tutorials (part of the COBOL course)</a
-					>
-				</li>
-				<li><a href="exercises/index.html">COBOL programming exercises</a></li>
-				<li><a href="examples/default.html">Example COBOL programs</a></li>
-				<li><a href="lectures/">COBOL lecture notes</a></li>
-				<li><a href="https://www.infogoal.com/cbd/index.htm">The COBOL Centre</a></li>
-				<li>
-					<a href="https://web.archive.org/web/20130424202748/http://www.cobug.com/"
-						>The COBUG portal site for COBOL users</a
-					>
-				</li>
-				<li>
-					<a
-						href="https://web.archive.org/web/20100201014654/http://www-949.ibm.com/software/rational/cafe/community/cobol/"
-						>IBM's COBOL Cafe</a
-					>
-				</li>
-				<li><a href="https://bushidocodes.github.io/klein-cobol-faq/">COBOL FAQ</a></li>
-			</ul>
+			<nav aria-label="COBOL resources">
+				<ul class="toc">
+					<li>
+						<a href="course/index.html">COBOL programming course (comprehensive COBOL tutorials)</a>
+					</li>
+					<li>
+						<a href="lectures/CS4312Topics.html#ReportWriter1"
+							>Report Writer Tutorials (part of the COBOL course)</a
+						>
+					</li>
+					<li><a href="exercises/index.html">COBOL programming exercises</a></li>
+					<li><a href="examples/default.html">Example COBOL programs</a></li>
+					<li><a href="lectures/">COBOL lecture notes</a></li>
+					<li><a href="https://www.infogoal.com/cbd/index.htm">The COBOL Centre</a></li>
+					<li>
+						<a href="https://web.archive.org/web/20130424202748/http://www.cobug.com/"
+							>The COBUG portal site for COBOL users</a
+						>
+					</li>
+					<li>
+						<a
+							href="https://web.archive.org/web/20100201014654/http://www-949.ibm.com/software/rational/cafe/community/cobol/"
+							>IBM's COBOL Cafe</a
+						>
+					</li>
+					<li><a href="https://bushidocodes.github.io/klein-cobol-faq/">COBOL FAQ</a></li>
+				</ul>
+			</nav>
 		</main>
 	</body>
 </html>

--- a/lectures/index.html
+++ b/lectures/index.html
@@ -72,102 +72,111 @@
 			</ul>
 			<hr />
 			<nav aria-label="Module contents">
-			<h2 id="Contents">Module Contents</h2>
-			<h3>
-				<span class="ball-blue" aria-hidden="true"></span
-				><a href="CS4312Topics.html#General">General Introduction</a>
-			</h3>
-			<h3>
-				<span class="ball-blue" aria-hidden="true"></span
-				><a href="CS4312Topics.html#Introduction">Introduction to COBOL</a>
-			</h3>
-			<h3>
-				<span class="ball-blue" aria-hidden="true"></span><a href="CS4312Topics.html#Basics1">COBOL Basics 1</a>
-			</h3>
-			<h3>
-				<span class="ball-blue" aria-hidden="true"></span><a href="CS4312Topics.html#Basics2">COBOL Basics 2</a>
-			</h3>
-			<h3>
-				<span class="ball-blue" aria-hidden="true"></span
-				><a href="CS4312Topics.html#IntroSeqFiles">Introduction to Sequential Files</a>
-			</h3>
-			<h3>
-				<span class="ball-blue" aria-hidden="true"></span
-				><a href="CS4312Topics.html#ProcessingSeqFiles">Processing Sequential Files</a>
-			</h3>
-			<h3>
-				<span class="ball-blue" aria-hidden="true"></span
-				><a href="CS4312Topics.html#PERFORM">Simple iteration with the PERFORM verb</a>
-			</h3>
-			<h3>
-				<span class="ball-blue" aria-hidden="true"></span
-				><a href="CS4312Topics.html#Arithmetic">Arithmetic and Edited Pictures</a>
-			</h3>
-			<h3>
-				<span class="ball-blue" aria-hidden="true"></span><a href="CS4312Topics.html#Conditions">Conditions</a>
-			</h3>
-			<h3>
-				<span class="ball-blue" aria-hidden="true"></span
-				><a href="CS4312Topics.html#Designing">Designing Programs</a>
-			</h3>
-			<h3>
-				<span class="ball-blue" aria-hidden="true"></span
-				><a href="CS4312Topics.html#DSR1">Introduction to Diagrammatic Stepwise Refinement</a>
-			</h3>
-			<h3>
-				<span class="ball-blue" aria-hidden="true"></span><a href="CS4312Topics.html#SORT">SORT and MERGE</a>
-			</h3>
-			<h3>
-				<span class="ball-blue" aria-hidden="true"></span
-				><a href="CS4312Topics.html#Tables">Tables and the PERFORM ... VARYING</a>
-			</h3>
-			<h3>
-				<span class="ball-blue" aria-hidden="true"></span
-				><a href="CS4312Topics.html#AdvancedTables">Advanced Tables</a>
-			</h3>
-			<h3>
-				<span class="ball-blue" aria-hidden="true"></span
-				><a href="CS4312Topics.html#SearchingTAbles">Searching Tables</a>
-			</h3>
-			<h3>
-				<span class="ball-blue" aria-hidden="true"></span
-				><a href="CS4312Topics.html#AdvancedSeqFiles">Advanced Sequential Files</a>
-			</h3>
-			<h3>
-				<span class="ball-blue" aria-hidden="true"></span
-				><a href="CS4312Topics.html#IntroDirectAccessFiles">Introduction to Direct Access Files</a>
-			</h3>
-			<h3>
-				<span class="ball-blue" aria-hidden="true"></span
-				><a href="CS4312Topics.html#RelativeFiles">Relative Files</a>
-			</h3>
-			<h3>
-				<span class="ball-blue" aria-hidden="true"></span
-				><a href="CS4312Topics.html#IndexedFiles">Indexed Files</a>
-			</h3>
-			<h3>
-				<span class="ball-blue" aria-hidden="true"></span
-				><a href="CS4312Topics.html#Calling">Calling Subprograms</a>
-			</h3>
-			<h3>
-				<span class="ball-blue" aria-hidden="true"></span><a href="CS4312Topics.html#Inspect">The INSPECT</a>
-			</h3>
-			<h3><span class="ball-blue" aria-hidden="true"></span><a href="CS4312Topics.html#String">The STRING</a></h3>
-			<h3>
-				<span class="ball-blue" aria-hidden="true"></span><a href="CS4312Topics.html#Unstring">The UNSTRING</a>
-			</h3>
-			<h3>
-				<span class="ball-blue" aria-hidden="true"></span><a href="CS4312Topics.html#Usage">The USAGE clause</a>
-			</h3>
-			<h3>
-				<span class="ball-blue" aria-hidden="true"></span
-				><a href="CS4312Topics.html#ReportWriter1">The COBOL Report Writer - A worked example</a>
-			</h3>
-			<h3>
-				<span class="ball-blue" aria-hidden="true"></span
-				><a href="CS4312Topics.html#ReportWriter2">The COBOL Report Writer - Syntax and Semantics</a>
-			</h3>
-			<h3><span class="ball-blue" aria-hidden="true"></span><a href="CS4312Topics.html#Copy">The COPY</a></h3>
+				<h2 id="Contents">Module Contents</h2>
+				<h3>
+					<span class="ball-blue" aria-hidden="true"></span
+					><a href="CS4312Topics.html#General">General Introduction</a>
+				</h3>
+				<h3>
+					<span class="ball-blue" aria-hidden="true"></span
+					><a href="CS4312Topics.html#Introduction">Introduction to COBOL</a>
+				</h3>
+				<h3>
+					<span class="ball-blue" aria-hidden="true"></span
+					><a href="CS4312Topics.html#Basics1">COBOL Basics 1</a>
+				</h3>
+				<h3>
+					<span class="ball-blue" aria-hidden="true"></span
+					><a href="CS4312Topics.html#Basics2">COBOL Basics 2</a>
+				</h3>
+				<h3>
+					<span class="ball-blue" aria-hidden="true"></span
+					><a href="CS4312Topics.html#IntroSeqFiles">Introduction to Sequential Files</a>
+				</h3>
+				<h3>
+					<span class="ball-blue" aria-hidden="true"></span
+					><a href="CS4312Topics.html#ProcessingSeqFiles">Processing Sequential Files</a>
+				</h3>
+				<h3>
+					<span class="ball-blue" aria-hidden="true"></span
+					><a href="CS4312Topics.html#PERFORM">Simple iteration with the PERFORM verb</a>
+				</h3>
+				<h3>
+					<span class="ball-blue" aria-hidden="true"></span
+					><a href="CS4312Topics.html#Arithmetic">Arithmetic and Edited Pictures</a>
+				</h3>
+				<h3>
+					<span class="ball-blue" aria-hidden="true"></span
+					><a href="CS4312Topics.html#Conditions">Conditions</a>
+				</h3>
+				<h3>
+					<span class="ball-blue" aria-hidden="true"></span
+					><a href="CS4312Topics.html#Designing">Designing Programs</a>
+				</h3>
+				<h3>
+					<span class="ball-blue" aria-hidden="true"></span
+					><a href="CS4312Topics.html#DSR1">Introduction to Diagrammatic Stepwise Refinement</a>
+				</h3>
+				<h3>
+					<span class="ball-blue" aria-hidden="true"></span
+					><a href="CS4312Topics.html#SORT">SORT and MERGE</a>
+				</h3>
+				<h3>
+					<span class="ball-blue" aria-hidden="true"></span
+					><a href="CS4312Topics.html#Tables">Tables and the PERFORM ... VARYING</a>
+				</h3>
+				<h3>
+					<span class="ball-blue" aria-hidden="true"></span
+					><a href="CS4312Topics.html#AdvancedTables">Advanced Tables</a>
+				</h3>
+				<h3>
+					<span class="ball-blue" aria-hidden="true"></span
+					><a href="CS4312Topics.html#SearchingTAbles">Searching Tables</a>
+				</h3>
+				<h3>
+					<span class="ball-blue" aria-hidden="true"></span
+					><a href="CS4312Topics.html#AdvancedSeqFiles">Advanced Sequential Files</a>
+				</h3>
+				<h3>
+					<span class="ball-blue" aria-hidden="true"></span
+					><a href="CS4312Topics.html#IntroDirectAccessFiles">Introduction to Direct Access Files</a>
+				</h3>
+				<h3>
+					<span class="ball-blue" aria-hidden="true"></span
+					><a href="CS4312Topics.html#RelativeFiles">Relative Files</a>
+				</h3>
+				<h3>
+					<span class="ball-blue" aria-hidden="true"></span
+					><a href="CS4312Topics.html#IndexedFiles">Indexed Files</a>
+				</h3>
+				<h3>
+					<span class="ball-blue" aria-hidden="true"></span
+					><a href="CS4312Topics.html#Calling">Calling Subprograms</a>
+				</h3>
+				<h3>
+					<span class="ball-blue" aria-hidden="true"></span
+					><a href="CS4312Topics.html#Inspect">The INSPECT</a>
+				</h3>
+				<h3>
+					<span class="ball-blue" aria-hidden="true"></span><a href="CS4312Topics.html#String">The STRING</a>
+				</h3>
+				<h3>
+					<span class="ball-blue" aria-hidden="true"></span
+					><a href="CS4312Topics.html#Unstring">The UNSTRING</a>
+				</h3>
+				<h3>
+					<span class="ball-blue" aria-hidden="true"></span
+					><a href="CS4312Topics.html#Usage">The USAGE clause</a>
+				</h3>
+				<h3>
+					<span class="ball-blue" aria-hidden="true"></span
+					><a href="CS4312Topics.html#ReportWriter1">The COBOL Report Writer - A worked example</a>
+				</h3>
+				<h3>
+					<span class="ball-blue" aria-hidden="true"></span
+					><a href="CS4312Topics.html#ReportWriter2">The COBOL Report Writer - Syntax and Semantics</a>
+				</h3>
+				<h3><span class="ball-blue" aria-hidden="true"></span><a href="CS4312Topics.html#Copy">The COPY</a></h3>
 			</nav>
 			<hr />
 			<p>

--- a/lectures/index.html
+++ b/lectures/index.html
@@ -71,6 +71,7 @@
 				The last button downloads the .pptx file containing the presentation
 			</ul>
 			<hr />
+			<nav aria-label="Module contents">
 			<h2 id="Contents">Module Contents</h2>
 			<h3>
 				<span class="ball-blue" aria-hidden="true"></span
@@ -167,6 +168,7 @@
 				><a href="CS4312Topics.html#ReportWriter2">The COBOL Report Writer - Syntax and Semantics</a>
 			</h3>
 			<h3><span class="ball-blue" aria-hidden="true"></span><a href="CS4312Topics.html#Copy">The COPY</a></h3>
+			</nav>
 			<hr />
 			<p>
 				The copyright for these presentations belongs to the author - Michael Coughlan. Permission is given to

--- a/lectures/index.html
+++ b/lectures/index.html
@@ -51,7 +51,7 @@
 						height="52"
 						src="../pics/B-BackArrow.gif"
 						width="52"
-						alt=""
+						alt="Back to Module Contents"
 						style="margin-left: 5px; margin-right: 5px" /></a
 				><img
 					height="52"


### PR DESCRIPTION
## Summary

- Wraps each index page's primary navigation list in a `<nav aria-label="...">` element so screen-reader users can jump to it via the landmark rotor
- Five pages updated: `index.html`, `course/index.html`, `exercises/index.html`, `examples/default.html`, `lectures/index.html`
- Skip links and `<main id="main-content">` were already universal — no changes needed there

## What changed

| File | `aria-label` |
|---|---|
| `index.html` | `"COBOL resources"` |
| `course/index.html` | `"Course topics"` |
| `exercises/index.html` | `"Simple programming exercises"` |
| `examples/default.html` | `"Example programs contents"` |
| `lectures/index.html` | `"Module contents"` |

## Reviewer notes

- Only the primary navigation lists received `<nav>` wrappers. The exam-specification tables and project-specification lists in `exercises/index.html` were intentionally left as-is — they are descriptive content, not navigation.
- The `examples/default.html` TOC links to in-page anchors (`#SimplePrograms`, `#Selection`, etc.); this is still genuine navigation and warrants a `<nav>`.
- No visual or CSS changes — `<nav>` is a block element and the existing styles are unaffected.

## Test plan

- [ ] Open each updated page in a browser and confirm layout is unchanged
- [ ] Use NVDA (Windows) or VoiceOver (macOS) landmark rotor to confirm the `<nav>` regions are reachable by name
- [ ] Run `pa11y-ci` and confirm `landmark-one-main` and `landmark-no-duplicate-main` still pass

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)