### PR TITLE
Add github-actions ecosystem to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
       schedule:
           interval: weekly
       open-pull-requests-limit: 5
+    - package-ecosystem: github-actions
+      directory: /
+      schedule:
+          interval: weekly
+      open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- Adds a second `updates:` entry for `package-ecosystem: github-actions` so Dependabot automatically bumps pinned action versions (`actions/checkout`, `actions/setup-node`, `crate-ci/typos`, etc.)
- Matches the same weekly schedule and PR limit as the existing `npm` entry

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)