### PR TITLE
feat: roll out <run-in-ce> to non-file-I/O examples (closes #423)

### DIFF
--- a/examples/Accept/ACCEPT.html
+++ b/examples/Accept/ACCEPT.html
@@ -42,6 +42,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/run-in-ce.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -59,6 +60,7 @@
 							fields. Also shows how the ACCEPT may be used to get and DISPLAY the system time and date.
 						</p>
 						<p><a href="AcceptAndDisplay.cbl" download>Download AcceptAndDisplay.cbl</a></p>
+						<p><run-in-ce></run-in-ce></p>
 						<related-content
 							lectures="../../course/COBOLIntro.html|Introduction to COBOL, ../../course/COBOLcommands.html|Basic COBOL Commands, ../../course/DataDeclaration.html|Declaring Data in COBOL, ../../course/EditedPics.html|Edited PICs"
 							examples="Shortest.html|Shortest COBOL Program, Multiplier.html|ACCEPT, DISPLAY and MULTIPLY Example"

--- a/examples/Accept/Multiplier.html
+++ b/examples/Accept/Multiplier.html
@@ -45,6 +45,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/run-in-ce.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -65,6 +66,7 @@
 							result.
 						</p>
 						<p><a href="Multiplier.cbl" download>Download Multiplier.cbl</a></p>
+						<p><run-in-ce></run-in-ce></p>
 						<related-content
 							lectures="../../course/COBOLcommands.html|Basic COBOL Commands, ../../course/DataDeclaration.html|Declaring Data in COBOL, ../../course/EditedPics.html|Edited PICs"
 							examples="ACCEPT.html|ACCEPT and DISPLAY Example"

--- a/examples/Accept/Shortest.html
+++ b/examples/Accept/Shortest.html
@@ -42,6 +42,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/run-in-ce.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -59,6 +60,7 @@
 							shorter still by leaving out the STOP RUN.
 						</p>
 						<p><a href="ShortestProgram.cbl" download>Download ShortestProgram.cbl</a></p>
+						<p><run-in-ce></run-in-ce></p>
 						<related-content
 							lectures="../../course/COBOLIntro.html|Introduction to COBOL"
 							examples="ACCEPT.html|ACCEPT and DISPLAY Example"

--- a/examples/Conditn/Conditions.html
+++ b/examples/Conditn/Conditions.html
@@ -42,6 +42,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/run-in-ce.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -59,6 +60,7 @@
 						</nav>
 						<p>An example program demonstrating the use of Condition Names (level 88's).</p>
 						<p><a href="CONDITIONS.cbl" download>Download CONDITIONS.cbl</a></p>
+						<p><run-in-ce></run-in-ce></p>
 						<related-content
 							lectures="../../course/Selection.html|Selection in COBOL"
 							examples="IterIf.html|Iteration with IF Example"

--- a/examples/Conditn/IterIf.html
+++ b/examples/Conditn/IterIf.html
@@ -42,6 +42,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/run-in-ce.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -59,6 +60,7 @@
 							additions and multiplications.
 						</p>
 						<p><a href="Iteration-If.cbl" download>Download Iteration-If.cbl</a></p>
+						<p><run-in-ce></run-in-ce></p>
 						<related-content
 							lectures="../../course/Selection.html|Selection in COBOL, ../../course/Iteration.html|Iteration in COBOL"
 							examples="Conditions.html|Condition Names Example, ../Perform/Perform1.html|PERFORM – Format 1, ../Perform/Perform2.html|PERFORM – Format 2, ../Perform/Perform3.html|PERFORM – Format 3"

--- a/examples/Perform/MileageCount.html
+++ b/examples/Perform/MileageCount.html
@@ -45,6 +45,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/run-in-ce.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -62,6 +63,7 @@
 							used to simulate a mileage counter.
 						</p>
 						<p><a href="MileageCounter.cbl" download>Download MileageCounter.cbl</a></p>
+						<p><run-in-ce></run-in-ce></p>
 						<related-content
 							lectures="../../course/Iteration.html|Iteration in COBOL"
 							examples="Perform1.html|PERFORM – Format 1, Perform2.html|PERFORM – Format 2, Perform3.html|PERFORM – Format 3, Perform4.html|PERFORM – Format 4"

--- a/examples/Perform/Perform1.html
+++ b/examples/Perform/Perform1.html
@@ -45,6 +45,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/run-in-ce.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -62,6 +63,7 @@
 							the flow of control through a program.
 						</p>
 						<p><a href="PerformFormat1.cbl" download>Download PerformFormat1.cbl</a></p>
+						<p><run-in-ce></run-in-ce></p>
 						<related-content
 							lectures="../../course/Iteration.html|Iteration in COBOL"
 							examples="Perform2.html|PERFORM – Format 2, Perform3.html|PERFORM – Format 3, Perform4.html|PERFORM – Format 4, MileageCount.html|Mileage Counter"

--- a/examples/Perform/Perform2.html
+++ b/examples/Perform/Perform2.html
@@ -45,6 +45,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/run-in-ce.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -62,6 +63,7 @@
 							block of code x number of times.
 						</p>
 						<p><a href="PerformFormat2.cbl" download>Download PerformFormat2.cbl</a></p>
+						<p><run-in-ce></run-in-ce></p>
 						<related-content
 							lectures="../../course/Iteration.html|Iteration in COBOL"
 							examples="Perform1.html|PERFORM – Format 1, Perform3.html|PERFORM – Format 3, Perform4.html|PERFORM – Format 4, MileageCount.html|Mileage Counter"

--- a/examples/Perform/Perform3.html
+++ b/examples/Perform/Perform3.html
@@ -45,6 +45,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/run-in-ce.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -62,6 +63,7 @@
 							where the length of the stream cannot be determined in advance.
 						</p>
 						<p><a href="PerformFormat3.cbl" download>Download PerformFormat3.cbl</a></p>
+						<p><run-in-ce></run-in-ce></p>
 						<related-content
 							lectures="../../course/Iteration.html|Iteration in COBOL"
 							examples="Perform1.html|PERFORM – Format 1, Perform2.html|PERFORM – Format 2, Perform4.html|PERFORM – Format 4, MileageCount.html|Mileage Counter"

--- a/examples/Perform/Perform4.html
+++ b/examples/Perform/Perform4.html
@@ -45,6 +45,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/run-in-ce.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -63,6 +64,7 @@
 							phrases.
 						</p>
 						<p><a href="PerformFormat4.cbl" download>Download PerformFormat4.cbl</a></p>
+						<p><run-in-ce></run-in-ce></p>
 						<related-content
 							lectures="../../course/Iteration.html|Iteration in COBOL"
 							examples="Perform1.html|PERFORM – Format 1, Perform2.html|PERFORM – Format 2, Perform3.html|PERFORM – Format 3, MileageCount.html|Mileage Counter"

--- a/examples/Strings/RefMod.html
+++ b/examples/Strings/RefMod.html
@@ -42,6 +42,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/run-in-ce.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -63,6 +64,7 @@
 							string.
 						</p>
 						<p><a href="RefModification.cbl" download>Download RefModification.cbl</a></p>
+						<p><run-in-ce></run-in-ce></p>
 						<related-content
 							lectures="../../course/String.html|STRING Verb, ../../course/Unstring.html|UNSTRING Verb, ../../course/RefMod.html|Reference Modification"
 							examples="UnstringFileEg.html|Unpacking Comma-Separated Records"

--- a/scripts/build-examples.js
+++ b/scripts/build-examples.js
@@ -29,6 +29,9 @@ const MAX_RELATED_PER_GROUP = 4;
 // `title`    – <title> text and og:title / twitter:title
 // `crumb`    – short label shown as the trailing breadcrumb span
 // `desc`     – full description shown in the <p> and (truncated) in meta tags
+// `runInCe`  – (optional) when true, inject the <run-in-ce> custom element and
+//              its script. Set for examples that work cleanly in Compiler
+//              Explorer's executor sandbox (no data files, single .cbl source).
 //
 // The <related-content> block is sourced from scripts/cross-links.json — see
 // `files` and `families` there for the mapping. To change which lessons or
@@ -43,6 +46,7 @@ const MANIFEST = [
 		title: "ACCEPT and DISPLAY example program",
 		crumb: "ACCEPT and DISPLAY",
 		desc: "The program accepts a simple student record from the user and displays the individual fields. Also shows how the ACCEPT may be used to get and DISPLAY the system time and date.",
+		runInCe: true,
 	},
 	{
 		file: "Accept/Multiplier.html",
@@ -50,6 +54,7 @@ const MANIFEST = [
 		title: "ACCEPT, DISPLAY and MULTIPLY example program",
 		crumb: "Multiplier",
 		desc: "Accepts two single digit numbers from the user, multiplies them together and displays the result.",
+		runInCe: true,
 	},
 	{
 		file: "Accept/Shortest.html",
@@ -57,6 +62,7 @@ const MANIFEST = [
 		title: "The Shortest COBOL program we can have",
 		crumb: "Shortest COBOL Program",
 		desc: "This example program is almost the shortest COBOL program we can have. We could make it shorter still by leaving out the STOP RUN.",
+		runInCe: true,
 	},
 	// ── Conditn ─────────────────────────────────────────────────────────────
 	{
@@ -65,6 +71,7 @@ const MANIFEST = [
 		title: "Condition Names (level 88) example program",
 		crumb: "Condition Names",
 		desc: "An example program demonstrating the use of Condition Names (level 88's).",
+		runInCe: true,
 	},
 	{
 		file: "Conditn/IterIf.html",
@@ -72,6 +79,7 @@ const MANIFEST = [
 		title: "Iteration with IF example program",
 		crumb: "Iteration with IF",
 		desc: "An example program that implements a primitive calculator. The calculator only does additions and multiplications.",
+		runInCe: true,
 	},
 	// ── Indexed ─────────────────────────────────────────────────────────────
 	{
@@ -110,6 +118,7 @@ const MANIFEST = [
 		title: "Mileage counter simulation",
 		crumb: "Mileage Counter",
 		desc: "Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used to simulate a mileage counter.",
+		runInCe: true,
 	},
 	{
 		file: "Perform/Perform1.html",
@@ -117,6 +126,7 @@ const MANIFEST = [
 		title: "Perform - Format 1 example program",
 		crumb: "PERFORM Format 1",
 		desc: "An example program demonstrating how the first format of the PERFORM may be used to change the flow of control through a program.",
+		runInCe: true,
 	},
 	{
 		file: "Perform/Perform2.html",
@@ -124,6 +134,7 @@ const MANIFEST = [
 		title: "Perform - Format 2 example program",
 		crumb: "PERFORM Format 2",
 		desc: "Demonstrates the second format of the PERFORM. The PERFORM..TIMES may be used to execute a block of code x number of times.",
+		runInCe: true,
 	},
 	{
 		file: "Perform/Perform3.html",
@@ -131,6 +142,7 @@ const MANIFEST = [
 		title: "Perform - Format 3 example program",
 		crumb: "PERFORM Format 3",
 		desc: "Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values where the length of the stream cannot be determined in advance.",
+		runInCe: true,
 	},
 	{
 		file: "Perform/Perform4.html",
@@ -138,6 +150,7 @@ const MANIFEST = [
 		title: "Perform - Format 4 example program",
 		crumb: "PERFORM Format 4",
 		desc: "Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used for counting iteration. Also introduces the WITH TEST BEFORE and WITH TEST AFTER phrases.",
+		runInCe: true,
 	},
 	// ── Relative ────────────────────────────────────────────────────────────
 	{
@@ -244,6 +257,7 @@ const MANIFEST = [
 		title: "String handling - Reference Modification examples",
 		crumb: "Reference Modification",
 		desc: "Solves a number of string handling tasks such as extracting substrings, removing leading or trailing blanks, and finding the location of the first occurrence of a character in a string.",
+		runInCe: true,
 	},
 	{
 		file: "Strings/UnstringFileEg.html",
@@ -426,6 +440,11 @@ function buildPage(entry) {
 
 	const relatedEl = relatedContentHtml(entry.file);
 
+	const runInCeScript = entry.runInCe
+		? `\t\t<script src="${pfx}components/run-in-ce.js" defer></script>\n`
+		: "";
+	const runInCeEl = entry.runInCe ? `\t\t\t\t\t\t<p><run-in-ce></run-in-ce></p>\n` : "";
+
 	return `<!doctype html>
 <html lang="en">
 \t<head>
@@ -461,7 +480,7 @@ function buildPage(entry) {
 \t\t<script src="${pfx}components/page-hero.js" defer></script>
 \t\t<script src="${pfx}components/related-content.js" defer></script>
 \t\t<script src="${pfx}components/copy-button.js" defer></script>
-\t</head>
+${runInCeScript}\t</head>
 \t<body>
 \t\t<a class="skip-link" href="#main-content">Skip to main content</a>
 \t\t<main id="main-content">
@@ -475,7 +494,7 @@ function buildPage(entry) {
 \t\t\t\t\t\t</nav>
 \t\t\t\t\t\t<p>${entry.desc}</p>
 \t\t\t\t\t\t<p><a href="${entry.cbl}" download>Download ${entry.cbl}</a></p>
-${relatedEl}\t\t\t\t\t\t<pre class="language-cobol"><code class="language-cobol">${escapedSource}
+${runInCeEl}${relatedEl}\t\t\t\t\t\t<pre class="language-cobol"><code class="language-cobol">${escapedSource}
 </code></pre>
 \t\t\t\t\t</div>
 \t\t\t\t</div>

--- a/scripts/build-examples.js
+++ b/scripts/build-examples.js
@@ -440,9 +440,7 @@ function buildPage(entry) {
 
 	const relatedEl = relatedContentHtml(entry.file);
 
-	const runInCeScript = entry.runInCe
-		? `\t\t<script src="${pfx}components/run-in-ce.js" defer></script>\n`
-		: "";
+	const runInCeScript = entry.runInCe ? `\t\t<script src="${pfx}components/run-in-ce.js" defer></script>\n` : "";
 	const runInCeEl = entry.runInCe ? `\t\t\t\t\t\t<p><run-in-ce></run-in-ce></p>\n` : "";
 
 	return `<!doctype html>


### PR DESCRIPTION
## Summary

Phase 2 of #259 / closes #423. Adds the **Run on Compiler Explorer** button (`<run-in-ce>`) to the 10 remaining example pages that work cleanly in CE's executor sandbox.

- Extended [`scripts/build-examples.js`](../blob/claude/lucid-chandrasekhar-2b8b3e/scripts/build-examples.js) with an optional `runInCe: true` flag on manifest entries. When set, the generator injects both the `<script src=".../run-in-ce.js" defer>` tag in `<head>` and the `<p><run-in-ce></run-in-ce></p>` element below the download link. Doing it in the generator (vs. hand-editing HTML) keeps the changes alive across future regens.
- Flagged 11 manifest entries: the 10 from the issue's table — `Accept/Multiplier`, `Accept/Shortest`, `Conditn/Conditions`, `Conditn/IterIf`, `Perform/MileageCount`, `Perform/{Perform1..4}`, `Strings/RefMod` — plus `Accept/ACCEPT`.

### Note on ACCEPT.html

The Phase 1 prototype landed via #406 was a direct hand-edit of `examples/Accept/ACCEPT.html`. That change was wiped by a subsequent auto-regen of the example HTML (commit 60e7d54 etc.) and the prototype was silently absent on `master` before this PR. Flagging it via the manifest restores it and makes it regen-stable.

## Screenshots

Verified locally via `http-server` + DOM inspection:

- `a.run-in-ce` renders on all 11 pages with the PR #406 styling — `display: inline-block`, dark theme background `rgb(46, 46, 46)`, light text `rgb(221, 221, 221)`, text `"Run on Compiler Explorer ↗"`.
- The generated `href` decodes to a valid CE ClientState payload: `language: "cobol"`, `compilerId: "gnucobol32"`, `options: "-x -free"`, executor pane present, and source captured from the page (including the `>>SOURCE FORMAT IS FREE` directive).
- No console errors.
- Confirmed non-target pages (Indexed, Merge, SubProg, Tables, etc.) were not accidentally flagged.

## Checklist

- [ ] `npm run validate` passes
- [ ] `npm run links` passes
- [ ] `npm run format:check` passes
- [ ] `npm run a11y` passes (if this PR touches page content or styling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)