### PR TITLE
Fix pa11y-ci Chrome OOM crashes in CI

### DIFF
--- a/.pa11yci.js
+++ b/.pa11yci.js
@@ -14,7 +14,11 @@ module.exports = {
 		wait: 500,
 		concurrency: 4,
 		chromeLaunchConfig: {
-			args: ["--no-sandbox"],
+			// --disable-dev-shm-usage works around GitHub Actions' 64 MB /dev/shm,
+			// the most common cause of puppeteer Chrome crashes in CI. The others
+			// trim memory pressure further. Without these, Chrome OOM-kills under
+			// the full 171-URL scan and pa11y reports `Target.closeTarget` errors.
+			args: ["--no-sandbox", "--disable-dev-shm-usage", "--disable-gpu", "--no-zygote"],
 		},
 	},
 	urls,


### PR DESCRIPTION
## Summary

- Add `--disable-dev-shm-usage`, `--disable-gpu`, `--no-zygote` to `.pa11yci.js`'s `chromeLaunchConfig.args`.
- Fixes #436: since #429 expanded the URL list to 171 pages, Chrome OOM-kills on the `ubuntu-latest` runner and puppeteer surfaces the dead tabs as `Error: Protocol error (Target.closeTarget): No target with given id found`, turning every push to master red.
- `--disable-dev-shm-usage` is the canonical puppeteer-in-Actions fix (the runner's `/dev/shm` is only 64 MB); the other two trim further memory pressure without changing scan behavior.

Per the issue, this is option #2 alone — concurrency stays at 4 and the URL list is unchanged. The one real a11y violation surfaced by the expanded scan (`Exm-AromaSalesSummaryRpt.html` image link missing alt) is intentionally left for a separate PR.

## Test plan

- [ ] CI's `Validate, links, and accessibility` job passes on this PR.
- [ ] After merge, the same job passes on the next direct push to `master` (which runs the full 171-URL scan, not the changed-files-only PR variant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)