### PR TITLE
fix: wire add-img-dimensions.js as npm run fix:img-dims

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"serve": "http-server . --cors -c-1 -p 8000 --silent",
 		"validate": "html-validate index.html 404.html \"course/**/*.html\" \"examples/**/*.html\" \"exercises/**/*.html\" \"lectures/**/*.html\"",
 		"check:img-dims": "node scripts/check-img-dimensions.js",
+		"fix:img-dims": "node scripts/add-img-dimensions.js",
 		"links:run": "linkinator http://localhost:8000 --config linkinator.config.json",
 		"links": "start-server-and-test serve http://localhost:8000 links:run",
 		"a11y:run": "pa11y-ci --config .pa11yci.js",

--- a/scripts/check-img-dimensions.js
+++ b/scripts/check-img-dimensions.js
@@ -44,7 +44,7 @@ for (const dir of SCAN_DIRS) {
 }
 
 if (violations > 0) {
-	console.error(`\n${violations} <img> tag(s) missing width/height. Run: node scripts/add-img-dimensions.js`);
+	console.error(`\n${violations} <img> tag(s) missing width/height. Run: npm run fix:img-dims`);
 	process.exit(1);
 } else {
 	console.log("OK: all <img> tags have width and height.");


### PR DESCRIPTION
## Summary

- Adds `fix:img-dims` to `package.json` scripts, pointing at `scripts/add-img-dimensions.js`
- Updates the error message in `check-img-dimensions.js` to reference `npm run fix:img-dims` instead of the bare `node scripts/add-img-dimensions.js` path

Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)