### PR TITLE
feat: add Web App Manifest for PWA install and theme color

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="favicon.svg" />
+		<link rel="manifest" href="manifest.json" />
 		<meta name="google-site-verification" content="g9Kb5_0qV7EdRel40vEW48IAmR1DCIYL7oBqiuPNTr8" />
 		<title>COBOL programming - tutorials, lectures, exercises, examples</title>
 		<meta name="resource-type" content="document" />

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,15 @@
+{
+	"name": "COBOL programming - tutorials, lectures, exercises, examples",
+	"short_name": "COBOL Course",
+	"start_url": "./",
+	"display": "browser",
+	"theme_color": "#1976D2",
+	"background_color": "#ffffff",
+	"icons": [
+		{
+			"src": "favicon.svg",
+			"type": "image/svg+xml",
+			"sizes": "any"
+		}
+	]
+}


### PR DESCRIPTION
## Summary

- Adds `manifest.json` at the repo root with `name`, `short_name`, `theme_color` (`#1976D2` — the brand blue from the favicon), `background_color` (`#ffffff`), and an SVG icon entry
- Wires it into `index.html` via `<link rel="manifest" href="manifest.json">`

Closes #342.

## Test plan

- [ ] Open DevTools → Application → Manifest on the index page and confirm all fields load without errors
- [ ] On Android Chrome, verify the address bar tints to the brand blue

🤖 Generated with [Claude Code](https://claude.com/claude-code)