### PR TITLE
ci: add concurrency group to format.yml to cancel superseded runs

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -10,6 +10,10 @@ on:
     pull_request:
         branches: [master]
 
+concurrency:
+    group: format-${{ github.ref }}
+    cancel-in-progress: true
+
 permissions:
     contents: write
 


### PR DESCRIPTION
## Summary
- Adds `concurrency: { group: format-${{ github.ref }}, cancel-in-progress: true }` at the workflow level in `.github/workflows/format.yml`
- Prevents race conditions when two pushes land within seconds of each other, which could cause concurrent runs to both try pushing formatting fixes back to the branch

Closes #334

## Test plan
- [ ] Push two commits to a PR branch in rapid succession and verify only one `auto-format` run completes (the other is cancelled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)