### PR TITLE
feat: add theme-color meta tags to all HTML pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/course/Resources/build-viewer.html
+++ b/course/Resources/build-viewer.html
@@ -3,6 +3,8 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>COBOL animation viewer</title>
 		<meta name="description" content="Click-through viewer for COBOL course animation build steps." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Resources/build-viewer.html" />

--- a/course/Resources/pdf-viewer.html
+++ b/course/Resources/pdf-viewer.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<meta charset="utf-8" />
 		<title>PDF slide viewer</title>
 		<meta name="description" content="COBOL programming lesson on PDF slide viewer." />

--- a/course/Resources/ppz/TC-Call.html
+++ b/course/Resources/ppz/TC-Call.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-Call - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Call." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Call.html" />

--- a/course/Resources/ppz/TC-CobIntro1.html
+++ b/course/Resources/ppz/TC-CobIntro1.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-CobIntro1 - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-CobIntro1." />
 		<link

--- a/course/Resources/ppz/TC-CobIntro2.html
+++ b/course/Resources/ppz/TC-CobIntro2.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-CobIntro2 - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-CobIntro2." />
 		<link

--- a/course/Resources/ppz/TC-CobIntro3.html
+++ b/course/Resources/ppz/TC-CobIntro3.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-CobIntro3 - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-CobIntro3." />
 		<link

--- a/course/Resources/ppz/TC-CobIntro4.html
+++ b/course/Resources/ppz/TC-CobIntro4.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-CobIntro4 - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-CobIntro4." />
 		<link

--- a/course/Resources/ppz/TC-CobIntro5.html
+++ b/course/Resources/ppz/TC-CobIntro5.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-CobIntro5 - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-CobIntro5." />
 		<link

--- a/course/Resources/ppz/TC-CobIntro6.html
+++ b/course/Resources/ppz/TC-CobIntro6.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-CobIntro6 - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-CobIntro6." />
 		<link

--- a/course/Resources/ppz/TC-Commands1.html
+++ b/course/Resources/ppz/TC-Commands1.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-Commands1 - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Commands1." />
 		<link

--- a/course/Resources/ppz/TC-Commands2.html
+++ b/course/Resources/ppz/TC-Commands2.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-Commands2 - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Commands2." />
 		<link

--- a/course/Resources/ppz/TC-Condition1.html
+++ b/course/Resources/ppz/TC-Condition1.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-Condition1 - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Condition1." />
 		<link

--- a/course/Resources/ppz/TC-Condition2.html
+++ b/course/Resources/ppz/TC-Condition2.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-Condition2 - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Condition2." />
 		<link

--- a/course/Resources/ppz/TC-Data1.html
+++ b/course/Resources/ppz/TC-Data1.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-Data1 - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Data1." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Data1.html" />

--- a/course/Resources/ppz/TC-Data2.html
+++ b/course/Resources/ppz/TC-Data2.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-Data2 - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Data2." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Data2.html" />

--- a/course/Resources/ppz/TC-Perform1.html
+++ b/course/Resources/ppz/TC-Perform1.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-Perform1 - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Perform1." />
 		<link

--- a/course/Resources/ppz/TC-Perform2.html
+++ b/course/Resources/ppz/TC-Perform2.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-Perform2 - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Perform2." />
 		<link

--- a/course/Resources/ppz/TC-Search2.html
+++ b/course/Resources/ppz/TC-Search2.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-Search2 - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Search2." />
 		<link

--- a/course/Resources/ppz/TC-SeqFile1.html
+++ b/course/Resources/ppz/TC-SeqFile1.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-SeqFile1 - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-SeqFile1." />
 		<link

--- a/course/Resources/ppz/TC-SeqFile2a.html
+++ b/course/Resources/ppz/TC-SeqFile2a.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-SeqFile2a - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-SeqFile2a." />
 		<link

--- a/course/Resources/ppz/TC-SeqFile2b.html
+++ b/course/Resources/ppz/TC-SeqFile2b.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-SeqFile2b - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-SeqFile2b." />
 		<link

--- a/course/Resources/ppz/TC-SeqFile2c.html
+++ b/course/Resources/ppz/TC-SeqFile2c.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-SeqFile2c - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-SeqFile2c." />
 		<link

--- a/course/Resources/ppz/TC-SeqFile2d.html
+++ b/course/Resources/ppz/TC-SeqFile2d.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-SeqFile2d - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-SeqFile2d." />
 		<link

--- a/course/Resources/ppz/TC-SeqFile2e.html
+++ b/course/Resources/ppz/TC-SeqFile2e.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-SeqFile2e - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-SeqFile2e." />
 		<link

--- a/course/Resources/ppz/TC-SeqFile3a.html
+++ b/course/Resources/ppz/TC-SeqFile3a.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-SeqFile3a - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-SeqFile3a." />
 		<link

--- a/course/Resources/ppz/TC-Tables1.html
+++ b/course/Resources/ppz/TC-Tables1.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-Tables1 - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Tables1." />
 		<link

--- a/course/Resources/ppz/TC-Tables2.html
+++ b/course/Resources/ppz/TC-Tables2.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-Tables2 - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Tables2." />
 		<link

--- a/course/Resources/ppz/TC-Tables3.html
+++ b/course/Resources/ppz/TC-Tables3.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-Tables3 - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Tables3." />
 		<link

--- a/course/Resources/ppz/TC-Tables4.html
+++ b/course/Resources/ppz/TC-Tables4.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-Tables4 - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Tables4." />
 		<link

--- a/course/Resources/ppz/TC-Tables5.html
+++ b/course/Resources/ppz/TC-Tables5.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-Tables5 - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Tables5." />
 		<link

--- a/course/Resources/ppz/TC-Tables7.html
+++ b/course/Resources/ppz/TC-Tables7.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-Tables7 - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Tables7." />
 		<link

--- a/course/Resources/ppz/TC-Tables8.html
+++ b/course/Resources/ppz/TC-Tables8.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>TC-Tables8 - COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Tables8." />
 		<link

--- a/course/Search.html
+++ b/course/Search.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/course/String.html
+++ b/course/String.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/course/glossary.html
+++ b/course/glossary.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/course/index.html
+++ b/course/index.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<script type="application/ld+json">

--- a/examples/Accept/ACCEPT.html
+++ b/examples/Accept/ACCEPT.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/Accept/Multiplier.html
+++ b/examples/Accept/Multiplier.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/Accept/Shortest.html
+++ b/examples/Accept/Shortest.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/Conditn/Conditions.html
+++ b/examples/Conditn/Conditions.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/Conditn/IterIf.html
+++ b/examples/Conditn/IterIf.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/Indexed/DirectReadIdx.html
+++ b/examples/Indexed/DirectReadIdx.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/Indexed/Seq2Index.html
+++ b/examples/Indexed/Seq2Index.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/Indexed/SeqReadIdx.html
+++ b/examples/Indexed/SeqReadIdx.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/Merge/Merge.html
+++ b/examples/Merge/Merge.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/Perform/MileageCount.html
+++ b/examples/Perform/MileageCount.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/Perform/Perform1.html
+++ b/examples/Perform/Perform1.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/Perform/Perform2.html
+++ b/examples/Perform/Perform2.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/Perform/Perform3.html
+++ b/examples/Perform/Perform3.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/Perform/Perform4.html
+++ b/examples/Perform/Perform4.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/Relative/ReadRel.html
+++ b/examples/Relative/ReadRel.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/Relative/Seq2Rel.html
+++ b/examples/Relative/Seq2Rel.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/ReportWriter/RepWriteA.html
+++ b/examples/ReportWriter/RepWriteA.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/ReportWriter/RepWriteB.html
+++ b/examples/ReportWriter/RepWriteB.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/ReportWriter/RepWriteFull.html
+++ b/examples/ReportWriter/RepWriteFull.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/ReportWriter/RepWriteSumm.html
+++ b/examples/ReportWriter/RepWriteSumm.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/SeqIns/SEQINSERT.html
+++ b/examples/SeqIns/SEQINSERT.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/SeqRead/SEQREAD.html
+++ b/examples/SeqRead/SEQREAD.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/SeqRead/SEQREADno88.html
+++ b/examples/SeqRead/SEQREADno88.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/SeqRpt/SEQRPT.html
+++ b/examples/SeqRpt/SEQRPT.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/SeqWrite/SEQWRITE.html
+++ b/examples/SeqWrite/SEQWRITE.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/Sort/InputSort.html
+++ b/examples/Sort/InputSort.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/Sort/MaleSort.html
+++ b/examples/Sort/MaleSort.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/Strings/RefMod.html
+++ b/examples/Strings/RefMod.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/Strings/UnstringFileEg.html
+++ b/examples/Strings/UnstringFileEg.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/SubProg/DateValid/DateDriver.html
+++ b/examples/SubProg/DateValid/DateDriver.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/SubProg/DateValid/ValiDate.html
+++ b/examples/SubProg/DateValid/ValiDate.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/SubProg/DayDiff/DayDiffDriver.html
+++ b/examples/SubProg/DayDiff/DayDiffDriver.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/SubProg/Multiply/DriverProg.html
+++ b/examples/SubProg/Multiply/DriverProg.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/SubProg/Multiply/Fickle.html
+++ b/examples/SubProg/Multiply/Fickle.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/SubProg/Multiply/MultiplyNums.html
+++ b/examples/SubProg/Multiply/MultiplyNums.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/SubProg/Multiply/Steadfast.html
+++ b/examples/SubProg/Multiply/Steadfast.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/Tables/MonthTable.html
+++ b/examples/Tables/MonthTable.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/examples/default.html
+++ b/examples/default.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>COBOL example programs</title>

--- a/exercises/COBOLExams/COBOLExams.html
+++ b/exercises/COBOLExams/COBOLExams.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/CountDown.html
+++ b/exercises/CountDown.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html
+++ b/exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html
+++ b/exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html
+++ b/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html
+++ b/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html
+++ b/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html
+++ b/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html
+++ b/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html
+++ b/exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html
+++ b/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html
+++ b/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html
+++ b/exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html
+++ b/exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html
+++ b/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html
+++ b/exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Exm-FileConversion/Exm-FileConversion.html
+++ b/exercises/Exm-FileConversion/Exm-FileConversion.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Exm-FileConversion/Prg-FileConversion.html
+++ b/exercises/Exm-FileConversion/Prg-FileConversion.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html
+++ b/exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html
+++ b/exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html
+++ b/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html
+++ b/exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Exm-SFbyMail/Exm-SFbyMail.html
+++ b/exercises/Exm-SFbyMail/Exm-SFbyMail.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Exm-SFbyMail/Prg-SFbyMail.html
+++ b/exercises/Exm-SFbyMail/Prg-SFbyMail.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Exm-StudFeesRpt/Exm-StudPay.html
+++ b/exercises/Exm-StudFeesRpt/Exm-StudPay.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Exm-StudFeesRpt/Prg-StudPay.html
+++ b/exercises/Exm-StudFeesRpt/Prg-StudPay.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html
+++ b/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html
+++ b/exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html
+++ b/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html
+++ b/exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/GettingStarted.html
+++ b/exercises/GettingStarted.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/MonthTable.html
+++ b/exercises/MonthTable.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html
+++ b/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html
+++ b/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html
+++ b/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html
+++ b/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html
+++ b/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/Proj-CSISEvalform/CSISEvalForm.html
+++ b/exercises/Proj-CSISEvalform/CSISEvalForm.html
@@ -2,6 +2,8 @@
 <html lang="en-GB">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/SeqInsert.html
+++ b/exercises/SeqInsert.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/SeqRead.html
+++ b/exercises/SeqRead.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/SeqReadIf.html
+++ b/exercises/SeqReadIf.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/SeqUpdate.html
+++ b/exercises/SeqUpdate.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/SeqWrite.html
+++ b/exercises/SeqWrite.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/SortIP.html
+++ b/exercises/SortIP.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/exercises/index.html
+++ b/exercises/index.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>COBOL Programming Exercises</title>

--- a/index.html
+++ b/index.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="favicon.svg" />
 		<meta name="google-site-verification" content="g9Kb5_0qV7EdRel40vEW48IAmR1DCIYL7oBqiuPNTr8" />

--- a/lectures/arithmetic.html
+++ b/lectures/arithmetic.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>Arithmetic - COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Arithmetic." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/arithmetic.html" />

--- a/lectures/basics1.html
+++ b/lectures/basics1.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>Basics1 - COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Basics1." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/basics1.html" />

--- a/lectures/basics2.html
+++ b/lectures/basics2.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>basics2 - COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering basics2." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/basics2.html" />

--- a/lectures/call.html
+++ b/lectures/call.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>call - COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering call." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/call.html" />

--- a/lectures/cobintro.html
+++ b/lectures/cobintro.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>cobintro - COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering cobintro." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/cobintro.html" />

--- a/lectures/conditions.html
+++ b/lectures/conditions.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>Conditions - COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Conditions." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/conditions.html" />

--- a/lectures/copy.html
+++ b/lectures/copy.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>COPY - COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering COPY." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/copy.html" />

--- a/lectures/cs4312topics.html
+++ b/lectures/cs4312topics.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>COBOL Course Outline</title>
 		<meta name="description" content="COBOL lecture slides covering COBOL Course Outline." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/cs4312topics.html" />

--- a/lectures/design.html
+++ b/lectures/design.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>design - COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering design." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/design.html" />

--- a/lectures/direct1.html
+++ b/lectures/direct1.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>direct1 - COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering direct1." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/direct1.html" />

--- a/lectures/dsr1.html
+++ b/lectures/dsr1.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>dsr1 - COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering dsr1." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/dsr1.html" />

--- a/lectures/genintro.html
+++ b/lectures/genintro.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>GenIntro - COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering GenIntro." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/genintro.html" />

--- a/lectures/index.html
+++ b/lectures/index.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");

--- a/lectures/indexed.html
+++ b/lectures/indexed.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>Indexed - COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Indexed." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/indexed.html" />

--- a/lectures/inspect.html
+++ b/lectures/inspect.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>Inspect - COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Inspect." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/inspect.html" />

--- a/lectures/perform.html
+++ b/lectures/perform.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>perform - COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering perform." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/perform.html" />

--- a/lectures/relative.html
+++ b/lectures/relative.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>Relative - COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Relative." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/relative.html" />

--- a/lectures/reportwriterssweb.html
+++ b/lectures/reportwriterssweb.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>COBOL Report Writer - Syntax and Semantics</title>
 		<meta name="description" content="COBOL lecture slides covering COBOL Report Writer - Syntax and Semantics." />

--- a/lectures/reportwriterweb.html
+++ b/lectures/reportwriterweb.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<title>COBOL Report Writer</title>
 		<meta name="description" content="COBOL lecture slides covering COBOL Report Writer." />

--- a/lectures/search.html
+++ b/lectures/search.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>Search - COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Search." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/search.html" />

--- a/lectures/seqfile1.html
+++ b/lectures/seqfile1.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>SeqFile1 - COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering SeqFile1." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/seqfile1.html" />

--- a/lectures/seqfile2.html
+++ b/lectures/seqfile2.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>SeqFile2 - COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering SeqFile2." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/seqfile2.html" />

--- a/lectures/seqfile3.html
+++ b/lectures/seqfile3.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>SeqFile3 - COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering SeqFile3." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/seqfile3.html" />

--- a/lectures/sort.html
+++ b/lectures/sort.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>SORT - COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering SORT." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/sort.html" />

--- a/lectures/string.html
+++ b/lectures/string.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>String - COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering String." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/string.html" />

--- a/lectures/tables1.html
+++ b/lectures/tables1.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>Tables1 - COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Tables1." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/tables1.html" />

--- a/lectures/tables2.html
+++ b/lectures/tables2.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>Tables2 - COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Tables2." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/tables2.html" />

--- a/lectures/unstring.html
+++ b/lectures/unstring.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>Unstring - COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Unstring." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/unstring.html" />

--- a/lectures/usage.html
+++ b/lectures/usage.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<title>Usage - COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Usage." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/usage.html" />


### PR DESCRIPTION
## Summary

- Adds `<meta name="theme-color">` light and dark variants to all 173 HTML pages
- Light: `content="#ffffff"` matching `--color-bg` in light mode
- Dark: `content="#1a1a1a"` matching `--color-bg` in dark mode
- Tags are placed immediately after `<meta name="viewport">` in each `<head>`

Closes #409

## Test plan

- [ ] Open a page on Chrome/Android — address bar should tint white in light mode and `#1a1a1a` in dark mode
- [ ] Verify viewport meta remains first in `<head>` on all pages
- [ ] Spot-check course pages, exercise pages, and ppz slideshow pages for correct placement

🤖 Generated with [Claude Code](https://claude.com/claude-code)