### PR TITLE
Fix partial a11y scan to actually scan only changed URLs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -63,7 +63,7 @@ jobs:
 
                   echo "Running a11y on ${#URLS[@]} changed file(s):"
                   printf '  %s\n' "${URLS[@]}"
-                  npx start-server-and-test 'npm run serve' http://localhost:8000 \
+                  PA11Y_PARTIAL=1 npx start-server-and-test 'npm run serve' http://localhost:8000 \
                     "npx pa11y-ci --config .pa11yci.js ${URLS[*]}"
 
     typos:

--- a/.pa11yci.js
+++ b/.pa11yci.js
@@ -3,11 +3,7 @@ const { collectHtmlFiles, REPO_ROOT } = require("./scripts/collect-html");
 
 const BASE_URL = "http://localhost:8000/";
 
-const urls = collectHtmlFiles()
-	.map((file) => BASE_URL + path.relative(REPO_ROOT, file).replace(/\\/g, "/"))
-	.sort();
-
-module.exports = {
+const config = {
 	defaults: {
 		standard: "WCAG2AA",
 		timeout: 30000,
@@ -21,5 +17,15 @@ module.exports = {
 			args: ["--no-sandbox", "--disable-dev-shm-usage", "--disable-gpu", "--no-zygote"],
 		},
 	},
-	urls,
 };
+
+// pa11y-ci concatenates CLI URLs onto config urls. For partial PR scans we
+// want only the CLI URLs, so the workflow sets PA11Y_PARTIAL=1 to skip this
+// list. Without that, every "partial" scan would silently run the full suite.
+if (!process.env.PA11Y_PARTIAL) {
+	config.urls = collectHtmlFiles()
+		.map((file) => BASE_URL + path.relative(REPO_ROOT, file).replace(/\\/g, "/"))
+		.sort();
+}
+
+module.exports = config;


### PR DESCRIPTION
## Summary

The partial-scan branch in `checks.yml` invoked `pa11y-ci --config .pa11yci.js <changed-urls...>`. Because `.pa11yci.js` exports a 172-URL list (every site HTML), and pa11y-ci **concatenates** config `urls` with CLI urls, every "partial" PR scan silently scanned all 174 URLs — slow and prone to the same Chrome OOM / `Target.closeTarget` failures that hit the full scan.

This change:
- `.pa11yci.js` skips its `urls` list when `PA11Y_PARTIAL=1`, so CLI urls become the only scanned set.
- `checks.yml` sets `PA11Y_PARTIAL=1` only on the partial-scan branch. The full-scan path (push to master, shared-asset PRs) is unchanged.

## Why

Verified locally on PR #455's two HTML files: previously the "partial" scan ran 174 URLs and surfaced unrelated failures; with this fix it scans exactly 2 URLs and both pass.

## Test plan

- [ ] CI on this PR passes (no HTML changes, so a11y step skips per the `URLS[@]` -eq 0 branch — workflow change still exercised).
- [ ] After merge, rebase PR #455 and confirm its a11y step scans only the two changed lecture pages.
- [ ] Push to master still triggers full scan (`npm run a11y`, no env var).

## Out of scope

Master's full-scan path keeps OOM-crashing some URLs under concurrency=4. That's a pre-existing issue worth a separate fix (likely lowering concurrency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)