### PR TITLE
refactor: move dept-banner out of headings into separate <p> elements

### DIFF
--- a/course/Resources/css/course.css
+++ b/course/Resources/css/course.css
@@ -292,12 +292,12 @@ ul.toc a {
 /* Department banner — replaces T-Dept.gif word-art on index pages.
    Maroon matches the original word-art hue; orange for dark mode. */
 .dept-banner {
-	display: inline-block;
 	font-family: Arial, Helvetica, sans-serif;
 	font-size: 1.5rem;
 	font-weight: bold;
 	letter-spacing: 0.04em;
 	color: var(--color-inline-warm);
+	margin: 0;
 }
 
 /* Recolor legacy <table>/<tr>/<td> bgcolor="..." attribute markup via CSS

--- a/course/index.html
+++ b/course/index.html
@@ -243,10 +243,8 @@
 			<!-- Header: flex row replaces 3-column layout table -->
 			<div class="course-header">
 				<div class="course-header-title">
-					<h1>
-						<span class="dept-banner">Department of CSIS</span><br />
-						COBOL Course
-					</h1>
+					<p class="dept-banner">Department of CSIS</p>
+					<h1>COBOL Course</h1>
 					<p class="center-block">
 						<b
 							>Includes tutorials, example programs, programming exercises and self assessment

--- a/examples/default.html
+++ b/examples/default.html
@@ -46,10 +46,8 @@
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
 		<main id="main-content">
-			<h2>
-				<span class="dept-banner">Department of CSIS</span><br />
-				COBOL Example Programs
-			</h2>
+			<p class="dept-banner">Department of CSIS</p>
+			<h2>COBOL Example Programs</h2>
 			<div class="center-block">
 				<site-search></site-search>
 			</div>

--- a/exercises/index.html
+++ b/exercises/index.html
@@ -100,6 +100,7 @@
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
 		<main id="main-content">
+			<p class="dept-banner">Department of CSIS</p>
 			<h2>
 				<img
 					height="40"
@@ -107,8 +108,7 @@
 					width="40"
 					alt=""
 					style="border: 1px solid"
-				/>&nbsp;<span class="dept-banner">Department of CSIS</span><br />
-				COBOL Programming Exercises&nbsp;
+				/>&nbsp;COBOL Programming Exercises&nbsp;
 			</h2>
 			<div class="center-block">
 				<site-search></site-search>

--- a/index.html
+++ b/index.html
@@ -81,10 +81,8 @@
 		<main id="main-content">
 			<div id="page-header">
 				<div>
-					<h1>
-						<span class="dept-banner">Department of CSIS</span><br />
-						COBOL programming - tutorials, lectures, exercises, examples
-					</h1>
+					<p class="dept-banner">Department of CSIS</p>
+					<h1>COBOL programming - tutorials, lectures, exercises, examples</h1>
 					<site-search></site-search>
 				</div>
 			</div>


### PR DESCRIPTION
## Summary

- Moves `<span class="dept-banner">Department of CSIS</span><br>` out of `<h1>`/`<h2>` headings on all four affected hub pages (`index.html`, `course/index.html`, `examples/default.html`, `exercises/index.html`)
- Replaces each with `<p class="dept-banner">Department of CSIS</p>` placed directly above the heading
- Updates `.dept-banner` CSS rule: removes `display: inline-block` (no longer needed on a block `<p>`) and adds `margin: 0` to suppress default paragraph margin

## Test plan

- [x] Verified accessibility tree in preview: "Department of CSIS" is now a `paragraph` role, no longer nested inside the `heading` role
- [x] Verified `<p class="dept-banner">` renders as `display: block` with correct color and is visually separated from the `<h1>` below it

Closes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)