### PR TITLE
Replace deprecated <hr size="1"> with hr.thin-rule CSS class (#373)

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -168,7 +168,7 @@
 							elements of the language. To provide an introduction to the major structures present in a
 							COBOL program.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Objectives</h3>
@@ -189,7 +189,7 @@
 								<code class="language-cobol">PROCEDURE</code> divisions.
 							</li>
 						</ol>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Prerequisites</h3>
@@ -227,7 +227,7 @@
 							systems programs. For instance you would not develop an operating system or a compiler using
 							COBOL.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>How widely used is COBOL?</h3>
@@ -263,7 +263,7 @@
 								programmers.
 							</p>
 						</blockquote>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Surprised by COBOL's success?</h3>
@@ -317,7 +317,7 @@
 							programmers. Many more programmers are involved in coding or maintaining one off, "bespoke",
 							applications. And these programmers generally write their programs in COBOL.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Some characteristics of COBOL applications</h3>
@@ -348,7 +348,7 @@
 							COBOL applications often deal with enormous volumes of data. Single production files and
 							databases measured in terabytes are not uncommon.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Some characteristics that contribute to COBOL's success</h3>
@@ -447,7 +447,7 @@
 							have no choice. COBOL's rigid hierarchical structure ensures that these items are restricted
 							to the Environment Division.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>References and further reading</h3>
@@ -560,7 +560,7 @@
 							Don't worry if you don't understand these programs at this point. The main purpose of this
 							section is to give you a first look at some simple COBOL programs.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Let's write a program</h3>
@@ -584,7 +584,7 @@
 							This section introduces COBOL programming by writing some simple COBOL programs using these
 							constructs.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Sequence Program Specification</h3>
@@ -603,7 +603,7 @@
 								computer executes them in the correct order.
 							</li>
 						</ol>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Program Statements and Data items</h3>
@@ -637,7 +637,7 @@
 						<pre
 							class="language-cobol"
 						><code class="language-cobol">DISPLAY "Result is = ", Result.</code></pre>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Getting the Algorithm right</h3>
@@ -696,7 +696,7 @@
 							program it is all to easy to make the mistake of trying to use, or output, the contents of a
 							data item before you have assigned it a value.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>An annotated look at the COBOL program</h3>
@@ -716,7 +716,7 @@
 									alt="Animation: annotated program"
 							/></a>
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Selection Program Specification</h3>
@@ -748,7 +748,7 @@
 									alt="Animation: selection program"
 							/></a>
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Iteration Program Specification</h3>
@@ -792,7 +792,7 @@
 							notation used in COBOL syntax diagrams and enumerates the COBOL coding rules. It shows how
 							user-defined names are constructed and examines the structure of COBOL programs.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>COBOL idiosyncrasies</h3>
@@ -820,7 +820,7 @@
 							to write well structured programs it also still retains elements which, if used, make it
 							difficult, and in some cases impossible, to write good programs.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>COBOL syntax</h3>
@@ -851,7 +851,7 @@
 							The ellipsis symbol <b>...</b> (three dots), indicates that the preceding syntax element may
 							be repeated at the programmer's discretion.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Some notes on syntax diagrams</h3>
@@ -956,7 +956,7 @@
 							brackets it must only be used when a <code class="language-cobol">SIZE ERROR</code> or
 							<code class="language-cobol">NOT SIZE ERROR</code> phrase is used.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>COBOL coding rules</h3>
@@ -1000,7 +1000,7 @@
 								style="border: 1px solid"
 							/>
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Name construction</h3>
@@ -1023,7 +1023,7 @@
 								<code class="language-cobol">TOTALPAY</code>.
 							</li>
 						</ol>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>The structure of COBOL programs</h3>
@@ -1123,7 +1123,7 @@ PROGRAM-ID.</code></pre>
 							<h4 class="center-block">PROCEDURE DIVISION.</h4>
 							<p class="center-block">Contains the program algorithms</p>
 						</blockquote>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>The IDENTIFICATION DIVISION</h3>
@@ -1167,7 +1167,7 @@ other entries here</code></pre>
 						<pre class="language-cobol"><code class="language-cobol">IDENTIFICATION DIVISION.
 PROGRAM-ID. SequenceProgram.
 AUTHOR. Michael Coughlan.</code></pre>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>The <code class="language-cobol">ENVIRONMENT DIVISION</code></h3>
@@ -1192,7 +1192,7 @@ AUTHOR. Michael Coughlan.</code></pre>
 							collating sequence, the currency symbol and the decimal point symbol may also be defined
 							here.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>The DATA DIVISION</h3>
@@ -1240,7 +1240,7 @@ WORKING-STORAGE SECTION.
 01 Num1   PIC 9  VALUE ZEROS.
 01 Num2   PIC 9  VALUE ZEROS.
 01 Result PIC 99 VALUE ZEROS.</code></pre>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>The PROCEDURE DIVISION</h3>

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -163,7 +163,7 @@
 						</p>
 						<p>The unit ends with a number of example programs.</p>
 
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Objectives</h3>
@@ -178,7 +178,7 @@
 								sections of it as required.
 							</li>
 						</ol>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Prerequisites</h3>
@@ -245,7 +245,7 @@
 							of the <code class="language-cobol">COPY</code> verb.
 						</p>
 
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>
@@ -287,7 +287,7 @@
 							recompilation of any affected programs. If a copy library were not used each affected
 							program would have to be changed
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<!-- Navigation -->
 					<div class="section-full">
@@ -399,7 +399,7 @@
 								</p>
 							</blockquote>
 						</div>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>
@@ -423,7 +423,7 @@ COPY CopyFile5 REPLACING X(3) BY X(19).
 COPY CopyFile3 IN EGLIB.
 COPY CopyFile5 REPLACING ==X(3)== BY ==X(19)==.
 COPY CopyFile4 IN EGLIB.</code></pre>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>How the REPLACING phrase works</h3>
@@ -443,7 +443,7 @@ COPY CopyFile4 IN EGLIB.</code></pre>
 							Comment lines in the library text is or in TextWord2 are copied into the target text
 							unchanged.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>COPY Rules</h3>
@@ -484,7 +484,7 @@ COPY CopyFile4 IN EGLIB.</code></pre>
 								For example - (Prefix) or :Prefix:
 							</li>
 						</ol>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<!-- Navigation -->
 					<div class="section-full">
@@ -614,7 +614,7 @@ BeginProg.
    END-PERFORM
    STOP RUN.</code></pre>
 						</div>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<!-- Example 2 -->
 					<div class="section-sidebar">
@@ -774,7 +774,7 @@ BeginProg.
 STOP RUN.
 </code></pre>
 						</div>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<!-- Example 3 -->
 					<div class="section-sidebar">
@@ -920,7 +920,7 @@ BeginProg.
    STOP RUN.
 </code></pre>
 						</div>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<!-- Example 4 -->
 					<div class="section-sidebar">

--- a/course/Resources/css/course-components.css
+++ b/course/Resources/css/course-components.css
@@ -1167,6 +1167,13 @@ copyright-notice {
 	display: block;
 }
 
+/* Replaces deprecated <hr size="1"> (issue #373). */
+hr.thin-rule {
+	border: none;
+	border-top: 1px solid currentColor;
+	margin: 0.75em 0;
+}
+
 copyright-notice hr {
 	border: none;
 	border-top: 1px solid currentColor;

--- a/course/Search.html
+++ b/course/Search.html
@@ -170,7 +170,7 @@
 								<code class="language-cobol">SEARCH</code> and
 								<code class="language-cobol">SEARCH ALL</code> may be used to search a table.
 							</p>
-							<hr size="1" />
+							<hr class="thin-rule" />
 						</div>
 					</div>
 					<div class="section-grid">
@@ -201,7 +201,7 @@
 								</li>
 								<li>Understand how a binary search works.</li>
 							</ol>
-							<hr size="1" />
+							<hr class="thin-rule" />
 						</div>
 					</div>
 					<div class="section-grid">
@@ -249,7 +249,7 @@
 								<code class="language-cobol">INDEXED BY</code> and
 								<code class="language-cobol">KEY IS</code> phrases is shown below.
 							</p>
-							<hr size="1" />
+							<hr class="thin-rule" />
 						</div>
 					</div>
 					<div class="section-grid">
@@ -420,7 +420,7 @@
 									<code class="language-cobol">SEARCH</code> ends.
 								</li>
 							</ul>
-							<hr size="1" />
+							<hr class="thin-rule" />
 						</div>
 					</div>
 					<div class="section-grid">
@@ -532,7 +532,7 @@ Begin.
             DISPLAY LetterIn, " is in position ", PrnPos
     END-SEARCH
     STOP RUN.</code></pre>
-							<hr size="1" />
+							<hr class="thin-rule" />
 						</div>
 					</div>
 					<div class="section-grid">
@@ -798,7 +798,7 @@ LoadTable.
       END-READ
    END-PERFORM
    CLOSE OccupancyFile.</code></pre>
-							<hr size="1" />
+							<hr class="thin-rule" />
 						</div>
 					</div>
 					<div class="section-grid">
@@ -955,7 +955,7 @@ END-SEARCH</code></pre>
 								the element. The key field must be identified by using the
 								<code class="language-cobol">KEY IS</code> phrase in the table declaration.
 							</p>
-							<hr size="1" />
+							<hr class="thin-rule" />
 						</div>
 					</div>
 					<div class="section-grid">
@@ -1011,7 +1011,7 @@ END-SEARCH</code></pre>
 								table is in descending sequence, the unpopulated elements should be filled with
 								<code class="language-cobol">LOW-VALUES</code>.
 							</p>
-							<hr size="1" />
+							<hr class="thin-rule" />
 						</div>
 					</div>
 					<div class="section-grid">
@@ -1125,7 +1125,7 @@ Begin.
     END-SEARCH
     STOP RUN.
 </code></pre>
-							<hr size="1" />
+							<hr class="thin-rule" />
 						</div>
 					</div>
 					<div class="section-grid">

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -163,7 +163,7 @@
 							<code class="language-cobol">SORT</code> and
 							<code class="language-cobol">MERGE</code> verbs.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Objectives</h3>
@@ -200,7 +200,7 @@
 							</li>
 							<li>Understand the significance of the merge keys.</li>
 						</ol>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Prerequisites</h3>
@@ -248,7 +248,7 @@
 							changes to the <code class="language-cobol">SORT</code>. This is rarely the case when
 							programs rely on a vendor-supplied or "bought in" sort.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Why sort the file?</h3>
@@ -345,7 +345,7 @@ END-IF</code></pre>
 							>
 							This thinking would lead us to the obvious conclusion - we must sort the calls file.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Syntax of a simplified SORT</h3>
@@ -541,7 +541,7 @@ Begin.
      USING  CallsFile
      GIVING SortedCallsFile.
 </code></pre>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Using multiple keys.</h3>
@@ -711,7 +711,7 @@ etc.</code></pre>
 							Since sorting is a disk-based process, and thus comparatively slow, every effort should be
 							made to reduce the amount of data that has to be sorted.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>SORT syntax with INPUT PROCEDURE</h3>
@@ -781,7 +781,7 @@ SORT WorkFile ON ASCENDING CountryNameWF, CustomerNameWF
 								used, must not overlap.
 							</li>
 						</ol>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>How a SORT with and INPUT PROCEDURE works.</h3>
@@ -833,7 +833,7 @@ SORT WorkFile ON ASCENDING CountryNameWF, CustomerNameWF
               INPUT PROCEDURE IS SelectForeignGuests
               GIVING SortedGuestsFile.
 </code></pre>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Creating an INPUT PROCEDURE</h3>
@@ -874,7 +874,7 @@ PERFORM UNTIL TerminatingCondition
 END-PERFORM
 CLOSE InFileName</code></pre>
 						</div>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>The Foreign Guests Report - example program</h3>
@@ -1032,7 +1032,7 @@ PrintReportBody.
    WRITE PrintLine FROM CountryLine
          AFTER ADVANCING 1 LINE.
 </code></pre>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Feeding the SORT from the keyboard - example program</h3>
@@ -1162,7 +1162,7 @@ GetStudentDetails.
 							the sorted records. The resulting sorted file contains summary records, rather than the
 							detail records, contained in the unsorted file.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>SORT syntax with OUTPUT PROCEDURE</h3>
@@ -1211,7 +1211,7 @@ SORT WorkFile ON ASCENDING KEY SalespersonNumWF
 								<code class="language-cobol">OUTPUT PROCEDURE</code> is used.
 							</li>
 						</ol>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>How the OUTPUT PROCEDURE works</h3>
@@ -1253,7 +1253,7 @@ SORT WorkFile ON ASCENDING KEY SalespersonNumWF
      USING SalesFile
      OUTPUT PROCEDURE IS SummariseSales.
 </code></pre>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Creating an OUTPUT PROCEDURE</h3>
@@ -1299,7 +1299,7 @@ END-PERFORM
 CLOSE OutFile
 </code></pre>
 						</div>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Sales summary file - example program</h3>
@@ -1373,7 +1373,7 @@ SummariseSales.
     END-PERFORM
     CLOSE SalesSummaryFile.
 </code></pre>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Revised Foreign Guests Report - example program</h3>
@@ -1528,7 +1528,7 @@ PrintReportBody.
 							and combines them, according to the key values specified. The combined file is then sent to
 							an output file or an <code class="language-cobol">OUTPUT PROCEDURE</code>.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>MERGE syntax</h3>
@@ -1599,7 +1599,7 @@ PrintReportBody.
 							been merged and must contain at least one
 							<code class="language-cobol">RETURN</code> statement to get the records from the SortFile.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>MERGE example</h3>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -153,7 +153,7 @@
 							To introduce Structured Design and to summarize its criteria for achieving good quality
 							subprograms.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Objectives</h3>
@@ -182,7 +182,7 @@
 							</li>
 							<li>Be able to create subprograms of good quality.</li>
 						</ol>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Prerequisites</h3>
@@ -256,7 +256,7 @@
 							In COBOL, the <code class="language-cobol">CALL</code> verb is used to invoke one program
 							from another.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>
@@ -273,7 +273,7 @@
 							The called program may be an independently compiled program, or it may be contained within
 							the text of the calling program (i.e. it may be a contained subprogram).
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<p>
@@ -354,7 +354,7 @@
 								extensions.
 							</li>
 						</ol>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<b>Parameter passing mechanisms</b>
@@ -409,7 +409,7 @@
 								alt="Diagram showing BY CONTENT parameter passing where the subprogram receives a copy of the data item"
 							/>
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<p>
@@ -500,7 +500,7 @@ Begin.
 							a single monolithic program) that the data connection between modules should be as limited
 							as possible.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<b>State memory and the IS INITIAL clause</b>
@@ -684,7 +684,7 @@ Begin.
 							parameter is still 12, the program "remembers" the value of
 							<i>RunningTotal</i> from the previous run and produces a result of 79 (12+67).
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>
@@ -722,7 +722,7 @@ Begin.
 CANCEL "Fickle"
 CALL "Fickle" USING BY CONTENT IncValue.</code></pre>
 						<p>we can force "Fickle" to act like "Steadfast".</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>
@@ -802,7 +802,7 @@ CALL "Fickle" USING BY CONTENT IncValue.</code></pre>
 								<code class="language-cobol">IS GLOBAL</code> clause in the data declaration.
 							</li>
 						</ol>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<b>Defining a contained subprogram</b>
@@ -829,7 +829,7 @@ CALL "Fickle" USING BY CONTENT IncValue.</code></pre>
 								<code class="language-cobol">PROGRAM-ID</code>.
 							</li>
 						</ol>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>
@@ -888,7 +888,7 @@ PROGRAM-ID. ReportFromTable.
    EXIT PROGRAM
 END-PROGRAM ReportFromTable.
 END-PROGRAM ContainerProgram.</code></pre>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Information Hiding using the IS GLOBAL clause and contained subprograms</h3>
@@ -941,7 +941,7 @@ END-PROGRAM ContainerProgram.</code></pre>
 								alt="Diagram showing the ContainerProgram acting as intermediary between MainProgram and contained subprograms"
 							/>
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<b>The IS COMMON PROGRAM clause</b>
@@ -983,7 +983,7 @@ END-PROGRAM ContainerProgram.</code></pre>
 								alt="Syntax diagram for IS INITIAL and IS COMMON PROGRAM clauses in PROGRAM-ID"
 							/>
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>
@@ -1036,7 +1036,7 @@ END PROGRAM DisplayData.
 
 END PROGRAM MainProgram.
 </code></pre>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Example program using the IS INITIAL and IS COMMON clauses and the CANCEL command.</h3>
@@ -1174,7 +1174,7 @@ Fickle total =  6
 Fickle total =  9
 Value - 0</code></pre>
 						</div>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>The IS EXTERNAL clause</h3>
@@ -1225,7 +1225,7 @@ Value - 0</code></pre>
 							practice. Myres (Myres, G.J. <i>Composite/Structured Design.</i> 1979), for instance,
 							indicates that this "Common Coupling" is nearly the worst kind of module coupling possible.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Designing a modular system</h3>
@@ -1251,7 +1251,7 @@ Value - 0</code></pre>
 							Prentice-Hall 1988.
 						</p>
 						<p>Myers, Glenford, <i>Composite/Structured Design</i>, Von Nostrand Reinhold 19</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -145,7 +145,7 @@
 							certain kinds of problems.
 						</p>
 
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Objectives</h3>
@@ -163,7 +163,7 @@
 							</li>
 							<li>Understand how the subscript of one table can be used an index into another.</li>
 						</ol>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Prerequisites</h3>
@@ -355,7 +355,7 @@ DISPLAY "County 3 total is ", County3TaxTotal
 								index/subscript in brackets (see examples below).
 							</li>
 						</ul>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Declaring the CountyTax table</h3>
@@ -403,7 +403,7 @@ DISPLAY "County 3 total is ", County3TaxTotal
 ADD TaxPaid TO CountyTax(CountyCode)
 ADD TaxPaid TO CountyTax(CountyCode + 1)
 ADD TaxPaid TO CountyTax(CountyCode - 2)</code></pre>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>The County Tax Report program</h3>
@@ -588,7 +588,7 @@ Begin.
 							How could we get the program to work then? How would we know, which element of the CountyTax
 							table to add the TaxPaid to?
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>An EVALUATE based solution</h3>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -184,7 +184,7 @@
 							how to create single and multi-dimension tables, how to create variable length tables and
 							how to set up a table pre-filled with data..
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Objectives</h3>
@@ -211,7 +211,7 @@
 								table pre-filled with data.
 							</li>
 						</ol>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Prerequisites</h3>
@@ -252,7 +252,7 @@
 							In this section we will examine, in more detail, how a single dimension table, like the
 							CountyTaxTable, may be created.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Tables - general notes</h3>
@@ -285,7 +285,7 @@
 							</li>
 						</ul>
 						<p>A table is stored in memory as a contiguous block of bytes.</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Using the <code class="language-cobol">OCCURS</code> clause to declare a table</h3>
@@ -338,7 +338,7 @@
 							When declared like this we can refer to <i>CountyTax(sub)</i> when we want to access an
 							element of the table and <i>CountyTaxTable</i> when we want to refer to the whole table.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>OCCURS clause syntax and rules</h3>
@@ -400,7 +400,7 @@
 							</li>
 							<li>Subscripts must be enclosed in parentheses/brackets.</li>
 						</ol>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Table examples and some SAQ's</h3>
@@ -483,7 +483,7 @@
 								</tr>
 							</table>
 						</div>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Declaring a variable length table.</h3>
@@ -585,7 +585,7 @@
 							<i>CountyTaxDetails</i>, <i>CountyTax</i> and <i>PayerCount</i> in the table above, the form
 							CountyTaxDetails(sub), CountyTax(sub) and PayerCount(sub) must be used.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Self Assessment Questions and animated example</h3>
@@ -636,7 +636,7 @@ MOVE ZEROS TO CountyTaxTable</code></pre>
 								</p>
 							</details>
 						</div>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Example program</h3>
@@ -903,7 +903,7 @@ END-EVALUATE.
 							expresses the data hierarchy inherent in the table description where one
 							<code class="language-cobol">OCCURS</code> clause is subordinate to the another.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Self Assessment Questions and examples</h3>
@@ -931,7 +931,7 @@ MOVE ZEROS TO Age(3)</code></pre>
 									alt="Click for animation: two-dimension PopulationTable statement effects"
 							/></a>
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Displaying the population report for each county</h3>
@@ -992,7 +992,7 @@ MOVE ZEROS TO Age(3)</code></pre>
 								alt="Diagram of a three-dimension PopulationTable with County (26), Age (3), and Gender (2) containing PopTotal"
 							/>
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Self Assessment Questions and examples</h3>
@@ -1018,7 +1018,7 @@ MOVE ZEROS TO PopulationTable</code></pre>
 									alt="Click for animation: three-dimension PopulationTable statement effects"
 							/></a>
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>One last tweak to the problem specification.</h3>
@@ -1139,7 +1139,7 @@ ADD 56 TO PopTotal(12,3,2)</code></pre>
 							successful when a small amount of data is involved. The standard way to create pre-filled
 							tables in COBOL is to use the <code class="language-cobol">REDEFINES</code> clause.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Non-tables uses for the REDEFINES clause - some examples</h3>
@@ -1248,7 +1248,7 @@ END-EVALUATE </code></pre>
 									alt="Click for animation: REDEFINES clause examples"
 							/></a>
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>REDEFINES syntax and rules</h3>
@@ -1297,7 +1297,7 @@ END-EVALUATE </code></pre>
 							</li>
 							<li>There can be no intervening entries that define additional character positions.</li>
 						</ol>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Using the REDEFINES clause to create a pre-filled table.</h3>
@@ -1343,7 +1343,7 @@ END-EVALUATE </code></pre>
 									alt="Click for animation: using REDEFINES to create a pre-filled table"
 							/></a>
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Example program</h3>
@@ -1458,7 +1458,7 @@ DisplayCountyTaxes.
       MOVE PayerCount(Idx) TO PrnPayers
       DISPLAY CountyTaxLine
    END-IF.</code></pre>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Creating pre-filled tables without using the REDEFINES clause.</h3>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -142,7 +142,7 @@
 							The <code class="language-cobol">SYNCHRONIZED</code> clause is introduced and a generalized
 							example given.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Objectives</h3>
@@ -161,7 +161,7 @@
 								<code class="language-cobol">SYNCHRONIZED</code> clause.
 							</li>
 						</ol>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3>Prerequisites</h3>
@@ -230,7 +230,7 @@
 							specified. When there is no explicit <code class="language-cobol">USAGE</code> clause, the
 							default - <code class="language-cobol">USAGE IS DISPLAY</code> - is applied.
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<h3><b>Problems with USAGE IS DISPLAY</b></h3>
@@ -2186,7 +2186,7 @@ Begin.
 								</td>
 							</tr>
 						</table>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<p>
@@ -2347,7 +2347,7 @@ Begin.
 							typed languages) and <code class="language-cobol">COMP-2</code> is usually defined as a
 							double precision, floating point number (LongReal or Double in typed languages).
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 					<div class="section-sidebar">
 						<b>The SYNCHRONIZED clause</b>
@@ -2420,7 +2420,7 @@ Begin.
 								alt="Diagram showing a COMP item aligned on a word boundary with SYNCHRONIZED, requiring only one fetch cycle"
 							/>
 						</p>
-						<hr size="1" />
+						<hr class="thin-rule" />
 					</div>
 				</div>
 				<div class="page-footer">


### PR DESCRIPTION
## Summary

- Adds `hr.thin-rule` class to `course/Resources/css/course-components.css` — renders as a 1px border-top rule, replacing the visual effect of the deprecated `size="1"` attribute
- Replaces all 108 occurrences of `<hr size="1" />` across 8 course pages with `<hr class="thin-rule" />`

## Files changed

| File | Replacements |
|------|-------------|
| `course/COBOLIntro.html` | 24 |
| `course/Tables2.html` | 18 |
| `course/Subprograms.html` | 18 |
| `course/SortMerge.html` | 17 |
| `course/Copy.html` | 11 |
| `course/Search.html` | 9 |
| `course/Usage.html` | 6 |
| `course/Tables1.html` | 5 |
| `course/Resources/css/course-components.css` | CSS rule added |

## Notes

The `scripts/fix-deprecated-attrs.py` script referenced in the issue doesn't exist in this repo (all audit scripts are `.js`). The Phase-4 sweep missed `<hr>` attributes; this PR handles the cleanup manually.

Closes #373