### PR TITLE
Add per-lesson progress tracker (closes #256)

### DIFF
--- a/components/course-progress.js
+++ b/components/course-progress.js
@@ -1,0 +1,69 @@
+// Light-DOM custom element. Mounted on course/index.html. Renders a summary
+// strip ("X of 25 lessons completed" + Reset button) and decorates every
+// matching lesson link in the surrounding course-topics nav with a green ✓
+// icon. Without JS, the element renders nothing and the index page works as
+// before — progressive enhancement.
+//
+// Depends on window.LessonProgress + window.COBOL_LESSONS (lesson-progress.js).
+//
+// Usage:
+//   <course-progress></course-progress>
+
+class CourseProgress extends HTMLElement {
+	connectedCallback() {
+		if (!window.LessonProgress) return;
+
+		this.innerHTML = `
+			<aside class="course-progress" aria-label="Course progress">
+				<div class="course-progress-summary" aria-live="polite"></div>
+				<button class="course-progress-reset" type="button">Reset progress</button>
+				<p class="course-progress-note">Progress is stored locally in your browser — nothing is sent to a server.</p>
+			</aside>
+		`;
+
+		const summary = this.querySelector(".course-progress-summary");
+		const reset = this.querySelector(".course-progress-reset");
+
+		const update = () => {
+			const count = window.LessonProgress.countComplete();
+			const total = window.LessonProgress.total();
+			summary.textContent = `${count} of ${total} lessons completed`;
+			this.#decorateLinks();
+		};
+
+		reset.addEventListener("click", () => {
+			if (window.confirm("Reset all lesson progress? This will clear every checkmark.")) {
+				window.LessonProgress.clear();
+			}
+		});
+
+		window.addEventListener(window.LessonProgress.CHANGE_EVENT, update);
+		update();
+	}
+
+	#decorateLinks() {
+		for (const lesson of window.COBOL_LESSONS) {
+			// Match anchors by relative href. The index page links to lessons by
+			// bare filename (e.g. "COBOLIntro.html"), so a CSS attribute selector
+			// is sufficient — no path normalisation needed.
+			const links = document.querySelectorAll(`a[href="${lesson.file}"]`);
+			const isComplete = window.LessonProgress.isComplete(lesson.id);
+			for (const link of links) {
+				const next = link.nextElementSibling;
+				const existingMark =
+					next && next.classList && next.classList.contains("lesson-completed-mark") ? next : null;
+				if (isComplete && !existingMark) {
+					const mark = document.createElement("span");
+					mark.className = "lesson-completed-mark";
+					mark.setAttribute("aria-label", "completed");
+					mark.textContent = "✓";
+					link.after(mark);
+				} else if (!isComplete && existingMark) {
+					existingMark.remove();
+				}
+			}
+		}
+	}
+}
+
+customElements.define("course-progress", CourseProgress);

--- a/components/lesson-checkbox.js
+++ b/components/lesson-checkbox.js
@@ -1,0 +1,65 @@
+// Light-DOM custom element. Renders a "Mark this lesson complete" checkbox at
+// the bottom of each course tutorial, persisting state to localStorage via
+// window.LessonProgress (defined in lesson-progress.js, which must be loaded
+// first via a <script> tag earlier in the page).
+//
+// Usage:
+//   <lesson-checkbox lesson="COBOLIntro"></lesson-checkbox>
+//
+// The `lesson` attribute matches the LESSON `id` field in lesson-progress.js
+// (the .html filename minus the extension).
+//
+// Light DOM keeps the checkbox label inheriting course.css typography. The
+// surrounding panel and the meta line use .lesson-checkbox-* hooks defined
+// in course-components.css.
+
+class LessonCheckbox extends HTMLElement {
+	connectedCallback() {
+		const lessonId = this.getAttribute("lesson");
+		if (!lessonId || !window.LessonProgress) {
+			return;
+		}
+
+		const total = window.LessonProgress.total();
+		const lessonIndex = window.COBOL_LESSONS.findIndex((l) => l.id === lessonId);
+		const positionLabel = lessonIndex >= 0 ? `Lesson ${lessonIndex + 1} of ${total}` : "";
+
+		this.innerHTML = `
+			<div class="lesson-checkbox">
+				<label class="lesson-checkbox-label">
+					<input type="checkbox" class="lesson-checkbox-input" />
+					<span class="lesson-checkbox-text">Mark this lesson complete</span>
+				</label>
+				<div class="lesson-checkbox-meta">
+					<span class="lesson-checkbox-position">${positionLabel}</span>
+					<span class="lesson-checkbox-count" aria-live="polite"></span>
+				</div>
+				<p class="lesson-checkbox-note">Progress is stored locally in your browser — nothing is sent to a server.</p>
+			</div>
+		`;
+
+		const input = this.querySelector(".lesson-checkbox-input");
+		const countSpan = this.querySelector(".lesson-checkbox-count");
+
+		const refreshChecked = () => {
+			input.checked = window.LessonProgress.isComplete(lessonId);
+		};
+		const refreshCount = () => {
+			countSpan.textContent = `${window.LessonProgress.countComplete()} completed`;
+		};
+
+		input.addEventListener("change", () => {
+			window.LessonProgress.setComplete(lessonId, input.checked);
+		});
+
+		window.addEventListener(window.LessonProgress.CHANGE_EVENT, () => {
+			refreshChecked();
+			refreshCount();
+		});
+
+		refreshChecked();
+		refreshCount();
+	}
+}
+
+customElements.define("lesson-checkbox", LessonCheckbox);

--- a/components/lesson-nav.js
+++ b/components/lesson-nav.js
@@ -1,40 +1,18 @@
-// Light-DOM custom element that renders Previous / Next lesson links.
-// Mirrors the style of page-hero.js and back-to-top.js: no shadow DOM so
-// course.css link colours and the .lesson-nav rule from course-components.css
-// apply without any extra piercing selectors.
+// Light-DOM custom element that renders Previous / Next lesson links plus a
+// "Lesson X of N" position indicator. Mirrors the style of page-hero.js and
+// back-to-top.js: no shadow DOM so course.css link colours and the
+// .lesson-nav rule from course-components.css apply without any extra
+// piercing selectors.
 //
-// The lesson sequence below is derived from the ordered tutorial links in
-// course/index.html (exercises and SAQ links are intentionally excluded).
-const LESSONS = [
-	{ file: "COBOLIntro.html", title: "The structure of COBOL programs" },
-	{ file: "DataDeclaration.html", title: "Declaring data in COBOL" },
-	{ file: "COBOLcommands.html", title: "Basic Procedure Division commands" },
-	{ file: "Selection.html", title: "Selection in COBOL" },
-	{ file: "Iteration.html", title: "Iteration in COBOL" },
-	{ file: "SequentialFiles1.html", title: "Introduction to Sequential files" },
-	{ file: "SequentialFiles2.html", title: "Processing Sequential files" },
-	{ file: "EditedPics.html", title: "Edited Pictures" },
-	{ file: "Usage.html", title: "The USAGE clause" },
-	{ file: "SequentialFiles3.html", title: "COBOL print files and variable-length records" },
-	{ file: "SortMerge.html", title: "Sorting and Merging" },
-	{ file: "Intro2DirectAccess.html", title: "Introduction to direct access files" },
-	{ file: "RelativeFiles.html", title: "Relative Files" },
-	{ file: "IndexedFiles.html", title: "Indexed Files" },
-	{ file: "Tables1.html", title: "Using tables" },
-	{ file: "Tables2.html", title: "Creating tables - syntax and semantics" },
-	{ file: "Search.html", title: "Searching tables" },
-	{ file: "Subprograms.html", title: "Contained and external sub-programs" },
-	{ file: "Copy.html", title: "The COPY verb" },
-	{ file: "Inspect.html", title: "Inspect" },
-	{ file: "String.html", title: "String" },
-	{ file: "Unstring.html", title: "Unstring" },
-	{ file: "RefMod.html", title: "Reference modification and Intrinsic Functions" },
-	{ file: "ReportWriter.html", title: "Report Writer by example" },
-	{ file: "ReportWriterSS.html", title: "Report Writer syntax and semantics" },
-];
+// Reads the lesson sequence from window.COBOL_LESSONS (lesson-progress.js),
+// which is loaded earlier in the page. If that script is missing we render
+// nothing — the lesson list lives in one place.
 
 class LessonNav extends HTMLElement {
 	connectedCallback() {
+		const LESSONS = window.COBOL_LESSONS;
+		if (!LESSONS) return;
+
 		// Determine the current page filename from the URL path.
 		const segments = window.location.pathname.split("/");
 		const currentFile = segments[segments.length - 1];
@@ -48,16 +26,18 @@ class LessonNav extends HTMLElement {
 		const prev = index > 0 ? LESSONS[index - 1] : null;
 		const next = index < LESSONS.length - 1 ? LESSONS[index + 1] : null;
 
-		// Build the two link slots. An empty span preserves space-between layout
-		// when only one link is present.
+		// Build the three slots. Empty spans on the prev/next ends preserve the
+		// space-between layout (and keep the position indicator centred) when
+		// only one of the two links is present.
 		const prevHTML = prev
 			? `<a class="lesson-nav-prev" href="${prev.file}">← Previous: ${prev.title}</a>`
 			: `<span></span>`;
+		const positionHTML = `<span class="lesson-nav-position">Lesson ${index + 1} of ${LESSONS.length}</span>`;
 		const nextHTML = next
 			? `<a class="lesson-nav-next" href="${next.file}">Next: ${next.title} →</a>`
 			: `<span></span>`;
 
-		this.innerHTML = `<nav class="lesson-nav" aria-label="Lesson navigation">${prevHTML}${nextHTML}</nav>`;
+		this.innerHTML = `<nav class="lesson-nav" aria-label="Lesson navigation">${prevHTML}${positionHTML}${nextHTML}</nav>`;
 	}
 }
 

--- a/components/lesson-progress.js
+++ b/components/lesson-progress.js
@@ -1,0 +1,121 @@
+// Single source of truth for the COBOL course lesson sequence and the
+// learner's per-lesson completion state.
+//
+// Loaded before lesson-nav.js, lesson-checkbox.js, and course-progress.js so
+// each component can rely on window.COBOL_LESSONS and window.LessonProgress
+// without depending on each other directly.
+//
+// The sequence is derived from the ordered tutorial links in
+// course/index.html (exercises and SAQ links are intentionally excluded).
+// `id` is the .html filename minus the extension and is the value passed as
+// the `lesson` attribute of <lesson-checkbox>.
+
+window.COBOL_LESSONS = Object.freeze([
+	{ id: "COBOLIntro", file: "COBOLIntro.html", title: "The structure of COBOL programs" },
+	{ id: "DataDeclaration", file: "DataDeclaration.html", title: "Declaring data in COBOL" },
+	{ id: "COBOLcommands", file: "COBOLcommands.html", title: "Basic Procedure Division commands" },
+	{ id: "Selection", file: "Selection.html", title: "Selection in COBOL" },
+	{ id: "Iteration", file: "Iteration.html", title: "Iteration in COBOL" },
+	{ id: "SequentialFiles1", file: "SequentialFiles1.html", title: "Introduction to Sequential files" },
+	{ id: "SequentialFiles2", file: "SequentialFiles2.html", title: "Processing Sequential files" },
+	{ id: "EditedPics", file: "EditedPics.html", title: "Edited Pictures" },
+	{ id: "Usage", file: "Usage.html", title: "The USAGE clause" },
+	{
+		id: "SequentialFiles3",
+		file: "SequentialFiles3.html",
+		title: "COBOL print files and variable-length records",
+	},
+	{ id: "SortMerge", file: "SortMerge.html", title: "Sorting and Merging" },
+	{ id: "Intro2DirectAccess", file: "Intro2DirectAccess.html", title: "Introduction to direct access files" },
+	{ id: "RelativeFiles", file: "RelativeFiles.html", title: "Relative Files" },
+	{ id: "IndexedFiles", file: "IndexedFiles.html", title: "Indexed Files" },
+	{ id: "Tables1", file: "Tables1.html", title: "Using tables" },
+	{ id: "Tables2", file: "Tables2.html", title: "Creating tables - syntax and semantics" },
+	{ id: "Search", file: "Search.html", title: "Searching tables" },
+	{ id: "Subprograms", file: "Subprograms.html", title: "Contained and external sub-programs" },
+	{ id: "Copy", file: "Copy.html", title: "The COPY verb" },
+	{ id: "Inspect", file: "Inspect.html", title: "Inspect" },
+	{ id: "String", file: "String.html", title: "String" },
+	{ id: "Unstring", file: "Unstring.html", title: "Unstring" },
+	{ id: "RefMod", file: "RefMod.html", title: "Reference modification and Intrinsic Functions" },
+	{ id: "ReportWriter", file: "ReportWriter.html", title: "Report Writer by example" },
+	{ id: "ReportWriterSS", file: "ReportWriterSS.html", title: "Report Writer syntax and semantics" },
+]);
+
+(function () {
+	const KEY_PREFIX = "lc-progress.";
+	const CHANGE_EVENT = "lc-progress-change";
+
+	function key(lesson) {
+		return KEY_PREFIX + lesson;
+	}
+
+	function safeGet(k) {
+		try {
+			return localStorage.getItem(k);
+		} catch (_e) {
+			return null;
+		}
+	}
+
+	function safeSet(k, value) {
+		try {
+			localStorage.setItem(k, value);
+		} catch (_e) {
+			/* private mode / quota — best-effort only */
+		}
+	}
+
+	function safeRemove(k) {
+		try {
+			localStorage.removeItem(k);
+		} catch (_e) {
+			/* private mode — best-effort only */
+		}
+	}
+
+	function emit(detail) {
+		window.dispatchEvent(new CustomEvent(CHANGE_EVENT, { detail }));
+	}
+
+	window.LessonProgress = {
+		KEY_PREFIX,
+		CHANGE_EVENT,
+		isComplete(lesson) {
+			return safeGet(key(lesson)) === "true";
+		},
+		setComplete(lesson, complete) {
+			if (complete) {
+				safeSet(key(lesson), "true");
+			} else {
+				safeRemove(key(lesson));
+			}
+			emit({ lesson, complete: !!complete });
+		},
+		countComplete() {
+			let n = 0;
+			for (const l of window.COBOL_LESSONS) {
+				if (safeGet(key(l.id)) === "true") n++;
+			}
+			return n;
+		},
+		total() {
+			return window.COBOL_LESSONS.length;
+		},
+		clear() {
+			for (const l of window.COBOL_LESSONS) {
+				safeRemove(key(l.id));
+			}
+			emit({ reset: true });
+		},
+	};
+
+	// Mirror cross-tab changes onto the same in-page event so listeners only
+	// need to subscribe to one channel.
+	window.addEventListener("storage", (e) => {
+		if (e.key && e.key.indexOf(KEY_PREFIX) === 0) {
+			const lesson = e.key.slice(KEY_PREFIX.length);
+			emit({ lesson, complete: e.newValue === "true" });
+		}
+	});
+})();

--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -65,7 +65,9 @@
 		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-progress.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
+		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
@@ -1280,6 +1282,7 @@ DisplayGreeting.
 							exercises="../exercises/GettingStarted.html|Getting Started with VISOC"
 						></related-content>
 						<hr />
+						<lesson-checkbox lesson="COBOLIntro"></lesson-checkbox>
 						<lesson-nav></lesson-nav>
 						<back-to-top></back-to-top>
 						<copyright-notice></copyright-notice>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -40,7 +40,9 @@
 		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-progress.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
+		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
@@ -1057,6 +1059,7 @@ The time is 14:41
 							exercises="../exercises/GettingStarted.html|Getting Started with VISOC"
 						></related-content>
 						<hr />
+						<lesson-checkbox lesson="COBOLcommands"></lesson-checkbox>
 						<lesson-nav></lesson-nav>
 						<back-to-top></back-to-top>
 						<copyright-notice></copyright-notice>

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -43,7 +43,9 @@
 		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-progress.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
+		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
@@ -1029,6 +1031,7 @@ COPY CopyFile7 REPLACING N1 BY Num1
 				<div class="page-footer">
 					<related-content lectures="../lectures/COPY.html|COPY Libraries Lecture"></related-content>
 					<hr />
+					<lesson-checkbox lesson="Copy"></lesson-checkbox>
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -40,7 +40,9 @@
 		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-progress.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
+		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
@@ -763,6 +765,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 							examples="../examples/Accept/ACCEPT.html|ACCEPT and DISPLAY Example"
 						></related-content>
 						<hr />
+						<lesson-checkbox lesson="DataDeclaration"></lesson-checkbox>
 						<lesson-nav></lesson-nav>
 						<back-to-top></back-to-top>
 						<copyright-notice></copyright-notice>

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -40,7 +40,9 @@
 		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-progress.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
+		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
@@ -1413,6 +1415,7 @@ B 0 / , + - CR DB 9</code></pre>
 						examples="../examples/Accept/Multiplier.html|ACCEPT, DISPLAY and MULTIPLY Example"
 					></related-content>
 					<hr />
+					<lesson-checkbox lesson="EditedPics"></lesson-checkbox>
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -46,7 +46,9 @@
 		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-progress.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
+		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
@@ -1142,6 +1144,7 @@ ProcessOneBook.
 						examples="../examples/Indexed/Seq2Index.html|Creating an Indexed File from Sequential, ../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly by Key"
 					></related-content>
 					<hr />
+					<lesson-checkbox lesson="IndexedFiles"></lesson-checkbox>
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -40,7 +40,9 @@
 		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-progress.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
+		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
@@ -642,6 +644,7 @@ END-PERFORM</code></pre>
 				<div class="page-footer">
 					<related-content lectures="../lectures/inspect.html|INSPECT Verb Lecture"></related-content>
 					<hr />
+					<lesson-checkbox lesson="Inspect"></lesson-checkbox>
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -43,7 +43,9 @@
 		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-progress.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
+		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
@@ -966,6 +968,7 @@ END-IF</code></pre>
 						examples="../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly by Key, ../examples/Indexed/Seq2Index.html|Creating an Indexed File from Sequential"
 					></related-content>
 					<hr />
+					<lesson-checkbox lesson="Intro2DirectAccess"></lesson-checkbox>
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -55,7 +55,9 @@
 		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-progress.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
+		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
@@ -1282,6 +1284,7 @@ CountMileage.
 							exercises="../exercises/CountDown.html|CountDown Exercise"
 						></related-content>
 						<hr />
+						<lesson-checkbox lesson="Iteration"></lesson-checkbox>
 						<lesson-nav></lesson-nav>
 						<back-to-top></back-to-top>
 						<copyright-notice></copyright-notice>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -40,7 +40,9 @@
 		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-progress.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
+		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
@@ -1226,6 +1228,7 @@ Begin.
 						examples="../examples/Strings/RefMod.html|Reference Modification Examples"
 					></related-content>
 					<hr />
+					<lesson-checkbox lesson="RefMod"></lesson-checkbox>
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -40,7 +40,9 @@
 		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-progress.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
+		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
@@ -792,6 +794,7 @@ Begin.</code></pre>
 						examples="../examples/Relative/Seq2Rel.html|Creating a Relative File from Sequential, ../examples/Relative/ReadRel.html|Reading a Relative File Directly"
 					></related-content>
 					<hr />
+					<lesson-checkbox lesson="RelativeFiles"></lesson-checkbox>
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -40,7 +40,9 @@
 		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-progress.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
+		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
@@ -1037,6 +1039,7 @@ Programmer - Michael Coughlan               Page :  1 </code></pre>
 								examples="../examples/ReportWriter/RepWriteFull.html|Full Report Writer Program, ../examples/ReportWriter/RepWriteA.html|Report Writer – One Control Break"
 							></related-content>
 							<hr />
+							<lesson-checkbox lesson="ReportWriter"></lesson-checkbox>
 							<lesson-nav></lesson-nav>
 							<back-to-top></back-to-top>
 							<copyright-notice></copyright-notice>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -40,7 +40,9 @@
 		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-progress.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
+		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
@@ -1270,6 +1272,7 @@ END DECLARATIVES.</code></pre>
 						examples="../examples/ReportWriter/RepWriteFull.html|Full Report Writer Program, ../examples/ReportWriter/RepWriteSumm.html|Report Writer Summary Version"
 					></related-content>
 					<hr />
+					<lesson-checkbox lesson="ReportWriterSS"></lesson-checkbox>
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>

--- a/course/Resources/css/course-components.css
+++ b/course/Resources/css/course-components.css
@@ -130,6 +130,19 @@ nav[aria-label="Breadcrumb"] {
 	font-size: 0.95em;
 }
 
+/* "Lesson X of N" indicator centred between Prev and Next. flex: 0 0 auto so
+   the surrounding space-between layout keeps the indicator centred when both
+   neighbour links are present; text-align stays inside in case the row wraps. */
+.lesson-nav-position {
+	font-size: 0.85em;
+	font-family: Arial, Helvetica, sans-serif;
+	color: var(--color-panel-text);
+	font-weight: bold;
+	letter-spacing: 0.04em;
+	text-align: center;
+	flex: 0 0 auto;
+}
+
 @media (prefers-color-scheme: dark) {
 	:root:not([data-theme="light"]) .lesson-nav {
 		border-top-color: var(--color-border-soft, #444);
@@ -138,6 +151,133 @@ nav[aria-label="Breadcrumb"] {
 
 :root[data-theme="dark"] .lesson-nav {
 	border-top-color: var(--color-border-soft, #444);
+}
+
+/* ============================================================================
+   Lesson-progress UI (components/lesson-checkbox.js, components/course-progress.js).
+   `lc-progress.<id>` flags in localStorage drive both the per-lesson checkbox
+   and the index-page summary + per-link checkmarks. Light DOM throughout, so
+   these rules apply directly without piercing selectors.
+   ============================================================================ */
+
+.lesson-checkbox {
+	margin: 1em 0;
+	padding: 0.75em 1em;
+	border: 1px solid var(--color-border-soft);
+	background-color: var(--color-panel-bg);
+	color: var(--color-panel-text);
+	border-radius: 3px;
+}
+
+.lesson-checkbox-label {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5em;
+	font-weight: bold;
+	cursor: pointer;
+}
+
+.lesson-checkbox-input {
+	width: 1.1em;
+	height: 1.1em;
+	cursor: pointer;
+	margin: 0;
+}
+
+.lesson-checkbox-meta {
+	margin-top: 0.4em;
+	font-size: 0.9em;
+}
+
+.lesson-checkbox-position {
+	font-weight: bold;
+}
+
+.lesson-checkbox-position:not(:empty) + .lesson-checkbox-count:not(:empty)::before {
+	content: " — ";
+}
+
+.lesson-checkbox-note {
+	margin: 0.4em 0 0;
+	font-size: 0.8em;
+	font-style: italic;
+	opacity: 0.8;
+}
+
+/* Index-page progress summary + reset button. Sized to match the .course-content
+   block above it so the strip lines up with the topic table. */
+.course-progress {
+	width: 605px;
+	max-width: 100%;
+	margin: 1em auto;
+	padding: 0.6em 1em;
+	border: 1px solid var(--color-border-soft);
+	background-color: var(--color-panel-bg);
+	color: var(--color-panel-text);
+	border-radius: 3px;
+	box-sizing: border-box;
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.5em 1em;
+}
+
+.course-progress-summary {
+	font-weight: bold;
+	flex: 1 1 auto;
+}
+
+.course-progress-reset {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 0.8em;
+	font-weight: bold;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	padding: 0.35em 0.8em;
+	cursor: pointer;
+	background-color: var(--color-bg);
+	color: var(--color-text);
+	border: 1px solid var(--color-border-mute);
+	border-radius: 3px;
+	flex: 0 0 auto;
+}
+
+.course-progress-reset:hover,
+.course-progress-reset:focus-visible {
+	background-color: var(--color-cell-label-bg);
+}
+
+.course-progress-reset:focus-visible {
+	outline: 2px solid currentColor;
+	outline-offset: 1px;
+}
+
+.course-progress-note {
+	flex: 1 0 100%;
+	margin: 0;
+	font-size: 0.8em;
+	font-style: italic;
+	opacity: 0.8;
+}
+
+/* Green ✓ inserted by course-progress.js next to each completed lesson link
+   in the course-topics nav. Rendered as a sibling of the <a> (not a child) so
+   the visited-link colour does not bleed onto the checkmark. */
+.lesson-completed-mark {
+	display: inline-block;
+	margin-left: 0.4em;
+	font-weight: bold;
+	color: #2e7d32;
+}
+
+@media (prefers-color-scheme: dark) {
+	:root:not([data-theme="light"]) .lesson-completed-mark {
+		color: #66bb6a;
+	}
+}
+
+:root[data-theme="dark"] .lesson-completed-mark {
+	color: #66bb6a;
 }
 
 /* ============================================================================

--- a/course/Search.html
+++ b/course/Search.html
@@ -40,7 +40,9 @@
 		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-progress.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
+		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
@@ -1208,6 +1210,7 @@ DisplayCountyTaxes.
 						examples="../examples/Tables/MonthTable.html|Month Table – Counting with a Table"
 					></related-content>
 					<hr />
+					<lesson-checkbox lesson="Search"></lesson-checkbox>
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -52,7 +52,9 @@
 		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-progress.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
+		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
@@ -1480,6 +1482,7 @@ END-EVALUATE
 							examples="../examples/Conditn/Conditions.html|Conditions – Condition Names Example, ../examples/Conditn/IterIf.html|IterIf – Conditions in a Loop"
 						></related-content>
 						<hr />
+						<lesson-checkbox lesson="Selection"></lesson-checkbox>
 						<lesson-nav></lesson-nav>
 						<back-to-top></back-to-top>
 						<copyright-notice></copyright-notice>

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -40,7 +40,9 @@
 		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-progress.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
+		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
@@ -849,6 +851,7 @@ GetStudentRecord.
 						exercises="../exercises/SeqWrite.html|Writing Records to a Sequential File"
 					></related-content>
 					<hr />
+					<lesson-checkbox lesson="SequentialFiles1"></lesson-checkbox>
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -40,7 +40,9 @@
 		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-progress.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
+		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
@@ -564,6 +566,7 @@ END-PERFORM
 						exercises="../exercises/SeqRead.html|Reading Sequential Files, ../exercises/SeqReadIf.html|Counting Records in a Sequential File"
 					></related-content>
 					<hr />
+					<lesson-checkbox lesson="SequentialFiles2"></lesson-checkbox>
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -40,7 +40,9 @@
 		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-progress.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
+		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
@@ -1012,6 +1014,7 @@ DisplayTransactions.
 							exercises="../exercises/SeqInsert.html|Inserting Records in a Sequential File, ../exercises/SeqUpdate.html|Updating a Sequential File"
 						></related-content>
 						<hr />
+						<lesson-checkbox lesson="SequentialFiles3"></lesson-checkbox>
 						<lesson-nav></lesson-nav>
 						<back-to-top></back-to-top>
 						<copyright-notice></copyright-notice>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -40,7 +40,9 @@
 		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-progress.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
+		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
@@ -1618,6 +1620,7 @@ Begin.
 						exercises="../exercises/SortIP.html|Sorting a Sequential File"
 					></related-content>
 					<hr />
+					<lesson-checkbox lesson="SortMerge"></lesson-checkbox>
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>

--- a/course/String.html
+++ b/course/String.html
@@ -40,7 +40,9 @@
 		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-progress.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
+		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
@@ -456,6 +458,7 @@ END-STRING.</code></pre>
 						examples="../examples/Strings/RefMod.html|Reference Modification Examples"
 					></related-content>
 					<hr />
+					<lesson-checkbox lesson="String"></lesson-checkbox>
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -40,7 +40,9 @@
 		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-progress.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
+		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
@@ -1265,6 +1267,7 @@ Value - 0</code></pre>
 						examples="../examples/SubProg/Multiply/DriverProg.html|Driver for Subprogram Examples, ../examples/SubProg/DateValid/DateDriver.html|Date Validation Subprogram"
 					></related-content>
 					<hr />
+					<lesson-checkbox lesson="Subprograms"></lesson-checkbox>
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -40,7 +40,9 @@
 		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-progress.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
+		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
@@ -643,6 +645,7 @@ Begin.
 						exercises="../exercises/MonthTable.html|Using Tables Exercise"
 					></related-content>
 					<hr />
+					<lesson-checkbox lesson="Tables1"></lesson-checkbox>
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -76,7 +76,9 @@
 		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-progress.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
+		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
@@ -1484,6 +1486,7 @@ DisplayCountyTaxes.
 							exercises="../exercises/MonthTable.html|Using Tables Exercise"
 						></related-content>
 						<hr />
+						<lesson-checkbox lesson="Tables2"></lesson-checkbox>
 						<lesson-nav></lesson-nav>
 						<back-to-top></back-to-top>
 						<copyright-notice></copyright-notice>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -40,7 +40,9 @@
 		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-progress.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
+		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
@@ -588,6 +590,7 @@ Begin.
 						examples="../examples/Strings/UnstringFileEg.html|Unpacking Comma-Separated Records"
 					></related-content>
 					<hr />
+					<lesson-checkbox lesson="Unstring"></lesson-checkbox>
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -40,7 +40,9 @@
 		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/back-to-top.js" defer></script>
+		<script src="../components/lesson-progress.js" defer></script>
 		<script src="../components/lesson-nav.js" defer></script>
+		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
@@ -2407,6 +2409,7 @@ Begin.
 				<div class="page-footer">
 					<related-content lectures="../lectures/Usage.html|USAGE Clause Lecture"></related-content>
 					<hr />
+					<lesson-checkbox lesson="Usage"></lesson-checkbox>
 					<lesson-nav></lesson-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice></copyright-notice>

--- a/course/index.html
+++ b/course/index.html
@@ -27,6 +27,8 @@
 		<link href="Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
 		<script src="Resources/vendor/prism/prism.min.js" charset="utf-8" defer></script>
 		<script src="Resources/vendor/prism/components/prism-cobol.min.js" charset="utf-8" defer></script>
+		<script src="../components/lesson-progress.js" defer></script>
+		<script src="../components/course-progress.js" defer></script>
 		<meta name="resource-type" content="document" />
 		<meta
 			name="description"
@@ -564,6 +566,7 @@
 					</div>
 				</div>
 			</nav>
+			<course-progress></course-progress>
 		</main>
 	</body>
 </html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,686 +2,686 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/COBOLIntro.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/COBOLcommands.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Copy.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/DataDeclaration.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/EditedPics.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/IndexedFiles.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Inspect.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Intro2DirectAccess.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Iteration.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/RefMod.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/RelativeFiles.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/ReportWriter.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/ReportWriterSS.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/build-viewer.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/pdf-viewer.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Call.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro2.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro3.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro4.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro5.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro6.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Commands1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Commands2.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Condition1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Condition2.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Data1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Data2.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Perform1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Perform2.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Search2.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2a.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2b.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2c.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2d.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2e.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile3a.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables2.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables3.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables4.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables5.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables7.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables8.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Search.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Selection.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles2.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles3.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SortMerge.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/String.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Subprograms.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Tables1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Tables2.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Unstring.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Usage.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/index.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Accept/ACCEPT.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Accept/Multiplier.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Accept/Shortest.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Conditn/Conditions.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Conditn/IterIf.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Indexed/DirectReadIdx.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Indexed/Seq2Index.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Indexed/SeqReadIdx.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Merge/Merge.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/MileageCount.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform2.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform3.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform4.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Relative/ReadRel.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Relative/Seq2Rel.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteA.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteB.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteFull.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteSumm.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqIns/SEQINSERT.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREAD.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREADno88.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqRpt/SEQRPT.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqWrite/SEQWRITE.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Sort/InputSort.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Sort/MaleSort.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Strings/RefMod.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Strings/UnstringFileEg.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/DateDriver.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/ValiDate.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DayDiff/DayDiffDriver.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/DriverProg.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Fickle.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/MultiplyNums.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Steadfast.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Tables/MonthTable.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/default.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/COBOLExams/COBOLExams.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/CountDown.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FileConversion/Exm-FileConversion.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FileConversion/Prg-FileConversion.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-SFbyMail/Exm-SFbyMail.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-SFbyMail/Prg-SFbyMail.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-StudFeesRpt/Exm-StudPay.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-StudFeesRpt/Prg-StudPay.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/GettingStarted.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/MonthTable.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Proj-CSISEvalform/CSISEvalForm.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqInsert.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqRead.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqReadIf.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqUpdate.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqWrite.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SortIP.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/index.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/index.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/Basics2.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/COPY.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/CS4312Topics.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/GenIntro.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/ReportWriterSSWeb.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/ReportWriterWeb.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/SeqFile3.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/Unstring.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/Usage.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/arithmetic.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/basics1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/call.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/cobintro.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/conditions.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/design.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/direct1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/dsr1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/index.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/indexed.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/inspect.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/perform.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/relative.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/search.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/seqfile1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/seqfile2.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/sort.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/string.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/tables1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/tables2.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary

Implements [#256](https://github.com/bushidocodes/limerick-cobol/issues/256). Three light-DOM custom elements + a small `localStorage` helper let learners track which of the 25 lessons they have completed:

- **`<lesson-checkbox lesson=\"ID\">`** — panel rendered at the bottom of every lesson page (above `<lesson-nav>`). \"Mark this lesson complete\" checkbox + a meta line reading `Lesson X of 25 — Y completed`. State persists to `localStorage` under `lc-progress.<id>`.
- **`<course-progress>`** — strip on `course/index.html` showing `X of 25 lessons completed`, a `Reset progress` button (with `confirm()` guard), and a privacy footnote. Decorates each completed lesson link in the topic table with a green `✓`.
- **`<lesson-nav>`** — extended to render a centred `Lesson X of 25` position indicator alongside Prev / Next.

The 25-lesson list and `window.LessonProgress` helper now live in a single new `components/lesson-progress.js` so all three components share one source of truth. The helper emits a `lc-progress-change` custom event on every write and mirrors cross-tab `storage` events onto the same channel, so every checkbox/summary on the page stays live without polling.

All UI is progressive enhancement — without JS the elements render nothing and pages still work, satisfying the acceptance criterion.

## Acceptance criteria

- [x] Marking a lesson complete persists across reloads (verified end-to-end in preview: click → `localStorage.lc-progress.COBOLIntro=true`).
- [x] Course index visibly distinguishes completed vs uncompleted (`✓` mark in green).
- [x] Lesson nav shows current position (`Lesson 5 of 25` verified for first / middle / last lessons).
- [x] Works without JS — `<lesson-checkbox>` / `<course-progress>` render nothing, pages still load.
- [x] Privacy footnote rendered in both the per-lesson panel and the index strip.

## Test plan

- [ ] Open any course tutorial → tick the checkbox → reload → still ticked.
- [ ] Tick a lesson → open `course/index.html` in a new tab → green `✓` next to that lesson, summary count updated.
- [ ] Open the index → click `Reset progress` → confirm → all marks gone.
- [ ] Open the same lesson in two tabs, tick in tab A, watch tab B's count update (cross-tab sync).
- [ ] Disable JS → lesson page still renders, checkbox panel just disappears.
- [ ] Resize to mobile width → progress strip wraps cleanly under the topic table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)