### PR TITLE
markup: wrap diagram images in figure/figcaption in RelativeFiles and IndexedFiles

### DIFF
--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -486,14 +486,15 @@ END-IF</code></pre>
 							<h3>Select and Assign clause syntax</h3>
 						</div>
 						<div class="section-content">
-							<p>
+							<figure class="img-figure">
 								<img
 									height="245"
 									src="Resources/pics/I-DFidx1.gif"
 									width="474"
 									alt="Indexed file SELECT and ASSIGN clause syntax diagram"
 								/>
-							</p>
+								<figcaption>SELECT and ASSIGN Clause Syntax</figcaption>
+							</figure>
 						</div>
 						<div class="section-sidebar">
 							<h3>The Record Key phrase</h3>
@@ -599,14 +600,15 @@ END-IF</code></pre>
 							<h3>Reading Sequentially</h3>
 						</div>
 						<div class="section-content">
-							<p>
+							<figure class="img-figure">
 								<img
 									src="Resources/pics/I-DFrel4.gif"
 									alt="READ NEXT syntax diagram for sequential access of an Indexed file with DYNAMIC access mode"
 									width="351"
 									height="81"
 								/>
-							</p>
+								<figcaption>READ NEXT Verb Syntax</figcaption>
+							</figure>
 							<h4>Notes</h4>
 							<p>
 								This format is used when the ACCESS MODE is DYNAMIC and we wish to read the file
@@ -635,14 +637,15 @@ END-IF</code></pre>
 							<h3>Reading using a key</h3>
 						</div>
 						<div class="section-content">
-							<p>
+							<figure class="img-figure">
 								<img
 									src="Resources/pics/I-DFrel3.gif"
 									alt="Direct READ syntax diagram for reading an Indexed file by key value"
 									width="301"
 									height="111"
 								/>
-							</p>
+								<figcaption>READ Verb Syntax (Direct Access)</figcaption>
+							</figure>
 							<p>
 								The syntax of the direct READ is the same as that for Relative files but the semantics
 								are somewhat different
@@ -726,14 +729,15 @@ END-IF</code></pre>
 								Where the START verb appears in a program it is usually followed by a sequential READ or
 								WRITE .
 							</p>
-							<p>
+							<figure class="img-figure">
 								<img
 									src="Resources/pics/I-DFrel8.gif"
 									alt="START verb syntax diagram for positioning the next record pointer in an Indexed file"
 									width="449"
 									height="198"
 								/>
-							</p>
+								<figcaption>START Verb Syntax</figcaption>
+							</figure>
 							<h4>Operation</h4>
 							<p>
 								To establish a key as the Key of Reference and position the Next Record Pointer at a

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -262,14 +262,15 @@ Enter supplier key (2 digits)-&gt; 05
 						<h3>Select and Assign clause syntax</h3>
 					</div>
 					<div class="section-content">
-						<p>
+						<figure class="img-figure">
 							<img
 								height="189"
 								src="Resources/pics/I-DFrel1.gif"
 								width="507"
 								alt="Syntax diagram for the SELECT and ASSIGN clause used to declare a relative file in COBOL."
 							/>
-						</p>
+							<figcaption>SELECT and ASSIGN Clause Syntax</figcaption>
+						</figure>
 					</div>
 				</div>
 				<div class="section-grid">
@@ -390,14 +391,15 @@ Enter supplier key (2 digits)-&gt; 05
 							The full syntax for the OPEN verbs is shown below. Note the new I-O entry. This is used with
 							direct access files when we intend to update or both read and write to the file.
 						</p>
-						<p>
+						<figure class="img-figure">
 							<img
 								src="Resources/pics/I-DFrel2.gif"
 								alt="Syntax diagram for the OPEN verb applied to relative files, showing INPUT, OUTPUT, I-O, and EXTEND modes."
 								width="225"
 								height="97"
 							/>
-						</p>
+							<figcaption>OPEN Verb Syntax</figcaption>
+						</figure>
 						<h4>Notes</h4>
 						<p>If the file is opened for input then only READ and START will be allowed.</p>
 						<p>If the file is opened for output then only WRITE will be allowed.</p>
@@ -433,14 +435,15 @@ Enter supplier key (2 digits)-&gt; 05
 						<h3>Reading using a key</h3>
 					</div>
 					<div class="section-content">
-						<p>
+						<figure class="img-figure">
 							<img
 								src="Resources/pics/I-DFrel3.gif"
 								alt="Syntax diagram for the READ verb used to read a record directly from a relative file by key value."
 								width="301"
 								height="111"
 							/>
-						</p>
+							<figcaption>READ Verb Syntax (Direct Access)</figcaption>
+						</figure>
 						<h4>Operation</h4>
 						<p>To read a record directly from a Relative file</p>
 						<ol>
@@ -483,14 +486,15 @@ Enter supplier key (2 digits)-&gt; 05
 							format of the ordinary sequential READ except that in this format the NEXT RECORD phrase is
 							used.
 						</p>
-						<p>
+						<figure class="img-figure">
 							<img
 								src="Resources/pics/I-DFrel4.gif"
 								alt="Syntax diagram for the sequential READ NEXT format used with relative files when ACCESS MODE is DYNAMIC."
 								width="351"
 								height="81"
 							/>
-						</p>
+							<figcaption>READ NEXT Verb Syntax</figcaption>
+						</figure>
 						<h4>Notes</h4>
 						<p>
 							This format is used to access a Relative file sequentially when the ACCESS MODE has been
@@ -519,14 +523,15 @@ Enter supplier key (2 digits)-&gt; 05
 							to a Sequential file, but to write directly to a Relative file a key must be used and this
 							requires a different WRITE format.
 						</p>
-						<p>
+						<figure class="img-figure">
 							<img
 								src="Resources/pics/I-DFrel5.gif"
 								alt="Syntax diagram for the WRITE verb used to write a record directly to a relative file using a key value."
 								width="271"
 								height="82"
 							/>
-						</p>
+							<figcaption>WRITE Verb Syntax (Direct Access)</figcaption>
+						</figure>
 						<h4>Operation</h4>
 						<p>To write a record directly to a Relative file</p>
 						<ol>
@@ -556,14 +561,15 @@ Enter supplier key (2 digits)-&gt; 05
 							The REWRITE is used to update a record in situ by overwriting it. The format of the REWRITE
 							verb is shown below.
 						</p>
-						<p>
+						<figure class="img-figure">
 							<img
 								src="Resources/pics/I-DFrel6.gif"
 								alt="Syntax diagram for the REWRITE verb used to update an existing record in place in a relative file."
 								width="285"
 								height="81"
 							/>
-						</p>
+							<figcaption>REWRITE Verb Syntax</figcaption>
+						</figure>
 						<h4>Operation</h4>
 						<p>The REWRITE is normally used in the following way;</p>
 						<ol>
@@ -593,14 +599,15 @@ Enter supplier key (2 digits)-&gt; 05
 						<h3>The DELETE verb</h3>
 					</div>
 					<div class="section-content">
-						<p>
+						<figure class="img-figure">
 							<img
 								src="Resources/pics/I-DFrel7.gif"
 								alt="Syntax diagram for the DELETE verb used to remove a record from a relative file by its relative record number."
 								width="259"
 								height="73"
 							/>
-						</p>
+							<figcaption>DELETE Verb Syntax</figcaption>
+						</figure>
 						<h4>Operation</h4>
 						<p>To delete a record</p>
 						<ol>
@@ -636,14 +643,15 @@ Enter supplier key (2 digits)-&gt; 05
 							the next record pointer. Where the START verb appears in a program it is usually followed by
 							a sequential READ or WRITE .
 						</p>
-						<p>
+						<figure class="img-figure">
 							<img
 								src="Resources/pics/I-DFrel8.gif"
 								alt="Syntax diagram for the START verb used to position the next-record pointer in a relative file."
 								width="449"
 								height="198"
 							/>
-						</p>
+							<figcaption>START Verb Syntax</figcaption>
+						</figure>
 						<h4>Operation</h4>
 						<p>To position the Next Record Pointer at a particular record</p>
 						<ol>
@@ -752,14 +760,15 @@ Begin.</code></pre>
 						<h3>The Use phrase</h3>
 					</div>
 					<div class="section-content">
-						<p>
+						<figure class="img-figure">
 							<img
 								src="Resources/pics/I-DFrel9.gif"
 								alt="Syntax diagram for the USE phrase in COBOL Declaratives, specifying error-handling procedures for file I-O conditions."
 								width="389"
 								height="152"
 							/>
-						</p>
+							<figcaption>USE Phrase Syntax</figcaption>
+						</figure>
 						<p><b>Notes</b></p>
 						<p>
 							A USE statement can be used only in a sentence immediately after a section header in the


### PR DESCRIPTION
## Summary

- Replaced bare `<p><img/></p>` wrappers with `<figure class="img-figure"><img/><figcaption>...</figcaption></figure>` in `course/RelativeFiles.html` (9 diagrams) and `course/IndexedFiles.html` (4 diagrams)
- Captions derived from surrounding section headings and verb context
- Follows the existing pattern established in `course/Intro2DirectAccess.html`

Closes #378

## Test plan

- [ ] Verify all 13 syntax diagrams render with visible captions in both pages
- [ ] Confirm no bare `<p><img>` patterns remain in the two files
- [ ] Check screen reader / accessibility tooling sees `<figcaption>` text

🤖 Generated with [Claude Code](https://claude.com/claude-code)