### PR TITLE
fix: escape href and title values in related-content component

### DIFF
--- a/components/related-content.js
+++ b/components/related-content.js
@@ -11,6 +11,10 @@
 // Renders into Light DOM (no Shadow DOM) so that course.css link colours and
 // course-components.css layout classes apply without any extra CSS piercing.
 
+function escapeAttr(str) {
+	return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
 class RelatedContent extends HTMLElement {
 	connectedCallback() {
 		const groups = [
@@ -26,7 +30,7 @@ class RelatedContent extends HTMLElement {
 				const items = this._parseLinks(raw);
 				if (!items.length) return "";
 				const lis = items
-					.map(({ href, title }) => `<li><a href="${href}">${title}</a></li>`)
+					.map(({ href, title }) => `<li><a href="${escapeAttr(href)}">${escapeAttr(title)}</a></li>`)
 					.join("\n\t\t\t\t");
 				return `
 			<div class="related-group">


### PR DESCRIPTION
## Summary

- Adds an `escapeAttr()` helper to `components/related-content.js` (matching the one in `scripts/build-examples.js`)
- Applies it to both the `href` attribute and text content interpolations in the `<a>` tag template literal
- Prevents broken markup from stray `"` characters in author-supplied `lectures=`/`examples=`/`exercises=` attribute values

Closes #352

## Test plan

- [ ] Verify a `<related-content>` element with normal values still renders correctly
- [ ] Verify a path containing `"` in an attribute value produces valid markup rather than broken HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)