### PR TITLE
Add explicit empty ignore array to .pa11yci.js

### DIFF
--- a/.pa11yci.js
+++ b/.pa11yci.js
@@ -17,6 +17,8 @@ const config = {
 			args: ["--no-sandbox", "--disable-dev-shm-usage", "--disable-gpu", "--no-zygote"],
 		},
 	},
+	// Debt ledger: each entry is a known pre-existing violation with an open issue tracking its removal.
+	ignore: [],
 };
 
 // pa11y-ci concatenates CLI URLs onto config urls. For partial PR scans we


### PR DESCRIPTION
## Summary

- Adds `ignore: []` to `.pa11yci.js` so the file matches the contract described in the README
- The README states this array is "an explicit debt ledger — each entry should reference an open issue tracking its eventual removal", but the array was absent entirely
- No behavior change: an empty array is equivalent to no array for pa11y-ci

Closes #395

## Test plan

- [ ] CI pa11y scan passes (no behavioral change, just makes the config explicit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)