### PR TITLE
style: tokenize remaining hardcoded hex colors in course.css

### DIFF
--- a/course/Resources/css/course.css
+++ b/course/Resources/css/course.css
@@ -20,6 +20,22 @@
 	--color-border: currentColor;
 	--color-border-soft: #cccccc;
 	--color-border-mute: #999999;
+
+	--color-text-muted: #6a6a6a;
+	--color-danger: #c00000;
+	--color-inline-warm: #993300;
+	--color-inline-green: #006600;
+	--color-toc-marker: #2e7d32;
+
+	--prism-bg: #f5f2f0;
+	--prism-text: #000000;
+	--prism-keyword: #006fa1;
+	--prism-string: #447a00;
+	--prism-punctuation: #6a6a6a;
+	--prism-comment: #546e7a;
+	--prism-function: #c03a58;
+	--prism-number: currentColor;
+	--prism-operator: currentColor;
 }
 
 /* Tighten color-scheme when the user has explicitly chosen a theme so the
@@ -52,6 +68,22 @@
 
 		--color-border-soft: #444444;
 		--color-border-mute: #666666;
+
+		--color-text-muted: #a0a0a0;
+		--color-danger: #ff8a8a;
+		--color-inline-warm: #ff9966;
+		--color-inline-green: #7ec47e;
+		--color-toc-marker: #66bb6a;
+
+		--prism-bg: #1f1f1f;
+		--prism-text: #e6e6e6;
+		--prism-keyword: #ff9d6e;
+		--prism-string: #b5e8a3;
+		--prism-punctuation: #c8c8c8;
+		--prism-comment: #8a8a8a;
+		--prism-function: #90c8ff;
+		--prism-number: #f8d57e;
+		--prism-operator: #d8a0ff;
 	}
 }
 
@@ -75,6 +107,22 @@
 
 	--color-border-soft: #444444;
 	--color-border-mute: #666666;
+
+	--color-text-muted: #a0a0a0;
+	--color-danger: #ff8a8a;
+	--color-inline-warm: #ff9966;
+	--color-inline-green: #7ec47e;
+	--color-toc-marker: #66bb6a;
+
+	--prism-bg: #1f1f1f;
+	--prism-text: #e6e6e6;
+	--prism-keyword: #ff9d6e;
+	--prism-string: #b5e8a3;
+	--prism-punctuation: #c8c8c8;
+	--prism-comment: #8a8a8a;
+	--prism-function: #90c8ff;
+	--prism-number: #f8d57e;
+	--prism-operator: #d8a0ff;
 }
 
 body {
@@ -226,7 +274,7 @@ ul.toc {
 }
 
 ul.toc ::marker {
-	color: #2e7d32;
+	color: var(--color-toc-marker);
 }
 
 ul.toc > li {
@@ -249,13 +297,7 @@ ul.toc a {
 	font-size: 1.5rem;
 	font-weight: bold;
 	letter-spacing: 0.04em;
-	color: #993300;
-}
-
-@media (prefers-color-scheme: dark) {
-	.dept-banner {
-		color: #ff9966;
-	}
+	color: var(--color-inline-warm);
 }
 
 /* Recolor legacy <table>/<tr>/<td> bgcolor="..." attribute markup via CSS
@@ -431,7 +473,7 @@ td[bgcolor="#ffffcc"] h4 {
 [style*="color: #cccccc"],
 [style*="color:#CCCCCC"],
 [style*="color: #CCCCCC"] {
-	color: #6a6a6a !important;
+	color: var(--color-text-muted) !important;
 }
 
 /* Legacy <span style="color: #ff0000"> fails 4.5:1 against light backgrounds
@@ -442,7 +484,7 @@ td[bgcolor="#ffffcc"] h4 {
 [style*="color: #ff0000"],
 [style*="color:#FF0000"],
 [style*="color: #FF0000"] {
-	color: #c00000 !important;
+	color: var(--color-danger) !important;
 }
 
 /* ============================================================================
@@ -455,7 +497,7 @@ td[bgcolor="#ffffcc"] h4 {
 body .token.atrule,
 body .token.attr-value,
 body .token.keyword {
-	color: #006fa1;
+	color: var(--prism-keyword);
 }
 
 body .token.attr-name,
@@ -464,23 +506,23 @@ body .token.char,
 body .token.inserted,
 body .token.selector,
 body .token.string {
-	color: #447a00;
+	color: var(--prism-string);
 }
 
 body .token.punctuation {
-	color: #6a6a6a;
+	color: var(--prism-punctuation);
 }
 
 body .token.comment,
 body .token.prolog,
 body .token.doctype,
 body .token.cdata {
-	color: #546e7a;
+	color: var(--prism-comment);
 }
 
 body .token.class-name,
 body .token.function {
-	color: #c03a58;
+	color: var(--prism-function);
 }
 
 /* ============================================================================
@@ -500,31 +542,31 @@ body .token.function {
 	   (0,1,1) selectors despite the vendor sheet loading after course.css. */
 	:root:not([data-theme="light"]) body pre[class*="language-"],
 	:root:not([data-theme="light"]) body code[class*="language-"] {
-		background: #1f1f1f;
-		color: #e6e6e6;
+		background: var(--prism-bg);
+		color: var(--prism-text);
 		text-shadow: none;
 	}
 
 	:root:not([data-theme="light"]) body :not(pre) > code[class*="language-"] {
-		background: #1f1f1f;
+		background: var(--prism-bg);
 	}
 
 	:root:not([data-theme="light"]) body .token.comment,
 	:root:not([data-theme="light"]) body .token.prolog,
 	:root:not([data-theme="light"]) body .token.doctype,
 	:root:not([data-theme="light"]) body .token.cdata {
-		color: #8a8a8a;
+		color: var(--prism-comment);
 	}
 
 	:root:not([data-theme="light"]) body .token.punctuation {
-		color: #c8c8c8;
+		color: var(--prism-punctuation);
 	}
 
 	:root:not([data-theme="light"]) body .token.keyword,
 	:root:not([data-theme="light"]) body .token.tag,
 	:root:not([data-theme="light"]) body .token.selector,
 	:root:not([data-theme="light"]) body .token.atrule {
-		color: #ff9d6e;
+		color: var(--prism-keyword);
 	}
 
 	:root:not([data-theme="light"]) body .token.string,
@@ -532,7 +574,7 @@ body .token.function {
 	:root:not([data-theme="light"]) body .token.char,
 	:root:not([data-theme="light"]) body .token.builtin,
 	:root:not([data-theme="light"]) body .token.inserted {
-		color: #b5e8a3;
+		color: var(--prism-string);
 	}
 
 	:root:not([data-theme="light"]) body .token.number,
@@ -540,12 +582,12 @@ body .token.function {
 	:root:not([data-theme="light"]) body .token.constant,
 	:root:not([data-theme="light"]) body .token.symbol,
 	:root:not([data-theme="light"]) body .token.deleted {
-		color: #f8d57e;
+		color: var(--prism-number);
 	}
 
 	:root:not([data-theme="light"]) body .token.function,
 	:root:not([data-theme="light"]) body .token.class-name {
-		color: #90c8ff;
+		color: var(--prism-function);
 	}
 
 	:root:not([data-theme="light"]) body .token.operator,
@@ -554,7 +596,7 @@ body .token.function {
 	:root:not([data-theme="light"]) body .token.variable,
 	:root:not([data-theme="light"]) body .language-css .token.string,
 	:root:not([data-theme="light"]) body .style .token.string {
-		color: #d8a0ff;
+		color: var(--prism-operator);
 		background: transparent;
 	}
 
@@ -586,7 +628,7 @@ body .token.function {
 
 	:root:not([data-theme="light"]) [style*="color:#993300"],
 	:root:not([data-theme="light"]) [style*="color: #993300"] {
-		color: #ff9966 !important;
+		color: var(--color-inline-warm) !important;
 	}
 
 	:root:not([data-theme="light"]) [style*="color:#000099"],
@@ -603,19 +645,19 @@ body .token.function {
 	:root:not([data-theme="light"]) [style*="color: #ff0000"],
 	:root:not([data-theme="light"]) [style*="color:#FF0000"],
 	:root:not([data-theme="light"]) [style*="color: #FF0000"] {
-		color: #ff8a8a !important;
+		color: var(--color-danger) !important;
 	}
 
 	:root:not([data-theme="light"]) [style*="color:#006600"],
 	:root:not([data-theme="light"]) [style*="color: #006600"] {
-		color: #7ec47e !important;
+		color: var(--color-inline-green) !important;
 	}
 
 	:root:not([data-theme="light"]) [style*="color:#cccccc"],
 	:root:not([data-theme="light"]) [style*="color: #cccccc"],
 	:root:not([data-theme="light"]) [style*="color:#CCCCCC"],
 	:root:not([data-theme="light"]) [style*="color: #CCCCCC"] {
-		color: #a0a0a0 !important;
+		color: var(--color-text-muted) !important;
 	}
 
 	/* Inline background-color: #ffffff stays white in dark mode, leaving light
@@ -644,31 +686,31 @@ body .token.function {
 /* Manual dark override — same non-token rules, applied regardless of OS. */
 :root[data-theme="dark"] body pre[class*="language-"],
 :root[data-theme="dark"] body code[class*="language-"] {
-	background: #1f1f1f;
-	color: #e6e6e6;
+	background: var(--prism-bg);
+	color: var(--prism-text);
 	text-shadow: none;
 }
 
 :root[data-theme="dark"] body :not(pre) > code[class*="language-"] {
-	background: #1f1f1f;
+	background: var(--prism-bg);
 }
 
 :root[data-theme="dark"] body .token.comment,
 :root[data-theme="dark"] body .token.prolog,
 :root[data-theme="dark"] body .token.doctype,
 :root[data-theme="dark"] body .token.cdata {
-	color: #8a8a8a;
+	color: var(--prism-comment);
 }
 
 :root[data-theme="dark"] body .token.punctuation {
-	color: #c8c8c8;
+	color: var(--prism-punctuation);
 }
 
 :root[data-theme="dark"] body .token.keyword,
 :root[data-theme="dark"] body .token.tag,
 :root[data-theme="dark"] body .token.selector,
 :root[data-theme="dark"] body .token.atrule {
-	color: #ff9d6e;
+	color: var(--prism-keyword);
 }
 
 :root[data-theme="dark"] body .token.string,
@@ -676,7 +718,7 @@ body .token.function {
 :root[data-theme="dark"] body .token.char,
 :root[data-theme="dark"] body .token.builtin,
 :root[data-theme="dark"] body .token.inserted {
-	color: #b5e8a3;
+	color: var(--prism-string);
 }
 
 :root[data-theme="dark"] body .token.number,
@@ -684,12 +726,12 @@ body .token.function {
 :root[data-theme="dark"] body .token.constant,
 :root[data-theme="dark"] body .token.symbol,
 :root[data-theme="dark"] body .token.deleted {
-	color: #f8d57e;
+	color: var(--prism-number);
 }
 
 :root[data-theme="dark"] body .token.function,
 :root[data-theme="dark"] body .token.class-name {
-	color: #90c8ff;
+	color: var(--prism-function);
 }
 
 :root[data-theme="dark"] body .token.operator,
@@ -698,7 +740,7 @@ body .token.function {
 :root[data-theme="dark"] body .token.variable,
 :root[data-theme="dark"] body .language-css .token.string,
 :root[data-theme="dark"] body .style .token.string {
-	color: #d8a0ff;
+	color: var(--prism-operator);
 	background: transparent;
 }
 
@@ -723,7 +765,7 @@ body .token.function {
 
 :root[data-theme="dark"] [style*="color:#993300"],
 :root[data-theme="dark"] [style*="color: #993300"] {
-	color: #ff9966 !important;
+	color: var(--color-inline-warm) !important;
 }
 
 :root[data-theme="dark"] [style*="color:#000099"],
@@ -740,19 +782,19 @@ body .token.function {
 :root[data-theme="dark"] [style*="color: #ff0000"],
 :root[data-theme="dark"] [style*="color:#FF0000"],
 :root[data-theme="dark"] [style*="color: #FF0000"] {
-	color: #ff8a8a !important;
+	color: var(--color-danger) !important;
 }
 
 :root[data-theme="dark"] [style*="color:#006600"],
 :root[data-theme="dark"] [style*="color: #006600"] {
-	color: #7ec47e !important;
+	color: var(--color-inline-green) !important;
 }
 
 :root[data-theme="dark"] [style*="color:#cccccc"],
 :root[data-theme="dark"] [style*="color: #cccccc"],
 :root[data-theme="dark"] [style*="color:#CCCCCC"],
 :root[data-theme="dark"] [style*="color: #CCCCCC"] {
-	color: #a0a0a0 !important;
+	color: var(--color-text-muted) !important;
 }
 
 :root[data-theme="dark"] [style*="background-color: #ffffff"],


### PR DESCRIPTION
Closes #357

## Summary

- Introduces 14 new CSS custom-property tokens (with light values in `:root` and dark values in both dark-mode blocks) to cover every hardcoded hex color that was previously outside the token block
- Groups: semantic inline-span remaps (`--color-text-muted`, `--color-danger`, `--color-inline-warm`, `--color-inline-green`), ToC markers (`--color-toc-marker`), and Prism syntax-highlight palette (`--prism-bg/text/keyword/string/punctuation/comment/function/number/operator`)
- Removes the bare `@media (prefers-color-scheme: dark)` override on `.dept-banner` — it lacked the `:not([data-theme="light"])` guard, so a manual Light theme couldn't beat it; `var(--color-inline-warm)` now handles all three theme states correctly
- Also adds previously-missing dark-mode support for `ul.toc ::marker` (was always rendered in light-mode green)

## Test plan

- [ ] Light mode: verify ToC bullets, dept-banner, Prism token colors, and inline span remaps look unchanged vs. before
- [ ] OS/auto dark mode: verify Prism blocks, dept-banner, and inline spans use the correct dark palette
- [ ] Manual Dark toggle: same checks as OS dark
- [ ] Manual Light toggle (with OS in dark): verify dept-banner and Prism stay light-themed (previously `.dept-banner` broke here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)