### PR TITLE
fix(theme-toggle): toggle attributes in place instead of re-rendering

### DIFF
--- a/components/theme-toggle.js
+++ b/components/theme-toggle.js
@@ -54,7 +54,11 @@ class ThemeToggle extends HTMLElement {
 			if (HAS_STORAGE) localStorage.setItem(ThemeToggle.#KEY, value);
 			document.documentElement.setAttribute("data-theme", value);
 		}
-		this.#render();
+		this.querySelectorAll("[data-theme-value]").forEach((btn) => {
+			const active = btn.dataset.themeValue === value;
+			btn.setAttribute("aria-pressed", active);
+			btn.classList.toggle("theme-toggle__btn--active", active);
+		});
 	}
 }
 


### PR DESCRIPTION
Closes #348

## What changed

In `components/theme-toggle.js`, `#set()` previously called `this.#render()` after every click, which destroyed and rebuilt all three buttons via `innerHTML`. This caused two problems:
- Keyboard focus was lost mid-navigation because the focused button was destroyed
- Three new event listeners were bound on every click (though AbortController cleaned up the old ones)

## Fix

Replaced the `this.#render()` call in `#set()` with an in-place update loop:

```js
this.querySelectorAll("[data-theme-value]").forEach((btn) => {
    const active = btn.dataset.themeValue === value;
    btn.setAttribute("aria-pressed", active);
    btn.classList.toggle("theme-toggle__btn--active", active);
});
```

The initial render via `connectedCallback` → `#render()` is unchanged — that still builds the DOM and binds the (now permanent) event listeners once.

## Verification

Tested via preview: confirmed button count stays at 3 after click (no DOM rebuild), `aria-pressed` and `--active` class update correctly, and `document.activeElement` remains the clicked button after the state change.