### PR TITLE
Rename `declar` anchor to `declare` to satisfy typos linter

### DIFF
--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -80,7 +80,7 @@
 							organized and shows how it is used to read a record directly.
 						</li>
 						<li>
-							<a href="#declar">Indexed file - declarations</a><br />
+							<a href="#declare">Indexed file - declarations</a><br />
 							Examines the <code class="language-cobol">SELECT</code> and
 							<code class="language-cobol">ASSIGN</code> clause declarations required for an Indexed file.
 						</li>
@@ -457,7 +457,7 @@ END-IF</code></pre>
 					<!-- Declarations -->
 					<div class="section-grid">
 						<div class="section-header">
-							<h2 id="declar">Indexed file - Declarations</h2>
+							<h2 id="declare">Indexed file - Declarations</h2>
 						</div>
 						<div class="section-sidebar">
 							<h3>Introduction</h3>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -67,7 +67,7 @@
 							and the second reads and displays records from the Relative file.
 						</li>
 						<li>
-							<a href="#declar">Relative file - declarations</a><br />
+							<a href="#declare">Relative file - declarations</a><br />
 							Examines the declarations required for a Relative file including the SELECT and ASSIGN
 							clause and the key.
 						</li>
@@ -225,7 +225,7 @@ Enter supplier key (2 digits)-&gt; 05
 					<back-to-top></back-to-top>
 				</div>
 				<div class="section-header">
-					<h2 id="declar">Relative file - Declarations</h2>
+					<h2 id="declare">Relative file - Declarations</h2>
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">

--- a/course/glossary.html
+++ b/course/glossary.html
@@ -958,7 +958,7 @@
 								Two-character data item set by every I/O operation, indicating success or the kind of
 								failure. Declared in <code class="language-cobol">SELECT … FILE STATUS IS …</code>.
 							</td>
-							<td class="ref"><a href="RelativeFiles.html#declar">Relative file declarations</a></td>
+							<td class="ref"><a href="RelativeFiles.html#declare">Relative file declarations</a></td>
 						</tr>
 						<tr>
 							<td class="term">indexed file</td>
@@ -1002,7 +1002,7 @@
 								Field within an indexed file's record that uniquely identifies it; declared in
 								<code class="language-cobol">SELECT … RECORD KEY IS …</code>.
 							</td>
-							<td class="ref"><a href="IndexedFiles.html#declar">Indexed file declarations</a></td>
+							<td class="ref"><a href="IndexedFiles.html#declare">Indexed file declarations</a></td>
 						</tr>
 						<tr>
 							<td class="term">relative file</td>
@@ -1010,7 +1010,7 @@
 								File whose records are addressed by their position number (1, 2, 3, …) rather than by a
 								key value.
 							</td>
-							<td class="ref"><a href="RelativeFiles.html#declar">Relative file declarations</a></td>
+							<td class="ref"><a href="RelativeFiles.html#declare">Relative file declarations</a></td>
 						</tr>
 						<tr>
 							<td class="term"><code class="language-cobol">REWRITE</code></td>


### PR DESCRIPTION
## Summary

- The `typos` linter flagged `declar` (a fragment-ID short form) as a misspelling of `declare` in `course/glossary.html`
- Renamed the `#declar` anchor IDs in `course/IndexedFiles.html` and `course/RelativeFiles.html` to `#declare`
- Updated all five inbound links (three in `course/glossary.html`, plus the in-page TOC link in each target file) so navigation stays intact

## Why

The anchor was an intentional ID but read as a typo. Renaming both the targets and the references together keeps the fragment links working while clearing the lint error — no broken links because every reference was updated in the same commit.

## Test plan

- [ ] Open `course/glossary.html` and click "Relative file declarations" / "Indexed file declarations" — should jump to the Declarations section in the respective page
- [ ] Open `course/RelativeFiles.html` and `course/IndexedFiles.html` and click the in-page TOC link for declarations — should scroll to the section header
- [ ] Confirm `typos` no longer reports `declar` warnings/errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)