### PR TITLE
Make typos job a blocking check

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -70,7 +70,6 @@ jobs:
     typos:
         name: Spell check (typos)
         runs-on: ubuntu-latest
-        continue-on-error: true
         steps:
             - uses: actions/checkout@v4
             - uses: crate-ci/typos@v1.46.1


### PR DESCRIPTION
## Summary

- Removes `continue-on-error: true` from the `typos` job in `.github/workflows/checks.yml`

## Why

Now that `.typos.toml` has a comprehensive ignore list for COBOL keywords and abbreviations, the spell check is reliable enough to block PRs on failure. Previously the flag silently swallowed regressions. Resolves #332.

## Reviewer notes

One-line deletion — no functional logic changed, just the job's failure policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)