### PR TITLE
feat: add :focus-visible outline for keyboard accessibility (#356)

### DIFF
--- a/course/Resources/css/course.css
+++ b/course/Resources/css/course.css
@@ -147,6 +147,15 @@ a:active {
 	color: var(--color-link-active);
 }
 
+a:focus-visible,
+button:focus-visible,
+summary:focus-visible,
+details:focus-visible {
+	outline: 2px solid var(--color-link);
+	outline-offset: 2px;
+	box-shadow: 0 0 0 4px var(--color-bg);
+}
+
 img {
 	max-width: 100%;
 	height: auto;


### PR DESCRIPTION
## Summary

- Adds a global `:focus-visible` rule in `course/Resources/css/course.css` covering `a`, `button`, `summary`, and `details`
- Uses `--color-link` for the 2px outline and `--color-bg` for a 4px box-shadow gap, producing a high-contrast double-ring that adapts to both light and dark themes
- Existing component-specific `:focus-visible` rules (`.theme-toggle__btn`, `.course-progress-reset`) are unaffected — they remain as targeted overrides

## Test plan

- [ ] Tab through a course page in light mode and verify a blue double-ring appears on links, buttons, and `<summary>` elements
- [ ] Repeat in dark mode and verify the ring uses the lighter `--color-link` (`#93c5fd`) against the dark `--color-bg` (`#1a1a1a`)
- [ ] Confirm mouse clicks on links do **not** show the outline (`:focus-visible` only fires on keyboard focus)
- [ ] Confirm the existing theme-toggle and reset-button outlines still appear unchanged

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)