### PR TITLE
fix: clean up theme-toggle listeners in disconnectedCallback (#351)

### DIFF
--- a/components/theme-toggle.js
+++ b/components/theme-toggle.js
@@ -8,9 +8,15 @@
 // already done by the time connectedCallback fires.
 class ThemeToggle extends HTMLElement {
 	static #KEY = "lc-theme";
+	#abort;
 
 	connectedCallback() {
+		this.#abort = new AbortController();
 		this.#render();
+	}
+
+	disconnectedCallback() {
+		this.#abort?.abort();
 	}
 
 	#render() {
@@ -21,7 +27,9 @@ class ThemeToggle extends HTMLElement {
 			</div>
 		`;
 		this.querySelectorAll("[data-theme-value]").forEach((btn) => {
-			btn.addEventListener("click", () => this.#set(btn.dataset.themeValue));
+			btn.addEventListener("click", () => this.#set(btn.dataset.themeValue), {
+				signal: this.#abort.signal,
+			});
 		});
 	}
 


### PR DESCRIPTION
## Summary
- Adds `disconnectedCallback()` to [`<theme-toggle>`](components/theme-toggle.js), using an `AbortController` to tear down the three button click listeners when the element is detached.
- Connects the listeners via `{ signal: this.#abort.signal }`; a fresh controller is created on each `connectedCallback`, so move-and-reattach also works.

## Scope (re: #351)
The issue lists seven files. After auditing each, only `theme-toggle.js` actually has listeners worth cleaning up:

| File | Has listeners? | Change |
| --- | --- | --- |
| `components/theme-toggle.js` | Yes (3 button clicks) | **Cleaned up via AbortController** |
| `components/page-hero.js` | No — pure `innerHTML` render | skip |
| `components/related-content.js` | No | skip |
| `components/back-to-top.js` | No | skip |
| `components/lesson-nav.js` | No | skip |
| `components/copyright-notice.js` | No (loads a sibling script, fire-and-forget) | skip |
| `components/copy-button.js` | N/A | **Not a custom element** — it's a top-level `DOMContentLoaded` handler; its button click listeners GC with their host buttons. No `disconnectedCallback` to define. |

Happy to circle back and add stub `disconnectedCallback()` methods to the listener-free elements if you want the lifecycle defined uniformly for documentation — flagged in https://github.com/bushidocodes/limerick-cobol/issues/351 but skipped here to avoid no-op methods.

There are also three *other* custom elements (not mentioned in the issue) that genuinely leak listeners on `window` / `document` and would benefit from the same treatment — happy to spin those off into a follow-up:
- `components/course-progress.js` (window `LessonProgress.CHANGE_EVENT` + reset-button click)
- `components/lesson-checkbox.js` (window `LessonProgress.CHANGE_EVENT`)
- `components/site-search.js` (document `keydown`, plus input listeners)

## Test plan
Verified in a local preview (http-server) on `course/glossary.html`:
- [x] `<theme-toggle>` renders 3 buttons; aria-pressed reflects the stored theme
- [x] Clicking Dark persists `lc-theme=dark` to `localStorage`, sets `data-theme="dark"` on `<html>`, and re-renders with Dark active
- [x] After `parent.removeChild(host)` (which fires `disconnectedCallback`), clicking an *orphaned* button reference no longer mutates `localStorage` — confirming the abort fired
- [x] After re-appending the host, a fresh `AbortController` is created and click handlers work again
- [x] No console errors