### PR TITLE
docs: document Dependabot-only policy for dependency CVEs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,3 +73,12 @@ message should mention which phase is being applied, e.g. `Apply Phase 4 moderni
 1. Run `npm run check` — fix any failures before opening the PR.
 2. Fill in the PR template (screenshots encouraged for visual changes).
 3. The CI suite runs `validate`, `links`, `a11y`, and `format:check` automatically.
+
+## Dependencies and CVEs
+
+Dependency CVEs are handled by [Dependabot](.github/dependabot.yml), which
+opens weekly npm update PRs and additional PRs for GitHub security advisories.
+CI does **not** run `npm audit` — all dev dependencies (`html-validate`,
+`linkinator`, `pa11y-ci`, `prettier`, `http-server`, `start-server-and-test`)
+are build-time tools that never ship to users, so a failing audit shouldn't
+gate PRs. If you want a local check, run `npm audit` manually.

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,686 +2,686 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/COBOLIntro.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/COBOLcommands.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Copy.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/DataDeclaration.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/EditedPics.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/IndexedFiles.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Inspect.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Intro2DirectAccess.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Iteration.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/RefMod.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/RelativeFiles.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/ReportWriter.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/ReportWriterSS.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/build-viewer.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/pdf-viewer.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Call.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro2.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro3.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro4.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro5.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro6.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Commands1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Commands2.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Condition1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Condition2.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Data1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Data2.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Perform1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Perform2.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Search2.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2a.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2b.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2c.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2d.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2e.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile3a.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables2.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables3.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables4.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables5.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables7.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables8.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Search.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Selection.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles2.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles3.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SortMerge.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/String.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Subprograms.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Tables1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Tables2.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Unstring.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Usage.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/index.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Accept/ACCEPT.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Accept/Multiplier.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Accept/Shortest.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Conditn/Conditions.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Conditn/IterIf.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Indexed/DirectReadIdx.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Indexed/Seq2Index.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Indexed/SeqReadIdx.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Merge/Merge.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/MileageCount.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform2.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform3.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform4.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Relative/ReadRel.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Relative/Seq2Rel.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteA.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteB.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteFull.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteSumm.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqIns/SEQINSERT.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREAD.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREADno88.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqRpt/SEQRPT.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqWrite/SEQWRITE.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Sort/InputSort.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Sort/MaleSort.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Strings/RefMod.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Strings/UnstringFileEg.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/DateDriver.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/ValiDate.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DayDiff/DayDiffDriver.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/DriverProg.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Fickle.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/MultiplyNums.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Steadfast.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Tables/MonthTable.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/default.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/COBOLExams/COBOLExams.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/CountDown.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FileConversion/Exm-FileConversion.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FileConversion/Prg-FileConversion.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-SFbyMail/Exm-SFbyMail.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-SFbyMail/Prg-SFbyMail.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-StudFeesRpt/Exm-StudPay.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-StudFeesRpt/Prg-StudPay.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/GettingStarted.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/MonthTable.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Proj-CSISEvalform/CSISEvalForm.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqInsert.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqRead.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqReadIf.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqUpdate.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqWrite.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SortIP.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/index.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/index.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/Basics2.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/COPY.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/CS4312Topics.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/GenIntro.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/ReportWriterSSWeb.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/ReportWriterWeb.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/SeqFile3.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/Unstring.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/Usage.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/arithmetic.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/basics1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/call.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/cobintro.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/conditions.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/design.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/direct1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/dsr1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/index.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/indexed.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/inspect.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/perform.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/relative.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/search.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/seqfile1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/seqfile2.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/sort.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/string.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/tables1.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/tables2.html</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary

Closes #414. Documents in [CONTRIBUTING.md](CONTRIBUTING.md) that dependency CVEs are handled exclusively via [Dependabot](.github/dependabot.yml) — weekly npm update PRs plus GitHub security advisories — rather than adding an `npm audit` step to CI.

Rationale: every npm dep here (`html-validate`, `linkinator`, `pa11y-ci`, `prettier`, `http-server`, `start-server-and-test`) is a build-time tool that never ships to users, so a failing audit shouldn't gate PRs. Contributors can still run `npm audit` locally.

No workflow changes.

## Screenshots

N/A — docs only.

## Checklist

- [x] `npm run validate` passes (no HTML touched)
- [x] `npm run links` passes (no link changes)
- [x] `npm run format:check` passes (markdown matches Prettier)
- [x] `npm run a11y` passes (no page content or styling touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)