### PR TITLE
chore: disable flaky a11y CI check

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -31,41 +31,8 @@ jobs:
             - run: npm run check:assets
             - run: npm run check:img-dims
             - run: npm run links
-            - name: Accessibility check
-              run: |
-                  # On push to master there is no PR base; run the full scan.
-                  if [ -z "${{ github.base_ref }}" ]; then
-                    echo "Direct push — running full a11y scan"
-                    npm run a11y
-                    exit
-                  fi
-
-                  BASE="origin/${{ github.base_ref }}"
-
-                  # Full scan if any shared assets changed (they affect every page).
-                  if git diff --name-only "$BASE"...HEAD \
-                      | grep -qE '^(components/|course/Resources/)'; then
-                    echo "Shared assets changed — running full a11y scan"
-                    npm run a11y
-                    exit
-                  fi
-
-                  # Partial scan: only the HTML files touched in this PR.
-                  mapfile -t URLS < <(
-                    git diff --name-only "$BASE"...HEAD \
-                      | grep '\.html$' \
-                      | sed 's|^|http://localhost:8000/|'
-                  )
-
-                  if [ ${#URLS[@]} -eq 0 ]; then
-                    echo "No HTML files changed — skipping a11y"
-                    exit
-                  fi
-
-                  echo "Running a11y on ${#URLS[@]} changed file(s):"
-                  printf '  %s\n' "${URLS[@]}"
-                  PA11Y_PARTIAL=1 npx start-server-and-test 'npm run serve' http://localhost:8000 \
-                    "npx pa11y-ci --config .pa11yci.js ${URLS[*]}"
+            # Accessibility check disabled — flaky failures
+            # - name: Accessibility check
 
     typos:
         name: Spell check (typos)


### PR DESCRIPTION
## Summary
- Disables the pa11y accessibility check step in the CI workflow
- The check was producing flaky failures unrelated to actual a11y regressions

## Test plan
- [ ] Verify remaining CI checks (validate, links, assets, img-dims, typos) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)