### PR TITLE
feat: add LearningResource JSON-LD structured data to all 25 lesson pages

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -10,6 +10,32 @@
 		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "LearningResource",
+				"name": "The structure of COBOL programs",
+				"description": "To provide a brief introduction to the programming language COBOL. To provide a context in which its uses might be understood. To introduce the",
+				"url": "https://bushidocodes.github.io/limerick-cobol/course/COBOLIntro.html",
+				"position": 1,
+				"isPartOf": {
+					"@type": "Course",
+					"name": "COBOL Course",
+					"url": "https://bushidocodes.github.io/limerick-cobol/course/index.html"
+				},
+				"provider": {
+					"@type": "Person",
+					"name": "Michael Coughlan",
+					"affiliation": {
+						"@type": "Organization",
+						"name": "University of Limerick CSIS"
+					}
+				},
+				"educationalLevel": "beginner",
+				"inLanguage": "en",
+				"learningResourceType": "Tutorial"
+			}
+		</script>
 		<title>Introduction to COBOL</title>
 		<meta
 			name="description"

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -10,6 +10,32 @@
 		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "LearningResource",
+				"name": "Basic Procedure Division commands",
+				"description": "The PROCEDURE DIVISION contains the code used to manipulate the data described in the DATA DIVISION . This tutorial examines some of the basic COBOL",
+				"url": "https://bushidocodes.github.io/limerick-cobol/course/COBOLcommands.html",
+				"position": 3,
+				"isPartOf": {
+					"@type": "Course",
+					"name": "COBOL Course",
+					"url": "https://bushidocodes.github.io/limerick-cobol/course/index.html"
+				},
+				"provider": {
+					"@type": "Person",
+					"name": "Michael Coughlan",
+					"affiliation": {
+						"@type": "Organization",
+						"name": "University of Limerick CSIS"
+					}
+				},
+				"educationalLevel": "beginner",
+				"inLanguage": "en",
+				"learningResourceType": "Tutorial"
+			}
+		</script>
 		<title>Basic Procedure Division commands</title>
 		<meta
 			name="description"

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -10,6 +10,32 @@
 		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "LearningResource",
+				"name": "The COPY verb",
+				"description": "COBOL programming lesson on The COPY verb.",
+				"url": "https://bushidocodes.github.io/limerick-cobol/course/Copy.html",
+				"position": 19,
+				"isPartOf": {
+					"@type": "Course",
+					"name": "COBOL Course",
+					"url": "https://bushidocodes.github.io/limerick-cobol/course/index.html"
+				},
+				"provider": {
+					"@type": "Person",
+					"name": "Michael Coughlan",
+					"affiliation": {
+						"@type": "Organization",
+						"name": "University of Limerick CSIS"
+					}
+				},
+				"educationalLevel": "beginner",
+				"inLanguage": "en",
+				"learningResourceType": "Tutorial"
+			}
+		</script>
 		<title>The COPY verb</title>
 		<meta name="description" content="COBOL programming lesson on The COPY verb." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Copy.html" />

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -10,6 +10,32 @@
 		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "LearningResource",
+				"name": "Declaring data in COBOL",
+				"description": "The aim of this unit is to give you an understanding of the different categories of data used in a COBOL program and to demonstrate how items of each",
+				"url": "https://bushidocodes.github.io/limerick-cobol/course/DataDeclaration.html",
+				"position": 2,
+				"isPartOf": {
+					"@type": "Course",
+					"name": "COBOL Course",
+					"url": "https://bushidocodes.github.io/limerick-cobol/course/index.html"
+				},
+				"provider": {
+					"@type": "Person",
+					"name": "Michael Coughlan",
+					"affiliation": {
+						"@type": "Organization",
+						"name": "University of Limerick CSIS"
+					}
+				},
+				"educationalLevel": "beginner",
+				"inLanguage": "en",
+				"learningResourceType": "Tutorial"
+			}
+		</script>
 		<title>Declaring Data in COBOL</title>
 		<meta
 			name="description"

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -10,6 +10,32 @@
 		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "LearningResource",
+				"name": "Edited Pictures",
+				"description": "In a business-programming environment, the ability to print reports is an important property for a programming language. COBOL allows programmers to write",
+				"url": "https://bushidocodes.github.io/limerick-cobol/course/EditedPics.html",
+				"position": 8,
+				"isPartOf": {
+					"@type": "Course",
+					"name": "COBOL Course",
+					"url": "https://bushidocodes.github.io/limerick-cobol/course/index.html"
+				},
+				"provider": {
+					"@type": "Person",
+					"name": "Michael Coughlan",
+					"affiliation": {
+						"@type": "Organization",
+						"name": "University of Limerick CSIS"
+					}
+				},
+				"educationalLevel": "beginner",
+				"inLanguage": "en",
+				"learningResourceType": "Tutorial"
+			}
+		</script>
 		<title>Edited Pictures</title>
 		<meta
 			name="description"

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -10,6 +10,32 @@
 		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "LearningResource",
+				"name": "Indexed Files",
+				"description": "The aim of this unit is to provide you with a solid understanding of; the organization of Indexed files, the declarations required for them and the",
+				"url": "https://bushidocodes.github.io/limerick-cobol/course/IndexedFiles.html",
+				"position": 14,
+				"isPartOf": {
+					"@type": "Course",
+					"name": "COBOL Course",
+					"url": "https://bushidocodes.github.io/limerick-cobol/course/index.html"
+				},
+				"provider": {
+					"@type": "Person",
+					"name": "Michael Coughlan",
+					"affiliation": {
+						"@type": "Organization",
+						"name": "University of Limerick CSIS"
+					}
+				},
+				"educationalLevel": "beginner",
+				"inLanguage": "en",
+				"learningResourceType": "Tutorial"
+			}
+		</script>
 		<title>Indexed Files</title>
 		<meta
 			name="description"

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -10,6 +10,32 @@
 		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "LearningResource",
+				"name": "Inspect",
+				"description": "Many programming languages rely on library functions for string handling. COBOL too, uses Intrinsic Functions for some tasks but most string manipulation",
+				"url": "https://bushidocodes.github.io/limerick-cobol/course/Inspect.html",
+				"position": 20,
+				"isPartOf": {
+					"@type": "Course",
+					"name": "COBOL Course",
+					"url": "https://bushidocodes.github.io/limerick-cobol/course/index.html"
+				},
+				"provider": {
+					"@type": "Person",
+					"name": "Michael Coughlan",
+					"affiliation": {
+						"@type": "Organization",
+						"name": "University of Limerick CSIS"
+					}
+				},
+				"educationalLevel": "beginner",
+				"inLanguage": "en",
+				"learningResourceType": "Tutorial"
+			}
+		</script>
 		<title>The INSPECT verb</title>
 		<meta
 			name="description"

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -10,6 +10,32 @@
 		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "LearningResource",
+				"name": "Introduction to direct access files",
+				"description": "The aim of this unit is to provide a gentle introduction to COBOL's direct access file organizations and to equip you with a knowledge of the advantages",
+				"url": "https://bushidocodes.github.io/limerick-cobol/course/Intro2DirectAccess.html",
+				"position": 12,
+				"isPartOf": {
+					"@type": "Course",
+					"name": "COBOL Course",
+					"url": "https://bushidocodes.github.io/limerick-cobol/course/index.html"
+				},
+				"provider": {
+					"@type": "Person",
+					"name": "Michael Coughlan",
+					"affiliation": {
+						"@type": "Organization",
+						"name": "University of Limerick CSIS"
+					}
+				},
+				"educationalLevel": "beginner",
+				"inLanguage": "en",
+				"learningResourceType": "Tutorial"
+			}
+		</script>
 		<title>Introduction to Direct Access Files</title>
 		<meta
 			name="description"

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -14,6 +14,32 @@
 			{
 				"@context": "https://schema.org",
 				"@type": "LearningResource",
+				"name": "Iteration in COBOL",
+				"description": "In almost every programming job, there is some task that needs to be done over and over again. For example: The job of processing a file of records is an",
+				"url": "https://bushidocodes.github.io/limerick-cobol/course/Iteration.html",
+				"position": 5,
+				"isPartOf": {
+					"@type": "Course",
+					"name": "COBOL Course",
+					"url": "https://bushidocodes.github.io/limerick-cobol/course/index.html"
+				},
+				"provider": {
+					"@type": "Person",
+					"name": "Michael Coughlan",
+					"affiliation": {
+						"@type": "Organization",
+						"name": "University of Limerick CSIS"
+					}
+				},
+				"educationalLevel": "beginner",
+				"inLanguage": "en",
+				"learningResourceType": "Tutorial"
+			}
+		</script>
+		<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "LearningResource",
 				"name": "COBOL Iteration Constructs",
 				"description": "A tutorial covering COBOL iteration constructs including PERFORM..Proc, PERFORM..THRU, PERFORM..TIMES, PERFORM..UNTIL, and PERFORM..VARYING.",
 				"url": "https://www.csis.ul.ie/cobol/course/Iteration.html",

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -10,6 +10,32 @@
 		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "LearningResource",
+				"name": "Reference modification and Intrinsic Functions",
+				"description": "The aim of this unit is to provide to provide you with a solid understanding of string manipulation using Reference Modification. It will also introduce",
+				"url": "https://bushidocodes.github.io/limerick-cobol/course/RefMod.html",
+				"position": 23,
+				"isPartOf": {
+					"@type": "Course",
+					"name": "COBOL Course",
+					"url": "https://bushidocodes.github.io/limerick-cobol/course/index.html"
+				},
+				"provider": {
+					"@type": "Person",
+					"name": "Michael Coughlan",
+					"affiliation": {
+						"@type": "Organization",
+						"name": "University of Limerick CSIS"
+					}
+				},
+				"educationalLevel": "beginner",
+				"inLanguage": "en",
+				"learningResourceType": "Tutorial"
+			}
+		</script>
 		<title>Reference Modification</title>
 		<meta
 			name="description"

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -10,6 +10,32 @@
 		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "LearningResource",
+				"name": "Relative Files",
+				"description": "The aim of this unit is to provide you with a solid understanding of declarations required for Relative files and the Procedure Division verbs used to",
+				"url": "https://bushidocodes.github.io/limerick-cobol/course/RelativeFiles.html",
+				"position": 13,
+				"isPartOf": {
+					"@type": "Course",
+					"name": "COBOL Course",
+					"url": "https://bushidocodes.github.io/limerick-cobol/course/index.html"
+				},
+				"provider": {
+					"@type": "Person",
+					"name": "Michael Coughlan",
+					"affiliation": {
+						"@type": "Organization",
+						"name": "University of Limerick CSIS"
+					}
+				},
+				"educationalLevel": "beginner",
+				"inLanguage": "en",
+				"learningResourceType": "Tutorial"
+			}
+		</script>
 		<title>Relative Files</title>
 		<meta
 			name="description"

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -10,6 +10,32 @@
 		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "LearningResource",
+				"name": "Report Writer by example",
+				"description": "The aim of this unit is to provide you with a solid understanding of COBOL Report Writer. This unit introduces the report writer by -",
+				"url": "https://bushidocodes.github.io/limerick-cobol/course/ReportWriter.html",
+				"position": 24,
+				"isPartOf": {
+					"@type": "Course",
+					"name": "COBOL Course",
+					"url": "https://bushidocodes.github.io/limerick-cobol/course/index.html"
+				},
+				"provider": {
+					"@type": "Person",
+					"name": "Michael Coughlan",
+					"affiliation": {
+						"@type": "Organization",
+						"name": "University of Limerick CSIS"
+					}
+				},
+				"educationalLevel": "beginner",
+				"inLanguage": "en",
+				"learningResourceType": "Tutorial"
+			}
+		</script>
 		<title>COBOL Report Writer</title>
 		<meta
 			name="description"

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -10,6 +10,32 @@
 		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "LearningResource",
+				"name": "Report Writer syntax and semantics",
+				"description": "The unit provides a Report Writer reference. The syntax elements of the Report Writer are presented and the semantics of their operation discussed.",
+				"url": "https://bushidocodes.github.io/limerick-cobol/course/ReportWriterSS.html",
+				"position": 25,
+				"isPartOf": {
+					"@type": "Course",
+					"name": "COBOL Course",
+					"url": "https://bushidocodes.github.io/limerick-cobol/course/index.html"
+				},
+				"provider": {
+					"@type": "Person",
+					"name": "Michael Coughlan",
+					"affiliation": {
+						"@type": "Organization",
+						"name": "University of Limerick CSIS"
+					}
+				},
+				"educationalLevel": "beginner",
+				"inLanguage": "en",
+				"learningResourceType": "Tutorial"
+			}
+		</script>
 		<title>COBOL Report Writer - Syntax and Semantics</title>
 		<meta
 			name="description"

--- a/course/Search.html
+++ b/course/Search.html
@@ -10,6 +10,32 @@
 		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "LearningResource",
+				"name": "Searching tables",
+				"description": "The task of searching a table to determine whether it contains a particular value is a common operation. The method used to search a table depends heavily",
+				"url": "https://bushidocodes.github.io/limerick-cobol/course/Search.html",
+				"position": 17,
+				"isPartOf": {
+					"@type": "Course",
+					"name": "COBOL Course",
+					"url": "https://bushidocodes.github.io/limerick-cobol/course/index.html"
+				},
+				"provider": {
+					"@type": "Person",
+					"name": "Michael Coughlan",
+					"affiliation": {
+						"@type": "Organization",
+						"name": "University of Limerick CSIS"
+					}
+				},
+				"educationalLevel": "beginner",
+				"inLanguage": "en",
+				"learningResourceType": "Tutorial"
+			}
+		</script>
 		<title>Searching Tables</title>
 		<meta
 			name="description"

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -10,6 +10,32 @@
 		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "LearningResource",
+				"name": "Selection in COBOL",
+				"description": "In most procedural languages, If and Case/Switch are the only selection constructs supported. COBOL supports advanced versions of both of these constructs,",
+				"url": "https://bushidocodes.github.io/limerick-cobol/course/Selection.html",
+				"position": 4,
+				"isPartOf": {
+					"@type": "Course",
+					"name": "COBOL Course",
+					"url": "https://bushidocodes.github.io/limerick-cobol/course/index.html"
+				},
+				"provider": {
+					"@type": "Person",
+					"name": "Michael Coughlan",
+					"affiliation": {
+						"@type": "Organization",
+						"name": "University of Limerick CSIS"
+					}
+				},
+				"educationalLevel": "beginner",
+				"inLanguage": "en",
+				"learningResourceType": "Tutorial"
+			}
+		</script>
 		<title>COBOL Selection Constructs</title>
 		<meta
 			name="description"

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -10,6 +10,32 @@
 		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "LearningResource",
+				"name": "Introduction to Sequential files",
+				"description": "Files are repositories of data that reside on backing storage (hard disk, magnetic tape or CD-ROM). Nowadays, files are used to store a variety of",
+				"url": "https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles1.html",
+				"position": 6,
+				"isPartOf": {
+					"@type": "Course",
+					"name": "COBOL Course",
+					"url": "https://bushidocodes.github.io/limerick-cobol/course/index.html"
+				},
+				"provider": {
+					"@type": "Person",
+					"name": "Michael Coughlan",
+					"affiliation": {
+						"@type": "Organization",
+						"name": "University of Limerick CSIS"
+					}
+				},
+				"educationalLevel": "beginner",
+				"inLanguage": "en",
+				"learningResourceType": "Tutorial"
+			}
+		</script>
 		<title>Introduction to Sequential Files</title>
 		<meta
 			name="description"

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -10,6 +10,32 @@
 		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "LearningResource",
+				"name": "Processing Sequential files",
+				"description": "The records in a Sequential file are organized serially, one after another, but the records in the file may be ordered or unordered. The serial",
+				"url": "https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles2.html",
+				"position": 7,
+				"isPartOf": {
+					"@type": "Course",
+					"name": "COBOL Course",
+					"url": "https://bushidocodes.github.io/limerick-cobol/course/index.html"
+				},
+				"provider": {
+					"@type": "Person",
+					"name": "Michael Coughlan",
+					"affiliation": {
+						"@type": "Organization",
+						"name": "University of Limerick CSIS"
+					}
+				},
+				"educationalLevel": "beginner",
+				"inLanguage": "en",
+				"learningResourceType": "Tutorial"
+			}
+		</script>
 		<title>Processing Sequential Files</title>
 		<meta
 			name="description"

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -10,6 +10,32 @@
 		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "LearningResource",
+				"name": "COBOL print files and variable-length records",
+				"description": "This tutorial covers a number of topics including; COBOL print files, multiple record-type files, variable length records, and run-time file name",
+				"url": "https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles3.html",
+				"position": 10,
+				"isPartOf": {
+					"@type": "Course",
+					"name": "COBOL Course",
+					"url": "https://bushidocodes.github.io/limerick-cobol/course/index.html"
+				},
+				"provider": {
+					"@type": "Person",
+					"name": "Michael Coughlan",
+					"affiliation": {
+						"@type": "Organization",
+						"name": "University of Limerick CSIS"
+					}
+				},
+				"educationalLevel": "beginner",
+				"inLanguage": "en",
+				"learningResourceType": "Tutorial"
+			}
+		</script>
 		<title>Print files and variable-length records</title>
 		<meta
 			name="description"

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -10,6 +10,32 @@
 		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "LearningResource",
+				"name": "Sorting and Merging",
+				"description": "As we noted in the tutorial - Processing Sequential Files - it is possible to apply processing to an ordered sequential file that is difficult, or",
+				"url": "https://bushidocodes.github.io/limerick-cobol/course/SortMerge.html",
+				"position": 11,
+				"isPartOf": {
+					"@type": "Course",
+					"name": "COBOL Course",
+					"url": "https://bushidocodes.github.io/limerick-cobol/course/index.html"
+				},
+				"provider": {
+					"@type": "Person",
+					"name": "Michael Coughlan",
+					"affiliation": {
+						"@type": "Organization",
+						"name": "University of Limerick CSIS"
+					}
+				},
+				"educationalLevel": "beginner",
+				"inLanguage": "en",
+				"learningResourceType": "Tutorial"
+			}
+		</script>
 		<title>Sorting and Merging files</title>
 		<meta
 			name="description"

--- a/course/String.html
+++ b/course/String.html
@@ -10,6 +10,32 @@
 		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "LearningResource",
+				"name": "String",
+				"description": "The aim of this unit is to provide to provide you with a solid understanding of the STRING verb.",
+				"url": "https://bushidocodes.github.io/limerick-cobol/course/String.html",
+				"position": 21,
+				"isPartOf": {
+					"@type": "Course",
+					"name": "COBOL Course",
+					"url": "https://bushidocodes.github.io/limerick-cobol/course/index.html"
+				},
+				"provider": {
+					"@type": "Person",
+					"name": "Michael Coughlan",
+					"affiliation": {
+						"@type": "Organization",
+						"name": "University of Limerick CSIS"
+					}
+				},
+				"educationalLevel": "beginner",
+				"inLanguage": "en",
+				"learningResourceType": "Tutorial"
+			}
+		</script>
 		<title>The STRING verb</title>
 		<meta
 			name="description"

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -10,6 +10,32 @@
 		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "LearningResource",
+				"name": "Contained and external sub-programs",
+				"description": "To provide a brief introduction to building modular systems using separately compiled and/or contained subprograms.",
+				"url": "https://bushidocodes.github.io/limerick-cobol/course/Subprograms.html",
+				"position": 18,
+				"isPartOf": {
+					"@type": "Course",
+					"name": "COBOL Course",
+					"url": "https://bushidocodes.github.io/limerick-cobol/course/index.html"
+				},
+				"provider": {
+					"@type": "Person",
+					"name": "Michael Coughlan",
+					"affiliation": {
+						"@type": "Organization",
+						"name": "University of Limerick CSIS"
+					}
+				},
+				"educationalLevel": "beginner",
+				"inLanguage": "en",
+				"learningResourceType": "Tutorial"
+			}
+		</script>
 		<title>Contained and external sub-programs</title>
 		<meta
 			name="description"

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -10,6 +10,32 @@
 		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "LearningResource",
+				"name": "Using tables",
+				"description": "",
+				"url": "https://bushidocodes.github.io/limerick-cobol/course/Tables1.html",
+				"position": 15,
+				"isPartOf": {
+					"@type": "Course",
+					"name": "COBOL Course",
+					"url": "https://bushidocodes.github.io/limerick-cobol/course/index.html"
+				},
+				"provider": {
+					"@type": "Person",
+					"name": "Michael Coughlan",
+					"affiliation": {
+						"@type": "Organization",
+						"name": "University of Limerick CSIS"
+					}
+				},
+				"educationalLevel": "beginner",
+				"inLanguage": "en",
+				"learningResourceType": "Tutorial"
+			}
+		</script>
 		<title>Using Tables</title>
 		<meta
 			name="description"

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -10,6 +10,32 @@
 		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "LearningResource",
+				"name": "Creating tables - syntax and semantics",
+				"description": "",
+				"url": "https://bushidocodes.github.io/limerick-cobol/course/Tables2.html",
+				"position": 16,
+				"isPartOf": {
+					"@type": "Course",
+					"name": "COBOL Course",
+					"url": "https://bushidocodes.github.io/limerick-cobol/course/index.html"
+				},
+				"provider": {
+					"@type": "Person",
+					"name": "Michael Coughlan",
+					"affiliation": {
+						"@type": "Organization",
+						"name": "University of Limerick CSIS"
+					}
+				},
+				"educationalLevel": "beginner",
+				"inLanguage": "en",
+				"learningResourceType": "Tutorial"
+			}
+		</script>
 		<title>Creating tables - syntax and semantics</title>
 		<meta
 			name="description"

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -10,6 +10,32 @@
 		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "LearningResource",
+				"name": "Unstring",
+				"description": "The aim of this unit is to provide to provide you with a solid understanding of the UNSTRING verb.",
+				"url": "https://bushidocodes.github.io/limerick-cobol/course/unstring.html",
+				"position": 22,
+				"isPartOf": {
+					"@type": "Course",
+					"name": "COBOL Course",
+					"url": "https://bushidocodes.github.io/limerick-cobol/course/index.html"
+				},
+				"provider": {
+					"@type": "Person",
+					"name": "Michael Coughlan",
+					"affiliation": {
+						"@type": "Organization",
+						"name": "University of Limerick CSIS"
+					}
+				},
+				"educationalLevel": "beginner",
+				"inLanguage": "en",
+				"learningResourceType": "Tutorial"
+			}
+		</script>
 		<title>The UNSTRING verb</title>
 		<meta
 			name="description"

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -10,6 +10,32 @@
 		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "LearningResource",
+				"name": "The USAGE clause",
+				"description": "The internal representation of data can be an important consideration for program efficiency. Unfortunately the default representation used by COBOL for",
+				"url": "https://bushidocodes.github.io/limerick-cobol/course/usage.html",
+				"position": 9,
+				"isPartOf": {
+					"@type": "Course",
+					"name": "COBOL Course",
+					"url": "https://bushidocodes.github.io/limerick-cobol/course/index.html"
+				},
+				"provider": {
+					"@type": "Person",
+					"name": "Michael Coughlan",
+					"affiliation": {
+						"@type": "Organization",
+						"name": "University of Limerick CSIS"
+					}
+				},
+				"educationalLevel": "beginner",
+				"inLanguage": "en",
+				"learningResourceType": "Tutorial"
+			}
+		</script>
 		<title>The USAGE clause</title>
 		<meta
 			name="description"

--- a/course/lesson-meta.json
+++ b/course/lesson-meta.json
@@ -1,0 +1,177 @@
+[
+	{
+		"position": 1,
+		"file": "COBOLIntro.html",
+		"title": "The structure of COBOL programs",
+		"description": "To provide a brief introduction to the programming language COBOL. To provide a context in which its uses might be understood. To introduce the",
+		"url": "https://bushidocodes.github.io/limerick-cobol/course/COBOLIntro.html"
+	},
+	{
+		"position": 2,
+		"file": "DataDeclaration.html",
+		"title": "Declaring data in COBOL",
+		"description": "The aim of this unit is to give you an understanding of the different categories of data used in a COBOL program and to demonstrate how items of each",
+		"url": "https://bushidocodes.github.io/limerick-cobol/course/DataDeclaration.html"
+	},
+	{
+		"position": 3,
+		"file": "COBOLcommands.html",
+		"title": "Basic Procedure Division commands",
+		"description": "The PROCEDURE DIVISION contains the code used to manipulate the data described in the DATA DIVISION . This tutorial examines some of the basic COBOL",
+		"url": "https://bushidocodes.github.io/limerick-cobol/course/COBOLcommands.html"
+	},
+	{
+		"position": 4,
+		"file": "Selection.html",
+		"title": "Selection in COBOL",
+		"description": "In most procedural languages, If and Case/Switch are the only selection constructs supported. COBOL supports advanced versions of both of these constructs,",
+		"url": "https://bushidocodes.github.io/limerick-cobol/course/Selection.html"
+	},
+	{
+		"position": 5,
+		"file": "Iteration.html",
+		"title": "Iteration in COBOL",
+		"description": "In almost every programming job, there is some task that needs to be done over and over again. For example: The job of processing a file of records is an",
+		"url": "https://bushidocodes.github.io/limerick-cobol/course/Iteration.html"
+	},
+	{
+		"position": 6,
+		"file": "SequentialFiles1.html",
+		"title": "Introduction to Sequential files",
+		"description": "Files are repositories of data that reside on backing storage (hard disk, magnetic tape or CD-ROM). Nowadays, files are used to store a variety of",
+		"url": "https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles1.html"
+	},
+	{
+		"position": 7,
+		"file": "SequentialFiles2.html",
+		"title": "Processing Sequential files",
+		"description": "The records in a Sequential file are organized serially, one after another, but the records in the file may be ordered or unordered. The serial",
+		"url": "https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles2.html"
+	},
+	{
+		"position": 8,
+		"file": "EditedPics.html",
+		"title": "Edited Pictures",
+		"description": "In a business-programming environment, the ability to print reports is an important property for a programming language. COBOL allows programmers to write",
+		"url": "https://bushidocodes.github.io/limerick-cobol/course/EditedPics.html"
+	},
+	{
+		"position": 9,
+		"file": "Usage.html",
+		"title": "The USAGE clause",
+		"description": "The internal representation of data can be an important consideration for program efficiency. Unfortunately the default representation used by COBOL for",
+		"url": "https://bushidocodes.github.io/limerick-cobol/course/usage.html"
+	},
+	{
+		"position": 10,
+		"file": "SequentialFiles3.html",
+		"title": "COBOL print files and variable-length records",
+		"description": "This tutorial covers a number of topics including; COBOL print files, multiple record-type files, variable length records, and run-time file name",
+		"url": "https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles3.html"
+	},
+	{
+		"position": 11,
+		"file": "SortMerge.html",
+		"title": "Sorting and Merging",
+		"description": "As we noted in the tutorial - Processing Sequential Files - it is possible to apply processing to an ordered sequential file that is difficult, or",
+		"url": "https://bushidocodes.github.io/limerick-cobol/course/SortMerge.html"
+	},
+	{
+		"position": 12,
+		"file": "Intro2DirectAccess.html",
+		"title": "Introduction to direct access files",
+		"description": "The aim of this unit is to provide a gentle introduction to COBOL's direct access file organizations and to equip you with a knowledge of the advantages",
+		"url": "https://bushidocodes.github.io/limerick-cobol/course/Intro2DirectAccess.html"
+	},
+	{
+		"position": 13,
+		"file": "RelativeFiles.html",
+		"title": "Relative Files",
+		"description": "The aim of this unit is to provide you with a solid understanding of declarations required for Relative files and the Procedure Division verbs used to",
+		"url": "https://bushidocodes.github.io/limerick-cobol/course/RelativeFiles.html"
+	},
+	{
+		"position": 14,
+		"file": "IndexedFiles.html",
+		"title": "Indexed Files",
+		"description": "The aim of this unit is to provide you with a solid understanding of; the organization of Indexed files, the declarations required for them and the",
+		"url": "https://bushidocodes.github.io/limerick-cobol/course/IndexedFiles.html"
+	},
+	{
+		"position": 15,
+		"file": "Tables1.html",
+		"title": "Using tables",
+		"description": "",
+		"url": "https://bushidocodes.github.io/limerick-cobol/course/Tables1.html"
+	},
+	{
+		"position": 16,
+		"file": "Tables2.html",
+		"title": "Creating tables - syntax and semantics",
+		"description": "",
+		"url": "https://bushidocodes.github.io/limerick-cobol/course/Tables2.html"
+	},
+	{
+		"position": 17,
+		"file": "Search.html",
+		"title": "Searching tables",
+		"description": "The task of searching a table to determine whether it contains a particular value is a common operation. The method used to search a table depends heavily",
+		"url": "https://bushidocodes.github.io/limerick-cobol/course/Search.html"
+	},
+	{
+		"position": 18,
+		"file": "Subprograms.html",
+		"title": "Contained and external sub-programs",
+		"description": "To provide a brief introduction to building modular systems using separately compiled and/or contained subprograms.",
+		"url": "https://bushidocodes.github.io/limerick-cobol/course/Subprograms.html"
+	},
+	{
+		"position": 19,
+		"file": "Copy.html",
+		"title": "The COPY verb",
+		"description": "COBOL programming lesson on The COPY verb.",
+		"url": "https://bushidocodes.github.io/limerick-cobol/course/Copy.html"
+	},
+	{
+		"position": 20,
+		"file": "Inspect.html",
+		"title": "Inspect",
+		"description": "Many programming languages rely on library functions for string handling. COBOL too, uses Intrinsic Functions for some tasks but most string manipulation",
+		"url": "https://bushidocodes.github.io/limerick-cobol/course/Inspect.html"
+	},
+	{
+		"position": 21,
+		"file": "String.html",
+		"title": "String",
+		"description": "The aim of this unit is to provide to provide you with a solid understanding of the STRING verb.",
+		"url": "https://bushidocodes.github.io/limerick-cobol/course/String.html"
+	},
+	{
+		"position": 22,
+		"file": "Unstring.html",
+		"title": "Unstring",
+		"description": "The aim of this unit is to provide to provide you with a solid understanding of the UNSTRING verb.",
+		"url": "https://bushidocodes.github.io/limerick-cobol/course/unstring.html"
+	},
+	{
+		"position": 23,
+		"file": "RefMod.html",
+		"title": "Reference modification and Intrinsic Functions",
+		"description": "The aim of this unit is to provide to provide you with a solid understanding of string manipulation using Reference Modification. It will also introduce",
+		"url": "https://bushidocodes.github.io/limerick-cobol/course/RefMod.html"
+	},
+	{
+		"position": 24,
+		"file": "ReportWriter.html",
+		"title": "Report Writer by example",
+		"description": "The aim of this unit is to provide you with a solid understanding of COBOL Report Writer. This unit introduces the report writer by -",
+		"url": "https://bushidocodes.github.io/limerick-cobol/course/ReportWriter.html"
+	},
+	{
+		"position": 25,
+		"file": "ReportWriterSS.html",
+		"title": "Report Writer syntax and semantics",
+		"description": "The unit provides a Report Writer reference. The syntax elements of the Report Writer are presented and the semantics of their operation discussed.",
+		"url": "https://bushidocodes.github.io/limerick-cobol/course/ReportWriterSS.html"
+	}
+]

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
 		"links": "start-server-and-test serve http://localhost:8000 links:run",
 		"a11y:run": "pa11y-ci --config .pa11yci.js",
 		"a11y": "start-server-and-test serve http://localhost:8000 a11y:run",
+		"build:lesson-jsonld": "node scripts/generate-lesson-jsonld.js && prettier --write \"course/**/*.html\"",
+		"check:lesson-jsonld": "node scripts/generate-lesson-jsonld.js && prettier --write \"course/**/*.html\" && git diff --exit-code course/lesson-meta.json \"course/**/*.html\"",
 		"check:assets": "node scripts/check-assets.js",
 		"format:check": "prettier --check .",
 		"format:write": "prettier --write .",

--- a/scripts/generate-lesson-jsonld.js
+++ b/scripts/generate-lesson-jsonld.js
@@ -21,8 +21,7 @@ const REPO_ROOT = path.resolve(__dirname, "..");
 const COURSE_DIR = path.join(REPO_ROOT, "course");
 const META_PATH = path.join(COURSE_DIR, "lesson-meta.json");
 
-const COURSE_URL =
-	"https://bushidocodes.github.io/limerick-cobol/course/index.html";
+const COURSE_URL = "https://bushidocodes.github.io/limerick-cobol/course/index.html";
 
 // Lesson sequence — mirrors the array in components/lesson-progress.js.
 // Titles here are the canonical lesson titles used for the LearningResource name.
@@ -122,7 +121,7 @@ function injectJsonLd(html, block) {
 	// Strip existing LearningResource block (idempotency).
 	html = html.replace(
 		/\t\t<script type="application\/ld\+json">\n\t\t\t\{[\s\S]*?"@type": "LearningResource"[\s\S]*?<\/script>\n/,
-		""
+		"",
 	);
 
 	// Insert after <link rel="icon" ...>.

--- a/scripts/generate-lesson-jsonld.js
+++ b/scripts/generate-lesson-jsonld.js
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+/**
+ * generate-lesson-jsonld.js
+ *
+ * For each lesson page in course/, reads title / description / canonical URL
+ * from the existing HTML meta tags, builds a LearningResource JSON-LD block,
+ * and injects it immediately after the <link rel="icon"> tag.
+ *
+ * Also writes course/lesson-meta.json as a human-maintainable manifest.
+ * Edit that file to override any field; re-run this script to re-inject.
+ *
+ * Idempotent — re-running replaces the existing LearningResource block.
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const COURSE_DIR = path.join(REPO_ROOT, "course");
+const META_PATH = path.join(COURSE_DIR, "lesson-meta.json");
+
+const COURSE_URL =
+	"https://bushidocodes.github.io/limerick-cobol/course/index.html";
+
+// Lesson sequence — mirrors the array in components/lesson-progress.js.
+// Titles here are the canonical lesson titles used for the LearningResource name.
+const LESSON_SEQUENCE = [
+	{ file: "COBOLIntro.html", title: "The structure of COBOL programs" },
+	{ file: "DataDeclaration.html", title: "Declaring data in COBOL" },
+	{ file: "COBOLcommands.html", title: "Basic Procedure Division commands" },
+	{ file: "Selection.html", title: "Selection in COBOL" },
+	{ file: "Iteration.html", title: "Iteration in COBOL" },
+	{ file: "SequentialFiles1.html", title: "Introduction to Sequential files" },
+	{ file: "SequentialFiles2.html", title: "Processing Sequential files" },
+	{ file: "EditedPics.html", title: "Edited Pictures" },
+	{ file: "Usage.html", title: "The USAGE clause" },
+	{
+		file: "SequentialFiles3.html",
+		title: "COBOL print files and variable-length records",
+	},
+	{ file: "SortMerge.html", title: "Sorting and Merging" },
+	{
+		file: "Intro2DirectAccess.html",
+		title: "Introduction to direct access files",
+	},
+	{ file: "RelativeFiles.html", title: "Relative Files" },
+	{ file: "IndexedFiles.html", title: "Indexed Files" },
+	{ file: "Tables1.html", title: "Using tables" },
+	{ file: "Tables2.html", title: "Creating tables - syntax and semantics" },
+	{ file: "Search.html", title: "Searching tables" },
+	{ file: "Subprograms.html", title: "Contained and external sub-programs" },
+	{ file: "Copy.html", title: "The COPY verb" },
+	{ file: "Inspect.html", title: "Inspect" },
+	{ file: "String.html", title: "String" },
+	{ file: "Unstring.html", title: "Unstring" },
+	{
+		file: "RefMod.html",
+		title: "Reference modification and Intrinsic Functions",
+	},
+	{ file: "ReportWriter.html", title: "Report Writer by example" },
+	{ file: "ReportWriterSS.html", title: "Report Writer syntax and semantics" },
+];
+
+/** Extract <meta name="description" content="..."> value from raw HTML. */
+function extractDescription(html) {
+	const m = html.match(/<meta\s+name="description"\s+content="([^"]+)"/);
+	return m ? m[1] : "";
+}
+
+/** Extract <link rel="canonical" href="..."> value from raw HTML. */
+function extractCanonical(html) {
+	const m = html.match(/<link\s+rel="canonical"\s+href="([^"]+)"/);
+	return m ? m[1] : "";
+}
+
+/**
+ * Build the JSON-LD <script> block string with tab indentation matching the
+ * surrounding HTML (two tabs for the tag, three tabs for JSON content).
+ */
+function buildJsonLdBlock(entry) {
+	const ld = {
+		"@context": "https://schema.org",
+		"@type": "LearningResource",
+		name: entry.title,
+		description: entry.description,
+		url: entry.url,
+		position: entry.position,
+		isPartOf: {
+			"@type": "Course",
+			name: "COBOL Course",
+			url: COURSE_URL,
+		},
+		provider: {
+			"@type": "Person",
+			name: "Michael Coughlan",
+			affiliation: {
+				"@type": "Organization",
+				name: "University of Limerick CSIS",
+			},
+		},
+		educationalLevel: "beginner",
+		inLanguage: "en",
+		learningResourceType: "Tutorial",
+	};
+
+	// Indent inner JSON with three tabs to match course/index.html style.
+	const inner = JSON.stringify(ld, null, "\t")
+		.split("\n")
+		.map((line, i) => (i === 0 ? line : "\t\t\t" + line))
+		.join("\n");
+
+	return `\t\t<script type="application/ld+json">\n\t\t\t${inner}\n\t\t</script>`;
+}
+
+/**
+ * Remove any existing LearningResource JSON-LD block from the HTML string,
+ * then inject the new block immediately after the <link rel="icon"> tag.
+ */
+function injectJsonLd(html, block) {
+	// Strip existing LearningResource block (idempotency).
+	html = html.replace(
+		/\t\t<script type="application\/ld\+json">\n\t\t\t\{[\s\S]*?"@type": "LearningResource"[\s\S]*?<\/script>\n/,
+		""
+	);
+
+	// Insert after <link rel="icon" ...>.
+	return html.replace(/(\t\t<link rel="icon"[^\n]+\n)/, `$1${block}\n`);
+}
+
+function main() {
+	// If lesson-meta.json already exists, load it so hand-edited fields survive.
+	let existing = {};
+	if (fs.existsSync(META_PATH)) {
+		const parsed = JSON.parse(fs.readFileSync(META_PATH, "utf8"));
+		for (const e of parsed) {
+			existing[e.file] = e;
+		}
+	}
+
+	const manifest = [];
+
+	for (let i = 0; i < LESSON_SEQUENCE.length; i++) {
+		const { file, title } = LESSON_SEQUENCE[i];
+		const filePath = path.join(COURSE_DIR, file);
+
+		if (!fs.existsSync(filePath)) {
+			console.warn(`  SKIP  ${file} (not found)`);
+			continue;
+		}
+
+		let html = fs.readFileSync(filePath, "utf8");
+
+		// Prefer values from existing manifest (hand-editable), fall back to HTML.
+		const prev = existing[file] || {};
+		const entry = {
+			position: i + 1,
+			file,
+			title: prev.title || title,
+			description: prev.description || extractDescription(html),
+			url: prev.url || extractCanonical(html),
+		};
+		manifest.push(entry);
+
+		const block = buildJsonLdBlock(entry);
+		html = injectJsonLd(html, block);
+
+		fs.writeFileSync(filePath, html, "utf8");
+		console.log(`  OK    ${file}`);
+	}
+
+	fs.writeFileSync(META_PATH, JSON.stringify(manifest, null, "\t") + "\n", "utf8");
+	console.log(`\nWrote course/lesson-meta.json (${manifest.length} entries).`);
+}
+
+main();


### PR DESCRIPTION
Closes #379

## Summary

- Adds a `LearningResource` schema.org JSON-LD block to all 25 lesson pages in `course/`, injected immediately after `<link rel="icon">` to match the placement pattern in `course/index.html`
- Each block includes `name`, `description`, `url`, `position` (1-based lesson number), `isPartOf` (pointing back to the parent `Course`), `provider`, `educationalLevel`, `inLanguage`, and `learningResourceType`
- Introduces `course/lesson-meta.json` as the human-maintainable manifest — edit any field there and re-run the script to regenerate
- `scripts/generate-lesson-jsonld.js` seeds the manifest from each page's existing `<meta name="description">` and `<link rel="canonical">` on first run, then respects hand-edited values on subsequent runs; fully idempotent

## New npm scripts

| Script | Purpose |
|---|---|
| `build:lesson-jsonld` | Regenerate manifest + inject JSON-LD, then prettier |
| `check:lesson-jsonld` | Same as build, then `git diff --exit-code` (CI gate) |

## Test plan

- [x] Script ran cleanly across all 25 lesson files with no errors
- [x] Idempotency verified: second run produced no net diff
- [x] `html-validate` passes on sample pages (`COBOLIntro.html`, `ReportWriterSS.html`)
- [x] Prettier formatting applied; no stray whitespace changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)