### PR TITLE
Add alt text to report layout thumbnails in exam exercises

### DIFF
--- a/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html
+++ b/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html
@@ -349,7 +349,8 @@
 									height="182"
 									src="SExm-AromaOilFileMainRpt.gif"
 									width="281"
-									style="border: 1px solid" /></a
+									style="border: 1px solid"
+									alt="Thumbnail of the print layout specification for the Oil Stock Report, showing detail lines per oil size with quantity in stock and stock value, an Oil-Value control footing, and final totals." /></a
 							><br />
 							Click to view full version
 						</p>

--- a/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html
+++ b/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html
@@ -215,7 +215,8 @@
 									height="196"
 									src="SExm-AromaSummarySalesRpt.gif"
 									width="311"
-									style="border: 1px solid" /></a
+									style="border: 1px solid"
+									alt="Thumbnail of the print layout specification for the Aromamora Summary Sales Report, showing one detail line per customer with sales count, quantity sold in millilitres, and sales value, plus final totals." /></a
 							><br />
 							Click to view full version
 						</p>

--- a/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html
+++ b/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html
@@ -301,7 +301,8 @@
 									height="213"
 									src="SExm-BookshopLectReqRpt.gif"
 									width="304"
-									style="border: 1px solid" /></a
+									style="border: 1px solid"
+									alt="Thumbnail of the print layout specification for the Bookshop Lecturer Requirements Report, showing book detail rows grouped by publisher with author, title, and quantity columns, page headings, and an end-of-report marker." /></a
 							><br />
 							Click to view full version
 						</p>


### PR DESCRIPTION
## Summary

- Add `alt` attributes to the report-layout thumbnail images on three exam exercise pages: `Exm-AromaSalesSummaryRpt.html`, `Exm-AromaOilFileMainRpt.html`, and `Exm-BookshopLectReqRpt.html`.
- Each thumbnail is the only child of an `<a>` tag, so an empty/missing alt left the link with no accessible name (WCAG 1.1.1).
- Mirrors the existing alt-text pattern already in use on `Exm-DueSubsRpt.html` and `Exm-USSRshipRpt.html`, with each alt describing the specific report layout.

Surfaced by the expanded pa11y-ci URL list added in #429. The issue (#436) only flagged Exm-AromaSalesSummaryRpt explicitly, but the same pattern exists in two more files; fixing all three together so they don't pop up as new failures once #450 unblocks the CI scan.

## Test plan

- [ ] CI's `Validate, links, and accessibility` job passes (will only be meaningful once #450 lands and the full a11y scan is no longer dominated by Chrome crashes).
- [ ] Manually confirm in the preview panel that the three pages render unchanged — the alt is for assistive tech only and shouldn't affect layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)