### PR TITLE
Add build-step animation viewer for click-through reveals

### DIFF
--- a/course/Resources/build-viewer.html
+++ b/course/Resources/build-viewer.html
@@ -1,0 +1,234 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>COBOL animation viewer</title>
+		<meta name="description" content="Click-through viewer for COBOL course animation build steps." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Resources/build-viewer.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="article" />
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/Resources/build-viewer.html" />
+		<meta property="og:title" content="COBOL animation viewer" />
+		<meta property="og:description" content="Click-through viewer for COBOL course animation build steps." />
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="COBOL animation viewer" />
+		<meta name="twitter:description" content="Click-through viewer for COBOL course animation build steps." />
+		<style>
+			html,
+			body {
+				margin: 0;
+				padding: 0;
+				height: 100%;
+				background: #2a2a2a;
+				color: #eee;
+				font-family: Arial, Helvetica, sans-serif;
+				overflow: hidden;
+			}
+
+			body {
+				display: flex;
+				flex-direction: column;
+			}
+
+			#stage {
+				flex: 1 1 auto;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				overflow: hidden;
+				min-height: 0;
+				cursor: pointer;
+				position: relative;
+			}
+
+			#frame {
+				display: block;
+				max-width: 100%;
+				max-height: 100%;
+				background: #fff;
+				box-shadow: 0 1px 4px rgba(0, 0, 0, 0.5);
+				user-select: none;
+				-webkit-user-drag: none;
+			}
+
+			#controls {
+				flex: 0 0 auto;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				gap: 10px;
+				padding: 6px 8px;
+				background: #1d1d1d;
+				border-top: 1px solid #444;
+				font-size: 12px;
+				user-select: none;
+			}
+
+			#controls button {
+				background: #444;
+				color: #eee;
+				border: 1px solid #666;
+				border-radius: 3px;
+				padding: 3px 10px;
+				cursor: pointer;
+				font: inherit;
+			}
+
+			#controls button:hover:not(:disabled) {
+				background: #555;
+			}
+
+			#controls button:disabled {
+				opacity: 0.4;
+				cursor: default;
+			}
+
+			#stepInfo {
+				min-width: 80px;
+				text-align: center;
+			}
+
+			#status {
+				position: absolute;
+				inset: 0;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				pointer-events: none;
+				font-size: 14px;
+				background: rgba(42, 42, 42, 0.85);
+			}
+
+			/* Hide controls in very narrow embeds — click-to-advance still works */
+			@media (max-height: 200px) {
+				#controls {
+					display: none;
+				}
+			}
+		</style>
+	</head>
+	<body>
+		<div id="stage" role="button" tabindex="0" aria-label="Click to advance to next step">
+			<img id="frame" alt="" />
+			<div id="status" role="status">Loading…</div>
+		</div>
+		<div id="controls">
+			<button id="prev" type="button" aria-label="Previous step">◀ Prev</button>
+			<span id="stepInfo">– / –</span>
+			<button id="next" type="button" aria-label="Next step">Next ▶</button>
+		</div>
+		<script>
+			(function () {
+				const params = new URLSearchParams(location.search);
+				const deck = params.get("deck");
+				const startStep = Math.max(1, parseInt(params.get("step") || "1", 10) || 1);
+				const stage = document.getElementById("stage");
+				const frame = document.getElementById("frame");
+				const status = document.getElementById("status");
+				const prevBtn = document.getElementById("prev");
+				const nextBtn = document.getElementById("next");
+				const stepInfo = document.getElementById("stepInfo");
+
+				if (!deck) {
+					showStatus("Missing ?deck= parameter");
+					return;
+				}
+
+				const baseDir = "ppz/frames/" + encodeURIComponent(deck) + "/";
+
+				let manifest = null;
+				let currentStep = startStep;
+				const preloaded = new Map();
+
+				function showStatus(msg) {
+					status.textContent = msg;
+					status.style.display = "flex";
+				}
+
+				function hideStatus() {
+					status.style.display = "none";
+				}
+
+				function preload(idx) {
+					if (!manifest || idx < 0 || idx >= manifest.frames.length) return;
+					const file = manifest.frames[idx];
+					if (preloaded.has(file)) return;
+					const img = new Image();
+					img.src = baseDir + file;
+					preloaded.set(file, img);
+				}
+
+				function render() {
+					if (!manifest) return;
+					const idx = currentStep - 1;
+					const file = manifest.frames[idx];
+					frame.src = baseDir + file;
+					frame.alt = "Step " + currentStep + " of " + manifest.frames.length;
+					stepInfo.textContent = currentStep + " / " + manifest.frames.length;
+					prevBtn.disabled = currentStep <= 1;
+					nextBtn.disabled = currentStep >= manifest.frames.length;
+					// Preload neighbors
+					preload(idx + 1);
+					preload(idx + 2);
+				}
+
+				function go(delta) {
+					if (!manifest) return;
+					const next = Math.min(manifest.frames.length, Math.max(1, currentStep + delta));
+					if (next === currentStep) return;
+					currentStep = next;
+					render();
+				}
+
+				stage.addEventListener("click", () => go(1));
+				prevBtn.addEventListener("click", (e) => {
+					e.stopPropagation();
+					go(-1);
+				});
+				nextBtn.addEventListener("click", (e) => {
+					e.stopPropagation();
+					go(1);
+				});
+
+				document.addEventListener("keydown", (e) => {
+					if (e.key === "ArrowLeft" || e.key === "PageUp") {
+						go(-1);
+						e.preventDefault();
+					} else if (e.key === "ArrowRight" || e.key === "PageDown" || e.key === " " || e.key === "Enter") {
+						go(1);
+						e.preventDefault();
+					} else if (e.key === "Home") {
+						currentStep = 1;
+						render();
+						e.preventDefault();
+					} else if (e.key === "End" && manifest) {
+						currentStep = manifest.frames.length;
+						render();
+						e.preventDefault();
+					}
+				});
+
+				fetch(baseDir + "manifest.json")
+					.then((r) => {
+						if (!r.ok) throw new Error("HTTP " + r.status);
+						return r.json();
+					})
+					.then((m) => {
+						if (!m.frames || !m.frames.length) throw new Error("Empty frame list");
+						manifest = m;
+						currentStep = Math.min(currentStep, manifest.frames.length);
+						// Preload the first few frames
+						for (let i = 0; i < Math.min(5, manifest.frames.length); i++) preload(i);
+						hideStatus();
+						render();
+					})
+					.catch((err) => {
+						showStatus("Failed to load animation: " + (err && err.message ? err.message : err));
+					});
+			})();
+		</script>
+	</body>
+</html>

--- a/course/Resources/build-viewer.html
+++ b/course/Resources/build-viewer.html
@@ -8,7 +8,10 @@
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Resources/build-viewer.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="article" />
-		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/Resources/build-viewer.html" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/build-viewer.html"
+		/>
 		<meta property="og:title" content="COBOL animation viewer" />
 		<meta property="og:description" content="Click-through viewer for COBOL course animation build steps." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/favicon.svg" />

--- a/course/Resources/ppz/TC-CobIntro4.html
+++ b/course/Resources/ppz/TC-CobIntro4.html
@@ -24,9 +24,9 @@
 	</head>
 	<body style="margin: 0; padding: 0">
 		<iframe
-			src="../pdf-viewer.html?src=ppz/TC-CobIntro4.pdf"
+			src="../build-viewer.html?deck=TC-CobIntro4"
 			style="border: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%"
-			title="Introduction to COBOL animation part 4 (PDF)"
+			title="Introduction to COBOL animation part 4"
 		></iframe>
 	</body>
 </html>


### PR DESCRIPTION
## Summary

Adds a generic build-step PNG gallery viewer that replaces the static PDF iframe pattern used by the TC-* tutorial pages and inline animation embeds across the course. The PDF iframe pattern is architecturally incapable of showing click-build animations — even from a cleanly-animated source `.pptx`, PowerPoint exports one PDF page per slide with all build elements visible at once. The new viewer steps through PNG snapshots of each animation state, restoring the click-anywhere-to-advance pedagogy that the original 1996 PowerPoint decks implemented.

## What changed

- **`course/Resources/build-viewer.html`** — generic viewer. Takes `?deck=<name>`, fetches `ppz/frames/<name>/manifest.json`, displays one PNG per build step. Click anywhere on the stage advances; Prev/Next buttons and arrow keys also work; arrow-key bindings, Home/End, and PageUp/PageDown all supported for parity with `pdf-viewer.html`. Dark chrome matches the existing PDF viewer.
- **`course/Resources/ppz/TC-CobIntro4.html`** — switched from `pdf-viewer.html?src=ppz/TC-CobIntro4.pdf` to `build-viewer.html?deck=TC-CobIntro4`. Proof of concept; the remaining ~50 references (29 other TC-*.html pages + ~22 inline iframes across `course/*.html`) will batch-update in a follow-up once frames are generated.
- **`course/Resources/ppz/frames/.gitkeep`** — directory placeholder for the per-deck PNG output.

## How frames are produced

Two helpers live alongside the existing PowerPoint conversion pipeline (in `C:\Convert\`, not in the repo):

- `export-build-steps.vba`: a PowerPoint 2003 macro that walks `Shape.AnimationSettings.AnimationOrder` and exports one PNG per build bucket per slide. Output: `C:\Convert\Frames\<DeckName>\##_step##.png` at 1280×960.
- `generate-manifests.ps1`: scans the frame folders and writes one `manifest.json` per deck with the ordered file list and image dimensions.

Once those run, the PNGs and manifests drop into `course/Resources/ppz/frames/<deck>/`.

## Status

The viewer is functional but currently shows "Failed to load animation: HTTP 404" because no manifests have been generated yet. That's expected — the wiring is correct, the frames just haven't been produced. After the macro runs in the VM and the manifests land in the repo, opening `course/Resources/ppz/TC-CobIntro4.html` will show a click-through gallery instead of a flattened PDF.

This PR depends on the deck rebuild in #302 (the upgraded `.ppt` source files needed by the macro). Either order of merge works; the viewer's content is fully self-contained.

## Reviewer notes

- Viewer is ~230 lines of HTML/CSS/JS, no external dependencies. Match to `pdf-viewer.html`'s style was intentional so the two viewers are visually consistent.
- The `<media (max-height: 200px)>` rule hides the bottom control bar on small inline embeds (e.g. the 125px-high embeds in `course/Inspect.html`) — click-to-advance still works in those contexts.

## Checklist

- [ ] `npm run validate` passes
- [ ] `npm run links` passes (note: TC-CobIntro4.html now points at build-viewer.html?deck=… — linkinator will follow that as a regular URL; the iframe-target `build-viewer.html` itself is a real file)
- [ ] `npm run format:check` passes
- [ ] `npm run a11y` passes — viewer has aria-labels on stage/buttons and role="status" on the loading overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)