### PR TITLE
Fix empty alt text on button images in lectures/index.html (issue #367)

### DIFF
--- a/lectures/index.html
+++ b/lectures/index.html
@@ -64,13 +64,13 @@
 					height="52"
 					src="../pics/B-BrowserPPT2.gif"
 					width="52"
-					alt=""
+					alt="View lecture in browser"
 					style="margin-left: 10px; margin-right: 10px"
 				/><img
 					height="52"
 					src="../pics/B-ZippedPPT2.gif"
 					width="52"
-					alt=""
+					alt="Download PowerPoint file"
 					style="margin-left: 5px; margin-right: 5px"
 				/><br />
 				The first button returns you to the module contents. Try it now.<br />


### PR DESCRIPTION
## Summary

- Adds `alt="View lecture in browser"` to `B-BrowserPPT2.gif`
- Adds `alt="Download PowerPoint file"` to `B-ZippedPPT2.gif`
- Both images are interactive buttons; the alt text was derived from the descriptive prose immediately below them in the page

Fixes #367.

## Test plan

- [ ] Confirm both button images in `lectures/index.html` now have non-empty, descriptive alt attributes
- [ ] Run accessibility audit (e.g. axe) on the page and verify no WCAG 1.1.1 violations remain for these elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)