### PR TITLE
feat(exercises): add <related-content> to COBOLExams page

### DIFF
--- a/exercises/COBOLExams/COBOLExams.html
+++ b/exercises/COBOLExams/COBOLExams.html
@@ -45,6 +45,7 @@
 		<script src="../../components/site-search.js" defer></script>
 		<script src="../../components/back-to-top.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -52,6 +53,10 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="COBOL Programming Exams" eyebrow="COBOL Exams"></page-hero>
+					<related-content
+						lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/RelativeFiles.html|Relative Files, ../../course/ReportWriter.html|Report Writer"
+						examples="../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly, ../../examples/Relative/Seq2Rel.html|Sequential to Relative File"
+					></related-content>
 					<hr />
 
 					<section>

--- a/scripts/cross-links.json
+++ b/scripts/cross-links.json
@@ -243,7 +243,8 @@
 		"exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html": ["sequential-files", "tables"],
 		"exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html": ["indexed-files", "tables"],
 		"exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html": ["indexed-files", "sequential-files"],
-		"exercises/Proj-CSISEvalform/CSISEvalForm.html": ["tables", "sort-merge"]
+		"exercises/Proj-CSISEvalform/CSISEvalForm.html": ["tables", "sort-merge"],
+		"exercises/COBOLExams/COBOLExams.html": ["indexed-files", "relative-files", "report-writer"]
 	},
 	"pairs": {
 		"_comment": "Exm/Prg pairs that should cross-link to each other directly, in addition to their family memberships.",


### PR DESCRIPTION
## Summary

- Registers `exercises/COBOLExams/COBOLExams.html` in `scripts/cross-links.json` under the `indexed-files`, `relative-files`, and `report-writer` families — the exam showcased on that page (Aromamora Oil File Maintenance and Report) uses all three topics
- Runs `scripts/inject-cross-links.js` to insert the `<related-content>` block (lectures + examples) and the `related-content.js` script tag

Closes #390.

## Test plan

- [ ] Open `exercises/COBOLExams/COBOLExams.html` locally and confirm the Related Content widget appears with links to the Indexed Files, Relative Files, and Report Writer lectures

🤖 Generated with [Claude Code](https://claude.com/claude-code)