### PR TITLE
feat: extend check-assets.js to validate CSS url(...) references

### DIFF
--- a/scripts/check-assets.js
+++ b/scripts/check-assets.js
@@ -2,10 +2,11 @@
 /**
  * check-assets.js
  *
- * Walk every *.html file in the repo (skipping node_modules, .git, .claude,
- * .playwright-mcp) and verify that every src/href attribute that points to a
- * local file actually exists on disk, and that every intra-page #fragment
- * target resolves to an id= attribute on the same page.
+ * Walk every *.html and *.css file in the repo (skipping node_modules, .git,
+ * .claude, .playwright-mcp) and verify that:
+ *   - every src/href attribute in HTML that points to a local file exists on disk
+ *   - every intra-page #fragment target in HTML resolves to an id= on the same page
+ *   - every url(...) reference in CSS that points to a local file exists on disk
  *
  * Exit code 0  – no broken references found.
  * Exit code 1  – one or more broken references found.
@@ -31,7 +32,7 @@ const SKIP_PREFIXES = ["http://", "https://", "ftp://", "mailto:", "data:", "//"
 // Walk the directory tree and collect *.html files
 // ---------------------------------------------------------------------------
 
-function walkHtmlFiles(dir, results = []) {
+function walkFilesByExtension(dir, ext, results = []) {
 	let entries;
 	try {
 		entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -42,9 +43,9 @@ function walkHtmlFiles(dir, results = []) {
 	for (const entry of entries) {
 		if (entry.isDirectory()) {
 			if (!SKIP_DIRS.has(entry.name)) {
-				walkHtmlFiles(path.join(dir, entry.name), results);
+				walkFilesByExtension(path.join(dir, entry.name), ext, results);
 			}
-		} else if (entry.isFile() && entry.name.endsWith(".html")) {
+		} else if (entry.isFile() && entry.name.endsWith(ext)) {
 			results.push(path.join(dir, entry.name));
 		}
 	}
@@ -58,6 +59,9 @@ function walkHtmlFiles(dir, results = []) {
 
 // Match src="..." href="..." (both " and ' delimiters).
 const ATTR_RE = /(?:src|href)\s*=\s*(?:"([^"]+)"|'([^']+)')/gi;
+
+// Match CSS url("..."), url('...'), url(...) — captures the inner path.
+const CSS_URL_RE = /url\(\s*(?:"([^"]+)"|'([^']+)'|([^)'"]\S*?))\s*\)/gi;
 
 function extractRefs(html) {
 	const refs = [];
@@ -96,6 +100,16 @@ function stripQueryAndFragment(ref) {
 	return ref.replace(/[?#].*$/, "");
 }
 
+function extractCssRefs(css) {
+	const refs = [];
+	let match;
+	CSS_URL_RE.lastIndex = 0;
+	while ((match = CSS_URL_RE.exec(css)) !== null) {
+		refs.push(match[1] ?? match[2] ?? match[3]);
+	}
+	return refs;
+}
+
 function decodeHtmlEntities(str) {
 	// Decode the handful of entities that commonly appear in href/src values.
 	return str
@@ -111,7 +125,8 @@ function decodeHtmlEntities(str) {
 // Main
 // ---------------------------------------------------------------------------
 
-const htmlFiles = walkHtmlFiles(REPO_ROOT);
+const htmlFiles = walkFilesByExtension(REPO_ROOT, ".html");
+const cssFiles = walkFilesByExtension(REPO_ROOT, ".css");
 
 let totalBroken = 0;
 const report = [];
@@ -153,6 +168,36 @@ for (const htmlFile of htmlFiles) {
 	if (broken.length > 0) {
 		totalBroken += broken.length;
 		report.push({ file: path.relative(REPO_ROOT, htmlFile), broken });
+	}
+}
+
+for (const cssFile of cssFiles) {
+	const cssDir = path.dirname(cssFile);
+	let css;
+	try {
+		css = fs.readFileSync(cssFile, "utf8");
+	} catch {
+		continue;
+	}
+
+	const refs = extractCssRefs(css);
+	const broken = [];
+
+	for (const rawRef of refs) {
+		if (!isLocalRef(rawRef)) continue;
+
+		const cleanRef = stripQueryAndFragment(rawRef);
+		if (!cleanRef) continue;
+
+		const resolved = path.resolve(cssDir, cleanRef);
+		if (!fs.existsSync(resolved)) {
+			broken.push({ ref: rawRef, resolved });
+		}
+	}
+
+	if (broken.length > 0) {
+		totalBroken += broken.length;
+		report.push({ file: path.relative(REPO_ROOT, cssFile), broken });
 	}
 }
 


### PR DESCRIPTION
## Summary

- Generalizes `walkHtmlFiles` into `walkFilesByExtension(dir, ext)` to support both `.html` and `.css`
- Adds `CSS_URL_RE` regex to match all three `url()` forms: double-quoted, single-quoted, and unquoted
- Adds `extractCssRefs()` to pull `url(...)` paths from CSS source
- Adds a CSS checking loop that resolves each path relative to its `.css` file and reports missing assets

Closes #328

## Test plan

- [x] `node scripts/check-assets.js` exits 0 on the current repo
- [ ] Manually introduce a broken `url(../images/missing.png)` in a CSS file and confirm the script reports it