### PR TITLE
examples/default.html: use eyebrow="COBOL Example" to match leaf pages

### DIFF
--- a/examples/default.html
+++ b/examples/default.html
@@ -56,7 +56,7 @@
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
 		<main id="main-content">
-			<page-hero title="COBOL Example Programs" eyebrow="Department of CSIS"></page-hero>
+			<page-hero title="COBOL Example Programs" eyebrow="COBOL Example"></page-hero>
 			<hr />
 			<table style="margin: 0 auto" width="700">
 				<tr>


### PR DESCRIPTION
## Summary

- Fixes #363
- Changes `eyebrow="Department of CSIS"` → `eyebrow="COBOL Example"` on the examples hub page
- PR #488 already added `<page-hero>` + theme-toggle scripts, but it carried over the old `<p class="dept-banner">Department of CSIS</p>` text as the eyebrow value; this aligns the hub with every individual example leaf page

## Test plan

- [ ] Open `examples/default.html` and confirm the eyebrow label reads "COBOL Example" (not "Department of CSIS")
- [ ] Confirm theme toggle is present and functional on the hub page

🤖 Generated with [Claude Code](https://claude.com/claude-code)