### PR TITLE
feat: add .copy-button.is-success visual feedback on clipboard copy

### DIFF
--- a/components/copy-button.js
+++ b/components/copy-button.js
@@ -18,8 +18,10 @@ document.addEventListener("DOMContentLoaded", () => {
 		btn.addEventListener("click", () => {
 			navigator.clipboard.writeText(code.textContent).then(() => {
 				btn.textContent = "Copied!";
+				btn.classList.add("is-success");
 				setTimeout(() => {
 					btn.textContent = "Copy";
+					btn.classList.remove("is-success");
 				}, 1500);
 			});
 		});

--- a/course/Resources/css/course-components.css
+++ b/course/Resources/css/course-components.css
@@ -824,7 +824,11 @@ body pre[class*="language-"] {
 	color: #333;
 	border: 1px solid #bbb;
 	opacity: 0.8;
-	transition: opacity 0.15s;
+	transition:
+		opacity 0.15s,
+		background-color 0.15s,
+		color 0.15s,
+		border-color 0.15s;
 }
 
 .copy-button:hover,
@@ -834,11 +838,24 @@ body pre[class*="language-"] {
 	outline-offset: 1px;
 }
 
+.copy-button.is-success {
+	background-color: #e8f5e9;
+	color: #2e7d32;
+	border-color: #a5d6a7;
+	opacity: 1;
+}
+
 @media (prefers-color-scheme: dark) {
 	:root:not([data-theme="light"]) .copy-button {
 		background-color: #2e2e2e;
 		color: #ddd;
 		border-color: #555;
+	}
+
+	:root:not([data-theme="light"]) .copy-button.is-success {
+		background-color: #1b3a1e;
+		color: #66bb6a;
+		border-color: #388e3c;
 	}
 }
 
@@ -846,6 +863,12 @@ body pre[class*="language-"] {
 	background-color: #2e2e2e;
 	color: #ddd;
 	border-color: #555;
+}
+
+:root[data-theme="dark"] .copy-button.is-success {
+	background-color: #1b3a1e;
+	color: #66bb6a;
+	border-color: #388e3c;
 }
 
 /* ============================================================================


### PR DESCRIPTION
## Summary

- Adds `.copy-button.is-success` CSS modifier class to `course-components.css` with green-tinted colours (light and both dark-mode paths)
- Toggles `is-success` on the button in `copy-button.js` during the 1500 ms success window alongside the existing "Copied!" text change
- Expands the base `.copy-button` transition to smooth the colour change across all four properties (`opacity`, `background-color`, `color`, `border-color`)

Closes #354

## Test plan

- [ ] Click a copy button on any page with a Prism code block (e.g. `examples/SeqRead/SEQREAD.html`)
- [ ] Confirm button turns green for ~1.5 s then reverts to idle colour
- [ ] Repeat with Light / Dark / Auto theme toggle to verify all three colour-scheme paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)