### PR TITLE
feat: add page chrome to all 37 example program pages (closes #250)

### DIFF
--- a/course/Resources/css/course-components.css
+++ b/course/Resources/css/course-components.css
@@ -7,6 +7,13 @@
 	text-align: center;
 }
 
+/* Breadcrumb nav on example pages — provides vertical separation from the
+   page-hero theme-toggle above it and the description below. */
+nav[aria-label="Breadcrumb"] {
+	margin-top: 0.75em;
+	margin-bottom: 0.5em;
+}
+
 /* Eyebrow label in page-hero — replaces t-CobolTut.gif word-art badge.
    Uses site maroon in light mode; warm orange in dark mode so it stays
    legible without the img invert filter. */

--- a/examples/Accept/ACCEPT.html
+++ b/examples/Accept/ACCEPT.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>ACCEPT and DISPLAY example program</title>
 		<meta
 			name="description"
@@ -26,12 +32,35 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero title="ACCEPT and DISPLAY example program" eyebrow="COBOL Example"></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>ACCEPT and DISPLAY</span>
+						</nav>
+						<p>
+							The program accepts a simple student record from the user and displays the individual
+							fields. Also shows how the ACCEPT may be used to get and DISPLAY the system time and date.
+						</p>
+						<p><a href="AcceptAndDisplay.cbl" download>Download AcceptAndDisplay.cbl</a></p>
+						<related-content
+							lectures="../../course/COBOLIntro.html|Introduction to COBOL"
+						></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  AcceptAndDisplay.
 AUTHOR.  Michael Coughlan.
@@ -88,5 +117,9 @@ Begin.
     DISPLAY "The time is " CurrentHour ":" CurrentMinute.
     STOP RUN.
 </code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/Accept/Multiplier.html
+++ b/examples/Accept/Multiplier.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>ACCEPT, DISPLAY and MULTIPLY example program</title>
 		<meta
 			name="description"
@@ -29,12 +35,38 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero
+							title="ACCEPT, DISPLAY and MULTIPLY example program"
+							eyebrow="COBOL Example"
+						></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>Multiplier</span>
+						</nav>
+						<p>
+							Accepts two single digit numbers from the user, multiplies them together and displays the
+							result.
+						</p>
+						<p><a href="Multiplier.cbl" download>Download Multiplier.cbl</a></p>
+						<related-content
+							lectures="../../course/COBOLIntro.html|Introduction to COBOL"
+						></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  Multiplier.
 AUTHOR.  Michael Coughlan.
@@ -58,5 +90,9 @@ PROCEDURE DIVISION.
     STOP RUN.
 
 </code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/Accept/Shortest.html
+++ b/examples/Accept/Shortest.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>The Shortest COBOL program we can have</title>
 		<meta
 			name="description"
@@ -26,12 +32,35 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero title="The Shortest COBOL program we can have" eyebrow="COBOL Example"></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>Shortest COBOL Program</span>
+						</nav>
+						<p>
+							This example program is almost the shortest COBOL program we can have. We could make it
+							shorter still by leaving out the STOP RUN.
+						</p>
+						<p><a href="ShortestProgram.cbl" download>Download ShortestProgram.cbl</a></p>
+						<related-content
+							lectures="../../course/COBOLIntro.html|Introduction to COBOL"
+						></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  ShortestProgram.
 
@@ -40,5 +69,9 @@ DisplayPrompt.
     DISPLAY "I did it".
     STOP RUN.
 </code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/Conditn/Conditions.html
+++ b/examples/Conditn/Conditions.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>Condition Names (level 88) example program</title>
 		<meta name="description" content="COBOL example program: Condition Names (level 88) example program." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Conditn/Conditions.html" />
@@ -20,12 +26,33 @@
 		<meta name="twitter:description" content="COBOL example program: Condition Names (level 88) example program." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero
+							title="Condition Names (level 88) example program"
+							eyebrow="COBOL Example"
+						></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>Condition Names</span>
+						</nav>
+						<p>An example program demonstrating the use of Condition Names (level 88's).</p>
+						<p><a href="CONDITIONS.cbl" download>Download CONDITIONS.cbl</a></p>
+						<related-content lectures="../../course/Selection.html|Selection in COBOL"></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  Conditions.
 AUTHOR.  Michael Coughlan.
@@ -56,5 +83,9 @@ Begin.
     END-PERFORM
     STOP RUN.
 </code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/Conditn/IterIf.html
+++ b/examples/Conditn/IterIf.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>Condition Names (level 88) example program</title>
 		<meta name="description" content="COBOL example program: Condition Names (level 88) example program." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Conditn/IterIf.html" />
@@ -17,12 +23,38 @@
 		<meta name="twitter:description" content="COBOL example program: Condition Names (level 88) example program." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero
+							title="Condition Names (level 88) example program"
+							eyebrow="COBOL Example"
+						></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>Iteration with IF</span>
+						</nav>
+						<p>
+							An example program that implements a primitive calculator. The calculator only does
+							additions and multiplications.
+						</p>
+						<p><a href="Iteration-If.cbl" download>Download Iteration-If.cbl</a></p>
+						<related-content
+							lectures="../../course/Selection.html|Selection in COBOL, ../../course/Iteration.html|Iteration in COBOL"
+						></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  Iteration-If.
 AUTHOR.  Michael Coughlan.
@@ -53,5 +85,9 @@ Calculator.
     END-PERFORM.
     STOP RUN.
 </code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/Indexed/DirectReadIdx.html
+++ b/examples/Indexed/DirectReadIdx.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>Reading an Indexed file directly by key</title>
 		<meta
 			name="description"
@@ -32,12 +38,33 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero title="Reading an Indexed file directly by key" eyebrow="COBOL Example"></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>Direct Read on Indexed File</span>
+						</nav>
+						<p>
+							Does a direct read on the Indexed file. Allows the user to choose which of the keys to use
+							for the direct read.
+						</p>
+						<p><a href="DirectReadIdx.cbl" download>Download DirectReadIdx.cbl</a></p>
+						<related-content lectures="../../course/IndexedFiles.html|Indexed Files"></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  DirectReadIdx.
 AUTHOR.  Michael Coughlan.
@@ -115,5 +142,9 @@ Begin.
    CLOSE VideoFile.
    STOP RUN.
 </code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/Indexed/Seq2Index.html
+++ b/examples/Indexed/Seq2Index.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>Creating an Indexed file from a sequential file</title>
 		<meta
 			name="description"
@@ -29,12 +35,33 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero
+							title="Creating an Indexed file from a sequential file"
+							eyebrow="COBOL Example"
+						></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>Sequential to Indexed</span>
+						</nav>
+						<p>Creates a direct access Indexed file from a Sequential file.</p>
+						<p><a href="Seq2Index.cbl" download>Download Seq2Index.cbl</a></p>
+						<related-content lectures="../../course/IndexedFiles.html|Indexed Files"></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  Seq2Index.
 AUTHOR.  Michael Coughlan.
@@ -95,5 +122,9 @@ Begin.
 
    CLOSE VideoFile, SeqVideoFile.
    STOP RUN.</code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/Indexed/SeqReadIdx.html
+++ b/examples/Indexed/SeqReadIdx.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>Reading an Indexed file sequentially on any of its keys</title>
 		<meta
 			name="description"
@@ -29,12 +35,36 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero
+							title="Reading an Indexed file sequentially on any of its keys"
+							eyebrow="COBOL Example"
+						></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>Sequential Read of Indexed File</span>
+						</nav>
+						<p>
+							Reads the Indexed file sequentially on whichever key is chosen by the user. Displays all the
+							records in the file.
+						</p>
+						<p><a href="SeqReadIdx.cbl" download>Download SeqReadIdx.cbl</a></p>
+						<related-content lectures="../../course/IndexedFiles.html|Indexed Files"></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  SeqReadIdx.
 AUTHOR.  Michael Coughlan.
@@ -116,5 +146,9 @@ Begin.
    CLOSE VideoFile.
    STOP RUN.
 </code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/Merge/Merge.html
+++ b/examples/Merge/Merge.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>Merge Files - Example Program</title>
 		<meta
 			name="description"
@@ -26,12 +32,30 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero title="Merge Files - Example Program" eyebrow="COBOL Example"></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>Merge Files</span>
+						</nav>
+						<p>Uses the MERGE to insert records from a transaction file into a sequential master file.</p>
+						<p><a href="MergeFiles.cbl" download>Download MergeFiles.cbl</a></p>
+						<related-content lectures="../../course/SortMerge.html|Sorting and Merging"></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. MergeFiles.
 AUTHOR. MICHAEL COUGHLAN.
@@ -81,5 +105,9 @@ Begin.
        GIVING NewStudentFile.
     STOP RUN.
 </code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/Perform/MileageCount.html
+++ b/examples/Perform/MileageCount.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>Mileage counter simulation</title>
 		<meta
 			name="description"
@@ -29,12 +35,33 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero title="Mileage counter simulation" eyebrow="COBOL Example"></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>Mileage Counter</span>
+						</nav>
+						<p>
+							Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be
+							used to simulate a mileage counter.
+						</p>
+						<p><a href="MileageCounter.cbl" download>Download MileageCounter.cbl</a></p>
+						<related-content lectures="../../course/Iteration.html|Iteration in COBOL"></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  MileageCounter.
 AUTHOR.  Michael Coughlan.
@@ -85,5 +112,9 @@ CountMileage.
    DISPLAY PrnHunds "-" PrnTens "-" PrnUnits.
 
  </code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/Perform/Perform1.html
+++ b/examples/Perform/Perform1.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>Perform - Format 1 example program</title>
 		<meta
 			name="description"
@@ -29,12 +35,33 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero title="Perform - Format 1 example program" eyebrow="COBOL Example"></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>PERFORM Format 1</span>
+						</nav>
+						<p>
+							An example program demonstrating how the first format of the PERFORM may be used to change
+							the flow of control through a program.
+						</p>
+						<p><a href="PerformFormat1.cbl" download>Download PerformFormat1.cbl</a></p>
+						<related-content lectures="../../course/Iteration.html|Iteration in COBOL"></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  PerformFormat1.
 AUTHOR.  Michael Coughlan.
@@ -66,5 +93,9 @@ OneLevelDown.
 ThreeLevelsDown.
     DISPLAY "&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Now in ThreeLevelsDown".
 </code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/Perform/Perform2.html
+++ b/examples/Perform/Perform2.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>Perform - Format 2 example program</title>
 		<meta
 			name="description"
@@ -29,12 +35,33 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero title="Perform - Format 2 example program" eyebrow="COBOL Example"></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>PERFORM Format 2</span>
+						</nav>
+						<p>
+							Demonstrates the second format of the PERFORM. The PERFORM..TIMES may be used to execute a
+							block of code x number of times.
+						</p>
+						<p><a href="PerformFormat2.cbl" download>Download PerformFormat2.cbl</a></p>
+						<related-content lectures="../../course/Iteration.html|Iteration in COBOL"></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  PerformFormat2.
 AUTHOR.  Michael Coughlan.
@@ -59,5 +86,9 @@ Begin.
 
 OutOfLineEG.
     DISPLAY "&gt;&gt;&gt;&gt; This is an out of line Perform".</code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/Perform/Perform3.html
+++ b/examples/Perform/Perform3.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>Perform - Format 3 example program</title>
 		<meta
 			name="description"
@@ -29,12 +35,33 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero title="Perform - Format 3 example program" eyebrow="COBOL Example"></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>PERFORM Format 3</span>
+						</nav>
+						<p>
+							Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values
+							where the length of the stream cannot be determined in advance.
+						</p>
+						<p><a href="PerformFormat3.cbl" download>Download PerformFormat3.cbl</a></p>
+						<related-content lectures="../../course/Iteration.html|Iteration in COBOL"></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  PerformFormat3.
 AUTHOR.  Michael Coughlan.
@@ -91,5 +118,9 @@ GetUserInput.
     DISPLAY "Count so far is - " IterCount
     DISPLAY "Enter number :- " WITH NO ADVANCING
     ACCEPT UserInput.</code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/Perform/Perform4.html
+++ b/examples/Perform/Perform4.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>Perform - Format 4 example program</title>
 		<meta
 			name="description"
@@ -29,12 +35,34 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero title="Perform - Format 4 example program" eyebrow="COBOL Example"></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>PERFORM Format 4</span>
+						</nav>
+						<p>
+							Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be
+							used for counting iteration. Also introduces the WITH TEST BEFORE and WITH TEST AFTER
+							phrases.
+						</p>
+						<p><a href="PerformFormat4.cbl" download>Download PerformFormat4.cbl</a></p>
+						<related-content lectures="../../course/Iteration.html|Iteration in COBOL"></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  PerformFormat4.
 AUTHOR.  Michael Coughlan.
@@ -88,5 +116,9 @@ LoopBody.
     DISPLAY "LoopBody " WITH NO ADVANCING
     DISPLAY "LoopCount = " LoopCount " LoopCount2 = " LoopCount2.
 </code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/Perform/PerformFormat2.cbl
+++ b/examples/Perform/PerformFormat2.cbl
@@ -1,0 +1,25 @@
+       >>SOURCE FORMAT IS FREE
+IDENTIFICATION DIVISION.
+PROGRAM-ID.  PerformFormat2.
+AUTHOR.  Michael Coughlan.
+*> Demonstrates the second format of the PERFORM.
+*> The PERFORM..TIMES format executes a block of code x
+*> number of times.
+
+DATA DIVISION.
+WORKING-STORAGE SECTION.
+01 NumofTimes           PIC 9 VALUE 5.
+
+PROCEDURE DIVISION.
+Begin.
+    DISPLAY "Starting to run program"
+    PERFORM 3 TIMES
+       DISPLAY ">>>>This is an in line Perform"
+    END-PERFORM
+    DISPLAY "Finished in line Perform"
+    PERFORM OutOfLineEG NumOfTimes TIMES
+    DISPLAY "Back in Begin. About to Stop".
+    STOP RUN.
+
+OutOfLineEG.
+    DISPLAY ">>>> This is an out of line Perform".

--- a/examples/Relative/ReadRel.html
+++ b/examples/Relative/ReadRel.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>Inserting records in a Sequential File</title>
 		<meta
 			name="description"
@@ -29,12 +35,33 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero title="Inserting records in a Sequential File" eyebrow="COBOL Example"></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>Read Relative File</span>
+						</nav>
+						<p>
+							Reads the Relative file and displays the records. Allows the user to choose to read
+							sequentially through all the records or to use a key to read a single record directly.
+						</p>
+						<p><a href="ReadRelative.cbl" download>Download ReadRelative.cbl</a></p>
+						<related-content lectures="../../course/RelativeFiles.html|Relative Files"></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  ReadRelative.
 AUTHOR.  MICHAEL COUGHLAN.
@@ -115,5 +142,9 @@ DisplayRecord.
         DISPLAY PrnSupplierRecord
     END-IF.
      </code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/Relative/Seq2Rel.html
+++ b/examples/Relative/Seq2Rel.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>Inserting records in a Sequential File</title>
 		<meta
 			name="description"
@@ -29,12 +35,30 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero title="Inserting records in a Sequential File" eyebrow="COBOL Example"></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>Sequential to Relative</span>
+						</nav>
+						<p>Creates a direct access Relative file from a Sequential File.</p>
+						<p><a href="Seq2Rel.cbl" download>Download Seq2Rel.cbl</a></p>
+						<related-content lectures="../../course/RelativeFiles.html|Relative Files"></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  Seq2Rel.
 AUTHOR.  MICHAEL COUGHLAN.
@@ -98,5 +122,9 @@ Begin.
 
     CLOSE  SupplierFile, SupplierFileSeq.
     STOP RUN.</code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/ReportWriter/RepWriteA.html
+++ b/examples/ReportWriter/RepWriteA.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>One control break version of full Report Writer example Program</title>
 		<meta
 			name="description"
@@ -32,12 +38,38 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero
+							title="One control break version of full Report Writer example Program"
+							eyebrow="COBOL Example"
+						></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>Report Writer Example A</span>
+						</nav>
+						<p>
+							A simplified version of the full report program using only one control break. Uses the
+							GBsales.dat data file.
+						</p>
+						<p><a href="ReportExampleA.cbl" download>Download ReportExampleA.cbl</a></p>
+						<related-content
+							lectures="../../course/ReportWriter.html|Report Writer by Example, ../../course/ReportWriterSS.html|Report Writer Syntax and Semantics"
+						></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  ReportExampleA.
 AUTHOR.  Michael Coughlan.
@@ -110,7 +142,7 @@ RD  SalesReport
                         SOURCE CityName(CityCode).
        03 COLUMN 15     PIC 9
                         SOURCE SalesPersonNum.
-       03 COLUMN 25     PIC $$,$$$.99 SOURCE ValueOfSale.
+       03 COLUMN 25     PIC $,$$.99 SOURCE ValueOfSale.
                 
 
 01  SalesPersonGrp
@@ -119,7 +151,7 @@ RD  SalesReport
        03 COLUMN 15     PIC X(21) VALUE "Sales for salesperson".
        03 COLUMN 37     PIC 9 SOURCE SalesPersonNum.
        03 COLUMN 43     PIC X VALUE "=".
-       03 SMS COLUMN 45 PIC $$$$$,$$$.99 SUM ValueOfSale.
+       03 SMS COLUMN 45 PIC $$$,$$.99 SUM ValueOfSale.
 
 
 01  TYPE IS PAGE FOOTING.
@@ -149,5 +181,9 @@ PrintSalaryReport.
     READ SalesFile
           AT END SET EndOfFile TO TRUE
     END-READ.   </code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/ReportWriter/RepWriteB.html
+++ b/examples/ReportWriter/RepWriteB.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>No Declaratives version of full Report Writer example program</title>
 		<meta
 			name="description"
@@ -32,12 +38,38 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero
+							title="No Declaratives version of full Report Writer example program"
+							eyebrow="COBOL Example"
+						></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>Report Writer Example B</span>
+						</nav>
+						<p>
+							A simplified version of the full report program containing all the control breaks but not
+							using Declaratives. Uses the GBsales.dat data file.
+						</p>
+						<p><a href="ReportExampleB.cbl" download>Download ReportExampleB.cbl</a></p>
+						<related-content
+							lectures="../../course/ReportWriter.html|Report Writer by Example, ../../course/ReportWriterSS.html|Report Writer Syntax and Semantics"
+						></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  ReportExampleB.
 AUTHOR.  Michael Coughlan.
@@ -113,7 +145,7 @@ RD  SalesReport
                         SOURCE CityName(CityCode) GROUP INDICATE.
        03 COLUMN 15     PIC 9
                         SOURCE SalesPersonNum  GROUP INDICATE.
-       03 COLUMN 25     PIC $$,$$$.99 SOURCE ValueOfSale.
+       03 COLUMN 25     PIC $,$$.99 SOURCE ValueOfSale.
                 
 
 01  SalesPersonGrp
@@ -122,7 +154,7 @@ RD  SalesReport
        03 COLUMN 15     PIC X(21) VALUE "Sales for salesperson".
        03 COLUMN 37     PIC 9 SOURCE SalesPersonNum.
        03 COLUMN 43     PIC X VALUE "=".
-       03 SMS COLUMN 45 PIC $$$$$,$$$.99 SUM ValueOfSale.
+       03 SMS COLUMN 45 PIC $$$,$$.99 SUM ValueOfSale.
 
 
 01  CityGrp TYPE IS CONTROL FOOTING CityCode NEXT GROUP PLUS 2.
@@ -130,7 +162,7 @@ RD  SalesReport
        03 COLUMN 15     PIC X(9) VALUE "Sales for".
        03 COLUMN 25     PIC X(9) SOURCE CityName(CityCode).
        03 COLUMN 43     PIC X VALUE "=".
-       03 CS COLUMN 45  PIC $$$$$,$$$.99 SUM SMS.
+       03 CS COLUMN 45  PIC $$$,$$.99 SUM SMS.
 
 
 01  TotalSalesGrp TYPE IS CONTROL FOOTING FINAL.
@@ -138,7 +170,7 @@ RD  SalesReport
        03 COLUMN 15     PIC X(11)
                         VALUE "Total sales".
        03 COLUMN 43     PIC X VALUE "=".
-       03 COLUMN 45     PIC $$$$$,$$$.99 SUM CS.
+       03 COLUMN 45     PIC $$$,$$.99 SUM CS.
 
 
 01  TYPE IS PAGE FOOTING.
@@ -171,5 +203,9 @@ PrintSalaryReport.
 
 
         </code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/ReportWriter/RepWriteFull.html
+++ b/examples/ReportWriter/RepWriteFull.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>Full Report Writer example program - includes Declaratives</title>
 		<meta
 			name="description"
@@ -32,12 +38,38 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero
+							title="Full Report Writer example program - includes Declaratives"
+							eyebrow="COBOL Example"
+						></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>Report Writer Full Example</span>
+						</nav>
+						<p>
+							The full version of the report program containing all the control breaks and using
+							Declaratives to calculate the salesperson salary and commission.
+						</p>
+						<p><a href="ReportExampleFull.cbl" download>Download ReportExampleFull.cbl</a></p>
+						<related-content
+							lectures="../../course/ReportWriter.html|Report Writer by Example, ../../course/ReportWriterSS.html|Report Writer Syntax and Semantics"
+						></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  ReportExampleFull.
 AUTHOR.  Michael Coughlan.
@@ -144,7 +176,7 @@ RD  SalesReport
                         SOURCE CityName(CityCode) GROUP INDICATE.
        03 COLUMN 15     PIC 9
                         SOURCE SalesPersonNum  GROUP INDICATE.
-       03 COLUMN 25     PIC $$,$$$.99 SOURCE ValueOfSale.
+       03 COLUMN 25     PIC $,$$.99 SOURCE ValueOfSale.
                 
 
 01  SalesPersonGrp
@@ -153,17 +185,17 @@ RD  SalesReport
        03 COLUMN 15     PIC X(21) VALUE "Sales for salesperson".
        03 COLUMN 37     PIC 9 SOURCE SalesPersonNum.
        03 COLUMN 43     PIC X VALUE "=".
-       03 SMS COLUMN 45 PIC $$$$$,$$$.99 SUM ValueOfSale.
+       03 SMS COLUMN 45 PIC $$$,$$.99 SUM ValueOfSale.
 
     02 LINE IS PLUS 1.
        03 COLUMN 15     PIC X(19) VALUE "Sales commission is".
        03 COLUMN 43     PIC X VALUE "=".
-       03 COLUMN 45     PIC $$$$$,$$$.99 SOURCE Commission.
+       03 COLUMN 45     PIC $$$,$$.99 SOURCE Commission.
 
     02 LINE IS PLUS 1.
        03 COLUMN 15     PIC X(22) VALUE "Salesperson salary is".
        03 COLUMN 43     PIC X VALUE "=".
-       03 COLUMN 45     PIC $$$$$,$$$.99 SOURCE Salary.
+       03 COLUMN 45     PIC $$$,$$.99 SOURCE Salary.
 
     02 LINE IS PLUS 1.
        03 COLUMN 15     PIC X(30)
@@ -182,7 +214,7 @@ RD  SalesReport
        03 COLUMN 15     PIC X(9) VALUE "Sales for".
        03 COLUMN 25     PIC X(9) SOURCE CityName(CityCode).
        03 COLUMN 43     PIC X VALUE "=".
-       03 CS COLUMN 45  PIC $$$$$,$$$.99 SUM SMS.
+       03 CS COLUMN 45  PIC $$$,$$.99 SUM SMS.
 
     02 LINE IS PLUS 1.
        03 COLUMN 15     PIC X(12)
@@ -202,7 +234,7 @@ RD  SalesReport
        03 COLUMN 15     PIC X(11)
                         VALUE "Total sales".
        03 COLUMN 43     PIC X VALUE "=".
-       03 COLUMN 45     PIC $$$$$,$$$.99 SUM CS.
+       03 COLUMN 45     PIC $$$,$$.99 SUM CS.
 
 
 01  TYPE IS PAGE FOOTING.
@@ -248,5 +280,9 @@ PrintSalaryReport.
 
 
         </code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/ReportWriter/RepWriteSumm.html
+++ b/examples/ReportWriter/RepWriteSumm.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>Summary version of the full Report Writer program</title>
 		<meta
 			name="description"
@@ -32,12 +38,38 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero
+							title="Summary version of the full Report Writer program"
+							eyebrow="COBOL Example"
+						></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>Report Writer Summary</span>
+						</nav>
+						<p>
+							The summary version of the full report program containing all the control breaks and using
+							Declaratives to calculate the salesperson salary and commission.
+						</p>
+						<p><a href="ReportExampleSummary.cbl" download>Download ReportExampleSummary.cbl</a></p>
+						<related-content
+							lectures="../../course/ReportWriter.html|Report Writer by Example, ../../course/ReportWriterSS.html|Report Writer Syntax and Semantics"
+						></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  ReportExampleSummary.
 AUTHOR.  Michael Coughlan.
@@ -144,7 +176,7 @@ RD  SalesReport
                         SOURCE CityName(CityCode) GROUP INDICATE.
        03 COLUMN 15     PIC 9
                         SOURCE SalesPersonNum  GROUP INDICATE.
-       03 COLUMN 25     PIC $$,$$$.99 SOURCE ValueOfSale.
+       03 COLUMN 25     PIC $,$$.99 SOURCE ValueOfSale.
                 
 
 01  SalesPersonGrp
@@ -153,17 +185,17 @@ RD  SalesReport
        03 COLUMN 15     PIC X(21) VALUE "Sales for salesperson".
        03 COLUMN 37     PIC 9 SOURCE SalesPersonNum.
        03 COLUMN 43     PIC X VALUE "=".
-       03 SMS COLUMN 45 PIC $$$$$,$$$.99 SUM ValueOfSale.
+       03 SMS COLUMN 45 PIC $$$,$$.99 SUM ValueOfSale.
 
     02 LINE IS PLUS 1.
        03 COLUMN 15     PIC X(19) VALUE "Sales commission is".
        03 COLUMN 43     PIC X VALUE "=".
-       03 COLUMN 45     PIC $$$$$,$$$.99 SOURCE Commission.
+       03 COLUMN 45     PIC $$$,$$.99 SOURCE Commission.
 
     02 LINE IS PLUS 1.
        03 COLUMN 15     PIC X(22) VALUE "Salesperson salary is".
        03 COLUMN 43     PIC X VALUE "=".
-       03 COLUMN 45     PIC $$$$$,$$$.99 SOURCE Salary.
+       03 COLUMN 45     PIC $$$,$$.99 SOURCE Salary.
 
     02 LINE IS PLUS 1.
        03 COLUMN 15     PIC X(30)
@@ -182,7 +214,7 @@ RD  SalesReport
        03 COLUMN 15     PIC X(9) VALUE "Sales for".
        03 COLUMN 25     PIC X(9) SOURCE CityName(CityCode).
        03 COLUMN 43     PIC X VALUE "=".
-       03 CS COLUMN 45  PIC $$$$$,$$$.99 SUM SMS.
+       03 CS COLUMN 45  PIC $$$,$$.99 SUM SMS.
 
     02 LINE IS PLUS 1.
        03 COLUMN 15     PIC X(12)
@@ -202,7 +234,7 @@ RD  SalesReport
        03 COLUMN 15     PIC X(11)
                         VALUE "Total sales".
        03 COLUMN 43     PIC X VALUE "=".
-       03 COLUMN 45     PIC $$$$$,$$$.99 SUM CS.
+       03 COLUMN 45     PIC $$$,$$.99 SUM CS.
 
 
 01  TYPE IS PAGE FOOTING.
@@ -248,5 +280,9 @@ PrintSalaryReport.
 
 
         </code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/SeqIns/SEQINSERT.html
+++ b/examples/SeqIns/SEQINSERT.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>Inserting records in a Sequential File</title>
 		<meta
 			name="description"
@@ -29,12 +35,35 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero title="Inserting records in a Sequential File" eyebrow="COBOL Example"></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>Insert Records</span>
+						</nav>
+						<p>
+							Demonstrates how to insert records into a sequential file from a file of transaction
+							records. A new file is created which contains the inserted records.
+						</p>
+						<p><a href="InsertRecords.cbl" download>Download InsertRecords.cbl</a></p>
+						<related-content
+							lectures="../../course/SequentialFiles2.html|Processing Sequential Files"
+						></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. InsertRecords.
 AUTHOR. Michael Coughlan.
@@ -119,5 +148,9 @@ BEGIN.
     CLOSE NewStudentRecords
     STOP RUN.
 </code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/SeqRead/SEQREAD.html
+++ b/examples/SeqRead/SEQREAD.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>Reading a Sequential File</title>
 		<meta
 			name="description"
@@ -26,12 +32,35 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero title="Reading a Sequential File" eyebrow="COBOL Example"></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>Sequential Read</span>
+						</nav>
+						<p>
+							An example program that reads a sequential file and displays the records. Uses the Condition
+							Name (level 88) "EndOfFile" to signal when the end of the file has been reached.
+						</p>
+						<p><a href="Seqread.cbl" download>Download Seqread.cbl</a></p>
+						<related-content
+							lectures="../../course/SequentialFiles1.html|Introduction to Sequential Files"
+						></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  SeqRead.
 AUTHOR.  Michael Coughlan.
@@ -74,5 +103,9 @@ Begin.
    END-PERFORM
    CLOSE StudentFile
    STOP RUN.</code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/SeqRead/SEQREADno88.html
+++ b/examples/SeqRead/SEQREADno88.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>Reading a Sequential File</title>
 		<meta name="description" content="COBOL example program: Reading a Sequential File." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREADno88.html" />
@@ -20,12 +26,35 @@
 		<meta name="twitter:description" content="COBOL example program: Reading a Sequential File." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero title="Reading a Sequential File" eyebrow="COBOL Example"></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>Sequential Read (without level 88s)</span>
+						</nav>
+						<p>
+							An example program that reads a sequential file and displays the records. This version does
+							not use level 88's to signal when the end of the file has been reached.
+						</p>
+						<p><a href="SeqreadNo88.cbl" download>Download SeqreadNo88.cbl</a></p>
+						<related-content
+							lectures="../../course/SequentialFiles1.html|Introduction to Sequential Files"
+						></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  SeqReadNo88.
 AUTHOR.  Michael Coughlan.
@@ -69,5 +98,9 @@ Begin.
    END-PERFORM
    CLOSE StudentFile
    STOP RUN.</code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/SeqRpt/SEQRPT.html
+++ b/examples/SeqRpt/SEQRPT.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>Sequential Student Number Report</title>
 		<meta
 			name="description"
@@ -26,12 +32,35 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero title="Sequential Student Number Report" eyebrow="COBOL Example"></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>Student Numbers Report</span>
+						</nav>
+						<p>
+							Reads records from the student file, counts the total number of student records and the
+							number of records for females and males, and prints the results in a short report.
+						</p>
+						<p><a href="StudentNumbersReport.cbl" download>Download StudentNumbersReport.cbl</a></p>
+						<related-content
+							lectures="../../course/SequentialFiles3.html|COBOL Print Files and Variable-Length Records"
+						></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION. 
 PROGRAM-ID.  StudentNumbersReport . 
 AUTHOR. Michael Coughlan. 
@@ -133,5 +162,9 @@ PrintReportLines.
     WRITE PrintLine FROM FemaleTotalLine 
             AFTER ADVANCING 2 LINES. 
 </code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/SeqWrite/SEQWRITE.html
+++ b/examples/SeqWrite/SEQWRITE.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>Writing to a Sequential File</title>
 		<meta name="description" content="COBOL example program: Writing to a Sequential File." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SeqWrite/SEQWRITE.html" />
@@ -20,12 +26,34 @@
 		<meta name="twitter:description" content="COBOL example program: Writing to a Sequential File." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero title="Writing to a Sequential File" eyebrow="COBOL Example"></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>Sequential Write</span>
+						</nav>
+						<p>
+							Example program demonstrating how to create a sequential file from data input by the user.
+						</p>
+						<p><a href="SEQWRITE.cbl" download>Download SEQWRITE.cbl</a></p>
+						<related-content
+							lectures="../../course/SequentialFiles1.html|Introduction to Sequential Files"
+						></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  SeqWrite.
 AUTHOR.  Michael Coughlan.
@@ -74,5 +102,9 @@ GetStudentDetails.
     DISPLAY "Enter - StudId, Surname, Initials, YOB, MOB, DOB, Course, Gender"
     DISPLAY "NNNNNNNSSSSSSSSIIYYYYMMDDCCCCG"
     ACCEPT  StudentDetails.  </code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/Sort/InputSort.html
+++ b/examples/Sort/InputSort.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>SORT with Input Procedure to get recs from user</title>
 		<meta
 			name="description"
@@ -26,12 +32,36 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero
+							title="SORT with Input Procedure to get recs from user"
+							eyebrow="COBOL Example"
+						></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>Input Sort</span>
+						</nav>
+						<p>
+							Uses the SORT and an INPUT PROCEDURE to accept records from the user and sort them on
+							ascending StudentId.
+						</p>
+						<p><a href="InputSORT.cbl" download>Download InputSORT.cbl</a></p>
+						<related-content lectures="../../course/SortMerge.html|Sorting and Merging"></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  InputSort.
 AUTHOR.  Michael Coughlan.
@@ -95,5 +125,9 @@ GetStudentDetails.
        RELEASE WorkRec
        ACCEPT WorkRec
     END-PERFORM.</code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/Sort/MaleSort.html
+++ b/examples/Sort/MaleSort.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>SORT file and select only male records</title>
 		<meta
 			name="description"
@@ -26,12 +32,33 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero title="SORT file and select only male records" eyebrow="COBOL Example"></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>Male Sort</span>
+						</nav>
+						<p>
+							Sorts the student masterfile and produces a new file, sorted on ascending student name,
+							containing only the records of male students.
+						</p>
+						<p><a href="MaleSORT.cbl" download>Download MaleSORT.cbl</a></p>
+						<related-content lectures="../../course/SortMerge.html|Sorting and Merging"></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  MaleSort.
 AUTHOR.  Michael Coughlan.
@@ -93,5 +120,9 @@ GetMaleStudents.
       END-READ 
    END-PERFORM
    CLOSE StudentFile.</code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/Strings/RefMod.html
+++ b/examples/Strings/RefMod.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>String handling - Reference Modification examples</title>
 		<meta
 			name="description"
@@ -26,12 +32,39 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero
+							title="String handling - Reference Modification examples"
+							eyebrow="COBOL Example"
+						></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>Reference Modification</span>
+						</nav>
+						<p>
+							Solves a number of string handling tasks such as extracting substrings, removing leading or
+							trailing blanks, and finding the location of the first occurrence of a character in a
+							string.
+						</p>
+						<p><a href="RefModification.cbl" download>Download RefModification.cbl</a></p>
+						<related-content
+							lectures="../../course/RefMod.html|Reference Modification and Intrinsic Functions"
+						></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  RefModification.
 AUTHOR.  Michael Coughlan.
@@ -139,5 +172,9 @@ Begin.
     DISPLAY "The character is " xStr(EndCount:1)
     STOP RUN.
 </code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/Strings/UnstringFileEg.html
+++ b/examples/Strings/UnstringFileEg.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>String handling - Unpacking and size-validating comma separated records</title>
 		<meta
 			name="description"
@@ -32,12 +38,36 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero
+							title="String handling - Unpacking and size-validating comma separated records"
+							eyebrow="COBOL Example"
+						></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>UNSTRING File Example</span>
+						</nav>
+						<p>
+							An example showing the unpacking of comma-separated records and the size validation of the
+							unpacked fields.
+						</p>
+						<p><a href="UnstringFileEg.cbl" download>Download UnstringFileEg.cbl</a></p>
+						<related-content lectures="../../course/Unstring.html|Unstring"></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  UnstringFileEg.
 AUTHOR.  Michael Coughlan.
@@ -132,5 +162,9 @@ CheckForErrors.
    IF NOT ValidSuppCode DISPLAY "Supplier Code Error"    END-IF
    IF NOT ValidSuppName DISPLAY "Supplier name Error"    END-IF
    IF NOT ValidSuppAdr  DISPLAY "Supplier address Error" END-IF.</code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/SubProg/DateValid/DateDriver.html
+++ b/examples/SubProg/DateValid/DateDriver.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>Driver program for date validation sub-program</title>
 		<meta
 			name="description"
@@ -32,12 +38,38 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../../components/theme-toggle.js" defer></script>
+		<script src="../../../components/page-hero.js" defer></script>
+		<script src="../../../components/related-content.js" defer></script>
+		<script src="../../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero
+							title="Driver program for date validation sub-program"
+							eyebrow="COBOL Example"
+						></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../../default.html">Example programs</a> ›
+							<span>Date Driver Program</span>
+						</nav>
+						<p>
+							A driver program for the date validation sub-program. Accepts a date from the user, passes
+							it to the date validation sub-program and interprets and displays the result.
+						</p>
+						<p><a href="DateDriver.cbl" download>Download DateDriver.cbl</a></p>
+						<related-content
+							lectures="../../../course/Subprograms.html|Contained and External Sub-programs"
+						></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. DateDriver.
 AUTHOR.  Michael Coughlan.
@@ -84,5 +116,9 @@ Begin.
 
 
 </code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/SubProg/DateValid/ValiDate.html
+++ b/examples/SubProg/DateValid/ValiDate.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>Date validation sub-program</title>
 		<meta
 			name="description"
@@ -32,12 +38,35 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../../components/theme-toggle.js" defer></script>
+		<script src="../../../components/page-hero.js" defer></script>
+		<script src="../../../components/related-content.js" defer></script>
+		<script src="../../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero title="Date validation sub-program" eyebrow="COBOL Example"></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../../default.html">Example programs</a> ›
+							<span>Date Validation Sub-program</span>
+						</nav>
+						<p>
+							A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a
+							code indicating whether the date was valid, and if not, why it was invalid.
+						</p>
+						<p><a href="Validate.cbl" download>Download Validate.cbl</a></p>
+						<related-content
+							lectures="../../../course/Subprograms.html|Contained and External Sub-programs"
+						></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. Validate IS INITIAL.
 AUTHOR.  Michael Coughlan.
@@ -119,5 +148,9 @@ CheckForValidDay.
      SET DateIsValid TO TRUE
   END-IF.
 </code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/SubProg/DayDiff/DayDiffDriver.html
+++ b/examples/SubProg/DayDiff/DayDiffDriver.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>Get difference between dates driver program</title>
 		<meta
 			name="description"
@@ -32,12 +38,39 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../../components/theme-toggle.js" defer></script>
+		<script src="../../../components/page-hero.js" defer></script>
+		<script src="../../../components/related-content.js" defer></script>
+		<script src="../../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero
+							title="Get difference between dates driver program"
+							eyebrow="COBOL Example"
+						></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../../default.html">Example programs</a> ›
+							<span>Day Difference Driver</span>
+						</nav>
+						<p>
+							A driver program that accepts two dates from the user and displays the difference in days
+							between them. Uses the Validate sub-program and also contains a number of contained
+							sub-programs.
+						</p>
+						<p><a href="DayDiffDriver.cbl" download>Download DayDiffDriver.cbl</a></p>
+						<related-content
+							lectures="../../../course/Subprograms.html|Contained and External Sub-programs"
+						></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. DayDiffDriver.
 AUTHOR. Michael Coughlan.
@@ -233,5 +266,9 @@ END PROGRAM GetDayDiff.
 
 END PROGRAM DayDiffDriver.
 </code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/SubProg/Multiply/DriverProg.html
+++ b/examples/SubProg/Multiply/DriverProg.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>A driver for the MultiplyNums, Fickle and Steafast sub-programs</title>
 		<meta
 			name="description"
@@ -32,12 +38,38 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../../components/theme-toggle.js" defer></script>
+		<script src="../../../components/page-hero.js" defer></script>
+		<script src="../../../components/related-content.js" defer></script>
+		<script src="../../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero
+							title="A driver for the MultiplyNums, Fickle and Steafast sub-programs"
+							eyebrow="COBOL Example"
+						></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../../default.html">Example programs</a> ›
+							<span>Sub-program Driver</span>
+						</nav>
+						<p>
+							Demonstrates the CALL verb by calling three external sub-programs that illustrate flow of
+							control, parameter passing, and state memory.
+						</p>
+						<p><a href="DriverProg.cbl" download>Download DriverProg.cbl</a></p>
+						<related-content
+							lectures="../../../course/Subprograms.html|Contained and External Sub-programs"
+						></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. DriverProg.
 AUTHOR.  Michael Coughlan. 
@@ -169,5 +201,9 @@ MakeFickleSteadfast.
 *&gt;   We can make Fickle act like Steadfast by using
 *&gt;   the CANCEL verb to set it into its initial state
 *&gt;   each time we call it</code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/SubProg/Multiply/Fickle.html
+++ b/examples/SubProg/Multiply/Fickle.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>The Fickle sub-program demonstrates State Memory</title>
 		<meta
 			name="description"
@@ -32,12 +38,38 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../../components/theme-toggle.js" defer></script>
+		<script src="../../../components/page-hero.js" defer></script>
+		<script src="../../../components/related-content.js" defer></script>
+		<script src="../../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero
+							title="The Fickle sub-program demonstrates State Memory"
+							eyebrow="COBOL Example"
+						></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../../default.html">Example programs</a> ›
+							<span>Fickle Sub-program</span>
+						</nav>
+						<p>
+							A sub-program that demonstrates State Memory — each time it is called it remembers its state
+							from the previous call.
+						</p>
+						<p><a href="Fickle.cbl" download>Download Fickle.cbl</a></p>
+						<related-content
+							lectures="../../../course/Subprograms.html|Contained and External Sub-programs"
+						></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. Fickle.
 AUTHOR. Michael Coughlan.
@@ -62,5 +94,9 @@ Begin.
 
     EXIT PROGRAM.
 </code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/SubProg/Multiply/MultiplyNums.html
+++ b/examples/SubProg/Multiply/MultiplyNums.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>The MultiplyNums sub-program</title>
 		<meta
 			name="description"
@@ -32,12 +38,35 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../../components/theme-toggle.js" defer></script>
+		<script src="../../../components/page-hero.js" defer></script>
+		<script src="../../../components/related-content.js" defer></script>
+		<script src="../../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero title="The MultiplyNums sub-program" eyebrow="COBOL Example"></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../../default.html">Example programs</a> ›
+							<span>MultiplyNums Sub-program</span>
+						</nav>
+						<p>
+							The MultiplyNums sub-program demonstrates flow of control from a driver program and the use
+							of numeric and string parameters with BY REFERENCE and BY CONTENT.
+						</p>
+						<p><a href="MultiplyNums.cbl" download>Download MultiplyNums.cbl</a></p>
+						<related-content
+							lectures="../../../course/Subprograms.html|Contained and External Sub-programs"
+						></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. MultiplyNums.
 AUTHOR. Michael Coughlan.
@@ -91,5 +120,9 @@ Begin.
     DISPLAY "&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt; Leaving sub-program now".
     EXIT PROGRAM.
 </code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/SubProg/Multiply/Steadfast.html
+++ b/examples/SubProg/Multiply/Steadfast.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>The Steadfast sub-program demonstrates the IS INITIAL phrase</title>
 		<meta
 			name="description"
@@ -32,12 +38,38 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../../components/theme-toggle.js" defer></script>
+		<script src="../../../components/page-hero.js" defer></script>
+		<script src="../../../components/related-content.js" defer></script>
+		<script src="../../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero
+							title="The Steadfast sub-program demonstrates the IS INITIAL phrase"
+							eyebrow="COBOL Example"
+						></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../../default.html">Example programs</a> ›
+							<span>Steadfast Sub-program</span>
+						</nav>
+						<p>
+							A sub-program identical to Fickle except that it uses the IS INITIAL phrase to avoid State
+							Memory — it always produces the same result for the same input.
+						</p>
+						<p><a href="Steadfast.cbl" download>Download Steadfast.cbl</a></p>
+						<related-content
+							lectures="../../../course/Subprograms.html|Contained and External Sub-programs"
+						></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. Steadfast IS INITIAL.
 AUTHOR. Michael Coughlan.
@@ -62,5 +94,9 @@ Begin.
 
     EXIT PROGRAM.
 </code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/examples/Tables/MonthTable.html
+++ b/examples/Tables/MonthTable.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<title>Tables - Counts number of students born in each month</title>
 		<meta
 			name="description"
@@ -29,12 +35,38 @@
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
 		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
 	</head>
-	<body bgcolor="#FFFFFF" background="../../lectures/Code.gif">
-		<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero
+							title="Tables - Counts number of students born in each month"
+							eyebrow="COBOL Example"
+						></page-hero>
+						<nav aria-label="Breadcrumb">
+							<a href="../default.html">Example programs</a> ›
+							<span>Month Table</span>
+						</nav>
+						<p>
+							Counts the number of students born in each month using a pre-filled table of month names and
+							displays the result.
+						</p>
+						<p><a href="MonthTable.cbl" download>Download MonthTable.cbl</a></p>
+						<related-content
+							lectures="../../course/Tables1.html|Using Tables, ../../course/Tables2.html|Creating Tables — Syntax and Semantics"
+						></related-content>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  MonthTable.
 AUTHOR.  Michael Coughlan.
@@ -109,5 +141,9 @@ Begin.
 
    CLOSE StudentFile
    STOP RUN.</code></pre>
+					</div>
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/scripts/add-example-chrome.js
+++ b/scripts/add-example-chrome.js
@@ -73,8 +73,7 @@ const MANIFEST = [
 		cbl: "Iteration-If.cbl",
 		crumb: "Iteration with IF",
 		desc: "An example program that implements a primitive calculator. The calculator only does additions and multiplications.",
-		lectures:
-			"../../course/Selection.html|Selection in COBOL, ../../course/Iteration.html|Iteration in COBOL",
+		lectures: "../../course/Selection.html|Selection in COBOL, ../../course/Iteration.html|Iteration in COBOL",
 	},
 	// ── Indexed ─────────────────────────────────────────────────────────────
 	{
@@ -389,12 +388,8 @@ function transform(entry) {
 	// 6. Build the new <body> content.
 	const defPath = defaultHtmlPath(entry.file);
 
-	const relatedAttr = entry.lectures
-		? `\n\t\t\t\t\t\tlectures="${entry.lectures}"\n\t\t\t\t\t`
-		: "";
-	const relatedEl = entry.lectures
-		? `\n\t\t\t\t\t\t<related-content${relatedAttr}></related-content>`
-		: "";
+	const relatedAttr = entry.lectures ? `\n\t\t\t\t\t\tlectures="${entry.lectures}"\n\t\t\t\t\t` : "";
+	const relatedEl = entry.lectures ? `\n\t\t\t\t\t\t<related-content${relatedAttr}></related-content>` : "";
 
 	const newBody = `<body>
 \t\t<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/scripts/add-example-chrome.js
+++ b/scripts/add-example-chrome.js
@@ -1,0 +1,446 @@
+#!/usr/bin/env node
+/**
+ * add-example-chrome.js
+ *
+ * One-time migration script (issue #250).
+ * Injects page chrome into every bare example-program HTML page under
+ * examples/<topic>/*.html:
+ *   - FOUC-prevention inline script
+ *   - course-components.css link
+ *   - component scripts (theme-toggle, page-hero, related-content, copy-button)
+ *   - skip-link, <main>, page-wrapper, section-grid, section-full
+ *   - <page-hero eyebrow="COBOL Example">
+ *   - breadcrumb <nav> back to examples/default.html
+ *   - one-line description paragraph
+ *   - download link to the sibling .cbl source file
+ *   - <related-content> cross-link to the relevant lecture(s)
+ *
+ * Run:  node scripts/add-example-chrome.js
+ * Then: npm run format:write   (Prettier will tidy the output)
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const ROOT = path.resolve(__dirname, "..");
+const EXAMPLES_DIR = path.join(ROOT, "examples");
+
+// ---------------------------------------------------------------------------
+// Manifest
+// Each entry maps one HTML file to the data needed for its chrome.
+// `file`     – path relative to examples/
+// `cbl`      – sibling .cbl filename
+// `crumb`    – short label shown as the trailing breadcrumb span
+// `desc`     – one-sentence description shown on the page
+// `lectures` – related-content `lectures` attribute value (optional)
+// ---------------------------------------------------------------------------
+
+const MANIFEST = [
+	// ── Accept ──────────────────────────────────────────────────────────────
+	{
+		file: "Accept/ACCEPT.html",
+		cbl: "AcceptAndDisplay.cbl",
+		crumb: "ACCEPT and DISPLAY",
+		desc: "The program accepts a simple student record from the user and displays the individual fields. Also shows how the ACCEPT may be used to get and DISPLAY the system time and date.",
+		lectures: "../../course/COBOLIntro.html|Introduction to COBOL",
+	},
+	{
+		file: "Accept/Multiplier.html",
+		cbl: "Multiplier.cbl",
+		crumb: "Multiplier",
+		desc: "Accepts two single digit numbers from the user, multiplies them together and displays the result.",
+		lectures: "../../course/COBOLIntro.html|Introduction to COBOL",
+	},
+	{
+		file: "Accept/Shortest.html",
+		cbl: "ShortestProgram.cbl",
+		crumb: "Shortest COBOL Program",
+		desc: "This example program is almost the shortest COBOL program we can have. We could make it shorter still by leaving out the STOP RUN.",
+		lectures: "../../course/COBOLIntro.html|Introduction to COBOL",
+	},
+	// ── Conditn ─────────────────────────────────────────────────────────────
+	{
+		file: "Conditn/Conditions.html",
+		cbl: "CONDITIONS.cbl",
+		crumb: "Condition Names",
+		desc: "An example program demonstrating the use of Condition Names (level 88's).",
+		lectures: "../../course/Selection.html|Selection in COBOL",
+	},
+	{
+		file: "Conditn/IterIf.html",
+		cbl: "Iteration-If.cbl",
+		crumb: "Iteration with IF",
+		desc: "An example program that implements a primitive calculator. The calculator only does additions and multiplications.",
+		lectures:
+			"../../course/Selection.html|Selection in COBOL, ../../course/Iteration.html|Iteration in COBOL",
+	},
+	// ── Indexed ─────────────────────────────────────────────────────────────
+	{
+		file: "Indexed/DirectReadIdx.html",
+		cbl: "DirectReadIdx.cbl",
+		crumb: "Direct Read on Indexed File",
+		desc: "Does a direct read on the Indexed file. Allows the user to choose which of the keys to use for the direct read.",
+		lectures: "../../course/IndexedFiles.html|Indexed Files",
+	},
+	{
+		file: "Indexed/Seq2Index.html",
+		cbl: "Seq2Index.cbl",
+		crumb: "Sequential to Indexed",
+		desc: "Creates a direct access Indexed file from a Sequential file.",
+		lectures: "../../course/IndexedFiles.html|Indexed Files",
+	},
+	{
+		file: "Indexed/SeqReadIdx.html",
+		cbl: "SeqReadIdx.cbl",
+		crumb: "Sequential Read of Indexed File",
+		desc: "Reads the Indexed file sequentially on whichever key is chosen by the user. Displays all the records in the file.",
+		lectures: "../../course/IndexedFiles.html|Indexed Files",
+	},
+	// ── Merge ───────────────────────────────────────────────────────────────
+	{
+		file: "Merge/Merge.html",
+		cbl: "MergeFiles.cbl",
+		crumb: "Merge Files",
+		desc: "Uses the MERGE to insert records from a transaction file into a sequential master file.",
+		lectures: "../../course/SortMerge.html|Sorting and Merging",
+	},
+	// ── Perform ─────────────────────────────────────────────────────────────
+	{
+		file: "Perform/MileageCount.html",
+		cbl: "MileageCounter.cbl",
+		crumb: "Mileage Counter",
+		desc: "Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used to simulate a mileage counter.",
+		lectures: "../../course/Iteration.html|Iteration in COBOL",
+	},
+	{
+		file: "Perform/Perform1.html",
+		cbl: "PerformFormat1.cbl",
+		crumb: "PERFORM Format 1",
+		desc: "An example program demonstrating how the first format of the PERFORM may be used to change the flow of control through a program.",
+		lectures: "../../course/Iteration.html|Iteration in COBOL",
+	},
+	{
+		file: "Perform/Perform2.html",
+		cbl: "PerformFormat2.cbl",
+		crumb: "PERFORM Format 2",
+		desc: "Demonstrates the second format of the PERFORM. The PERFORM..TIMES may be used to execute a block of code x number of times.",
+		lectures: "../../course/Iteration.html|Iteration in COBOL",
+	},
+	{
+		file: "Perform/Perform3.html",
+		cbl: "PerformFormat3.cbl",
+		crumb: "PERFORM Format 3",
+		desc: "Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values where the length of the stream cannot be determined in advance.",
+		lectures: "../../course/Iteration.html|Iteration in COBOL",
+	},
+	{
+		file: "Perform/Perform4.html",
+		cbl: "PerformFormat4.cbl",
+		crumb: "PERFORM Format 4",
+		desc: "Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used for counting iteration. Also introduces the WITH TEST BEFORE and WITH TEST AFTER phrases.",
+		lectures: "../../course/Iteration.html|Iteration in COBOL",
+	},
+	// ── Relative ────────────────────────────────────────────────────────────
+	{
+		file: "Relative/ReadRel.html",
+		cbl: "ReadRelative.cbl",
+		crumb: "Read Relative File",
+		desc: "Reads the Relative file and displays the records. Allows the user to choose to read sequentially through all the records or to use a key to read a single record directly.",
+		lectures: "../../course/RelativeFiles.html|Relative Files",
+	},
+	{
+		file: "Relative/Seq2Rel.html",
+		cbl: "Seq2Rel.cbl",
+		crumb: "Sequential to Relative",
+		desc: "Creates a direct access Relative file from a Sequential File.",
+		lectures: "../../course/RelativeFiles.html|Relative Files",
+	},
+	// ── ReportWriter ────────────────────────────────────────────────────────
+	{
+		file: "ReportWriter/RepWriteA.html",
+		cbl: "ReportExampleA.cbl",
+		crumb: "Report Writer Example A",
+		desc: "A simplified version of the full report program using only one control break. Uses the GBsales.dat data file.",
+		lectures:
+			"../../course/ReportWriter.html|Report Writer by Example, ../../course/ReportWriterSS.html|Report Writer Syntax and Semantics",
+	},
+	{
+		file: "ReportWriter/RepWriteB.html",
+		cbl: "ReportExampleB.cbl",
+		crumb: "Report Writer Example B",
+		desc: "A simplified version of the full report program containing all the control breaks but not using Declaratives. Uses the GBsales.dat data file.",
+		lectures:
+			"../../course/ReportWriter.html|Report Writer by Example, ../../course/ReportWriterSS.html|Report Writer Syntax and Semantics",
+	},
+	{
+		file: "ReportWriter/RepWriteFull.html",
+		cbl: "ReportExampleFull.cbl",
+		crumb: "Report Writer Full Example",
+		desc: "The full version of the report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission.",
+		lectures:
+			"../../course/ReportWriter.html|Report Writer by Example, ../../course/ReportWriterSS.html|Report Writer Syntax and Semantics",
+	},
+	{
+		file: "ReportWriter/RepWriteSumm.html",
+		cbl: "ReportExampleSummary.cbl",
+		crumb: "Report Writer Summary",
+		desc: "The summary version of the full report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission.",
+		lectures:
+			"../../course/ReportWriter.html|Report Writer by Example, ../../course/ReportWriterSS.html|Report Writer Syntax and Semantics",
+	},
+	// ── SeqIns ──────────────────────────────────────────────────────────────
+	{
+		file: "SeqIns/SEQINSERT.html",
+		cbl: "InsertRecords.cbl",
+		crumb: "Insert Records",
+		desc: "Demonstrates how to insert records into a sequential file from a file of transaction records. A new file is created which contains the inserted records.",
+		lectures: "../../course/SequentialFiles2.html|Processing Sequential Files",
+	},
+	// ── SeqRead ─────────────────────────────────────────────────────────────
+	{
+		file: "SeqRead/SEQREAD.html",
+		cbl: "Seqread.cbl",
+		crumb: "Sequential Read",
+		desc: 'An example program that reads a sequential file and displays the records. Uses the Condition Name (level 88) "EndOfFile" to signal when the end of the file has been reached.',
+		lectures: "../../course/SequentialFiles1.html|Introduction to Sequential Files",
+	},
+	{
+		file: "SeqRead/SEQREADno88.html",
+		cbl: "SeqreadNo88.cbl",
+		crumb: "Sequential Read (without level 88s)",
+		desc: "An example program that reads a sequential file and displays the records. This version does not use level 88's to signal when the end of the file has been reached.",
+		lectures: "../../course/SequentialFiles1.html|Introduction to Sequential Files",
+	},
+	// ── SeqRpt ──────────────────────────────────────────────────────────────
+	{
+		file: "SeqRpt/SEQRPT.html",
+		cbl: "StudentNumbersReport.cbl",
+		crumb: "Student Numbers Report",
+		desc: "Reads records from the student file, counts the total number of student records and the number of records for females and males, and prints the results in a short report.",
+		lectures: "../../course/SequentialFiles3.html|COBOL Print Files and Variable-Length Records",
+	},
+	// ── SeqWrite ────────────────────────────────────────────────────────────
+	{
+		file: "SeqWrite/SEQWRITE.html",
+		cbl: "SEQWRITE.cbl",
+		crumb: "Sequential Write",
+		desc: "Example program demonstrating how to create a sequential file from data input by the user.",
+		lectures: "../../course/SequentialFiles1.html|Introduction to Sequential Files",
+	},
+	// ── Sort ────────────────────────────────────────────────────────────────
+	{
+		file: "Sort/InputSort.html",
+		cbl: "InputSORT.cbl",
+		crumb: "Input Sort",
+		desc: "Uses the SORT and an INPUT PROCEDURE to accept records from the user and sort them on ascending StudentId.",
+		lectures: "../../course/SortMerge.html|Sorting and Merging",
+	},
+	{
+		file: "Sort/MaleSort.html",
+		cbl: "MaleSORT.cbl",
+		crumb: "Male Sort",
+		desc: "Sorts the student masterfile and produces a new file, sorted on ascending student name, containing only the records of male students.",
+		lectures: "../../course/SortMerge.html|Sorting and Merging",
+	},
+	// ── Strings ─────────────────────────────────────────────────────────────
+	{
+		file: "Strings/RefMod.html",
+		cbl: "RefModification.cbl",
+		crumb: "Reference Modification",
+		desc: "Solves a number of string handling tasks such as extracting substrings, removing leading or trailing blanks, and finding the location of the first occurrence of a character in a string.",
+		lectures: "../../course/RefMod.html|Reference Modification and Intrinsic Functions",
+	},
+	{
+		file: "Strings/UnstringFileEg.html",
+		cbl: "UnstringFileEg.cbl",
+		crumb: "UNSTRING File Example",
+		desc: "An example showing the unpacking of comma-separated records and the size validation of the unpacked fields.",
+		lectures: "../../course/Unstring.html|Unstring",
+	},
+	// ── SubProg/DateValid (depth 3) ──────────────────────────────────────────
+	{
+		file: "SubProg/DateValid/DateDriver.html",
+		cbl: "DateDriver.cbl",
+		crumb: "Date Driver Program",
+		desc: "A driver program for the date validation sub-program. Accepts a date from the user, passes it to the date validation sub-program and interprets and displays the result.",
+		lectures: "../../../course/Subprograms.html|Contained and External Sub-programs",
+	},
+	{
+		file: "SubProg/DateValid/ValiDate.html",
+		cbl: "Validate.cbl",
+		crumb: "Date Validation Sub-program",
+		desc: "A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a code indicating whether the date was valid, and if not, why it was invalid.",
+		lectures: "../../../course/Subprograms.html|Contained and External Sub-programs",
+	},
+	// ── SubProg/DayDiff (depth 3) ────────────────────────────────────────────
+	{
+		file: "SubProg/DayDiff/DayDiffDriver.html",
+		cbl: "DayDiffDriver.cbl",
+		crumb: "Day Difference Driver",
+		desc: "A driver program that accepts two dates from the user and displays the difference in days between them. Uses the Validate sub-program and also contains a number of contained sub-programs.",
+		lectures: "../../../course/Subprograms.html|Contained and External Sub-programs",
+	},
+	// ── SubProg/Multiply (depth 3) ───────────────────────────────────────────
+	{
+		file: "SubProg/Multiply/DriverProg.html",
+		cbl: "DriverProg.cbl",
+		crumb: "Sub-program Driver",
+		desc: "Demonstrates the CALL verb by calling three external sub-programs that illustrate flow of control, parameter passing, and state memory.",
+		lectures: "../../../course/Subprograms.html|Contained and External Sub-programs",
+	},
+	{
+		file: "SubProg/Multiply/Fickle.html",
+		cbl: "Fickle.cbl",
+		crumb: "Fickle Sub-program",
+		desc: "A sub-program that demonstrates State Memory — each time it is called it remembers its state from the previous call.",
+		lectures: "../../../course/Subprograms.html|Contained and External Sub-programs",
+	},
+	{
+		file: "SubProg/Multiply/MultiplyNums.html",
+		cbl: "MultiplyNums.cbl",
+		crumb: "MultiplyNums Sub-program",
+		desc: "The MultiplyNums sub-program demonstrates flow of control from a driver program and the use of numeric and string parameters with BY REFERENCE and BY CONTENT.",
+		lectures: "../../../course/Subprograms.html|Contained and External Sub-programs",
+	},
+	{
+		file: "SubProg/Multiply/Steadfast.html",
+		cbl: "Steadfast.cbl",
+		crumb: "Steadfast Sub-program",
+		desc: "A sub-program identical to Fickle except that it uses the IS INITIAL phrase to avoid State Memory — it always produces the same result for the same input.",
+		lectures: "../../../course/Subprograms.html|Contained and External Sub-programs",
+	},
+	// ── Tables ──────────────────────────────────────────────────────────────
+	{
+		file: "Tables/MonthTable.html",
+		cbl: "MonthTable.cbl",
+		crumb: "Month Table",
+		desc: "Counts the number of students born in each month using a pre-filled table of month names and displays the result.",
+		lectures:
+			"../../course/Tables1.html|Using Tables, ../../course/Tables2.html|Creating Tables — Syntax and Semantics",
+	},
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the path prefix to reach the repo root from examples/<relFile>.
+ * e.g. "Accept/ACCEPT.html"          -> "../../"
+ *      "SubProg/Multiply/Foo.html"   -> "../../../"
+ */
+function prefix(relFile) {
+	const depth = relFile.split("/").length - 1; // segments minus filename
+	return "../".repeat(depth + 1); // +1 for the examples/ directory
+}
+
+/**
+ * Return the relative path from examples/<relFile> back to examples/default.html.
+ * e.g. "Accept/ACCEPT.html"          -> "../default.html"
+ *      "SubProg/Multiply/Foo.html"   -> "../../default.html"
+ */
+function defaultHtmlPath(relFile) {
+	const depth = relFile.split("/").length - 1;
+	return "../".repeat(depth) + "default.html";
+}
+
+// ---------------------------------------------------------------------------
+// Transform one HTML file
+// ---------------------------------------------------------------------------
+
+function transform(entry) {
+	const absPath = path.join(EXAMPLES_DIR, entry.file);
+	let html = fs.readFileSync(absPath, "utf8");
+
+	const pfx = prefix(entry.file);
+
+	// 1. Read the existing <title> text from the file.
+	const titleMatch = html.match(/<title>([\s\S]*?)<\/title>/);
+	const title = titleMatch ? titleMatch[1].trim() : entry.crumb;
+
+	// 2. Extract the <pre> block (the entire element, HTML-entities intact).
+	const preMatch = html.match(/(<pre[\s\S]*?<\/pre>)/);
+	if (!preMatch) {
+		console.error(`  SKIP: no <pre> block found in ${entry.file}`);
+		return;
+	}
+	const preBlock = preMatch[1];
+
+	// 3. Insert FOUC-prevention script after the viewport <meta>.
+	html = html.replace(
+		/(<meta name="viewport" content="width=device-width, initial-scale=1" \/>)/,
+		`$1\n\t\t<script>\n\t\t\t(function () {\n\t\t\t\tvar t = localStorage.getItem("lc-theme");\n\t\t\t\tif (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);\n\t\t\t})();\n\t\t</script>`,
+	);
+
+	// 4. Add course-components.css link after course.css.
+	html = html.replace(
+		/(<link href="[^"]*course\/Resources\/css\/course\.css" rel="stylesheet" \/>)/,
+		`$1\n\t\t<link href="${pfx}course/Resources/css/course-components.css" rel="stylesheet" />`,
+	);
+
+	// 5. Add component scripts after the last Prism script.
+	html = html.replace(
+		/(<script src="[^"]*prism-cobol\.min\.js" defer><\/script>)/,
+		`$1\n\t\t<script src="${pfx}components/theme-toggle.js" defer></script>\n\t\t<script src="${pfx}components/page-hero.js" defer></script>\n\t\t<script src="${pfx}components/related-content.js" defer></script>\n\t\t<script src="${pfx}components/copy-button.js" defer></script>`,
+	);
+
+	// 6. Build the new <body> content.
+	const defPath = defaultHtmlPath(entry.file);
+
+	const relatedAttr = entry.lectures
+		? `\n\t\t\t\t\t\tlectures="${entry.lectures}"\n\t\t\t\t\t`
+		: "";
+	const relatedEl = entry.lectures
+		? `\n\t\t\t\t\t\t<related-content${relatedAttr}></related-content>`
+		: "";
+
+	const newBody = `<body>
+\t\t<a class="skip-link" href="#main-content">Skip to main content</a>
+\t\t<main id="main-content">
+\t\t\t<div class="page-wrapper">
+\t\t\t\t<div class="section-grid">
+\t\t\t\t\t<div class="section-full">
+\t\t\t\t\t\t<page-hero title="${title}" eyebrow="COBOL Example"></page-hero>
+\t\t\t\t\t\t<nav aria-label="Breadcrumb">
+\t\t\t\t\t\t\t<a href="${defPath}">Example programs</a> ›
+\t\t\t\t\t\t\t<span>${entry.crumb}</span>
+\t\t\t\t\t\t</nav>
+\t\t\t\t\t\t<p>${entry.desc}</p>
+\t\t\t\t\t\t<p><a href="${entry.cbl}" download>Download ${entry.cbl}</a></p>${relatedEl}
+\t\t\t\t\t\t${preBlock}
+\t\t\t\t\t</div>
+\t\t\t\t</div>
+\t\t\t</div>
+\t\t</main>
+\t</body>`;
+
+	// 7. Replace the entire <body>...</body> section.
+	html = html.replace(/<body[\s\S]*<\/body>/, newBody);
+
+	fs.writeFileSync(absPath, html, "utf8");
+	console.log(`  OK  ${entry.file}`);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+console.log("Adding page chrome to example HTML files…\n");
+
+let ok = 0;
+let fail = 0;
+
+for (const entry of MANIFEST) {
+	try {
+		transform(entry);
+		ok++;
+	} catch (err) {
+		console.error(`  ERR ${entry.file}: ${err.message}`);
+		fail++;
+	}
+}
+
+console.log(`\nDone. ${ok} updated, ${fail} failed.`);
+if (fail > 0) process.exit(1);


### PR DESCRIPTION
## Summary

- Wraps every bare `<pre>` code dump under `examples/<topic>/*.html` with full page chrome: `<page-hero>`, breadcrumb nav, one-line description, `.cbl` download link, and `<related-content>` cross-links to relevant lectures
- Removes deprecated `bgcolor`/`background` attributes from `<body>` so pages render correctly in light and dark mode
- Adds `examples/Perform/PerformFormat2.cbl` — the source existed only embedded in `Perform2.html`; this closes the gap so `check:assets` passes for that page
- Adds `nav[aria-label="Breadcrumb"]` margin rule to `course-components.css` for proper spacing between the theme toggle and the breadcrumb
- Adds `scripts/add-example-chrome.js` as the documented migration tool

## What each page now has

| Element | Detail |
|---|---|
| `<page-hero eyebrow="COBOL Example">` | Existing page title; eyebrow label differentiates from course pages |
| Breadcrumb `<nav>` | Links back to `examples/default.html` |
| Description `<p>` | Full sentence from the `examples/default.html` table |
| Download `<a download>` | Resolves to the sibling `.cbl` file (`check:assets` confirmed) |
| `<related-content lectures="…">` | Cross-links to the relevant lecture page(s) |
| FOUC script + `course-components.css` | Matches the pattern used on all course pages |
| Copy button | Via `copy-button.js` already used on course pages |

## Test plan

- [x] `node scripts/check-assets.js` — all download links resolve ✓
- [x] `npx html-validate "examples/**/*.html"` — no errors ✓
- [x] `npm run format:check` — Prettier clean ✓
- [x] Spot-checked in browser: light mode, dark mode (theme toggle), mobile viewport
- [x] `examples/Accept/ACCEPT.html` and `examples/SubProg/Multiply/DriverProg.html` (depth-3 path) both verified visually

Closes #250

🤖 Generated with [Claude Code](https://claude.ai/claude-code)