### PR TITLE
fix(exercises/index.html): replace deprecated hr width attribute with inline style

### DIFF
--- a/exercises/index.html
+++ b/exercises/index.html
@@ -113,7 +113,7 @@
 			<div class="center-block">
 				<site-search></site-search>
 			</div>
-			<hr width="800" />
+			<hr style="max-width: 800px" />
 			<div>
 				<table width="750">
 					<tr>
@@ -150,7 +150,7 @@
 					</tr>
 				</table>
 			</div>
-			<hr width="800" />
+			<hr style="max-width: 800px" />
 			<nav aria-label="Simple programming exercises">
 				<h3>Simple Programming Exercises</h3>
 				<ul class="toc">


### PR DESCRIPTION
## Summary

- Replaces two instances of `<hr width="800" />` with `<hr style="max-width: 800px" />` in `exercises/index.html`
- The `width` attribute on `<hr>` is deprecated in HTML5; inline `max-width` style achieves the same layout effect without the deprecated attribute

Closes #374

## Test plan

- [ ] Verify the horizontal rules in `exercises/index.html` still render at ~800px width
- [ ] Validate HTML5 compliance (no deprecated `width` attribute on `<hr>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)