### PR TITLE
fix: resolve all WCAG 2.1 AA contrast violations (closes #201)

### DIFF
--- a/.pa11yci.json
+++ b/.pa11yci.json
@@ -5,8 +5,7 @@
 		"wait": 500,
 		"chromeLaunchConfig": {
 			"args": ["--no-sandbox"]
-		},
-		"ignore": ["WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail", "WCAG2AA.Principle1.Guideline1_4.1_4_3.G145.Fail"]
+		}
 	},
 	"urls": [
 		"http://localhost:8000/index.html",

--- a/course/Resources/css/course.css
+++ b/course/Resources/css/course.css
@@ -262,8 +262,11 @@ ul.toc a {
    theme tokens drive colors on pages that haven't been migrated to component
    classes. */
 table[bgcolor="#993300"],
+table[bgcolor="#990000"],
 tr[bgcolor="#993300"],
-td[bgcolor="#993300"] {
+tr[bgcolor="#990000"],
+td[bgcolor="#993300"],
+td[bgcolor="#990000"] {
 	background-color: var(--color-header-bg);
 }
 
@@ -326,7 +329,10 @@ td[bgcolor="#e8e8e8"] {
 	background-color: var(--color-cell-label-bg);
 }
 
-td[bgcolor="#993300"] h2 {
+td[bgcolor="#993300"] h2,
+td[bgcolor="#990000"] h2,
+tr[bgcolor="#993300"] h2,
+tr[bgcolor="#990000"] h2 {
 	color: var(--color-header-text);
 	font-family: Arial, Helvetica, sans-serif;
 }
@@ -425,6 +431,17 @@ td[bgcolor="#ffffcc"] h4 {
 [style*="color:#CCCCCC"],
 [style*="color: #CCCCCC"] {
 	color: #6a6a6a !important;
+}
+
+/* Legacy <span style="color: #ff0000"> fails 4.5:1 against light backgrounds
+   (#E1FFE1 gives 3.73:1, #FFFFCC gives 3.89:1, white gives 4:1). Remap to a
+   darker red. Dark-mode override below uses higher-specificity selectors and
+   maps to #ff8a8a for legibility on dark panel backgrounds. */
+[style*="color:#ff0000"],
+[style*="color: #ff0000"],
+[style*="color:#FF0000"],
+[style*="color: #FF0000"] {
+	color: #c00000 !important;
 }
 
 /* ============================================================================

--- a/course/Resources/css/course.css
+++ b/course/Resources/css/course.css
@@ -415,6 +415,44 @@ td[bgcolor="#ffffcc"] h4 {
 	}
 }
 
+/* Inline style colour corrections — light mode.
+   Legacy <span style="color: #cccccc"> fails 4.5:1 against any light
+   background. Remap to a dark grey that passes without the rule being
+   visible in dark mode (the dark-mode block below uses higher-specificity
+   :root:not([data-theme="light"]) selectors and overrides this). */
+[style*="color:#cccccc"],
+[style*="color: #cccccc"],
+[style*="color:#CCCCCC"],
+[style*="color: #CCCCCC"] {
+	color: #6a6a6a !important;
+}
+
+/* ============================================================================
+   Prism token colour corrections — light mode
+   Overrides the default Prism theme to meet WCAG 2.1 AA (≥ 4.5:1) against
+   Prism's #f5f2f0 code-block background. The `body` prefix raises specificity
+   to (0,2,1), beating prism.min.css's (0,2,0). Dark-mode overrides below use
+   (0,3,1) selectors and are unaffected.
+   ============================================================================ */
+body .token.atrule,
+body .token.attr-value,
+body .token.keyword {
+	color: #006fa1;
+}
+
+body .token.attr-name,
+body .token.builtin,
+body .token.char,
+body .token.inserted,
+body .token.selector,
+body .token.string {
+	color: #447a00;
+}
+
+body .token.punctuation {
+	color: #6a6a6a;
+}
+
 /* ============================================================================
    Dark-mode overrides
    The :root token swap above handles backgrounds and text. The rules below
@@ -547,7 +585,17 @@ td[bgcolor="#ffffcc"] h4 {
 	:root:not([data-theme="light"]) [style*="color: #cccccc"],
 	:root:not([data-theme="light"]) [style*="color:#CCCCCC"],
 	:root:not([data-theme="light"]) [style*="color: #CCCCCC"] {
-		color: #888888 !important;
+		color: #a0a0a0 !important;
+	}
+
+	/* Inline background-color: #ffffff stays white in dark mode, leaving light
+	   inherited text on a white canvas — very low contrast. Map to the dark
+	   page background so normal dark-mode text colours apply. */
+	:root:not([data-theme="light"]) [style*="background-color: #ffffff"],
+	:root:not([data-theme="light"]) [style*="background-color:#ffffff"],
+	:root:not([data-theme="light"]) [style*="background-color: #FFFFFF"],
+	:root:not([data-theme="light"]) [style*="background-color:#FFFFFF"] {
+		background-color: var(--color-bg) !important;
 	}
 
 	/* #CCCCCC has no matching light-mode token (only used as decorative
@@ -674,7 +722,14 @@ td[bgcolor="#ffffcc"] h4 {
 :root[data-theme="dark"] [style*="color: #cccccc"],
 :root[data-theme="dark"] [style*="color:#CCCCCC"],
 :root[data-theme="dark"] [style*="color: #CCCCCC"] {
-	color: #888888 !important;
+	color: #a0a0a0 !important;
+}
+
+:root[data-theme="dark"] [style*="background-color: #ffffff"],
+:root[data-theme="dark"] [style*="background-color:#ffffff"],
+:root[data-theme="dark"] [style*="background-color: #FFFFFF"],
+:root[data-theme="dark"] [style*="background-color:#FFFFFF"] {
+	background-color: var(--color-bg) !important;
 }
 
 :root[data-theme="dark"] table[bgcolor="#CCCCCC"],

--- a/course/Resources/css/course.css
+++ b/course/Resources/css/course.css
@@ -453,6 +453,18 @@ body .token.punctuation {
 	color: #6a6a6a;
 }
 
+body .token.comment,
+body .token.prolog,
+body .token.doctype,
+body .token.cdata {
+	color: #546e7a;
+}
+
+body .token.class-name,
+body .token.function {
+	color: #c03a58;
+}
+
 /* ============================================================================
    Dark-mode overrides
    The :root token swap above handles backgrounds and text. The rules below

--- a/course/index.html
+++ b/course/index.html
@@ -182,7 +182,7 @@
 			}
 
 			.icon-saq {
-				background-color: #e65100;
+				background-color: #c84a00;
 			}
 
 			@media (max-width: 600px) {


### PR DESCRIPTION
## Summary

- **Prism token colours** — override the three failing token groups in `course.css` so they meet 4.5:1 against Prism's `#f5f2f0` code-block background: `keyword` `#0077aa`→`#006fa1`, `string` `#669900`→`#447a00`, `punctuation` `#999999`→`#6a6a6a`
- **Pre-existing failures unmasked** — removing the broad G18/G145 ignore entries in `.pa11yci.json` exposed three more contrast issues that were being suppressed alongside the Prism ones; all three are fixed here
- **`.icon-saq` background** — darkened `#e65100`→`#c84a00` in `course/index.html` (3.79:1→4.74:1 with white text)
- **`#cccccc` inline text** — added a light-mode override (`→#6a6a6a`) and tightened the dark-mode remap (`#888888`→`#a0a0a0`) to pass against the dark panel background `#3a3520`
- **Inline `background-color:#ffffff` in dark mode** — added a CSS override in both dark-mode blocks to convert white-background divs to `var(--color-bg)`, preventing light inherited text from stranding on a white canvas

Removes both `WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail` and `WCAG2AA.Principle1.Guideline1_4.1_4_3.G145.Fail` from the `.pa11yci.json` ignore list.

## Test plan

- [x] `npx pa11y-ci --config .pa11yci.json` — **35/35 URLs passed** (0 errors, contrast rules fully enabled)
- [x] Computed token colours verified via `preview_inspect`: `keyword` = `rgb(0,111,161)`, `string` = `rgb(68,122,0)`, `punctuation` = `rgb(106,106,106)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)