### PR TITLE
fix: replace &nbsp; layout spacing with CSS margins/padding

### DIFF
--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -709,11 +709,17 @@ The time is 14:41
 							</tr>
 							<tr>
 								<td width="45%"><b>PIC 9(3)V9</b></td>
-								<td width="19%">
-									<b>&nbsp;&nbsp;245.9<span style="color: #ff0000">6</span></b>
+								<td
+									width="19%"
+									style="font-family: monospace; text-align: right; padding-inline-end: 0.5em"
+								>
+									<b>245.9<span style="color: #ff0000">6</span></b>
 								</td>
-								<td width="22%">
-									<b>&nbsp;&nbsp;&nbsp;245.9</b>
+								<td
+									width="22%"
+									style="font-family: monospace; text-align: right; padding-inline-end: 0.5em"
+								>
+									<b>245.9</b>
 								</td>
 								<td width="14%">
 									<div class="center-block">
@@ -723,11 +729,17 @@ The time is 14:41
 							</tr>
 							<tr>
 								<td width="45%"><b>PIC 9(3)V9</b></td>
-								<td width="19%">
-									<b>&nbsp;&nbsp;<span style="color: #ff0000">3</span>245.9</b>
+								<td
+									width="19%"
+									style="font-family: monospace; text-align: right; padding-inline-end: 0.5em"
+								>
+									<b><span style="color: #ff0000">3</span>245.9</b>
 								</td>
-								<td width="22%">
-									<b>&nbsp;&nbsp;&nbsp;245.9</b>
+								<td
+									width="22%"
+									style="font-family: monospace; text-align: right; padding-inline-end: 0.5em"
+								>
+									<b>245.9</b>
 								</td>
 								<td width="14%">
 									<div class="center-block">
@@ -739,11 +751,17 @@ The time is 14:41
 							</tr>
 							<tr>
 								<td width="45%"><b>PIC 9(3)</b></td>
-								<td width="19%">
-									<b>&nbsp;&nbsp;324</b>
+								<td
+									width="19%"
+									style="font-family: monospace; text-align: right; padding-inline-end: 0.5em"
+								>
+									<b>324</b>
 								</td>
-								<td width="22%">
-									<b>&nbsp;&nbsp;&nbsp;324</b>
+								<td
+									width="22%"
+									style="font-family: monospace; text-align: right; padding-inline-end: 0.5em"
+								>
+									<b>324</b>
 								</td>
 								<td width="14%">
 									<div class="center-block">
@@ -755,11 +773,17 @@ The time is 14:41
 							</tr>
 							<tr>
 								<td width="45%"><b>PIC 9(3)</b></td>
-								<td width="19%">
-									<b>&nbsp;<span style="color: #ff0000">&nbsp;5</span>324</b>
+								<td
+									width="19%"
+									style="font-family: monospace; text-align: right; padding-inline-end: 0.5em"
+								>
+									<b><span style="color: #ff0000">5</span>324</b>
 								</td>
-								<td width="22%">
-									<b>&nbsp;&nbsp;&nbsp;324</b>
+								<td
+									width="22%"
+									style="font-family: monospace; text-align: right; padding-inline-end: 0.5em"
+								>
+									<b>324</b>
 								</td>
 								<td width="14%">
 									<div class="center-block">
@@ -771,11 +795,17 @@ The time is 14:41
 							</tr>
 							<tr>
 								<td width="45%" style="vertical-align: top"><b>PIC 9(3)V9 not Rounded</b></td>
-								<td width="19%">
-									<b>&nbsp;&nbsp;523.3<span style="color: #ff0000">5</span></b>
+								<td
+									width="19%"
+									style="font-family: monospace; text-align: right; padding-inline-end: 0.5em"
+								>
+									<b>523.3<span style="color: #ff0000">5</span></b>
 								</td>
-								<td width="22%">
-									<b>&nbsp;&nbsp;&nbsp;523.3</b>
+								<td
+									width="22%"
+									style="font-family: monospace; text-align: right; padding-inline-end: 0.5em"
+								>
+									<b>523.3</b>
 								</td>
 								<td width="14%">
 									<div class="center-block">
@@ -787,10 +817,18 @@ The time is 14:41
 							</tr>
 							<tr>
 								<td width="45%"><b>PIC 9(3)V9 Rounded</b></td>
-								<td width="19%">
-									<b>&nbsp;&nbsp;523.3<span style="color: #ff0000">5</span></b>
+								<td
+									width="19%"
+									style="font-family: monospace; text-align: right; padding-inline-end: 0.5em"
+								>
+									<b>523.3<span style="color: #ff0000">5</span></b>
 								</td>
-								<td width="22%"><b>&nbsp;&nbsp;&nbsp;523.4</b></td>
+								<td
+									width="22%"
+									style="font-family: monospace; text-align: right; padding-inline-end: 0.5em"
+								>
+									<b>523.4</b>
+								</td>
 								<td width="14%">
 									<div class="center-block">
 										<b>
@@ -801,16 +839,21 @@ The time is 14:41
 							</tr>
 							<tr>
 								<td width="45%"><b>PIC 9(3)V9 Rounded</b></td>
-								<td width="19%">
-									<b>
-										<span style="color: #ff0000">&nbsp;&nbsp;3</span>523.3<span
-											style="color: #ff0000"
+								<td
+									width="19%"
+									style="font-family: monospace; text-align: right; padding-inline-end: 0.5em"
+								>
+									<b
+										><span style="color: #ff0000">3</span>523.3<span style="color: #ff0000"
 											>5</span
-										>
-									</b>
+										></b
+									>
 								</td>
-								<td width="22%">
-									<b>&nbsp;&nbsp;&nbsp;523.4</b>
+								<td
+									width="22%"
+									style="font-family: monospace; text-align: right; padding-inline-end: 0.5em"
+								>
+									<b>523.4</b>
 								</td>
 								<td width="14%">
 									<div class="center-block">

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -297,10 +297,12 @@
 								</li>
 								<li>Any literal including opening and closing quotes</li>
 								<li>
-									Any separator other than;<br />
-									&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;A space<br />
-									&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;A Pseudo-Text delimiter<br />
-									&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;A Comma
+									Any separator other than;
+									<ul>
+										<li>A space</li>
+										<li>A Pseudo-Text delimiter</li>
+										<li>A Comma</li>
+									</ul>
 								</li>
 							</ul>
 							<ul>

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -272,7 +272,7 @@ Enter key : 1=VideoCode, 2=VideoTitle -&gt;2
 							<p>
 								If you downloaded the first example program and its data file you should already have
 								the Indexed file (it was produced when you ran the first example program). You can use
-								this file with the second Indexed file example program.&nbsp;
+								this file with the second Indexed file example program.
 							</p>
 							<p>
 								<a href="Resources/progs/INX-EG2.cbl">Download Indexed file example program 2</a>
@@ -326,7 +326,7 @@ VIDEO STATUS :- 23</code></pre>
 							<hr />
 							<p>
 								You can use the Indexed file that is created when you run the first sexample program
-								with this third Indexed example program.&nbsp;
+								with this third Indexed example program.
 							</p>
 							<p>
 								<a href="Resources/progs/INX-EG3.cbl">Download Indexed file example program 3</a>
@@ -676,7 +676,7 @@ END-IF</code></pre>
 								pointer will point to the next alternate index base record.
 							</p>
 							<p>The file must have an ACCESS MODE of DYNAMIC or RANDOM.</p>
-							<p>The file must be opened for I-O or INPUT.&nbsp;</p>
+							<p>The file must be opened for I-O or INPUT.</p>
 							<hr />
 						</div>
 						<div class="section-sidebar">

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -401,7 +401,7 @@ INSPECT SourceLine TALLYING ECount
 						</p>
 						<p>
 							Click on the storage schematic to see the result of each of these INSPECT statements (use
-							left click or PageDown for next item and right click or PageUp for previous item) .&nbsp;
+							left click or PageDown for next item and right click or PageUp for previous item) .
 						</p>
 						<pre class="language-cobol"><code class="language-cobol">
 1. INSPECT StringData REPLACING ALL "R" BY "G"
@@ -501,7 +501,7 @@ END-PERFORM</code></pre>
 					</p>
 					<p>
 						This format of the INSPECT combines the syntactic elements of the previous two formats allowing
-						both counting and replacing to be done in one statement.&nbsp;
+						both counting and replacing to be done in one statement.
 					</p>
 				</div>
 				<div class="section-full">
@@ -571,7 +571,7 @@ END-PERFORM</code></pre>
 						</p>
 						<p>
 							Click on the storage schematic to see the result of each of these INSPECT statements (use
-							left click or PageDown for next item and right click or PageUp for previous item).&nbsp;
+							left click or PageDown for next item and right click or PageUp for previous item).
 						</p>
 						<pre class="language-cobol"><code class="language-cobol">
 1. INSPECT StringData CONVERTING "fxtd" TO "ZYAB".

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -683,8 +683,7 @@ END-IF</code></pre>
 										</p>
 										<p>
 											For instance, if the first record written to the file has a Relative Record
-											Number of 10,000 then room for that many records is allocated to the
-											file.&nbsp;
+											Number of 10,000 then room for that many records is allocated to the file.
 										</p>
 										<p>
 											The fact that there is only one key and that it must be numeric and must

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -215,7 +215,7 @@ Enter supplier key (2 digits)-&gt; 05
 						<p>
 							If you downloaded the first example program and its data file you should already have the
 							Relative file (it was produced when you ran the first example program). You can use this
-							file with the second Relative file example program.&nbsp;
+							file with the second Relative file example program.
 						</p>
 						<p>
 							<a href="Resources/progs/ReadRelative.cbl">Download Relative file example program 2</a>
@@ -387,12 +387,11 @@ Enter supplier key (2 digits)-&gt; 05
 						<p>If the file is opened for input then only READ and START will be allowed.</p>
 						<p>If the file is opened for output then only WRITE will be allowed.</p>
 						<p>
-							If the file is opened for I-O then READ, WRITE, START, REWRITE and DELETE will be
-							allowed.&nbsp;
+							If the file is opened for I-O then READ, WRITE, START, REWRITE and DELETE will be allowed.
 						</p>
 						<p>
 							If OPEN INPUT is used, and the file does not possess the OPTIONAL tag, then the file must
-							exist or the OPEN will fail. &nbsp;
+							exist or the OPEN will fail.
 						</p>
 						<p>
 							If OPEN OUTPUT or I-O is used then the file will be created if it does not already exist as
@@ -454,7 +453,7 @@ Enter supplier key (2 digits)-&gt; 05
 							The file must have an ACCESS MODE declaration for the file specifying an ACCESS MODE DYNAMIC
 							or RANDOM.
 						</p>
-						<p>The file must be opened for I-O or INPUT.&nbsp;</p>
+						<p>The file must be opened for I-O or INPUT.</p>
 					</div>
 				</div>
 				<div class="section-grid">

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -526,12 +526,14 @@ END-IF
 								<code class="language-cobol">NOT</code> <b>(Amnt1 &lt;10)</b>.<br />
 								The <code class="language-cobol">AND</code> is next in precedence so we must bracket
 								-<br />
-								&nbsp;&nbsp;&nbsp;&nbsp;<b
-									>((Amnt2=50) <code class="language-cobol">AND</code> (Amnt3 &gt; 150))</b
+								<span style="padding-inline-start: 2em; display: inline-block"
+									><b>((Amnt2=50) <code class="language-cobol">AND</code> (Amnt3 &gt; 150))</b></span
 								>.<br />
 								Finally the <code class="language-cobol">OR</code> is evaluated to give the full
 								condition as -<br />
-								&nbsp;&nbsp;&nbsp;&nbsp;(<code class="language-cobol">NOT</code> (Amnt1 &lt; 10))
+								<span style="padding-inline-start: 2em; display: inline-block"
+									>(<code class="language-cobol">NOT</code> (Amnt1 &lt; 10))</span
+								>
 								<code class="language-cobol">OR</code> ((Amnt2 = 50)
 								<code class="language-cobol">AND</code>
 								(Amnt3 &gt; 150))
@@ -543,7 +545,7 @@ END-IF
 								<th scope="row" bgcolor="#FFFFCC" width="16%" style="text-align: center">Condition</th>
 								<td bgcolor="#E1FFE1" width="84%">
 									<p style="text-align: center; margin: 0.3em 0">
-										&nbsp;(<code class="language-cobol">NOT</code> (Amnt1 &lt; 10))
+										(<code class="language-cobol">NOT</code> (Amnt1 &lt; 10))
 										<code class="language-cobol">OR</code> ((Amnt2 = 50)
 										<code class="language-cobol">AND</code> (Amnt3 &gt; 150))
 									</p>
@@ -555,9 +557,9 @@ END-IF
 								</th>
 								<td bgcolor="#E1FFE1" width="84%">
 									<div class="eval-row eval-row-3col">
-										<span>(<code class="language-cobol">NOT</code>&nbsp;(T))</span>
+										<span>(<code class="language-cobol">NOT</code> (T))</span>
 										<code class="language-cobol">OR</code>
-										<span>((T)&nbsp;<code class="language-cobol">AND</code>&nbsp;(T))</span>
+										<span>((T) <code class="language-cobol">AND</code> (T))</span>
 									</div>
 								</td>
 							</tr>
@@ -586,7 +588,7 @@ END-IF
 						</table>
 						<p>
 							Consider the condition in the table below and ask the same question. Is the Complex
-							Condition true if all the Simple Conditions are true? &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+							Condition true if all the Simple Conditions are true?
 						</p>
 						<table class="data-table" width="93%" style="display: table; margin-inline: auto">
 							<tr>
@@ -606,7 +608,7 @@ END-IF
 								<td bgcolor="#E1FFE1" width="84%">
 									<div class="eval-row eval-row-4col">
 										<code class="language-cobol">NOT</code>
-										<span>((T)&nbsp;<code class="language-cobol">OR</code>&nbsp;(T))</span>
+										<span>((T) <code class="language-cobol">OR</code> (T))</span>
 										<code class="language-cobol">AND</code>
 										<span>(T)</span>
 									</div>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -1231,7 +1231,7 @@ SORT WorkFile ON ASCENDING KEY SalespersonNumWF
 									>INTO</code
 								>
 								<i>Identifier</i>]<br />
-								&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;AT END
+								<span style="padding-inline-start: 4.5em; display: inline-block">AT END</span>
 								<i>StatementBlock</i><br />
 								END-RETURN
 							</p>

--- a/course/String.html
+++ b/course/String.html
@@ -446,7 +446,7 @@ END-STRING.</code></pre>
 						></iframe>
 						<p>
 							Left click or PageDown to go to the next answer and right click or press PageUp to go to the
-							previous answer.&nbsp;
+							previous answer.
 						</p>
 					</div>
 				</div>

--- a/examples/default.html
+++ b/examples/default.html
@@ -96,7 +96,7 @@
 						>) example programs.
 					</li>
 					<li>
-						<a href="#SequentialFiles">Sequential Files</a>&nbsp; - Programs that demonstrate how to process
+						<a href="#SequentialFiles">Sequential Files</a> - Programs that demonstrate how to process
 						sequential files.
 					</li>
 					<li>
@@ -259,8 +259,7 @@
 					<td height="49" width="298">
 						<p>
 							An example program that implements a primitive calculator. The calculator only does
-							additions and multiplications.<br />
-							&nbsp;
+							additions and multiplications.
 						</p>
 					</td>
 					<td height="49" width="189">
@@ -281,8 +280,7 @@
 						<div style="text-align: center">Conditions.cbl</div>
 					</td>
 					<td height="24" width="298">
-						An example program demonstrating the use of Condition Names (level 88's).<br />
-						&nbsp;
+						An example program demonstrating the use of Condition Names (level 88's).
 					</td>
 					<td height="24" width="189">
 						<div style="text-align: center">
@@ -303,8 +301,7 @@
 					</td>
 					<td width="298">
 						An example program demonstrating how the first format of the PERFORM may be used to change the
-						flow of control through a program.<br />
-						&nbsp;<br />
+						flow of control through a program.
 					</td>
 					<td width="189">
 						<div style="text-align: center">
@@ -324,8 +321,7 @@
 					</td>
 					<td width="298">
 						Demonstrates the second format of the PERFORM. The PERFORM..TIMES may be used to execute a block
-						of code x number of times.<br />
-						&nbsp;
+						of code x number of times.
 					</td>
 					<td width="189">
 						<div style="text-align: center">
@@ -346,8 +342,7 @@
 					<td width="298">
 						Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values
 						where the length of the stream cannot be determined in advance (although in this case there is a
-						set maximum number of values in the stream).<br />
-						&nbsp;<br />
+						set maximum number of values in the stream).
 					</td>
 					<td width="189">
 						<div style="text-align: center">
@@ -370,9 +365,7 @@
 					</td>
 					<td width="298">
 						Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be
-						used for counting iteration. Also introduces the WITH TEST BEFORE and WITH TEST AFTER
-						phrases.<br />
-						&nbsp;
+						used for counting iteration. Also introduces the WITH TEST BEFORE and WITH TEST AFTER phrases.
 					</td>
 					<td width="189">
 						<div style="text-align: center">
@@ -391,8 +384,7 @@
 					</td>
 					<td width="298">
 						Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be
-						used to simulate a mileage counter.<br />
-						&nbsp;
+						used to simulate a mileage counter.
 					</td>
 					<td width="189">
 						<div style="text-align: center">
@@ -455,8 +447,7 @@
 						<div style="text-align: center">SeqWrite.cbl</div>
 					</td>
 					<td height="31" width="298">
-						Example program demonstrating how to create a sequential file from data input by the user.<br />
-						&nbsp;
+						Example program demonstrating how to create a sequential file from data input by the user.
 					</td>
 					<td height="31" width="189">
 						<div style="text-align: center">
@@ -479,8 +470,7 @@
 					<td height="21" width="298">
 						An example program that reads a sequential file and displays the records. This version does not
 						use level 88's to signal when the end of the file has been reached.<br />
-						To test the program download this<a href="SeqRead/STUDENTS.dat">testdata file</a>.<br />
-						&nbsp;
+						To test the program download this<a href="SeqRead/STUDENTS.dat">testdata file</a>.
 					</td>
 					<td height="21" width="189">
 						<div style="text-align: center">
@@ -505,8 +495,7 @@
 						version which uses the Condition Name (level 88) "EndOfFile"to signal when the end of the file
 						has been reached.<br />
 						To test the program download this
-						<a href="SeqRead/STUDENTS.dat">testdata file</a>.<br />
-						&nbsp;
+						<a href="SeqRead/STUDENTS.dat">testdata file</a>.
 					</td>
 					<td width="189">
 						<div style="text-align: center">
@@ -532,8 +521,7 @@
 						To test this program you will need to download Student Masterfile -
 						<a href="SeqIns/STUDENTS.dat">Students.dat</a> and the Transaction file
 						<a href="SeqIns/TRANSINS.dat">Transins.dat</a>
-						.<br />
-						&nbsp;
+						.
 					</td>
 					<td width="189">
 						<div style="text-align: center">
@@ -556,8 +544,7 @@
 						This program reads records from the student file, counts the total number of student records in
 						the file and the number records for females and males. Prints the results in a very short
 						report.<br />
-						To test the program download <a href="SeqIns/STUDENTS.dat">Students.dat</a><br />
-						&nbsp;
+						To test the program download <a href="SeqIns/STUDENTS.dat">Students.dat</a>
 					</td>
 					<td width="189">
 						<div style="text-align: center">
@@ -621,8 +608,7 @@
 					</td>
 					<td width="298">
 						Uses the SORT and an INPUT PROCEDURE to accept records from the user and sort them on ascending
-						StudentId.<br />
-						&nbsp;
+						StudentId.
 					</td>
 					<td width="189">
 						<div style="text-align: center"><code class="language-cobol">SORT</code>, Input Procedure</div>
@@ -641,8 +627,7 @@
 					<td width="298">
 						Sorts the student masterfile (sorted on ascending Student Id) and produces a new file, sorted on
 						ascending student name, containing only the records of male students.<br />
-						To test the program download <a href="SeqIns/STUDENTS.dat">Students.dat</a><br />
-						&nbsp;
+						To test the program download <a href="SeqIns/STUDENTS.dat">Students.dat</a>
 					</td>
 					<td width="189">
 						<div style="text-align: center"><code class="language-cobol">SORT</code>, Input Procedure</div>
@@ -663,8 +648,7 @@
 						To test this program you will need to download Student Masterfile -
 						<a href="SeqIns/STUDENTS.dat">Students.dat</a> and the Transaction file
 						<a href="SeqIns/TRANSINS.dat">Transins.dat</a>
-						.<br />
-						&nbsp;
+						.
 					</td>
 					<td width="189">
 						<div style="text-align: center">
@@ -688,8 +672,7 @@
 						customers.<br />
 						Read the
 						<a href="../exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html">program specification</a>
-						first. The required data files may be downloaded from there.<br />
-						&nbsp;<br />
+						first. The required data files may be downloaded from there.
 					</td>
 					<td width="189">
 						<div style="text-align: center">
@@ -714,8 +697,7 @@
 							<a href="../exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html"
 								>program specification</a
 							>
-							first. The required data files may be downloaded from there.<br />
-							&nbsp;
+							first. The required data files may be downloaded from there.
 						</p>
 					</td>
 					<td height="75" width="189">
@@ -742,8 +724,7 @@
 						sold) in the Book Club.<br />
 						Read the
 						<a href="../exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html">program specification</a>
-						first. The required data files may be downloaded from there.<br />
-						&nbsp;<br />
+						first. The required data files may be downloaded from there.
 					</td>
 					<td height="75" width="189">
 						(Sequential Files, Print Files, SORT with Input Procedure and Output Procedure, Tables)
@@ -764,8 +745,7 @@
 						USENET news feed with over 15,000 news groups. Access to this server is available to internet
 						users all over the world. Users of the system pay a subscription fee for access. A program is
 						required to produce a report showing the subscriptions which are now due. The report will be
-						based on the Due Subscriptions file.<br />
-						&nbsp;
+						based on the Due Subscriptions file.
 					</td>
 					<td height="116" width="189">
 						(Sequential Files, Print Files, <code class="language-cobol">SORT</code> with Input Procedure,
@@ -829,8 +809,7 @@
 						Creates a direct access Relative file from a Sequential File. Note that Relative files are not
 						standard ASCII files and so cannot be created with an editor as Sequential files can.<br />
 						To create the Relative file you will need to download the supplier file
-						<a href="Relative/SEQSUPP.dat">SEQSUPP.dat</a><br />
-						&nbsp;
+						<a href="Relative/SEQSUPP.dat">SEQSUPP.dat</a>
 					</td>
 					<td width="189">
 						<div style="text-align: center">
@@ -854,8 +833,7 @@
 					<td width="298">
 						Reads the Relative file - RELSUPP.dat - created in the previous example program and displays the
 						records. Allows the user to choose to read through and display all the records in the file
-						sequentially, or to use a key to read just one record directly.<br />
-						&nbsp;
+						sequentially, or to use a key to read just one record directly.
 					</td>
 					<td width="189">
 						<div style="text-align: center">
@@ -882,8 +860,7 @@
 						Creates a direct access Indexed file from a Sequential file. Note that Microfocus Indexed files
 						actually consist of two files - the data file and the index file (.idx).<br />
 						To create the Indexed file you will need to download the supplier file
-						<a href="Indexed/SEQVIDEO.dat">SEQVIDEO.dat</a><br />
-						&nbsp;
+						<a href="Indexed/SEQVIDEO.dat">SEQVIDEO.dat</a>
 					</td>
 					<td width="189">
 						<div style="text-align: center">
@@ -906,8 +883,7 @@
 					</td>
 					<td width="298">
 						Does a direct read on the Indexed file created by the previous example program. Allows the user
-						to choose which of the keys to use for the direct read.<br />
-						&nbsp;
+						to choose which of the keys to use for the direct read.
 					</td>
 					<td width="189">
 						<div style="text-align: center">
@@ -927,8 +903,7 @@
 					</td>
 					<td width="298">
 						Reads the Indexed file sequentially on whichever key is chosen by the user. Displays all the
-						records in the file.<br />
-						&nbsp;
+						records in the file.
 					</td>
 					<td width="189">
 						<div style="text-align: center">
@@ -953,8 +928,7 @@
 							Student Master File and which then produces a report showing those students whose fees are
 							partially or wholly outstanding. Read the
 							<a href="../exercises/Exm-StudFeesRpt/Exm-StudPay.html">program specification</a> first. The
-							required data files may be downloaded from there.<br />
-							&nbsp;
+							required data files may be downloaded from there.
 						</p>
 					</td>
 					<td height="87" width="189">
@@ -986,8 +960,7 @@
 						<a href="../exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html"
 							>program specification</a
 						>
-						first. The required data files may be downloaded from there.<br />
-						&nbsp;<br />
+						first. The required data files may be downloaded from there.
 					</td>
 					<td height="87" width="189">
 						<div style="text-align: center">
@@ -1020,8 +993,7 @@
 							<a href="../exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html"
 								>program specification</a
 							>
-							first. The required data files may be downloaded from there.<br />
-							&nbsp;
+							first. The required data files may be downloaded from there.
 						</p>
 					</td>
 					<td height="131" width="189">
@@ -1051,8 +1023,7 @@
 						payments, and shows the breakdown of each author payment into royalty payments per book.<br />
 						Read the
 						<a href="../exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html">program specification</a>
-						first. The required data files may be downloaded from there.<br />
-						&nbsp;
+						first. The required data files may be downloaded from there.
 					</td>
 					<td height="159" width="189">
 						<div style="text-align: center">
@@ -1077,8 +1048,7 @@
 						each of the top three the most popular video title (by average earnings) must be shown.<br />
 						Read the
 						<a href="../exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html">program specification</a>
-						first. The required data files may be downloaded from there.<br />
-						&nbsp;
+						first. The required data files may be downloaded from there.
 					</td>
 					<td height="138" width="189">
 						<div style="text-align: center">
@@ -1147,8 +1117,7 @@
 						again - and the use of parameters.<br />
 						The "Fickle" sub-program demonstrates State Memory.<br />
 						The "Steadfast" sub-program shows how a sub-program can use the IS INITIAL phrase to avoid State
-						Memory.<br />
-						&nbsp;
+						Memory.
 					</td>
 					<td width="189">
 						<div style="text-align: center">
@@ -1173,8 +1142,7 @@
 						The "MultiplyNums" sub-program, called from the driver program above, demonstrates the flow of
 						control from the driver program to the called sub-program and back again. It uses numeric and
 						string parameters and demonstrates the BY REFERENCE (the default) and BY CONTENT parameter
-						passing mechanisms.<br />
-						&nbsp;
+						passing mechanisms.
 					</td>
 					<td width="189">
 						<div style="text-align: center">
@@ -1195,8 +1163,7 @@
 					</td>
 					<td width="298">
 						Fickle is a sub-program called from DriverProg.cbl above. Fickle is a program that demonstrates
-						State Memory. Each time the program is called it remembers its state from the previous call.<br />
-						&nbsp;
+						State Memory. Each time the program is called it remembers its state from the previous call.
 					</td>
 					<td width="189">
 						<div style="text-align: center">
@@ -1217,8 +1184,7 @@
 					</td>
 					<td width="298">
 						Steadfast is a sub-program called from DriverProg.cbl above. Steadfast is identical to Fickle
-						except that it uses the IS INITIAL phrase to avoid State Memory.<br />
-						&nbsp;
+						except that it uses the IS INITIAL phrase to avoid State Memory.
 					</td>
 					<td width="189">
 						<div style="text-align: center">
@@ -1240,8 +1206,7 @@
 					</td>
 					<td width="298">
 						A driver program for the date validation sub-program below. Accepts a date from the user, passes
-						it to the date validation sub-program and interprets and displays the result.<br />
-						&nbsp;
+						it to the date validation sub-program and interprets and displays the result.
 					</td>
 					<td width="189">
 						<div style="text-align: center">
@@ -1291,8 +1256,7 @@
 						A driver program that accepts two dates from the user and displays the difference in days
 						between them. This program uses the
 						<a href="SubProg/DateValid/Validate.cbl">Validate.cbl</a> sub-program above and also contains a
-						number of contained sub-programs.<br />
-						&nbsp;
+						number of contained sub-programs.
 					</td>
 					<td width="189">
 						<div style="text-align: center">
@@ -1325,8 +1289,7 @@
 							<a href="../exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html"
 								>program specification</a
 							>
-							first. The required data files may be downloaded from there.<br />
-							&nbsp;
+							first. The required data files may be downloaded from there.
 						</p>
 					</td>
 					<td height="157" width="189">
@@ -1424,8 +1387,7 @@
 						Extracting the last x number of chars from a string.<br />
 						Removing trailing blanks from a string.<br />
 						Removing leading blanks from a string.<br />
-						Finding the location of the first occurrence of any of a substring's chars in a string<br />
-						&nbsp;
+						Finding the location of the first occurrence of any of a substring's chars in a string
 					</td>
 					<td width="189">
 						<div style="text-align: center">
@@ -1447,8 +1409,7 @@
 					<td width="298">
 						An example showing the unpacking of comma separated records and the size validation of the
 						unpacked fields.<br />
-						To test this program use the data file <a href="Strings/VarLen.dat">VarLen.dat</a>.<br />
-						&nbsp;
+						To test this program use the data file <a href="Strings/VarLen.dat">VarLen.dat</a>.
 					</td>
 					<td width="189">
 						<div style="text-align: center">
@@ -1475,8 +1436,7 @@
 						convert it to a county number.<br />
 						Read the
 						<a href="../exercises/Exm-FileConversion/Exm-FileConversion.html">program specification</a>
-						first. The required data files may be downloaded from there.<br />
-						&nbsp; &nbsp;
+						first. The required data files may be downloaded from there.
 					</td>
 					<td height="154" width="189">
 						<div style="text-align: center">
@@ -1543,8 +1503,7 @@
 					<td width="298">
 						A simplified version of ReportExampleFull.cbl using only one control break.<br />
 						All four of these Report Writer programs use the
-						<a href="ReportWriter/GBSALES.dat">GBsales.dat</a> data file.<br />
-						&nbsp;
+						<a href="ReportWriter/GBSALES.dat">GBsales.dat</a> data file.
 					</td>
 					<td width="189">
 						<div style="text-align: center">
@@ -1567,8 +1526,7 @@
 						A simplified version of ReportExampleFull.cbl containing all the control breaks but not using
 						Declaratives.<br />
 						All four of these Report Writer programs use the
-						<a href="ReportWriter/GBSALES.dat">GBsales.dat</a> data file.<br />
-						&nbsp;
+						<a href="ReportWriter/GBSALES.dat">GBsales.dat</a> data file.
 					</td>
 					<td width="189">
 						<div style="text-align: center">
@@ -1591,8 +1549,7 @@
 						The full version of the report program containing all the control breaks and using Declaratives
 						to calculate the salesperson salary and commission.<br />
 						All four of these Report Writer programs use the
-						<a href="ReportWriter/GBSALES.dat">GBsales.dat</a> data file.<br />
-						&nbsp;
+						<a href="ReportWriter/GBSALES.dat">GBsales.dat</a> data file.
 					</td>
 					<td width="189">
 						<div style="text-align: center">
@@ -1616,8 +1573,7 @@
 						The summary version of the full report program containing all the control breaks and using
 						Declaratives to calculate the salesperson salary and commission.<br />
 						All four of these Report Writer programs use the
-						<a href="ReportWriter/GBSALES.dat">GBsales.dat</a> data file.<br />
-						&nbsp;
+						<a href="ReportWriter/GBSALES.dat">GBsales.dat</a> data file.
 					</td>
 					<td width="189">
 						<div style="text-align: center">
@@ -1685,8 +1641,7 @@
 							This program counts the number of students born in each month and displays the result.<br />
 							The program uses a pre-filled table of month names.<br />
 							This program is the solution to one of the programming exercises.<br />
-							Read the <a href="../exercises/MonthTable.html">program specification</a> first.<br />
-							&nbsp;
+							Read the <a href="../exercises/MonthTable.html">program specification</a> first.
 						</p>
 					</td>
 					<td width="189">
@@ -1713,8 +1668,7 @@
 						produce a Summary file sequenced upon ascending Destination-Name.<br />
 						Read the
 						<a href="../exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html">program specification</a> first.
-						The required data files may be downloaded from there.<br />
-						&nbsp;<br />
+						The required data files may be downloaded from there.
 					</td>
 					<td width="189">
 						<div style="text-align: center">
@@ -1740,8 +1694,7 @@
 						world.<br />
 						Read the
 						<a href="../exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html">program specification</a> first.
-						The required data files may be downloaded from there.<br />
-						&nbsp;<br />
+						The required data files may be downloaded from there.
 					</td>
 					<td width="189">
 						<div style="text-align: center">

--- a/lectures/cs4312topics.html
+++ b/lectures/cs4312topics.html
@@ -65,7 +65,7 @@
 	<body id="top">
 		<h2>
 			<span class="dept-banner">Department of CSIS</span><br />
-			&nbsp;Software Engineering 2 - Module Outline
+			Software Engineering 2 - Module Outline
 		</h2>
 		<hr />
 		<h3 id="General">General Introduction</h3>

--- a/lectures/index.html
+++ b/lectures/index.html
@@ -205,13 +205,13 @@
 								height="52"
 								src="../pics/B-BackArrow.gif"
 								width="52" /></a
-						>&nbsp;<br />
+						><br />
 						To COBOL resources
 					</td>
 					<td>
 						<a href="#"
 							><img alt="To the CSIS Home Page" height="52" src="../pics/B-CSISHome.gif" width="52" /></a
-						>&nbsp;<br />
+						><br />
 						To the CSIS HomePage
 					</td>
 					<td>


### PR DESCRIPTION
Closes #376

## Summary

- **Trailing `&nbsp;`**: Removed spurious trailing non-breaking spaces after sentence-ending punctuation in `IndexedFiles`, `Inspect`, `Intro2DirectAccess`, `RelativeFiles`, `String`, and `Selection` course pages
- **`Copy.html`**: Converted `&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;` sub-item indentation inside a `<li>` to a proper nested `<ul><li>` structure
- **`SortMerge.html`**: Replaced leading `&nbsp;` COBOL syntax indentation with a `padding-inline-start` span
- **`Selection.html`**: Replaced blockquote indentation `&nbsp;` sequences with CSS `padding-inline-start` spans; converted inline formula `&nbsp;` (e.g. `NOT&nbsp;(T)`) to regular spaces
- **`examples/default.html`**: Removed ~48 standalone `&nbsp;` spacers used to add height to table cells; replaced `&nbsp;` between a link and dash with a regular space
- **`COBOLcommands.html`**: Replaced leading `&nbsp;` number-alignment in the ROUNDED table with `font-family: monospace; text-align: right` on the `<td>` elements
- **`lectures/index.html`** and **`lectures/cs4312topics.html`**: Removed `&nbsp;` before `<br />` between icon and label, and leading `&nbsp;` before heading text

The one file left untouched is `exercises/Exm-AcmeStockReorder.html`: its `<td>&nbsp;</td>` cells are structural grid elements in a form simulation, and `500&nbsp; g` / `1&nbsp;&nbsp;&nbsp; kg` are measurement units where the non-breaking space is semantically correct.

## Test plan

- [x] HTML validation passes (`npx html-validate`) on all modified files
- [x] Prettier formatting applied to all 12 changed files
- [ ] Visual spot-check of COBOLcommands.html number table at narrow widths
- [ ] Visual spot-check of Copy.html nested list rendering
- [ ] Visual spot-check of Selection.html blockquote indentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)