### PR TITLE
ci: wire check:img-dims into checks workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,6 +29,7 @@ jobs:
               run: npm run format:check
             - run: npm run validate
             - run: npm run check:assets
+            - run: npm run check:img-dims
             - run: npm run links
             - name: Accessibility check
               run: |

--- a/course/Resources/build-viewer.html
+++ b/course/Resources/build-viewer.html
@@ -115,7 +115,7 @@
 	</head>
 	<body>
 		<div id="stage" role="button" tabindex="0" aria-label="Click to advance to next step">
-			<img id="frame" alt="" />
+			<img id="frame" alt="" width="1000" height="640" />
 			<div id="status" role="status">Loading…</div>
 		</div>
 		<div id="controls">
@@ -222,6 +222,8 @@
 					.then((m) => {
 						if (!m.frames || !m.frames.length) throw new Error("Empty frame list");
 						manifest = m;
+						if (manifest.width) frame.width = manifest.width;
+						if (manifest.height) frame.height = manifest.height;
 						currentStep = Math.min(currentStep, manifest.frames.length);
 						// Preload the first few frames
 						for (let i = 0; i < Math.min(5, manifest.frames.length); i++) preload(i);


### PR DESCRIPTION
## Summary
- Adds `npm run check:img-dims` to `.github/workflows/checks.yml` so CI matches the local `npm run check` script and CLS-prevention regressions can't land unnoticed.
- Fixes the lone existing violation in [course/Resources/build-viewer.html](course/Resources/build-viewer.html) (added in 418e580): the dynamic-frame `<img>` had no width/height. Adds placeholder dimensions and has the JS overwrite them from the deck manifest at load time so the aspect ratio is correct per deck.

Fixes #329

## Test plan
- [x] `npm run check:img-dims` passes locally
- [x] `prettier --check` passes on the two changed files
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)