### PR TITLE
feat: replace layout tables in examples/default.html with CSS

### DIFF
--- a/course/Resources/css/course.css
+++ b/course/Resources/css/course.css
@@ -419,7 +419,12 @@ td[bgcolor="#ffffcc"] h4 {
 	box-sizing: border-box;
 }
 
-.page-content,
+.page-content {
+	max-width: 700px;
+	margin-inline: auto;
+	padding: 2px;
+}
+
 .page-footer {
 	padding: 2px;
 }

--- a/examples/default.html
+++ b/examples/default.html
@@ -60,22 +60,20 @@
 			<hr />
 			<div class="page-content">
 				<p>
-					These pages contain a large number of example COBOL programs. The programs may be
-					downloaded, or viewed in your browser. Test data for the example COBOL programs is also
-					provided where appropriate.
+					These pages contain a large number of example COBOL programs. The programs may be downloaded, or
+					viewed in your browser. Test data for the example COBOL programs is also provided where appropriate.
 				</p>
 				<p>
-					The programs have been compiled and tested using Microfocus NetExpress but they should work
-					on any COBOL-85 compliant compiler with very few changes.<br />
-					You may have to reformat the programs if your compiler does not have the equivalent of the $
-					SET SOURCEFORMAT"FREE". This compiler directive frees Microfocus COBOL programs from the
-					normal COBOL formatting conventions.<br />
+					The programs have been compiled and tested using Microfocus NetExpress but they should work on any
+					COBOL-85 compliant compiler with very few changes.<br />
+					You may have to reformat the programs if your compiler does not have the equivalent of the $ SET
+					SOURCEFORMAT"FREE". This compiler directive frees Microfocus COBOL programs from the normal COBOL
+					formatting conventions.<br />
 					You may also have to remove the
 					<code class="language-cobol">ORGANIZATION IS LINE SEQUENTIAL</code> phrase in the
-					<code class="language-cobol">SELECT</code> and
-					<code class="language-cobol">ASSIGN</code> clause of sequential files. In Microfocus COBOL,
-					<code class="language-cobol">LINE SEQUENTIAL</code> files terminate each record with a
-					carriage return and line feed.
+					<code class="language-cobol">SELECT</code> and <code class="language-cobol">ASSIGN</code> clause of
+					sequential files. In Microfocus COBOL, <code class="language-cobol">LINE SEQUENTIAL</code> files
+					terminate each record with a carriage return and line feed.
 				</p>
 				<copyright-notice type="examples"></copyright-notice>
 			</div>

--- a/examples/default.html
+++ b/examples/default.html
@@ -58,33 +58,28 @@
 		<main id="main-content">
 			<page-hero title="COBOL Example Programs" eyebrow="COBOL Example"></page-hero>
 			<hr />
-			<table style="margin: 0 auto" width="700">
-				<tr>
-					<td>
-						<p>
-							These pages contain a large number of example COBOL programs. The programs may be
-							downloaded, or viewed in your browser. Test data for the example COBOL programs is also
-							provided where appropriate.
-						</p>
-						<p>
-							The programs have been compiled and tested using Microfocus NetExpress but they should work
-							on any COBOL-85 compliant compiler with very few changes.<br />
-							You may have to reformat the programs if your compiler does not have the equivalent of the $
-							SET SOURCEFORMAT"FREE". This compiler directive frees Microfocus COBOL programs from the
-							normal COBOL formatting conventions.<br />
-							You may also have to remove the
-							<code class="language-cobol">ORGANIZATION IS LINE SEQUENTIAL</code> phrase in the
-							<code class="language-cobol">SELECT</code> and
-							<code class="language-cobol">ASSIGN</code> clause of sequential files. In Microfocus COBOL,
-							<code class="language-cobol">LINE SEQUENTIAL</code> files terminate each record with a
-							carriage return and line feed.
-						</p>
-						<copyright-notice type="examples"></copyright-notice>
-					</td>
-				</tr>
-			</table>
+			<div class="page-content">
+				<p>
+					These pages contain a large number of example COBOL programs. The programs may be
+					downloaded, or viewed in your browser. Test data for the example COBOL programs is also
+					provided where appropriate.
+				</p>
+				<p>
+					The programs have been compiled and tested using Microfocus NetExpress but they should work
+					on any COBOL-85 compliant compiler with very few changes.<br />
+					You may have to reformat the programs if your compiler does not have the equivalent of the $
+					SET SOURCEFORMAT"FREE". This compiler directive frees Microfocus COBOL programs from the
+					normal COBOL formatting conventions.<br />
+					You may also have to remove the
+					<code class="language-cobol">ORGANIZATION IS LINE SEQUENTIAL</code> phrase in the
+					<code class="language-cobol">SELECT</code> and
+					<code class="language-cobol">ASSIGN</code> clause of sequential files. In Microfocus COBOL,
+					<code class="language-cobol">LINE SEQUENTIAL</code> files terminate each record with a
+					carriage return and line feed.
+				</p>
+				<copyright-notice type="examples"></copyright-notice>
+			</div>
 			<hr />
-			<a id="pagetop"></a>
 			<nav aria-label="Example programs contents">
 				<ul class="toc">
 					<li>
@@ -127,7 +122,7 @@
 					<li><a href="#Tables">COBOL Tables</a> - Example programs using tables.</li>
 				</ul>
 			</nav>
-			<table bordercolordark="#000000" bordercolorlight="#FFFFFF" width="725">
+			<table class="data-table" bordercolordark="#000000" bordercolorlight="#FFFFFF" width="725">
 				<tr bgcolor="#990000" style="vertical-align: top">
 					<td colspan="4">
 						<h2 style="text-align: center" id="SimplePrograms">
@@ -214,27 +209,8 @@
 					</td>
 				</tr>
 			</table>
-			<table width="725">
-				<tr>
-					<td>
-						<div style="text-align: center">
-							<a href="#pagetop"
-								><span
-									aria-hidden="true"
-									style="
-										display: inline-block;
-										font-size: 36px;
-										line-height: 1;
-										vertical-align: middle;
-									"
-									>🔝</span
-								></a
-							>
-						</div>
-					</td>
-				</tr>
-			</table>
-			<table bordercolordark="#999999" bordercolorlight="#FFFFFF" width="725">
+			<back-to-top></back-to-top>
+			<table class="data-table" bordercolordark="#999999" bordercolorlight="#FFFFFF" width="725">
 				<tr bgcolor="#990000" style="vertical-align: top">
 					<td colspan="4">
 						<h2 style="text-align: center" id="Selection">
@@ -404,27 +380,8 @@
 					</td>
 				</tr>
 			</table>
-			<table width="725">
-				<tr>
-					<td>
-						<div style="text-align: center">
-							<a href="#pagetop"
-								><span
-									aria-hidden="true"
-									style="
-										display: inline-block;
-										font-size: 36px;
-										line-height: 1;
-										vertical-align: middle;
-									"
-									>🔝</span
-								></a
-							>
-						</div>
-					</td>
-				</tr>
-			</table>
-			<table bordercolorlight="#FFFFFF" width="725">
+			<back-to-top></back-to-top>
+			<table class="data-table" bordercolorlight="#FFFFFF" width="725">
 				<tr bgcolor="#990000" style="vertical-align: top">
 					<td colspan="4">
 						<h2 style="text-align: center" id="SequentialFiles">
@@ -564,27 +521,8 @@
 					</td>
 				</tr>
 			</table>
-			<table width="725">
-				<tr>
-					<td>
-						<div style="text-align: center">
-							<a href="#pagetop"
-								><span
-									aria-hidden="true"
-									style="
-										display: inline-block;
-										font-size: 36px;
-										line-height: 1;
-										vertical-align: middle;
-									"
-									>🔝</span
-								></a
-							>
-						</div>
-					</td>
-				</tr>
-			</table>
-			<table bordercolorlight="#FFFFFF" width="725">
+			<back-to-top></back-to-top>
+			<table class="data-table" bordercolorlight="#FFFFFF" width="725">
 				<tr bgcolor="#990000" style="vertical-align: top">
 					<td colspan="4">
 						<h2 style="text-align: center" id="Sort">
@@ -763,27 +701,8 @@
 					</td>
 				</tr>
 			</table>
-			<table width="725">
-				<tr>
-					<td>
-						<div style="text-align: center">
-							<a href="#pagetop"
-								><span
-									aria-hidden="true"
-									style="
-										display: inline-block;
-										font-size: 36px;
-										line-height: 1;
-										vertical-align: middle;
-									"
-									>🔝</span
-								></a
-							>
-						</div>
-					</td>
-				</tr>
-			</table>
-			<table bordercolorlight="#FFFFFF" width="725">
+			<back-to-top></back-to-top>
+			<table class="data-table" bordercolorlight="#FFFFFF" width="725">
 				<tr bgcolor="#990000" style="vertical-align: top">
 					<td colspan="4">
 						<h2 style="text-align: center" id="Direct">
@@ -1069,27 +988,8 @@
 					</td>
 				</tr>
 			</table>
-			<table width="725">
-				<tr>
-					<td>
-						<div style="text-align: center">
-							<a href="#pagetop"
-								><span
-									aria-hidden="true"
-									style="
-										display: inline-block;
-										font-size: 36px;
-										line-height: 1;
-										vertical-align: middle;
-									"
-									>🔝</span
-								></a
-							>
-						</div>
-					</td>
-				</tr>
-			</table>
-			<table bordercolorlight="#FFFFFF" width="725">
+			<back-to-top></back-to-top>
+			<table class="data-table" bordercolorlight="#FFFFFF" width="725">
 				<tr bgcolor="#990000" style="vertical-align: top">
 					<td colspan="4">
 						<h2 style="text-align: center" id="Call">
@@ -1338,27 +1238,8 @@
 					</td>
 				</tr>
 			</table>
-			<table width="725">
-				<tr>
-					<td>
-						<div style="text-align: center">
-							<a href="#pagetop"
-								><span
-									aria-hidden="true"
-									style="
-										display: inline-block;
-										font-size: 36px;
-										line-height: 1;
-										vertical-align: middle;
-									"
-									>🔝</span
-								></a
-							>
-						</div>
-					</td>
-				</tr>
-			</table>
-			<table bordercolorlight="#FFFFFF" width="725">
+			<back-to-top></back-to-top>
+			<table class="data-table" bordercolorlight="#FFFFFF" width="725">
 				<tr bgcolor="#990000" style="vertical-align: top">
 					<td colspan="4">
 						<h2 style="text-align: center" id="Strings">
@@ -1458,27 +1339,8 @@
 					</td>
 				</tr>
 			</table>
-			<table width="725">
-				<tr>
-					<td>
-						<div style="text-align: center">
-							<a href="#pagetop"
-								><span
-									aria-hidden="true"
-									style="
-										display: inline-block;
-										font-size: 36px;
-										line-height: 1;
-										vertical-align: middle;
-									"
-									>🔝</span
-								></a
-							>
-						</div>
-					</td>
-				</tr>
-			</table>
-			<table bordercolorlight="#FFFFFF" width="725">
+			<back-to-top></back-to-top>
+			<table class="data-table" bordercolorlight="#FFFFFF" width="725">
 				<tr bgcolor="#990000" style="vertical-align: top">
 					<td colspan="4">
 						<h2 style="text-align: center" id="Reports">
@@ -1594,27 +1456,8 @@
 					</td>
 				</tr>
 			</table>
-			<table width="725">
-				<tr>
-					<td>
-						<div style="text-align: center">
-							<a href="#pagetop"
-								><span
-									aria-hidden="true"
-									style="
-										display: inline-block;
-										font-size: 36px;
-										line-height: 1;
-										vertical-align: middle;
-									"
-									>🔝</span
-								></a
-							>
-						</div>
-					</td>
-				</tr>
-			</table>
-			<table bordercolorlight="#FFFFFF" width="725">
+			<back-to-top></back-to-top>
+			<table class="data-table" bordercolorlight="#FFFFFF" width="725">
 				<tr bgcolor="#990000" style="vertical-align: top">
 					<td colspan="4">
 						<h2 style="text-align: center" id="Tables">
@@ -1714,26 +1557,7 @@
 					</td>
 				</tr>
 			</table>
-			<table width="725">
-				<tr>
-					<td height="2">
-						<div style="text-align: center">
-							<a href="#pagetop"
-								><span
-									aria-hidden="true"
-									style="
-										display: inline-block;
-										font-size: 36px;
-										line-height: 1;
-										vertical-align: middle;
-									"
-									>🔝</span
-								></a
-							>
-						</div>
-					</td>
-				</tr>
-			</table>
+			<back-to-top></back-to-top>
 		</main>
 	</body>
 </html>


### PR DESCRIPTION
Closes #361

## Summary

- Replaces the intro `<table style="margin: 0 auto" width="700">` wrapper with `<div class="page-content">`
- Adds `max-width: 700px; margin-inline: auto` to `.page-content` in `course.css` so standalone use centers correctly
- Adds `class="data-table"` to all 9 per-topic program-listing tables (Phase 4 convention)
- Replaces all 9 back-to-top layout tables with `<back-to-top>` web component
- Removes the now-unused `<a id="pagetop">` anchor

## Test plan

- [ ] Intro paragraph block is centered at ~700px
- [ ] Program listing tables render correctly with data-table styling
- [ ] Back-to-top links scroll to page top
- [ ] No `<table>` elements remain as layout wrappers

🤖 Generated with [Claude Code](https://claude.com/claude-code)