### PR TITLE
feat: generate example HTML pages from .cbl source (closes #272)

### DIFF
--- a/examples/Accept/ACCEPT.html
+++ b/examples/Accept/ACCEPT.html
@@ -83,13 +83,13 @@ WORKING-STORAGE SECTION.
    02  CourseCode      PIC X(4).
    02  Gender          PIC X.
 
-*&gt; YYMMDD
+*&gt; YYYYMMDD
 01 CurrentDate.
    02  CurrentYear     PIC 9(4).
    02  CurrentMonth    PIC 99.
    02  CurrentDay      PIC 99.
 
-*&gt; YYDDD
+*&gt; YYYYDDD
 01 DayOfYear.
    02  FILLER          PIC 9(4).
    02  YearDay         PIC 9(3).

--- a/examples/Accept/Multiplier.html
+++ b/examples/Accept/Multiplier.html
@@ -88,7 +88,6 @@ PROCEDURE DIVISION.
     MULTIPLY Num1 BY Num2 GIVING Result.
     DISPLAY "Result is = ", Result.
     STOP RUN.
-
 </code></pre>
 					</div>
 				</div>

--- a/examples/Conditn/Conditions.html
+++ b/examples/Conditn/Conditions.html
@@ -9,7 +9,7 @@
 			})();
 		</script>
 		<title>Condition Names (level 88) example program</title>
-		<meta name="description" content="COBOL example program: Condition Names (level 88) example program." />
+		<meta name="description" content="An example program demonstrating the use of Condition Names (level 88's)." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Conditn/Conditions.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
@@ -18,12 +18,18 @@
 			content="https://bushidocodes.github.io/limerick-cobol/examples/Conditn/Conditions.html"
 		/>
 		<meta property="og:title" content="Condition Names (level 88) example program" />
-		<meta property="og:description" content="COBOL example program: Condition Names (level 88) example program." />
+		<meta
+			property="og:description"
+			content="An example program demonstrating the use of Condition Names (level 88's)."
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary" />
 		<meta name="twitter:title" content="Condition Names (level 88) example program" />
-		<meta name="twitter:description" content="COBOL example program: Condition Names (level 88) example program." />
+		<meta
+			name="twitter:description"
+			content="An example program demonstrating the use of Condition Names (level 88's)."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/examples/Conditn/IterIf.html
+++ b/examples/Conditn/IterIf.html
@@ -8,19 +8,28 @@
 				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
 			})();
 		</script>
-		<title>Condition Names (level 88) example program</title>
-		<meta name="description" content="COBOL example program: Condition Names (level 88) example program." />
+		<title>Iteration with IF example program</title>
+		<meta
+			name="description"
+			content="An example program that implements a primitive calculator. The calculator only does additions and multiplications."
+		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Conditn/IterIf.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Conditn/IterIf.html" />
-		<meta property="og:title" content="Condition Names (level 88) example program" />
-		<meta property="og:description" content="COBOL example program: Condition Names (level 88) example program." />
+		<meta property="og:title" content="Iteration with IF example program" />
+		<meta
+			property="og:description"
+			content="An example program that implements a primitive calculator. The calculator only does additions and multiplications."
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary" />
-		<meta name="twitter:title" content="Condition Names (level 88) example program" />
-		<meta name="twitter:description" content="COBOL example program: Condition Names (level 88) example program." />
+		<meta name="twitter:title" content="Iteration with IF example program" />
+		<meta
+			name="twitter:description"
+			content="An example program that implements a primitive calculator. The calculator only does additions and multiplications."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -38,10 +47,7 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero
-							title="Condition Names (level 88) example program"
-							eyebrow="COBOL Example"
-						></page-hero>
+						<page-hero title="Iteration with IF example program" eyebrow="COBOL Example"></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../default.html">Example programs</a> ›
 							<span>Iteration with IF</span>

--- a/examples/Indexed/DirectReadIdx.html
+++ b/examples/Indexed/DirectReadIdx.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -11,7 +11,7 @@
 		<title>Reading an Indexed file directly by key</title>
 		<meta
 			name="description"
-			content="Does a direct read on the Indexed file created by the previous example program. Allows the user to choose which of the keys to use for the direct read."
+			content="Does a direct read on the Indexed file. Allows the user to choose which of the keys to use for the direct read."
 		/>
 		<link
 			rel="canonical"
@@ -26,7 +26,7 @@
 		<meta property="og:title" content="Reading an Indexed file directly by key" />
 		<meta
 			property="og:description"
-			content="Does a direct read on the Indexed file created by the previous example program. Allows the user to choose which of the keys to use for the direct read."
+			content="Does a direct read on the Indexed file. Allows the user to choose which of the keys to use for the direct read."
 		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
 		<!-- Twitter Card -->
@@ -34,7 +34,7 @@
 		<meta name="twitter:title" content="Reading an Indexed file directly by key" />
 		<meta
 			name="twitter:description"
-			content="Does a direct read on the Indexed file created by the previous example program. Allows the user to choose which of the keys to use for the direct read."
+			content="Does a direct read on the Indexed file. Allows the user to choose which of the keys to use for the direct read."
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />

--- a/examples/Indexed/Seq2Index.html
+++ b/examples/Indexed/Seq2Index.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -9,10 +9,7 @@
 			})();
 		</script>
 		<title>Creating an Indexed file from a sequential file</title>
-		<meta
-			name="description"
-			content="Creates a direct access Indexed file from a Sequential file. Note that Microfocus Indexed files actually consist of two files - the data file and the index"
-		/>
+		<meta name="description" content="Creates a direct access Indexed file from a Sequential file." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Indexed/Seq2Index.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
@@ -21,18 +18,12 @@
 			content="https://bushidocodes.github.io/limerick-cobol/examples/Indexed/Seq2Index.html"
 		/>
 		<meta property="og:title" content="Creating an Indexed file from a sequential file" />
-		<meta
-			property="og:description"
-			content="Creates a direct access Indexed file from a Sequential file. Note that Microfocus Indexed files actually consist of two files - the data file and the index"
-		/>
+		<meta property="og:description" content="Creates a direct access Indexed file from a Sequential file." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary" />
 		<meta name="twitter:title" content="Creating an Indexed file from a sequential file" />
-		<meta
-			name="twitter:description"
-			content="Creates a direct access Indexed file from a Sequential file. Note that Microfocus Indexed files actually consist of two files - the data file and the index"
-		/>
+		<meta name="twitter:description" content="Creates a direct access Indexed file from a Sequential file." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -121,7 +112,8 @@ Begin.
    END-PERFORM.
 
    CLOSE VideoFile, SeqVideoFile.
-   STOP RUN.</code></pre>
+   STOP RUN.
+</code></pre>
 					</div>
 				</div>
 			</div>

--- a/examples/Indexed/SeqReadIdx.html
+++ b/examples/Indexed/SeqReadIdx.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/examples/Merge/Merge.html
+++ b/examples/Merge/Merge.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -11,7 +11,7 @@
 		<title>Merge Files - Example Program</title>
 		<meta
 			name="description"
-			content="Uses the MERGE to insert records from a transaction file into a sequential master file. . To test this program you will need to download Student Masterfile"
+			content="Uses the MERGE to insert records from a transaction file into a sequential master file."
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Merge/Merge.html" />
 		<!-- Open Graph -->
@@ -20,7 +20,7 @@
 		<meta property="og:title" content="Merge Files - Example Program" />
 		<meta
 			property="og:description"
-			content="Uses the MERGE to insert records from a transaction file into a sequential master file. . To test this program you will need to download Student Masterfile"
+			content="Uses the MERGE to insert records from a transaction file into a sequential master file."
 		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
 		<!-- Twitter Card -->
@@ -28,7 +28,7 @@
 		<meta name="twitter:title" content="Merge Files - Example Program" />
 		<meta
 			name="twitter:description"
-			content="Uses the MERGE to insert records from a transaction file into a sequential master file. . To test this program you will need to download Student Masterfile"
+			content="Uses the MERGE to insert records from a transaction file into a sequential master file."
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
@@ -64,7 +64,7 @@ AUTHOR. MICHAEL COUGHLAN.
 *&gt; Transins.dat to create a new file Students.New.
 *&gt; A problem with using the MERGE for inserting records is that 
 *&gt; duplicate records are not detected.
-*&gt; See the example program - InsertRecords.cbl - for a more traditional 
+*&gt; See the example program - SeqInsert.cbl - for a more traditional 
 *&gt; approach to inserting records in a Sequential File.
 
 ENVIRONMENT DIVISION.

--- a/examples/Perform/MileageCount.html
+++ b/examples/Perform/MileageCount.html
@@ -105,13 +105,13 @@ Begin.
    STOP RUN.
 
 
+
 CountMileage.
    MOVE HundredsCount TO PrnHunds
    MOVE TensCount     TO  PrnTens
    MOVE UnitsCount    TO PrnUnits
    DISPLAY PrnHunds "-" PrnTens "-" PrnUnits.
-
- </code></pre>
+</code></pre>
 					</div>
 				</div>
 			</div>

--- a/examples/Perform/Perform2.html
+++ b/examples/Perform/Perform2.html
@@ -66,7 +66,7 @@ IDENTIFICATION DIVISION.
 PROGRAM-ID.  PerformFormat2.
 AUTHOR.  Michael Coughlan.
 *&gt; Demonstrates the second format of the PERFORM.
-*&gt; The PERFORM..TIMES format executes a block of code x 
+*&gt; The PERFORM..TIMES format executes a block of code x
 *&gt; number of times.
 
 DATA DIVISION.
@@ -85,7 +85,8 @@ Begin.
     STOP RUN.
 
 OutOfLineEG.
-    DISPLAY "&gt;&gt;&gt;&gt; This is an out of line Perform".</code></pre>
+    DISPLAY "&gt;&gt;&gt;&gt; This is an out of line Perform".
+</code></pre>
 					</div>
 				</div>
 			</div>

--- a/examples/Perform/Perform3.html
+++ b/examples/Perform/Perform3.html
@@ -11,7 +11,7 @@
 		<title>Perform - Format 3 example program</title>
 		<meta
 			name="description"
-			content="Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values where the length of the stream cannot be determined in advance"
+			content="Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values where the length of the stream cannot be determined in"
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform3.html" />
 		<!-- Open Graph -->
@@ -23,7 +23,7 @@
 		<meta property="og:title" content="Perform - Format 3 example program" />
 		<meta
 			property="og:description"
-			content="Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values where the length of the stream cannot be determined in advance"
+			content="Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values where the length of the stream cannot be determined in"
 		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
 		<!-- Twitter Card -->
@@ -31,7 +31,7 @@
 		<meta name="twitter:title" content="Perform - Format 3 example program" />
 		<meta
 			name="twitter:description"
-			content="Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values where the length of the stream cannot be determined in advance"
+			content="Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values where the length of the stream cannot be determined in"
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
@@ -117,7 +117,8 @@ GetUserInput.
     DISPLAY "Total so far is - " RunningTotal
     DISPLAY "Count so far is - " IterCount
     DISPLAY "Enter number :- " WITH NO ADVANCING
-    ACCEPT UserInput.</code></pre>
+    ACCEPT UserInput.
+</code></pre>
 					</div>
 				</div>
 			</div>

--- a/examples/Relative/ReadRel.html
+++ b/examples/Relative/ReadRel.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -8,10 +8,10 @@
 				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
 			})();
 		</script>
-		<title>Inserting records in a Sequential File</title>
+		<title>Read Relative File example program</title>
 		<meta
 			name="description"
-			content="Reads the Relative file - RELSUPP.dat - created in the previous example program and displays the records. Allows the user to choose to read through and"
+			content="Reads the Relative file and displays the records. Allows the user to choose to read sequentially through all the records or to use a key to read a single"
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Relative/ReadRel.html" />
 		<!-- Open Graph -->
@@ -20,18 +20,18 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/examples/Relative/ReadRel.html"
 		/>
-		<meta property="og:title" content="Inserting records in a Sequential File" />
+		<meta property="og:title" content="Read Relative File example program" />
 		<meta
 			property="og:description"
-			content="Reads the Relative file - RELSUPP.dat - created in the previous example program and displays the records. Allows the user to choose to read through and"
+			content="Reads the Relative file and displays the records. Allows the user to choose to read sequentially through all the records or to use a key to read a single"
 		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary" />
-		<meta name="twitter:title" content="Inserting records in a Sequential File" />
+		<meta name="twitter:title" content="Read Relative File example program" />
 		<meta
 			name="twitter:description"
-			content="Reads the Relative file - RELSUPP.dat - created in the previous example program and displays the records. Allows the user to choose to read through and"
+			content="Reads the Relative file and displays the records. Allows the user to choose to read sequentially through all the records or to use a key to read a single"
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
@@ -50,7 +50,7 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="Inserting records in a Sequential File" eyebrow="COBOL Example"></page-hero>
+						<page-hero title="Read Relative File example program" eyebrow="COBOL Example"></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../default.html">Example programs</a> ›
 							<span>Read Relative File</span>
@@ -141,7 +141,7 @@ DisplayRecord.
         MOVE SupplierAddress TO PrnSupplierAddress
         DISPLAY PrnSupplierRecord
     END-IF.
-     </code></pre>
+</code></pre>
 					</div>
 				</div>
 			</div>

--- a/examples/Relative/Seq2Rel.html
+++ b/examples/Relative/Seq2Rel.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -8,11 +8,8 @@
 				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
 			})();
 		</script>
-		<title>Inserting records in a Sequential File</title>
-		<meta
-			name="description"
-			content="Creates a direct access Relative file from a Sequential File. Note that Relative files are not standard ASCII files and so cannot be created with an editor"
-		/>
+		<title>Sequential to Relative File example program</title>
+		<meta name="description" content="Creates a direct access Relative file from a Sequential File." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Relative/Seq2Rel.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
@@ -20,19 +17,13 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/examples/Relative/Seq2Rel.html"
 		/>
-		<meta property="og:title" content="Inserting records in a Sequential File" />
-		<meta
-			property="og:description"
-			content="Creates a direct access Relative file from a Sequential File. Note that Relative files are not standard ASCII files and so cannot be created with an editor"
-		/>
+		<meta property="og:title" content="Sequential to Relative File example program" />
+		<meta property="og:description" content="Creates a direct access Relative file from a Sequential File." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary" />
-		<meta name="twitter:title" content="Inserting records in a Sequential File" />
-		<meta
-			name="twitter:description"
-			content="Creates a direct access Relative file from a Sequential File. Note that Relative files are not standard ASCII files and so cannot be created with an editor"
-		/>
+		<meta name="twitter:title" content="Sequential to Relative File example program" />
+		<meta name="twitter:description" content="Creates a direct access Relative file from a Sequential File." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -50,7 +41,10 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="Inserting records in a Sequential File" eyebrow="COBOL Example"></page-hero>
+						<page-hero
+							title="Sequential to Relative File example program"
+							eyebrow="COBOL Example"
+						></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../default.html">Example programs</a> ›
 							<span>Sequential to Relative</span>
@@ -74,7 +68,7 @@ FILE-CONTROL.
            FILE STATUS IS Supplierstatus.
 
     SELECT SupplierFileSeq ASSIGN TO "SEQSUPP.dat"
-                   ORGANIZATION IS LINE SEQUENTIAL.
+	  	   ORGANIZATION IS LINE SEQUENTIAL.
         
 
 DATA DIVISION.
@@ -121,7 +115,8 @@ Begin.
     END-PERFORM.    
 
     CLOSE  SupplierFile, SupplierFileSeq.
-    STOP RUN.</code></pre>
+    STOP RUN.
+</code></pre>
 					</div>
 				</div>
 			</div>

--- a/examples/ReportWriter/RepWriteA.html
+++ b/examples/ReportWriter/RepWriteA.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -11,7 +11,7 @@
 		<title>One control break version of full Report Writer example Program</title>
 		<meta
 			name="description"
-			content="A simplified version of ReportExampleFull.cbl using only one control break. All four of these Report Writer programs use the GBsales.dat data file."
+			content="A simplified version of the full report program using only one control break. Uses the GBsales.dat data file."
 		/>
 		<link
 			rel="canonical"
@@ -26,7 +26,7 @@
 		<meta property="og:title" content="One control break version of full Report Writer example Program" />
 		<meta
 			property="og:description"
-			content="A simplified version of ReportExampleFull.cbl using only one control break. All four of these Report Writer programs use the GBsales.dat data file."
+			content="A simplified version of the full report program using only one control break. Uses the GBsales.dat data file."
 		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
 		<!-- Twitter Card -->
@@ -34,7 +34,7 @@
 		<meta name="twitter:title" content="One control break version of full Report Writer example Program" />
 		<meta
 			name="twitter:description"
-			content="A simplified version of ReportExampleFull.cbl using only one control break. All four of these Report Writer programs use the GBsales.dat data file."
+			content="A simplified version of the full report program using only one control break. Uses the GBsales.dat data file."
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
@@ -142,8 +142,8 @@ RD  SalesReport
                         SOURCE CityName(CityCode).
        03 COLUMN 15     PIC 9
                         SOURCE SalesPersonNum.
-       03 COLUMN 25     PIC $,$$.99 SOURCE ValueOfSale.
-                
+       03 COLUMN 25     PIC $$,$$$.99 SOURCE ValueOfSale.
+		
 
 01  SalesPersonGrp
     TYPE IS CONTROL FOOTING SalesPersonNum  NEXT GROUP PLUS 2.
@@ -151,7 +151,7 @@ RD  SalesReport
        03 COLUMN 15     PIC X(21) VALUE "Sales for salesperson".
        03 COLUMN 37     PIC 9 SOURCE SalesPersonNum.
        03 COLUMN 43     PIC X VALUE "=".
-       03 SMS COLUMN 45 PIC $$$,$$.99 SUM ValueOfSale.
+       03 SMS COLUMN 45 PIC $$$$$,$$$.99 SUM ValueOfSale.
 
 
 01  TYPE IS PAGE FOOTING.
@@ -180,7 +180,8 @@ PrintSalaryReport.
     GENERATE DetailLine.
     READ SalesFile
           AT END SET EndOfFile TO TRUE
-    END-READ.   </code></pre>
+    END-READ.
+</code></pre>
 					</div>
 				</div>
 			</div>

--- a/examples/ReportWriter/RepWriteB.html
+++ b/examples/ReportWriter/RepWriteB.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -11,7 +11,7 @@
 		<title>No Declaratives version of full Report Writer example program</title>
 		<meta
 			name="description"
-			content="A simplified version of ReportExampleFull.cbl containing all the control breaks but not using Declaratives. All four of these Report Writer programs use the"
+			content="A simplified version of the full report program containing all the control breaks but not using Declaratives. Uses the GBsales.dat data file."
 		/>
 		<link
 			rel="canonical"
@@ -26,7 +26,7 @@
 		<meta property="og:title" content="No Declaratives version of full Report Writer example program" />
 		<meta
 			property="og:description"
-			content="A simplified version of ReportExampleFull.cbl containing all the control breaks but not using Declaratives. All four of these Report Writer programs use the"
+			content="A simplified version of the full report program containing all the control breaks but not using Declaratives. Uses the GBsales.dat data file."
 		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
 		<!-- Twitter Card -->
@@ -34,7 +34,7 @@
 		<meta name="twitter:title" content="No Declaratives version of full Report Writer example program" />
 		<meta
 			name="twitter:description"
-			content="A simplified version of ReportExampleFull.cbl containing all the control breaks but not using Declaratives. All four of these Report Writer programs use the"
+			content="A simplified version of the full report program containing all the control breaks but not using Declaratives. Uses the GBsales.dat data file."
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
@@ -145,8 +145,8 @@ RD  SalesReport
                         SOURCE CityName(CityCode) GROUP INDICATE.
        03 COLUMN 15     PIC 9
                         SOURCE SalesPersonNum  GROUP INDICATE.
-       03 COLUMN 25     PIC $,$$.99 SOURCE ValueOfSale.
-                
+       03 COLUMN 25     PIC $$,$$$.99 SOURCE ValueOfSale.
+		
 
 01  SalesPersonGrp
     TYPE IS CONTROL FOOTING SalesPersonNum  NEXT GROUP PLUS 2.
@@ -154,7 +154,7 @@ RD  SalesReport
        03 COLUMN 15     PIC X(21) VALUE "Sales for salesperson".
        03 COLUMN 37     PIC 9 SOURCE SalesPersonNum.
        03 COLUMN 43     PIC X VALUE "=".
-       03 SMS COLUMN 45 PIC $$$,$$.99 SUM ValueOfSale.
+       03 SMS COLUMN 45 PIC $$$$$,$$$.99 SUM ValueOfSale.
 
 
 01  CityGrp TYPE IS CONTROL FOOTING CityCode NEXT GROUP PLUS 2.
@@ -162,7 +162,7 @@ RD  SalesReport
        03 COLUMN 15     PIC X(9) VALUE "Sales for".
        03 COLUMN 25     PIC X(9) SOURCE CityName(CityCode).
        03 COLUMN 43     PIC X VALUE "=".
-       03 CS COLUMN 45  PIC $$$,$$.99 SUM SMS.
+       03 CS COLUMN 45  PIC $$$$$,$$$.99 SUM SMS.
 
 
 01  TotalSalesGrp TYPE IS CONTROL FOOTING FINAL.
@@ -170,7 +170,7 @@ RD  SalesReport
        03 COLUMN 15     PIC X(11)
                         VALUE "Total sales".
        03 COLUMN 43     PIC X VALUE "=".
-       03 COLUMN 45     PIC $$$,$$.99 SUM CS.
+       03 COLUMN 45     PIC $$$$$,$$$.99 SUM CS.
 
 
 01  TYPE IS PAGE FOOTING.
@@ -200,9 +200,7 @@ PrintSalaryReport.
     READ SalesFile
           AT END SET EndOfFile TO TRUE
     END-READ.
-
-
-        </code></pre>
+</code></pre>
 					</div>
 				</div>
 			</div>

--- a/examples/ReportWriter/RepWriteFull.html
+++ b/examples/ReportWriter/RepWriteFull.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -11,7 +11,7 @@
 		<title>Full Report Writer example program - includes Declaratives</title>
 		<meta
 			name="description"
-			content="The full version of the report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission. All"
+			content="The full version of the report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission."
 		/>
 		<link
 			rel="canonical"
@@ -26,7 +26,7 @@
 		<meta property="og:title" content="Full Report Writer example program - includes Declaratives" />
 		<meta
 			property="og:description"
-			content="The full version of the report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission. All"
+			content="The full version of the report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission."
 		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
 		<!-- Twitter Card -->
@@ -34,7 +34,7 @@
 		<meta name="twitter:title" content="Full Report Writer example program - includes Declaratives" />
 		<meta
 			name="twitter:description"
-			content="The full version of the report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission. All"
+			content="The full version of the report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission."
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
@@ -176,8 +176,8 @@ RD  SalesReport
                         SOURCE CityName(CityCode) GROUP INDICATE.
        03 COLUMN 15     PIC 9
                         SOURCE SalesPersonNum  GROUP INDICATE.
-       03 COLUMN 25     PIC $,$$.99 SOURCE ValueOfSale.
-                
+       03 COLUMN 25     PIC $$,$$$.99 SOURCE ValueOfSale.
+		
 
 01  SalesPersonGrp
     TYPE IS CONTROL FOOTING SalesPersonNum  NEXT GROUP PLUS 2.
@@ -185,17 +185,17 @@ RD  SalesReport
        03 COLUMN 15     PIC X(21) VALUE "Sales for salesperson".
        03 COLUMN 37     PIC 9 SOURCE SalesPersonNum.
        03 COLUMN 43     PIC X VALUE "=".
-       03 SMS COLUMN 45 PIC $$$,$$.99 SUM ValueOfSale.
+       03 SMS COLUMN 45 PIC $$$$$,$$$.99 SUM ValueOfSale.
 
     02 LINE IS PLUS 1.
        03 COLUMN 15     PIC X(19) VALUE "Sales commission is".
        03 COLUMN 43     PIC X VALUE "=".
-       03 COLUMN 45     PIC $$$,$$.99 SOURCE Commission.
+       03 COLUMN 45     PIC $$$$$,$$$.99 SOURCE Commission.
 
     02 LINE IS PLUS 1.
        03 COLUMN 15     PIC X(22) VALUE "Salesperson salary is".
        03 COLUMN 43     PIC X VALUE "=".
-       03 COLUMN 45     PIC $$$,$$.99 SOURCE Salary.
+       03 COLUMN 45     PIC $$$$$,$$$.99 SOURCE Salary.
 
     02 LINE IS PLUS 1.
        03 COLUMN 15     PIC X(30)
@@ -214,7 +214,7 @@ RD  SalesReport
        03 COLUMN 15     PIC X(9) VALUE "Sales for".
        03 COLUMN 25     PIC X(9) SOURCE CityName(CityCode).
        03 COLUMN 43     PIC X VALUE "=".
-       03 CS COLUMN 45  PIC $$$,$$.99 SUM SMS.
+       03 CS COLUMN 45  PIC $$$$$,$$$.99 SUM SMS.
 
     02 LINE IS PLUS 1.
        03 COLUMN 15     PIC X(12)
@@ -234,7 +234,7 @@ RD  SalesReport
        03 COLUMN 15     PIC X(11)
                         VALUE "Total sales".
        03 COLUMN 43     PIC X VALUE "=".
-       03 COLUMN 45     PIC $$$,$$.99 SUM CS.
+       03 COLUMN 45     PIC $$$$$,$$$.99 SUM CS.
 
 
 01  TYPE IS PAGE FOOTING.
@@ -277,9 +277,7 @@ PrintSalaryReport.
     READ SalesFile
           AT END SET EndOfFile TO TRUE
     END-READ.
-
-
-        </code></pre>
+</code></pre>
 					</div>
 				</div>
 			</div>

--- a/examples/ReportWriter/RepWriteSumm.html
+++ b/examples/ReportWriter/RepWriteSumm.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -176,8 +176,8 @@ RD  SalesReport
                         SOURCE CityName(CityCode) GROUP INDICATE.
        03 COLUMN 15     PIC 9
                         SOURCE SalesPersonNum  GROUP INDICATE.
-       03 COLUMN 25     PIC $,$$.99 SOURCE ValueOfSale.
-                
+       03 COLUMN 25     PIC $$,$$$.99 SOURCE ValueOfSale.
+		
 
 01  SalesPersonGrp
     TYPE IS CONTROL FOOTING SalesPersonNum  NEXT GROUP PLUS 2.
@@ -185,17 +185,17 @@ RD  SalesReport
        03 COLUMN 15     PIC X(21) VALUE "Sales for salesperson".
        03 COLUMN 37     PIC 9 SOURCE SalesPersonNum.
        03 COLUMN 43     PIC X VALUE "=".
-       03 SMS COLUMN 45 PIC $$$,$$.99 SUM ValueOfSale.
+       03 SMS COLUMN 45 PIC $$$$$,$$$.99 SUM ValueOfSale.
 
     02 LINE IS PLUS 1.
        03 COLUMN 15     PIC X(19) VALUE "Sales commission is".
        03 COLUMN 43     PIC X VALUE "=".
-       03 COLUMN 45     PIC $$$,$$.99 SOURCE Commission.
+       03 COLUMN 45     PIC $$$$$,$$$.99 SOURCE Commission.
 
     02 LINE IS PLUS 1.
        03 COLUMN 15     PIC X(22) VALUE "Salesperson salary is".
        03 COLUMN 43     PIC X VALUE "=".
-       03 COLUMN 45     PIC $$$,$$.99 SOURCE Salary.
+       03 COLUMN 45     PIC $$$$$,$$$.99 SOURCE Salary.
 
     02 LINE IS PLUS 1.
        03 COLUMN 15     PIC X(30)
@@ -214,7 +214,7 @@ RD  SalesReport
        03 COLUMN 15     PIC X(9) VALUE "Sales for".
        03 COLUMN 25     PIC X(9) SOURCE CityName(CityCode).
        03 COLUMN 43     PIC X VALUE "=".
-       03 CS COLUMN 45  PIC $$$,$$.99 SUM SMS.
+       03 CS COLUMN 45  PIC $$$$$,$$$.99 SUM SMS.
 
     02 LINE IS PLUS 1.
        03 COLUMN 15     PIC X(12)
@@ -234,7 +234,7 @@ RD  SalesReport
        03 COLUMN 15     PIC X(11)
                         VALUE "Total sales".
        03 COLUMN 43     PIC X VALUE "=".
-       03 COLUMN 45     PIC $$$,$$.99 SUM CS.
+       03 COLUMN 45     PIC $$$$$,$$$.99 SUM CS.
 
 
 01  TYPE IS PAGE FOOTING.
@@ -277,9 +277,7 @@ PrintSalaryReport.
     READ SalesFile
           AT END SET EndOfFile TO TRUE
     END-READ.
-
-
-        </code></pre>
+</code></pre>
 					</div>
 				</div>
 			</div>

--- a/examples/SeqIns/SEQINSERT.html
+++ b/examples/SeqIns/SEQINSERT.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -11,7 +11,7 @@
 		<title>Inserting records in a Sequential File</title>
 		<meta
 			name="description"
-			content="Demonstrates how to insert records into a sequential file from a file of transaction records. A new file is created which contains the inserted records. To"
+			content="Demonstrates how to insert records into a sequential file from a file of transaction records. A new file is created which contains the inserted records."
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SeqIns/SEQINSERT.html" />
 		<!-- Open Graph -->
@@ -23,7 +23,7 @@
 		<meta property="og:title" content="Inserting records in a Sequential File" />
 		<meta
 			property="og:description"
-			content="Demonstrates how to insert records into a sequential file from a file of transaction records. A new file is created which contains the inserted records. To"
+			content="Demonstrates how to insert records into a sequential file from a file of transaction records. A new file is created which contains the inserted records."
 		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
 		<!-- Twitter Card -->
@@ -31,7 +31,7 @@
 		<meta name="twitter:title" content="Inserting records in a Sequential File" />
 		<meta
 			name="twitter:description"
-			content="Demonstrates how to insert records into a sequential file from a file of transaction records. A new file is created which contains the inserted records. To"
+			content="Demonstrates how to insert records into a sequential file from a file of transaction records. A new file is created which contains the inserted records."
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />

--- a/examples/SeqRead/SEQREAD.html
+++ b/examples/SeqRead/SEQREAD.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -11,7 +11,7 @@
 		<title>Reading a Sequential File</title>
 		<meta
 			name="description"
-			content="An example program that reads a sequential file and displays the records. This is the correct version which uses the Condition Name (level 88)"
+			content='An example program that reads a sequential file and displays the records. Uses the Condition Name (level 88) "EndOfFile" to signal when the end of the file'
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREAD.html" />
 		<!-- Open Graph -->
@@ -20,7 +20,7 @@
 		<meta property="og:title" content="Reading a Sequential File" />
 		<meta
 			property="og:description"
-			content="An example program that reads a sequential file and displays the records. This is the correct version which uses the Condition Name (level 88)"
+			content='An example program that reads a sequential file and displays the records. Uses the Condition Name (level 88) "EndOfFile" to signal when the end of the file'
 		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
 		<!-- Twitter Card -->
@@ -28,7 +28,7 @@
 		<meta name="twitter:title" content="Reading a Sequential File" />
 		<meta
 			name="twitter:description"
-			content="An example program that reads a sequential file and displays the records. This is the correct version which uses the Condition Name (level 88)"
+			content='An example program that reads a sequential file and displays the records. Uses the Condition Name (level 88) "EndOfFile" to signal when the end of the file'
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
@@ -71,7 +71,7 @@ ENVIRONMENT DIVISION.
 INPUT-OUTPUT SECTION.
 FILE-CONTROL.
     SELECT StudentFile ASSIGN TO "STUDENTS.dat"
-                ORGANIZATION IS LINE SEQUENTIAL.
+		ORGANIZATION IS LINE SEQUENTIAL.
 
 DATA DIVISION.
 FILE SECTION.
@@ -102,7 +102,8 @@ Begin.
       END-READ
    END-PERFORM
    CLOSE StudentFile
-   STOP RUN.</code></pre>
+   STOP RUN.
+</code></pre>
 					</div>
 				</div>
 			</div>

--- a/examples/SeqRead/SEQREADno88.html
+++ b/examples/SeqRead/SEQREADno88.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -9,7 +9,10 @@
 			})();
 		</script>
 		<title>Reading a Sequential File</title>
-		<meta name="description" content="COBOL example program: Reading a Sequential File." />
+		<meta
+			name="description"
+			content="An example program that reads a sequential file and displays the records. This version does not use level 88's to signal when the end of the file has been"
+		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREADno88.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
@@ -18,12 +21,18 @@
 			content="https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREADno88.html"
 		/>
 		<meta property="og:title" content="Reading a Sequential File" />
-		<meta property="og:description" content="COBOL example program: Reading a Sequential File." />
+		<meta
+			property="og:description"
+			content="An example program that reads a sequential file and displays the records. This version does not use level 88's to signal when the end of the file has been"
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary" />
 		<meta name="twitter:title" content="Reading a Sequential File" />
-		<meta name="twitter:description" content="COBOL example program: Reading a Sequential File." />
+		<meta
+			name="twitter:description"
+			content="An example program that reads a sequential file and displays the records. This version does not use level 88's to signal when the end of the file has been"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -60,14 +69,14 @@ PROGRAM-ID.  SeqReadNo88.
 AUTHOR.  Michael Coughlan.
 *&gt; An example showing how to read a sequential file without
 *&gt; using condition names.
-*&gt; See SeqRead.cbl for the definitive example.
+*&gt; See Seqread.cbl for the definitive example.
 
 
 ENVIRONMENT DIVISION.
 INPUT-OUTPUT SECTION.
 FILE-CONTROL.
     SELECT StudentFile ASSIGN TO "STUDENTS.dat"
-                ORGANIZATION IS LINE SEQUENTIAL.
+		ORGANIZATION IS LINE SEQUENTIAL.
 
 DATA DIVISION.
 FILE SECTION.
@@ -97,7 +106,8 @@ Begin.
       END-READ
    END-PERFORM
    CLOSE StudentFile
-   STOP RUN.</code></pre>
+   STOP RUN.
+</code></pre>
 					</div>
 				</div>
 			</div>

--- a/examples/SeqRpt/SEQRPT.html
+++ b/examples/SeqRpt/SEQRPT.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -11,7 +11,7 @@
 		<title>Sequential Student Number Report</title>
 		<meta
 			name="description"
-			content="This program reads records from the student file, counts the total number of student records in the file and the number records for females and males."
+			content="Reads records from the student file, counts the total number of student records and the number of records for females and males, and prints the results in"
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SeqRpt/SEQRPT.html" />
 		<!-- Open Graph -->
@@ -20,7 +20,7 @@
 		<meta property="og:title" content="Sequential Student Number Report" />
 		<meta
 			property="og:description"
-			content="This program reads records from the student file, counts the total number of student records in the file and the number records for females and males."
+			content="Reads records from the student file, counts the total number of student records and the number of records for females and males, and prints the results in"
 		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
 		<!-- Twitter Card -->
@@ -28,7 +28,7 @@
 		<meta name="twitter:title" content="Sequential Student Number Report" />
 		<meta
 			name="twitter:description"
-			content="This program reads records from the student file, counts the total number of student records in the file and the number records for females and males."
+			content="Reads records from the student file, counts the total number of student records and the number of records for females and males, and prints the results in"
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
@@ -160,7 +160,7 @@ PrintReportLines.
     WRITE PrintLine FROM MaleTotalLine 
             AFTER ADVANCING 2 LINES 
     WRITE PrintLine FROM FemaleTotalLine 
-            AFTER ADVANCING 2 LINES. 
+            AFTER ADVANCING 2 LINES.
 </code></pre>
 					</div>
 				</div>

--- a/examples/SeqWrite/SEQWRITE.html
+++ b/examples/SeqWrite/SEQWRITE.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -9,7 +9,10 @@
 			})();
 		</script>
 		<title>Writing to a Sequential File</title>
-		<meta name="description" content="COBOL example program: Writing to a Sequential File." />
+		<meta
+			name="description"
+			content="Example program demonstrating how to create a sequential file from data input by the user."
+		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SeqWrite/SEQWRITE.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
@@ -18,12 +21,18 @@
 			content="https://bushidocodes.github.io/limerick-cobol/examples/SeqWrite/SEQWRITE.html"
 		/>
 		<meta property="og:title" content="Writing to a Sequential File" />
-		<meta property="og:description" content="COBOL example program: Writing to a Sequential File." />
+		<meta
+			property="og:description"
+			content="Example program demonstrating how to create a sequential file from data input by the user."
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary" />
 		<meta name="twitter:title" content="Writing to a Sequential File" />
-		<meta name="twitter:description" content="COBOL example program: Writing to a Sequential File." />
+		<meta
+			name="twitter:description"
+			content="Example program demonstrating how to create a sequential file from data input by the user."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -68,7 +77,7 @@ ENVIRONMENT DIVISION.
 INPUT-OUTPUT SECTION.
 FILE-CONTROL.
     SELECT StudentFile ASSIGN TO "STUDENTS.dat"
-                ORGANIZATION IS LINE SEQUENTIAL.
+		ORGANIZATION IS LINE SEQUENTIAL.
 
 DATA DIVISION.
 FILE SECTION.
@@ -101,7 +110,8 @@ Begin.
 GetStudentDetails.
     DISPLAY "Enter - StudId, Surname, Initials, YOB, MOB, DOB, Course, Gender"
     DISPLAY "NNNNNNNSSSSSSSSIIYYYYMMDDCCCCG"
-    ACCEPT  StudentDetails.  </code></pre>
+    ACCEPT  StudentDetails.
+</code></pre>
 					</div>
 				</div>
 			</div>

--- a/examples/Sort/InputSort.html
+++ b/examples/Sort/InputSort.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -76,7 +76,7 @@ ENVIRONMENT DIVISION.
 INPUT-OUTPUT SECTION.
 FILE-CONTROL.
     SELECT StudentFile ASSIGN TO "SORTSTUD.dat"
-                ORGANIZATION IS LINE SEQUENTIAL.
+		ORGANIZATION IS LINE SEQUENTIAL.
     SELECT WorkFile ASSIGN TO "WORK.tmp".
 
 
@@ -124,7 +124,8 @@ GetStudentDetails.
     PERFORM UNTIL WorkRec = SPACES
        RELEASE WorkRec
        ACCEPT WorkRec
-    END-PERFORM.</code></pre>
+    END-PERFORM.
+</code></pre>
 					</div>
 				</div>
 			</div>

--- a/examples/Sort/MaleSort.html
+++ b/examples/Sort/MaleSort.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -11,7 +11,7 @@
 		<title>SORT file and select only male records</title>
 		<meta
 			name="description"
-			content="Sorts the student masterfile (sorted on ascending Student Id) and produces a new file, sorted on ascending student name, containing only the records of"
+			content="Sorts the student masterfile and produces a new file, sorted on ascending student name, containing only the records of male students."
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Sort/MaleSort.html" />
 		<!-- Open Graph -->
@@ -20,7 +20,7 @@
 		<meta property="og:title" content="SORT file and select only male records" />
 		<meta
 			property="og:description"
-			content="Sorts the student masterfile (sorted on ascending Student Id) and produces a new file, sorted on ascending student name, containing only the records of"
+			content="Sorts the student masterfile and produces a new file, sorted on ascending student name, containing only the records of male students."
 		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
 		<!-- Twitter Card -->
@@ -28,7 +28,7 @@
 		<meta name="twitter:title" content="SORT file and select only male records" />
 		<meta
 			name="twitter:description"
-			content="Sorts the student masterfile (sorted on ascending Student Id) and produces a new file, sorted on ascending student name, containing only the records of"
+			content="Sorts the student masterfile and produces a new file, sorted on ascending student name, containing only the records of male students."
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
@@ -71,10 +71,10 @@ ENVIRONMENT DIVISION.
 INPUT-OUTPUT SECTION.
 FILE-CONTROL.
     SELECT StudentFile ASSIGN TO "STUDENTS.dat"
-                ORGANIZATION IS LINE SEQUENTIAL.
+		ORGANIZATION IS LINE SEQUENTIAL.
 
     SELECT MaleStudentFile ASSIGN TO "MALESTUDS.dat"
-                ORGANIZATION IS LINE SEQUENTIAL.
+		ORGANIZATION IS LINE SEQUENTIAL.
 
     SELECT WorkFile ASSIGN TO "WORK.tmp".
 
@@ -119,7 +119,8 @@ GetMaleStudents.
         AT END SET EndOfFile TO TRUE
       END-READ 
    END-PERFORM
-   CLOSE StudentFile.</code></pre>
+   CLOSE StudentFile.
+</code></pre>
 					</div>
 				</div>
 			</div>

--- a/examples/Strings/RefMod.html
+++ b/examples/Strings/RefMod.html
@@ -11,7 +11,7 @@
 		<title>String handling - Reference Modification examples</title>
 		<meta
 			name="description"
-			content="Solves a number of string handling tasks such as : - Extracting a substring from a string given the start position and length of the substring. Extracting"
+			content="Solves a number of string handling tasks such as extracting substrings, removing leading or trailing blanks, and finding the location of the first"
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Strings/RefMod.html" />
 		<!-- Open Graph -->
@@ -20,7 +20,7 @@
 		<meta property="og:title" content="String handling - Reference Modification examples" />
 		<meta
 			property="og:description"
-			content="Solves a number of string handling tasks such as : - Extracting a substring from a string given the start position and length of the substring. Extracting"
+			content="Solves a number of string handling tasks such as extracting substrings, removing leading or trailing blanks, and finding the location of the first"
 		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
 		<!-- Twitter Card -->
@@ -28,7 +28,7 @@
 		<meta name="twitter:title" content="String handling - Reference Modification examples" />
 		<meta
 			name="twitter:description"
-			content="Solves a number of string handling tasks such as : - Extracting a substring from a string given the start position and length of the substring. Extracting"
+			content="Solves a number of string handling tasks such as extracting substrings, removing leading or trailing blanks, and finding the location of the first"
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
@@ -115,7 +115,7 @@ Begin.
 *&gt;   Solution 1 
 *&gt;   Use the REVERSE intrinsic function to reverse the string
 *&gt;   then use the INSPECT tallying to count the number of spaces at the
-*&gt;   beginning of the reversed string.  The substring length is then the
+*&gt;   begining of the reversed string.  The substring length is then the
 *&gt;   FullStringLength - CharCount.
 *&gt;   Use reference modification of get the substring.
     DISPLAY "Task4 Before = " xStr "&lt;&lt;&lt;&lt;&lt;&lt;"

--- a/examples/Strings/RefMod.html
+++ b/examples/Strings/RefMod.html
@@ -115,7 +115,7 @@ Begin.
 *&gt;   Solution 1 
 *&gt;   Use the REVERSE intrinsic function to reverse the string
 *&gt;   then use the INSPECT tallying to count the number of spaces at the
-*&gt;   begining of the reversed string.  The substring length is then the
+*&gt;   beginning of the reversed string.  The substring length is then the
 *&gt;   FullStringLength - CharCount.
 *&gt;   Use reference modification of get the substring.
     DISPLAY "Task4 Before = " xStr "&lt;&lt;&lt;&lt;&lt;&lt;"

--- a/examples/Strings/RefModification.cbl
+++ b/examples/Strings/RefModification.cbl
@@ -49,7 +49,7 @@ Begin.
 *>   Solution 1 
 *>   Use the REVERSE intrinsic function to reverse the string
 *>   then use the INSPECT tallying to count the number of spaces at the
-*>   begining of the reversed string.  The substring length is then the
+*>   beginning of the reversed string.  The substring length is then the
 *>   FullStringLength - CharCount.
 *>   Use reference modification of get the substring.
     DISPLAY "Task4 Before = " xStr "<<<<<<"

--- a/examples/Strings/UnstringFileEg.html
+++ b/examples/Strings/UnstringFileEg.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -11,7 +11,7 @@
 		<title>String handling - Unpacking and size-validating comma separated records</title>
 		<meta
 			name="description"
-			content="An example showing the unpacking of comma separated records and the size validation of the unpacked fields. To test this program use the data file"
+			content="An example showing the unpacking of comma-separated records and the size validation of the unpacked fields."
 		/>
 		<link
 			rel="canonical"
@@ -26,7 +26,7 @@
 		<meta property="og:title" content="String handling - Unpacking and size-validating comma separated records" />
 		<meta
 			property="og:description"
-			content="An example showing the unpacking of comma separated records and the size validation of the unpacked fields. To test this program use the data file"
+			content="An example showing the unpacking of comma-separated records and the size validation of the unpacked fields."
 		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
 		<!-- Twitter Card -->
@@ -34,7 +34,7 @@
 		<meta name="twitter:title" content="String handling - Unpacking and size-validating comma separated records" />
 		<meta
 			name="twitter:description"
-			content="An example showing the unpacking of comma separated records and the size validation of the unpacked fields. To test this program use the data file"
+			content="An example showing the unpacking of comma-separated records and the size validation of the unpacked fields."
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
@@ -80,7 +80,7 @@ ENVIRONMENT DIVISION.
 INPUT-OUTPUT SECTION.
 FILE-CONTROL.
     SELECT VarLengthRecFile ASSIGN TO "VarLen.dat"
-                ORGANIZATION IS LINE SEQUENTIAL.
+		ORGANIZATION IS LINE SEQUENTIAL.
 
 DATA DIVISION.
 FILE SECTION.
@@ -161,7 +161,8 @@ CheckForErrors.
    IF NOT ValidDate     DISPLAY "Date Size Error"        END-IF
    IF NOT ValidSuppCode DISPLAY "Supplier Code Error"    END-IF
    IF NOT ValidSuppName DISPLAY "Supplier name Error"    END-IF
-   IF NOT ValidSuppAdr  DISPLAY "Supplier address Error" END-IF.</code></pre>
+   IF NOT ValidSuppAdr  DISPLAY "Supplier address Error" END-IF.
+</code></pre>
 					</div>
 				</div>
 			</div>

--- a/examples/SubProg/DateValid/DateDriver.html
+++ b/examples/SubProg/DateValid/DateDriver.html
@@ -11,7 +11,7 @@
 		<title>Driver program for date validation sub-program</title>
 		<meta
 			name="description"
-			content="A driver program for the date validation sub-program below. Accepts a date from the user, passes it to the date validation sub-program and interprets and"
+			content="A driver program for the date validation sub-program. Accepts a date from the user, passes it to the date validation sub-program and interprets and"
 		/>
 		<link
 			rel="canonical"
@@ -26,7 +26,7 @@
 		<meta property="og:title" content="Driver program for date validation sub-program" />
 		<meta
 			property="og:description"
-			content="A driver program for the date validation sub-program below. Accepts a date from the user, passes it to the date validation sub-program and interprets and"
+			content="A driver program for the date validation sub-program. Accepts a date from the user, passes it to the date validation sub-program and interprets and"
 		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
 		<!-- Twitter Card -->
@@ -34,7 +34,7 @@
 		<meta name="twitter:title" content="Driver program for date validation sub-program" />
 		<meta
 			name="twitter:description"
-			content="A driver program for the date validation sub-program below. Accepts a date from the user, passes it to the date validation sub-program and interprets and"
+			content="A driver program for the date validation sub-program. Accepts a date from the user, passes it to the date validation sub-program and interprets and"
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/css/course.css" rel="stylesheet" />
@@ -113,8 +113,6 @@ Begin.
     END-EVALUATE.
 
     STOP RUN.
-
-
 </code></pre>
 					</div>
 				</div>

--- a/examples/SubProg/DateValid/ValiDate.html
+++ b/examples/SubProg/DateValid/ValiDate.html
@@ -11,7 +11,7 @@
 		<title>Date validation sub-program</title>
 		<meta
 			name="description"
-			content="A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a code indicating if the date was valid or not. If not valid, the"
+			content="A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a code indicating whether the date was valid, and if not, why it was"
 		/>
 		<link
 			rel="canonical"
@@ -26,7 +26,7 @@
 		<meta property="og:title" content="Date validation sub-program" />
 		<meta
 			property="og:description"
-			content="A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a code indicating if the date was valid or not. If not valid, the"
+			content="A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a code indicating whether the date was valid, and if not, why it was"
 		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
 		<!-- Twitter Card -->
@@ -34,7 +34,7 @@
 		<meta name="twitter:title" content="Date validation sub-program" />
 		<meta
 			name="twitter:description"
-			content="A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a code indicating if the date was valid or not. If not valid, the"
+			content="A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a code indicating whether the date was valid, and if not, why it was"
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/css/course.css" rel="stylesheet" />

--- a/examples/SubProg/DayDiff/DayDiffDriver.html
+++ b/examples/SubProg/DayDiff/DayDiffDriver.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -11,7 +11,7 @@
 		<title>Get difference between dates driver program</title>
 		<meta
 			name="description"
-			content="A driver program that accepts two dates from the user and displays the difference in days between them. This program uses the Validate.cbl sub-program"
+			content="A driver program that accepts two dates from the user and displays the difference in days between them. Uses the Validate sub-program and also contains a"
 		/>
 		<link
 			rel="canonical"
@@ -26,7 +26,7 @@
 		<meta property="og:title" content="Get difference between dates driver program" />
 		<meta
 			property="og:description"
-			content="A driver program that accepts two dates from the user and displays the difference in days between them. This program uses the Validate.cbl sub-program"
+			content="A driver program that accepts two dates from the user and displays the difference in days between them. Uses the Validate sub-program and also contains a"
 		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
 		<!-- Twitter Card -->
@@ -34,7 +34,7 @@
 		<meta name="twitter:title" content="Get difference between dates driver program" />
 		<meta
 			name="twitter:description"
-			content="A driver program that accepts two dates from the user and displays the difference in days between them. This program uses the Validate.cbl sub-program"
+			content="A driver program that accepts two dates from the user and displays the difference in days between them. Uses the Validate sub-program and also contains a"
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/css/course.css" rel="stylesheet" />
@@ -112,7 +112,7 @@ WORKING-STORAGE SECTION.
             
 
 PROCEDURE DIVISION.
-10START.
+Begin.
     SET DateIsNotValid TO TRUE.
     PERFORM GetValidFirstDate UNTIL DateIsValid.
 
@@ -196,7 +196,7 @@ LINKAGE SECTION.
 01  YYYYDDMMDate                   PIC X(8).
 
 PROCEDURE DIVISION USING DDMMYYYYDate, YYYYDDMMDate.
-10Start.
+Begin.
     MOVE DDMMDay      TO YYYYDay.
     MOVE DDMMMonth    TO YYYYMonth.
     MOVE DDMMYear     TO YYYYYear.
@@ -229,7 +229,7 @@ LINKAGE SECTION.
 01  DDMMYYYYDate                   PIC X(8).
 
 PROCEDURE DIVISION USING YYYYDDMMDate, DDMMYYYYDate.
-10Start.
+Begin.
     MOVE YYYYDay      TO DDMMDay.
     MOVE YYYYMonth    TO DDMMMonth.
     MOVE YYYYYear     TO DDMMYear.

--- a/examples/SubProg/Multiply/DriverProg.cbl
+++ b/examples/SubProg/Multiply/DriverProg.cbl
@@ -27,7 +27,7 @@ WORKING-STORAGE SECTION.
 *> need not be declared.
   
 
-*> Parameters must be either 01-level's or elementry
+*> Parameters must be either 01-level's or elementary
 *> data-items. 
 01 Parameters.
    02 Number1         PIC 9(3).

--- a/examples/SubProg/Multiply/DriverProg.html
+++ b/examples/SubProg/Multiply/DriverProg.html
@@ -98,7 +98,7 @@ WORKING-STORAGE SECTION.
 *&gt; need not be declared.
   
 
-*&gt; Parameters must be either 01-level's or elementry
+*&gt; Parameters must be either 01-level's or elementary
 *&gt; data-items. 
 01 Parameters.
    02 Number1         PIC 9(3).

--- a/examples/SubProg/Multiply/DriverProg.html
+++ b/examples/SubProg/Multiply/DriverProg.html
@@ -11,7 +11,7 @@
 		<title>A driver for the MultiplyNums, Fickle and Steafast sub-programs</title>
 		<meta
 			name="description"
-			content='This program demonstrates the CALL verb by calling three external sub-programs. The "MultiplyNums" sub-program demonstrates flow of control - from caller'
+			content="Demonstrates the CALL verb by calling three external sub-programs that illustrate flow of control, parameter passing, and state memory."
 		/>
 		<link
 			rel="canonical"
@@ -26,7 +26,7 @@
 		<meta property="og:title" content="A driver for the MultiplyNums, Fickle and Steafast sub-programs" />
 		<meta
 			property="og:description"
-			content='This program demonstrates the CALL verb by calling three external sub-programs. The "MultiplyNums" sub-program demonstrates flow of control - from caller'
+			content="Demonstrates the CALL verb by calling three external sub-programs that illustrate flow of control, parameter passing, and state memory."
 		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
 		<!-- Twitter Card -->
@@ -34,7 +34,7 @@
 		<meta name="twitter:title" content="A driver for the MultiplyNums, Fickle and Steafast sub-programs" />
 		<meta
 			name="twitter:description"
-			content='This program demonstrates the CALL verb by calling three external sub-programs. The "MultiplyNums" sub-program demonstrates flow of control - from caller'
+			content="Demonstrates the CALL verb by calling three external sub-programs that illustrate flow of control, parameter passing, and state memory."
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/css/course.css" rel="stylesheet" />
@@ -98,7 +98,7 @@ WORKING-STORAGE SECTION.
 *&gt; need not be declared.
   
 
-*&gt; Parameters must be either 01-level's or elementary
+*&gt; Parameters must be either 01-level's or elementry
 *&gt; data-items. 
 01 Parameters.
    02 Number1         PIC 9(3).
@@ -200,7 +200,8 @@ MakeFickleSteadfast.
     CALL "Fickle" USING BY CONTENT UserNumber.
 *&gt;   We can make Fickle act like Steadfast by using
 *&gt;   the CANCEL verb to set it into its initial state
-*&gt;   each time we call it</code></pre>
+*&gt;   each time we call it
+</code></pre>
 					</div>
 				</div>
 			</div>

--- a/examples/SubProg/Multiply/Fickle.html
+++ b/examples/SubProg/Multiply/Fickle.html
@@ -11,7 +11,7 @@
 		<title>The Fickle sub-program demonstrates State Memory</title>
 		<meta
 			name="description"
-			content="Fickle is a sub-program called from DriverProg.cbl above. Fickle is a program that demonstrates State Memory. Each time the program is called it remembers"
+			content="A sub-program that demonstrates State Memory — each time it is called it remembers its state from the previous call."
 		/>
 		<link
 			rel="canonical"
@@ -26,7 +26,7 @@
 		<meta property="og:title" content="The Fickle sub-program demonstrates State Memory" />
 		<meta
 			property="og:description"
-			content="Fickle is a sub-program called from DriverProg.cbl above. Fickle is a program that demonstrates State Memory. Each time the program is called it remembers"
+			content="A sub-program that demonstrates State Memory — each time it is called it remembers its state from the previous call."
 		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
 		<!-- Twitter Card -->
@@ -34,7 +34,7 @@
 		<meta name="twitter:title" content="The Fickle sub-program demonstrates State Memory" />
 		<meta
 			name="twitter:description"
-			content="Fickle is a sub-program called from DriverProg.cbl above. Fickle is a program that demonstrates State Memory. Each time the program is called it remembers"
+			content="A sub-program that demonstrates State Memory — each time it is called it remembers its state from the previous call."
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/css/course.css" rel="stylesheet" />

--- a/examples/SubProg/Multiply/MultiplyNums.cbl
+++ b/examples/SubProg/Multiply/MultiplyNums.cbl
@@ -42,7 +42,7 @@ Begin.
 
     MOVE "VALUE OVERWRITTEN" TO StrA
     MOVE "VALUE OVERWRITTEN" TO StrB
-*>   This is done to demonstrate the differece between passing
+*>   This is done to demonstrate the difference between passing
 *>   BY CONTENT and passing BY REFERENCE.  If you pass BY REFERENCE
 *>   you give the called program the opportunity to corrupt your data. 
 *>   You should only pass BY REFERENCE if you require the called

--- a/examples/SubProg/Multiply/MultiplyNums.html
+++ b/examples/SubProg/Multiply/MultiplyNums.html
@@ -11,7 +11,7 @@
 		<title>The MultiplyNums sub-program</title>
 		<meta
 			name="description"
-			content='The "MultiplyNums" sub-program, called from the driver program above, demonstrates the flow of control from the driver program to the called sub-program'
+			content="The MultiplyNums sub-program demonstrates flow of control from a driver program and the use of numeric and string parameters with BY REFERENCE and BY"
 		/>
 		<link
 			rel="canonical"
@@ -26,7 +26,7 @@
 		<meta property="og:title" content="The MultiplyNums sub-program" />
 		<meta
 			property="og:description"
-			content='The "MultiplyNums" sub-program, called from the driver program above, demonstrates the flow of control from the driver program to the called sub-program'
+			content="The MultiplyNums sub-program demonstrates flow of control from a driver program and the use of numeric and string parameters with BY REFERENCE and BY"
 		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
 		<!-- Twitter Card -->
@@ -34,7 +34,7 @@
 		<meta name="twitter:title" content="The MultiplyNums sub-program" />
 		<meta
 			name="twitter:description"
-			content='The "MultiplyNums" sub-program, called from the driver program above, demonstrates the flow of control from the driver program to the called sub-program'
+			content="The MultiplyNums sub-program demonstrates flow of control from a driver program and the use of numeric and string parameters with BY REFERENCE and BY"
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/css/course.css" rel="stylesheet" />
@@ -110,7 +110,7 @@ Begin.
 
     MOVE "VALUE OVERWRITTEN" TO StrA
     MOVE "VALUE OVERWRITTEN" TO StrB
-*&gt;   This is done to demonstrate the difference between passing
+*&gt;   This is done to demonstrate the differece between passing
 *&gt;   BY CONTENT and passing BY REFERENCE.  If you pass BY REFERENCE
 *&gt;   you give the called program the opportunity to corrupt your data. 
 *&gt;   You should only pass BY REFERENCE if you require the called

--- a/examples/SubProg/Multiply/MultiplyNums.html
+++ b/examples/SubProg/Multiply/MultiplyNums.html
@@ -110,7 +110,7 @@ Begin.
 
     MOVE "VALUE OVERWRITTEN" TO StrA
     MOVE "VALUE OVERWRITTEN" TO StrB
-*&gt;   This is done to demonstrate the differece between passing
+*&gt;   This is done to demonstrate the difference between passing
 *&gt;   BY CONTENT and passing BY REFERENCE.  If you pass BY REFERENCE
 *&gt;   you give the called program the opportunity to corrupt your data. 
 *&gt;   You should only pass BY REFERENCE if you require the called

--- a/examples/SubProg/Multiply/Steadfast.html
+++ b/examples/SubProg/Multiply/Steadfast.html
@@ -11,7 +11,7 @@
 		<title>The Steadfast sub-program demonstrates the IS INITIAL phrase</title>
 		<meta
 			name="description"
-			content="Steadfast is a sub-program called from DriverProg.cbl above. Steadfast is identical to Fickle except that it uses the IS INITIAL phrase to avoid State"
+			content="A sub-program identical to Fickle except that it uses the IS INITIAL phrase to avoid State Memory — it always produces the same result for the same input."
 		/>
 		<link
 			rel="canonical"
@@ -26,7 +26,7 @@
 		<meta property="og:title" content="The Steadfast sub-program demonstrates the IS INITIAL phrase" />
 		<meta
 			property="og:description"
-			content="Steadfast is a sub-program called from DriverProg.cbl above. Steadfast is identical to Fickle except that it uses the IS INITIAL phrase to avoid State"
+			content="A sub-program identical to Fickle except that it uses the IS INITIAL phrase to avoid State Memory — it always produces the same result for the same input."
 		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
 		<!-- Twitter Card -->
@@ -34,7 +34,7 @@
 		<meta name="twitter:title" content="The Steadfast sub-program demonstrates the IS INITIAL phrase" />
 		<meta
 			name="twitter:description"
-			content="Steadfast is a sub-program called from DriverProg.cbl above. Steadfast is identical to Fickle except that it uses the IS INITIAL phrase to avoid State"
+			content="A sub-program identical to Fickle except that it uses the IS INITIAL phrase to avoid State Memory — it always produces the same result for the same input."
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/css/course.css" rel="stylesheet" />

--- a/examples/Tables/MonthTable.html
+++ b/examples/Tables/MonthTable.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -11,7 +11,7 @@
 		<title>Tables - Counts number of students born in each month</title>
 		<meta
 			name="description"
-			content="This program counts the number of students born in each month and displays the result. The program uses a pre-filled table of month names. This program is"
+			content="Counts the number of students born in each month using a pre-filled table of month names and displays the result."
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Tables/MonthTable.html" />
 		<!-- Open Graph -->
@@ -23,7 +23,7 @@
 		<meta property="og:title" content="Tables - Counts number of students born in each month" />
 		<meta
 			property="og:description"
-			content="This program counts the number of students born in each month and displays the result. The program uses a pre-filled table of month names. This program is"
+			content="Counts the number of students born in each month using a pre-filled table of month names and displays the result."
 		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
 		<!-- Twitter Card -->
@@ -31,7 +31,7 @@
 		<meta name="twitter:title" content="Tables - Counts number of students born in each month" />
 		<meta
 			name="twitter:description"
-			content="This program counts the number of students born in each month and displays the result. The program uses a pre-filled table of month names. This program is"
+			content="Counts the number of students born in each month using a pre-filled table of month names and displays the result."
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
@@ -70,14 +70,14 @@
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  MonthTable.
 AUTHOR.  Michael Coughlan.
-*&gt; This program counts the number of students born in each month and 
+*&gt; This program counts the number of students born in each month and
 *&gt; displays the result.
 
 ENVIRONMENT DIVISION.
 INPUT-OUTPUT SECTION.
 FILE-CONTROL.
     SELECT StudentFile ASSIGN TO "STUDENTS.dat"
-                ORGANIZATION IS LINE SEQUENTIAL.
+		ORGANIZATION IS LINE SEQUENTIAL.
 
 DATA DIVISION.
 FILE SECTION.
@@ -104,7 +104,7 @@ WORKING-STORAGE SECTION.
       03 FILLER       PIC X(18) VALUE "July     August".
       03 FILLER       PIC X(18) VALUE "SeptemberOctober".
       03 FILLER       PIC X(18) VALUE "November December".
-   02 FILLERh REDEFINES TableValues.
+   02 FILLER REDEFINES TableValues.
       03 Month OCCURS 12 TIMES PIC X(9).
 
 01 MonthCount OCCURS 12 TIMES PIC 999 VALUE ZEROS.
@@ -117,7 +117,7 @@ WORKING-STORAGE SECTION.
    02 PrnMonth          PIC X(9).
    02 FILLER            PIC X(4) VALUE SPACES.
    02 PrnStudentCount   PIC ZZ9.
- 
+
 
 PROCEDURE DIVISION.
 Begin.
@@ -140,7 +140,8 @@ Begin.
    END-PERFORM.
 
    CLOSE StudentFile
-   STOP RUN.</code></pre>
+   STOP RUN.
+</code></pre>
 					</div>
 				</div>
 			</div>

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
 	"description": "Static-site checks for the Limerick COBOL tutorial.",
 	"scripts": {
 		"build:sitemap": "node scripts/build-sitemap.js",
+		"build:examples": "node scripts/build-examples.js && prettier --write \"examples/**/*.html\"",
+		"check:examples": "node scripts/build-examples.js && prettier --write \"examples/**/*.html\" && git diff --exit-code examples/",
 		"serve": "http-server . --cors -c-1 -p 8000 --silent",
 		"validate": "html-validate index.html \"course/**/*.html\" \"examples/**/*.html\" \"exercises/**/*.html\" \"lectures/**/*.html\"",
 		"check:img-dims": "node scripts/check-img-dimensions.js",
@@ -14,7 +16,7 @@
 		"check:assets": "node scripts/check-assets.js",
 		"format:check": "prettier --check .",
 		"format:write": "prettier --write .",
-		"check": "npm run validate && npm run check:assets && npm run check:img-dims && npm run links && npm run a11y"
+		"check": "npm run check:examples && npm run validate && npm run check:assets && npm run check:img-dims && npm run links && npm run a11y"
 	},
 	"devDependencies": {
 		"html-validate": "^10.15.0",

--- a/scripts/build-examples.js
+++ b/scripts/build-examples.js
@@ -360,11 +360,7 @@ function escapeHtml(str) {
 }
 
 function escapeAttr(str) {
-	return str
-		.replace(/&/g, "&amp;")
-		.replace(/</g, "&lt;")
-		.replace(/>/g, "&gt;")
-		.replace(/"/g, "&quot;");
+	return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 }
 
 /** Truncate description to ≤155 chars, breaking at a word boundary. */

--- a/scripts/build-examples.js
+++ b/scripts/build-examples.js
@@ -1,0 +1,499 @@
+#!/usr/bin/env node
+/**
+ * build-examples.js
+ *
+ * Generates each examples/<topic>/<NAME>.html from its sibling .cbl COBOL
+ * source file. Re-run this script whenever a .cbl file is edited, then run
+ * prettier to normalise formatting before committing.
+ *
+ * Usage:  npm run build:examples
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const ROOT = path.resolve(__dirname, "..");
+const EXAMPLES_DIR = path.join(ROOT, "examples");
+const BASE_URL = "https://bushidocodes.github.io/limerick-cobol/";
+const OG_IMAGE = "https://bushidocodes.github.io/limerick-cobol/favicon.svg";
+
+// ---------------------------------------------------------------------------
+// Manifest
+// Each entry maps one .cbl source file to the data needed for its HTML page.
+// `file`     – path of the output .html file, relative to examples/
+// `cbl`      – sibling .cbl filename (must live in the same directory as file)
+// `title`    – <title> text and og:title / twitter:title
+// `crumb`    – short label shown as the trailing breadcrumb span
+// `desc`     – full description shown in the <p> and (truncated) in meta tags
+// `lectures` – related-content `lectures` attribute value (optional)
+// ---------------------------------------------------------------------------
+
+const MANIFEST = [
+	// ── Accept ──────────────────────────────────────────────────────────────
+	{
+		file: "Accept/ACCEPT.html",
+		cbl: "AcceptAndDisplay.cbl",
+		title: "ACCEPT and DISPLAY example program",
+		crumb: "ACCEPT and DISPLAY",
+		desc: "The program accepts a simple student record from the user and displays the individual fields. Also shows how the ACCEPT may be used to get and DISPLAY the system time and date.",
+		lectures: "../../course/COBOLIntro.html|Introduction to COBOL",
+	},
+	{
+		file: "Accept/Multiplier.html",
+		cbl: "Multiplier.cbl",
+		title: "ACCEPT, DISPLAY and MULTIPLY example program",
+		crumb: "Multiplier",
+		desc: "Accepts two single digit numbers from the user, multiplies them together and displays the result.",
+		lectures: "../../course/COBOLIntro.html|Introduction to COBOL",
+	},
+	{
+		file: "Accept/Shortest.html",
+		cbl: "ShortestProgram.cbl",
+		title: "The Shortest COBOL program we can have",
+		crumb: "Shortest COBOL Program",
+		desc: "This example program is almost the shortest COBOL program we can have. We could make it shorter still by leaving out the STOP RUN.",
+		lectures: "../../course/COBOLIntro.html|Introduction to COBOL",
+	},
+	// ── Conditn ─────────────────────────────────────────────────────────────
+	{
+		file: "Conditn/Conditions.html",
+		cbl: "CONDITIONS.cbl",
+		title: "Condition Names (level 88) example program",
+		crumb: "Condition Names",
+		desc: "An example program demonstrating the use of Condition Names (level 88's).",
+		lectures: "../../course/Selection.html|Selection in COBOL",
+	},
+	{
+		file: "Conditn/IterIf.html",
+		cbl: "Iteration-If.cbl",
+		title: "Iteration with IF example program",
+		crumb: "Iteration with IF",
+		desc: "An example program that implements a primitive calculator. The calculator only does additions and multiplications.",
+		lectures: "../../course/Selection.html|Selection in COBOL, ../../course/Iteration.html|Iteration in COBOL",
+	},
+	// ── Indexed ─────────────────────────────────────────────────────────────
+	{
+		file: "Indexed/DirectReadIdx.html",
+		cbl: "DirectReadIdx.cbl",
+		title: "Reading an Indexed file directly by key",
+		crumb: "Direct Read on Indexed File",
+		desc: "Does a direct read on the Indexed file. Allows the user to choose which of the keys to use for the direct read.",
+		lectures: "../../course/IndexedFiles.html|Indexed Files",
+	},
+	{
+		file: "Indexed/Seq2Index.html",
+		cbl: "Seq2Index.cbl",
+		title: "Creating an Indexed file from a sequential file",
+		crumb: "Sequential to Indexed",
+		desc: "Creates a direct access Indexed file from a Sequential file.",
+		lectures: "../../course/IndexedFiles.html|Indexed Files",
+	},
+	{
+		file: "Indexed/SeqReadIdx.html",
+		cbl: "SeqReadIdx.cbl",
+		title: "Reading an Indexed file sequentially on any of its keys",
+		crumb: "Sequential Read of Indexed File",
+		desc: "Reads the Indexed file sequentially on whichever key is chosen by the user. Displays all the records in the file.",
+		lectures: "../../course/IndexedFiles.html|Indexed Files",
+	},
+	// ── Merge ───────────────────────────────────────────────────────────────
+	{
+		file: "Merge/Merge.html",
+		cbl: "MergeFiles.cbl",
+		title: "Merge Files - Example Program",
+		crumb: "Merge Files",
+		desc: "Uses the MERGE to insert records from a transaction file into a sequential master file.",
+		lectures: "../../course/SortMerge.html|Sorting and Merging",
+	},
+	// ── Perform ─────────────────────────────────────────────────────────────
+	{
+		file: "Perform/MileageCount.html",
+		cbl: "MileageCounter.cbl",
+		title: "Mileage counter simulation",
+		crumb: "Mileage Counter",
+		desc: "Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used to simulate a mileage counter.",
+		lectures: "../../course/Iteration.html|Iteration in COBOL",
+	},
+	{
+		file: "Perform/Perform1.html",
+		cbl: "PerformFormat1.cbl",
+		title: "Perform - Format 1 example program",
+		crumb: "PERFORM Format 1",
+		desc: "An example program demonstrating how the first format of the PERFORM may be used to change the flow of control through a program.",
+		lectures: "../../course/Iteration.html|Iteration in COBOL",
+	},
+	{
+		file: "Perform/Perform2.html",
+		cbl: "PerformFormat2.cbl",
+		title: "Perform - Format 2 example program",
+		crumb: "PERFORM Format 2",
+		desc: "Demonstrates the second format of the PERFORM. The PERFORM..TIMES may be used to execute a block of code x number of times.",
+		lectures: "../../course/Iteration.html|Iteration in COBOL",
+	},
+	{
+		file: "Perform/Perform3.html",
+		cbl: "PerformFormat3.cbl",
+		title: "Perform - Format 3 example program",
+		crumb: "PERFORM Format 3",
+		desc: "Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values where the length of the stream cannot be determined in advance.",
+		lectures: "../../course/Iteration.html|Iteration in COBOL",
+	},
+	{
+		file: "Perform/Perform4.html",
+		cbl: "PerformFormat4.cbl",
+		title: "Perform - Format 4 example program",
+		crumb: "PERFORM Format 4",
+		desc: "Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used for counting iteration. Also introduces the WITH TEST BEFORE and WITH TEST AFTER phrases.",
+		lectures: "../../course/Iteration.html|Iteration in COBOL",
+	},
+	// ── Relative ────────────────────────────────────────────────────────────
+	{
+		file: "Relative/ReadRel.html",
+		cbl: "ReadRelative.cbl",
+		title: "Read Relative File example program",
+		crumb: "Read Relative File",
+		desc: "Reads the Relative file and displays the records. Allows the user to choose to read sequentially through all the records or to use a key to read a single record directly.",
+		lectures: "../../course/RelativeFiles.html|Relative Files",
+	},
+	{
+		file: "Relative/Seq2Rel.html",
+		cbl: "Seq2Rel.cbl",
+		title: "Sequential to Relative File example program",
+		crumb: "Sequential to Relative",
+		desc: "Creates a direct access Relative file from a Sequential File.",
+		lectures: "../../course/RelativeFiles.html|Relative Files",
+	},
+	// ── ReportWriter ────────────────────────────────────────────────────────
+	{
+		file: "ReportWriter/RepWriteA.html",
+		cbl: "ReportExampleA.cbl",
+		title: "One control break version of full Report Writer example Program",
+		crumb: "Report Writer Example A",
+		desc: "A simplified version of the full report program using only one control break. Uses the GBsales.dat data file.",
+		lectures:
+			"../../course/ReportWriter.html|Report Writer by Example, ../../course/ReportWriterSS.html|Report Writer Syntax and Semantics",
+	},
+	{
+		file: "ReportWriter/RepWriteB.html",
+		cbl: "ReportExampleB.cbl",
+		title: "No Declaratives version of full Report Writer example program",
+		crumb: "Report Writer Example B",
+		desc: "A simplified version of the full report program containing all the control breaks but not using Declaratives. Uses the GBsales.dat data file.",
+		lectures:
+			"../../course/ReportWriter.html|Report Writer by Example, ../../course/ReportWriterSS.html|Report Writer Syntax and Semantics",
+	},
+	{
+		file: "ReportWriter/RepWriteFull.html",
+		cbl: "ReportExampleFull.cbl",
+		title: "Full Report Writer example program - includes Declaratives",
+		crumb: "Report Writer Full Example",
+		desc: "The full version of the report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission.",
+		lectures:
+			"../../course/ReportWriter.html|Report Writer by Example, ../../course/ReportWriterSS.html|Report Writer Syntax and Semantics",
+	},
+	{
+		file: "ReportWriter/RepWriteSumm.html",
+		cbl: "ReportExampleSummary.cbl",
+		title: "Summary version of the full Report Writer program",
+		crumb: "Report Writer Summary",
+		desc: "The summary version of the full report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission.",
+		lectures:
+			"../../course/ReportWriter.html|Report Writer by Example, ../../course/ReportWriterSS.html|Report Writer Syntax and Semantics",
+	},
+	// ── SeqIns ──────────────────────────────────────────────────────────────
+	{
+		file: "SeqIns/SEQINSERT.html",
+		cbl: "InsertRecords.cbl",
+		title: "Inserting records in a Sequential File",
+		crumb: "Insert Records",
+		desc: "Demonstrates how to insert records into a sequential file from a file of transaction records. A new file is created which contains the inserted records.",
+		lectures: "../../course/SequentialFiles2.html|Processing Sequential Files",
+	},
+	// ── SeqRead ─────────────────────────────────────────────────────────────
+	{
+		file: "SeqRead/SEQREAD.html",
+		cbl: "Seqread.cbl",
+		title: "Reading a Sequential File",
+		crumb: "Sequential Read",
+		desc: 'An example program that reads a sequential file and displays the records. Uses the Condition Name (level 88) "EndOfFile" to signal when the end of the file has been reached.',
+		lectures: "../../course/SequentialFiles1.html|Introduction to Sequential Files",
+	},
+	{
+		file: "SeqRead/SEQREADno88.html",
+		cbl: "SeqreadNo88.cbl",
+		title: "Reading a Sequential File",
+		crumb: "Sequential Read (without level 88s)",
+		desc: "An example program that reads a sequential file and displays the records. This version does not use level 88's to signal when the end of the file has been reached.",
+		lectures: "../../course/SequentialFiles1.html|Introduction to Sequential Files",
+	},
+	// ── SeqRpt ──────────────────────────────────────────────────────────────
+	{
+		file: "SeqRpt/SEQRPT.html",
+		cbl: "StudentNumbersReport.cbl",
+		title: "Sequential Student Number Report",
+		crumb: "Student Numbers Report",
+		desc: "Reads records from the student file, counts the total number of student records and the number of records for females and males, and prints the results in a short report.",
+		lectures: "../../course/SequentialFiles3.html|COBOL Print Files and Variable-Length Records",
+	},
+	// ── SeqWrite ────────────────────────────────────────────────────────────
+	{
+		file: "SeqWrite/SEQWRITE.html",
+		cbl: "SEQWRITE.cbl",
+		title: "Writing to a Sequential File",
+		crumb: "Sequential Write",
+		desc: "Example program demonstrating how to create a sequential file from data input by the user.",
+		lectures: "../../course/SequentialFiles1.html|Introduction to Sequential Files",
+	},
+	// ── Sort ────────────────────────────────────────────────────────────────
+	{
+		file: "Sort/InputSort.html",
+		cbl: "InputSORT.cbl",
+		title: "SORT with Input Procedure to get recs from user",
+		crumb: "Input Sort",
+		desc: "Uses the SORT and an INPUT PROCEDURE to accept records from the user and sort them on ascending StudentId.",
+		lectures: "../../course/SortMerge.html|Sorting and Merging",
+	},
+	{
+		file: "Sort/MaleSort.html",
+		cbl: "MaleSORT.cbl",
+		title: "SORT file and select only male records",
+		crumb: "Male Sort",
+		desc: "Sorts the student masterfile and produces a new file, sorted on ascending student name, containing only the records of male students.",
+		lectures: "../../course/SortMerge.html|Sorting and Merging",
+	},
+	// ── Strings ─────────────────────────────────────────────────────────────
+	{
+		file: "Strings/RefMod.html",
+		cbl: "RefModification.cbl",
+		title: "String handling - Reference Modification examples",
+		crumb: "Reference Modification",
+		desc: "Solves a number of string handling tasks such as extracting substrings, removing leading or trailing blanks, and finding the location of the first occurrence of a character in a string.",
+		lectures: "../../course/RefMod.html|Reference Modification and Intrinsic Functions",
+	},
+	{
+		file: "Strings/UnstringFileEg.html",
+		cbl: "UnstringFileEg.cbl",
+		title: "String handling - Unpacking and size-validating comma separated records",
+		crumb: "UNSTRING File Example",
+		desc: "An example showing the unpacking of comma-separated records and the size validation of the unpacked fields.",
+		lectures: "../../course/Unstring.html|Unstring",
+	},
+	// ── SubProg/DateValid (depth 3) ──────────────────────────────────────────
+	{
+		file: "SubProg/DateValid/DateDriver.html",
+		cbl: "DateDriver.cbl",
+		title: "Driver program for date validation sub-program",
+		crumb: "Date Driver Program",
+		desc: "A driver program for the date validation sub-program. Accepts a date from the user, passes it to the date validation sub-program and interprets and displays the result.",
+		lectures: "../../../course/Subprograms.html|Contained and External Sub-programs",
+	},
+	{
+		file: "SubProg/DateValid/ValiDate.html",
+		cbl: "Validate.cbl",
+		title: "Date validation sub-program",
+		crumb: "Date Validation Sub-program",
+		desc: "A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a code indicating whether the date was valid, and if not, why it was invalid.",
+		lectures: "../../../course/Subprograms.html|Contained and External Sub-programs",
+	},
+	// ── SubProg/DayDiff (depth 3) ────────────────────────────────────────────
+	{
+		file: "SubProg/DayDiff/DayDiffDriver.html",
+		cbl: "DayDiffDriver.cbl",
+		title: "Get difference between dates driver program",
+		crumb: "Day Difference Driver",
+		desc: "A driver program that accepts two dates from the user and displays the difference in days between them. Uses the Validate sub-program and also contains a number of contained sub-programs.",
+		lectures: "../../../course/Subprograms.html|Contained and External Sub-programs",
+	},
+	// ── SubProg/Multiply (depth 3) ───────────────────────────────────────────
+	{
+		file: "SubProg/Multiply/DriverProg.html",
+		cbl: "DriverProg.cbl",
+		title: "A driver for the MultiplyNums, Fickle and Steafast sub-programs",
+		crumb: "Sub-program Driver",
+		desc: "Demonstrates the CALL verb by calling three external sub-programs that illustrate flow of control, parameter passing, and state memory.",
+		lectures: "../../../course/Subprograms.html|Contained and External Sub-programs",
+	},
+	{
+		file: "SubProg/Multiply/Fickle.html",
+		cbl: "Fickle.cbl",
+		title: "The Fickle sub-program demonstrates State Memory",
+		crumb: "Fickle Sub-program",
+		desc: "A sub-program that demonstrates State Memory — each time it is called it remembers its state from the previous call.",
+		lectures: "../../../course/Subprograms.html|Contained and External Sub-programs",
+	},
+	{
+		file: "SubProg/Multiply/MultiplyNums.html",
+		cbl: "MultiplyNums.cbl",
+		title: "The MultiplyNums sub-program",
+		crumb: "MultiplyNums Sub-program",
+		desc: "The MultiplyNums sub-program demonstrates flow of control from a driver program and the use of numeric and string parameters with BY REFERENCE and BY CONTENT.",
+		lectures: "../../../course/Subprograms.html|Contained and External Sub-programs",
+	},
+	{
+		file: "SubProg/Multiply/Steadfast.html",
+		cbl: "Steadfast.cbl",
+		title: "The Steadfast sub-program demonstrates the IS INITIAL phrase",
+		crumb: "Steadfast Sub-program",
+		desc: "A sub-program identical to Fickle except that it uses the IS INITIAL phrase to avoid State Memory — it always produces the same result for the same input.",
+		lectures: "../../../course/Subprograms.html|Contained and External Sub-programs",
+	},
+	// ── Tables ──────────────────────────────────────────────────────────────
+	{
+		file: "Tables/MonthTable.html",
+		cbl: "MonthTable.cbl",
+		title: "Tables - Counts number of students born in each month",
+		crumb: "Month Table",
+		desc: "Counts the number of students born in each month using a pre-filled table of month names and displays the result.",
+		lectures:
+			"../../course/Tables1.html|Using Tables, ../../course/Tables2.html|Creating Tables — Syntax and Semantics",
+	},
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function escapeHtml(str) {
+	return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function escapeAttr(str) {
+	return str
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;");
+}
+
+/** Truncate description to ≤155 chars, breaking at a word boundary. */
+function truncate(text, max = 155) {
+	if (text.length <= max) return text;
+	const cut = text.lastIndexOf(" ", max);
+	return (cut > 80 ? text.slice(0, cut) : text.slice(0, max)).trimEnd();
+}
+
+/**
+ * Return the path prefix to reach the repo root from examples/<relFile>.
+ * e.g. "Accept/ACCEPT.html"        -> "../../"
+ *      "SubProg/Multiply/Foo.html" -> "../../../"
+ */
+function prefix(relFile) {
+	const depth = relFile.split("/").length - 1;
+	return "../".repeat(depth + 1);
+}
+
+/**
+ * Return the relative path from examples/<relFile> back to examples/default.html.
+ * e.g. "Accept/ACCEPT.html"        -> "../default.html"
+ *      "SubProg/Multiply/Foo.html" -> "../../default.html"
+ */
+function defaultHtmlPath(relFile) {
+	const depth = relFile.split("/").length - 1;
+	return "../".repeat(depth) + "default.html";
+}
+
+// ---------------------------------------------------------------------------
+// Page builder
+// ---------------------------------------------------------------------------
+
+function buildPage(entry) {
+	const pfx = prefix(entry.file);
+	const defPath = defaultHtmlPath(entry.file);
+	const canonical = BASE_URL + "examples/" + entry.file;
+	const metaDesc = escapeAttr(truncate(entry.desc));
+	const metaTitle = escapeAttr(entry.title);
+	const metaUrl = escapeAttr(canonical);
+
+	const cblPath = path.join(EXAMPLES_DIR, path.dirname(entry.file), entry.cbl);
+	// Strip UTF-8 BOM and normalise CRLF → LF (several .cbl files use Windows line endings).
+	const cblSource = fs.readFileSync(cblPath, "utf8").replace(/^﻿/, "").replace(/\r\n/g, "\n").trimEnd();
+	const escapedSource = escapeHtml(cblSource);
+
+	const relatedEl = entry.lectures
+		? `\t\t\t\t\t\t<related-content lectures="${entry.lectures}"></related-content>\n`
+		: "";
+
+	return `<!doctype html>
+<html lang="en">
+\t<head>
+\t\t<meta name="viewport" content="width=device-width, initial-scale=1" />
+\t\t<script>
+\t\t\t(function () {
+\t\t\t\tvar t = localStorage.getItem("lc-theme");
+\t\t\t\tif (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+\t\t\t})();
+\t\t</script>
+\t\t<title>${entry.title}</title>
+\t\t<meta name="description" content="${metaDesc}" />
+\t\t<link rel="canonical" href="${metaUrl}" />
+\t\t<!-- Open Graph -->
+\t\t<meta property="og:type" content="website" />
+\t\t<meta property="og:url" content="${metaUrl}" />
+\t\t<meta property="og:title" content="${metaTitle}" />
+\t\t<meta property="og:description" content="${metaDesc}" />
+\t\t<meta property="og:image" content="${OG_IMAGE}" />
+\t\t<!-- Twitter Card -->
+\t\t<meta name="twitter:card" content="summary" />
+\t\t<meta name="twitter:title" content="${metaTitle}" />
+\t\t<meta name="twitter:description" content="${metaDesc}" />
+\t\t<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+\t\t<link href="${pfx}course/Resources/css/course.css" rel="stylesheet" />
+\t\t<link href="${pfx}course/Resources/css/course-components.css" rel="stylesheet" />
+\t\t<link href="${pfx}course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
+\t\t<script src="${pfx}course/Resources/vendor/prism/prism.min.js" defer></script>
+\t\t<script src="${pfx}course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+\t\t<script src="${pfx}components/theme-toggle.js" defer></script>
+\t\t<script src="${pfx}components/page-hero.js" defer></script>
+\t\t<script src="${pfx}components/related-content.js" defer></script>
+\t\t<script src="${pfx}components/copy-button.js" defer></script>
+\t</head>
+\t<body>
+\t\t<a class="skip-link" href="#main-content">Skip to main content</a>
+\t\t<main id="main-content">
+\t\t\t<div class="page-wrapper">
+\t\t\t\t<div class="section-grid">
+\t\t\t\t\t<div class="section-full">
+\t\t\t\t\t\t<page-hero title="${metaTitle}" eyebrow="COBOL Example"></page-hero>
+\t\t\t\t\t\t<nav aria-label="Breadcrumb">
+\t\t\t\t\t\t\t<a href="${defPath}">Example programs</a> ›
+\t\t\t\t\t\t\t<span>${entry.crumb}</span>
+\t\t\t\t\t\t</nav>
+\t\t\t\t\t\t<p>${entry.desc}</p>
+\t\t\t\t\t\t<p><a href="${entry.cbl}" download>Download ${entry.cbl}</a></p>
+${relatedEl}\t\t\t\t\t\t<pre class="language-cobol"><code class="language-cobol">${escapedSource}
+</code></pre>
+\t\t\t\t\t</div>
+\t\t\t\t</div>
+\t\t\t</div>
+\t\t</main>
+\t</body>
+</html>
+`;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+console.log("Building example HTML pages from .cbl sources…\n");
+
+let ok = 0;
+let fail = 0;
+
+for (const entry of MANIFEST) {
+	const absPath = path.join(EXAMPLES_DIR, entry.file);
+	try {
+		const html = buildPage(entry);
+		fs.writeFileSync(absPath, html, "utf8");
+		console.log(`  OK  ${entry.file}`);
+		ok++;
+	} catch (err) {
+		console.error(`  ERR ${entry.file}: ${err.message}`);
+		fail++;
+	}
+}
+
+console.log(`\nDone. ${ok} written, ${fail} failed.`);
+if (fail > 0) process.exit(1);


### PR DESCRIPTION
## Summary

- Adds `scripts/build-examples.js` — reads each `.cbl` file, HTML-escapes it, wraps it in the standard page chrome template, and writes `<NAME>.html`. Handles UTF-8 BOMs and CRLF line endings that several `.cbl` files carry.
- Adds `npm run build:examples` (build script + prettier pass) and `npm run check:examples` (build + prettier + `git diff --exit-code`) so CI will catch future drift before it lands.
- Wires `check:examples` into `npm run check`.
- Committed the freshly-generated HTML for all 37 example pages, fixing accumulated drift:
  - **COBOL source fixes**: e.g. `ACCEPT.html` had stale `YYMMDD`/`YYDDD` comments; source now matches the `.cbl` file exactly.
  - **Title corrections**: `IterIf`, `ReadRel`, and `Seq2Rel` pages had titles copied from wrong pages.
  - **Meta description improvements**: all 37 pages now carry the authoritative MANIFEST descriptions instead of auto-generated title-based fallbacks.
  - **BOM / trailing-whitespace cleanup** inside `<pre>` blocks.

## Semantic web metadata

The `desc` field in the MANIFEST is used for `<meta name="description">`, `og:description`, and `twitter:description` (truncated to ≤155 chars at a word boundary, matching `add-page-meta.js`'s existing logic). The canonical URL is derived from the file path. Titles, crumbs, and lecture links come from the same MANIFEST already used by `add-example-chrome.js`.

## Test plan

- [x] `node scripts/build-examples.js` — all 37 OK, 0 failed
- [x] `npx html-validate "examples/**/*.html"` — exits 0, no errors
- [x] Build is idempotent: running build+prettier twice produces byte-for-byte identical output
- [ ] `npm run check` (full suite — requires local server for link/a11y checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)