### PR TITLE
feat: add page-hero + theme-toggle to lectures/index.html

### DIFF
--- a/lectures/index.html
+++ b/lectures/index.html
@@ -2,6 +2,12 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+			})();
+		</script>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<meta content="COBOL,lectures, tutorials" name="keywords" />
@@ -25,15 +31,14 @@
 		/>
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />
+		<script src="../components/theme-toggle.js" defer></script>
+		<script src="../components/page-hero.js" defer></script>
 	</head>
 
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
 		<main id="main-content">
-			<h2>
-				<span class="dept-banner">Department of CSIS</span><br />
-				COBOL lectures and tutorials
-			</h2>
+			<page-hero title="COBOL Lectures and Tutorials" eyebrow="Department of CSIS"></page-hero>
 			<hr />
 			<p>
 				These pages contain the COBOL programming lectures and tutorials for CS4312 - Software Engineering 2.


### PR DESCRIPTION
## Summary
- Closes #370. Replace the bare `<h2>`/dept-banner header on `lectures/index.html` with `<page-hero>`, which embeds `<theme-toggle>` so visitors can switch theme directly from the hub instead of clicking into a leaf page first.
- Wires up the FOUC-prevention inline theme script (reads `lc-theme` from localStorage before first paint) and loads `theme-toggle.js` + `page-hero.js`.
- The original "Department of CSIS" sub-banner is preserved as the page-hero `eyebrow`.

## Test plan
- [ ] Visit `lectures/index.html` and confirm the Light/Auto/Dark toggle is visible in the header and switches theme correctly.
- [ ] Reload with `lc-theme=dark` set; verify no flash of light theme on first paint.
- [ ] Confirm the "DEPARTMENT OF CSIS" eyebrow + "COBOL Lectures and Tutorials" title render above the existing intro text.
- [ ] Verify the rest of the page (contents list, copyright block, bottom nav table) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)