### PR TITLE
chore: add common per-OS/per-editor noise patterns to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,18 @@
 .claude/launch.json
 node_modules/
 
+# OS
+.DS_Store
+Thumbs.db
+
+# Editors
+*.swp
+.idea/
+.vscode/*
+!.vscode/settings.json
+!.vscode/extensions.json
+!.vscode/tasks.json
+!.vscode/launch.json
+
+# Logs
+*.log


### PR DESCRIPTION
## Summary
- Adds `.DS_Store`, `Thumbs.db`, `*.swp`, `.idea/`, `.vscode/*`, and `*.log` to [.gitignore](.gitignore) so contributors on different platforms don't accidentally commit local clutter.
- Preserves the currently tracked [.vscode/settings.json](.vscode/settings.json) via a `!` exception, plus exceptions for the other commonly-shared VS Code files (`extensions.json`, `tasks.json`, `launch.json`).

Closes #340

## Test plan
- [x] `git check-ignore -v` confirms `.DS_Store`, `Thumbs.db`, `*.swp`, `.idea/`, `*.log` are now ignored
- [x] `.vscode/settings.json` remains tracked and is not ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)