### PR TITLE
feat: add per-lesson reading-time estimates to course pages

### DIFF
--- a/components/page-hero.js
+++ b/components/page-hero.js
@@ -13,16 +13,21 @@ class PageHero extends HTMLElement {
 	connectedCallback() {
 		const title = this.getAttribute("title") || "";
 		const eyebrow = this.getAttribute("eyebrow") || "COBOL Tutorial";
+		const readingTime = this.getAttribute("reading-time") || "";
 		this.innerHTML = `
 			<div class="hero">
 				<p id="top" class="page-hero-eyebrow"></p>
 				<h1></h1>
+				${readingTime ? `<p class="page-hero-reading-time"></p>` : ""}
 				<theme-toggle></theme-toggle>
 				<site-search></site-search>
 			</div>
 		`;
 		this.querySelector(".page-hero-eyebrow").textContent = eyebrow;
 		this.querySelector("h1").textContent = title;
+		if (readingTime) {
+			this.querySelector(".page-hero-reading-time").textContent = `~${readingTime} read`;
+		}
 	}
 
 	disconnectedCallback() {}

--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -126,7 +126,7 @@
 				<page-toc></page-toc>
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="Introduction to COBOL"></page-hero>
+						<page-hero title="Introduction to COBOL" reading-time="26 min"></page-hero>
 						<hr />
 						<ul class="toc">
 							<li>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -100,7 +100,7 @@
 			<div class="page-wrapper">
 				<page-toc></page-toc>
 				<div class="page-content">
-					<page-hero title="Basic Procedure Division Commands"></page-hero>
+					<page-hero title="Basic Procedure Division Commands" reading-time="14 min"></page-hero>
 					<hr />
 					<ul class="toc">
 						<li>

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -107,7 +107,7 @@
 				<div class="section-grid">
 					<!-- Header -->
 					<div class="section-full">
-						<page-hero title="The COPY verb"></page-hero>
+						<page-hero title="The COPY verb" reading-time="14 min"></page-hero>
 						<hr />
 						<ul class="toc">
 							<li>

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -100,7 +100,7 @@
 				<page-toc></page-toc>
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="Declaring Data in COBOL"></page-hero>
+						<page-hero title="Declaring Data in COBOL" reading-time="11 min"></page-hero>
 						<hr />
 						<ul class="toc">
 							<li>

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -100,7 +100,7 @@
 			<div class="page-wrapper">
 				<page-toc></page-toc>
 				<div class="page-content">
-					<page-hero title="Edited Pictures"></page-hero>
+					<page-hero title="Edited Pictures" reading-time="14 min"></page-hero>
 					<hr />
 					<ul class="toc">
 						<li>

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -105,7 +105,7 @@
 			<div class="page-wrapper">
 				<page-toc></page-toc>
 				<div class="page-content">
-					<page-hero title="Indexed Files"></page-hero>
+					<page-hero title="Indexed Files" reading-time="19 min"></page-hero>
 					<hr />
 					<ul class="toc">
 						<li>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -99,7 +99,7 @@
 			<div class="page-wrapper">
 				<page-toc></page-toc>
 				<div class="page-content">
-					<page-hero title="The INSPECT verb"></page-hero>
+					<page-hero title="The INSPECT verb" reading-time="8 min"></page-hero>
 					<hr />
 					<ul class="toc">
 						<li>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -102,7 +102,7 @@
 			<div class="page-wrapper">
 				<page-toc></page-toc>
 				<div class="page-content">
-					<page-hero title="Introduction to Direct Access Files"></page-hero>
+					<page-hero title="Introduction to Direct Access Files" reading-time="15 min"></page-hero>
 					<hr />
 					<ul class="toc">
 						<li>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -115,7 +115,7 @@
 			<div class="page-wrapper">
 				<page-toc></page-toc>
 				<div class="page-content">
-					<page-hero title="COBOL Iteration Constructs"></page-hero>
+					<page-hero title="COBOL Iteration Constructs" reading-time="21 min"></page-hero>
 					<hr />
 					<ul class="toc">
 						<li>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -99,7 +99,7 @@
 			<div class="page-wrapper">
 				<page-toc></page-toc>
 				<div class="page-content">
-					<page-hero title="Reference Modification and Intrinsic Functions"></page-hero>
+					<page-hero title="Reference Modification and Intrinsic Functions" reading-time="15 min"></page-hero>
 					<hr />
 					<ul class="toc">
 						<li>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -99,7 +99,7 @@
 			<div class="page-wrapper">
 				<page-toc></page-toc>
 				<div class="page-content">
-					<page-hero title="Relative Files"></page-hero>
+					<page-hero title="Relative Files" reading-time="12 min"></page-hero>
 					<hr />
 					<ul class="toc">
 						<li>

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -101,7 +101,7 @@
 				<page-toc></page-toc>
 				<div class="page-content">
 					<div>
-						<page-hero title="The COBOL Report Writer"></page-hero>
+						<page-hero title="The COBOL Report Writer" reading-time="19 min"></page-hero>
 						<hr />
 						<ul class="toc">
 							<li>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -101,7 +101,10 @@
 				<page-toc></page-toc>
 				<div class="page-content">
 					<div>
-						<page-hero title="The COBOL Report Writer - Syntax and Semantics" reading-time="20 min"></page-hero>
+						<page-hero
+							title="The COBOL Report Writer - Syntax and Semantics"
+							reading-time="20 min"
+						></page-hero>
 						<hr />
 						<ul class="toc">
 							<li>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -101,7 +101,7 @@
 				<page-toc></page-toc>
 				<div class="page-content">
 					<div>
-						<page-hero title="The COBOL Report Writer - Syntax and Semantics"></page-hero>
+						<page-hero title="The COBOL Report Writer - Syntax and Semantics" reading-time="20 min"></page-hero>
 						<hr />
 						<ul class="toc">
 							<li>

--- a/course/Resources/css/course-components.css
+++ b/course/Resources/css/course-components.css
@@ -37,6 +37,17 @@ nav[aria-label="Breadcrumb"] {
 	color: #ff9966;
 }
 
+/* Estimated reading-time badge rendered by page-hero.js when the
+   reading-time attribute is present. Sits between the h1 and theme-toggle;
+   muted via opacity so it recedes behind the title without a theme-specific
+   colour override. */
+.page-hero-reading-time {
+	margin: 0.1em 0 0;
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 0.8em;
+	opacity: 0.65;
+}
+
 /* Decorative disc bullet — replaces BallBlueG.gif (13×13 px) used inline
    in h3 headings on lectures/index.html. Sized and coloured to match the
    original blue ball. Inline-block so it sits on the text baseline. */

--- a/course/Search.html
+++ b/course/Search.html
@@ -101,7 +101,7 @@
 				<page-toc></page-toc>
 				<div class="page-content">
 					<div>
-						<page-hero title="Searching Tables"></page-hero>
+						<page-hero title="Searching Tables" reading-time="21 min"></page-hero>
 						<hr />
 						<ul class="toc">
 							<li>

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -113,7 +113,7 @@
 				<page-toc></page-toc>
 				<!-- Header / TOC -->
 				<div class="page-content">
-					<page-hero title="COBOL Selection Constructs"></page-hero>
+					<page-hero title="COBOL Selection Constructs" reading-time="21 min"></page-hero>
 					<hr />
 					<ul class="toc">
 						<li>

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -100,7 +100,7 @@
 			<div class="page-wrapper">
 				<page-toc></page-toc>
 				<div class="page-content">
-					<page-hero title="Introduction to Sequential Files"></page-hero>
+					<page-hero title="Introduction to Sequential Files" reading-time="16 min"></page-hero>
 					<hr />
 					<ul class="toc">
 						<li>

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -100,7 +100,7 @@
 			<div class="page-wrapper">
 				<page-toc></page-toc>
 				<div class="page-content">
-					<page-hero title="Processing Sequential Files"></page-hero>
+					<page-hero title="Processing Sequential Files" reading-time="9 min"></page-hero>
 					<hr />
 					<ul class="toc">
 						<li>

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -100,7 +100,7 @@
 			<div class="page-wrapper">
 				<page-toc></page-toc>
 				<div class="page-content">
-					<page-hero title="Print files and variable-length records"></page-hero>
+					<page-hero title="Print files and variable-length records" reading-time="19 min"></page-hero>
 					<hr />
 					<ul class="toc">
 						<li>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -101,7 +101,7 @@
 				<page-toc></page-toc>
 				<div class="page-content">
 					<div>
-						<page-hero title="Sorting and Merging files"></page-hero>
+						<page-hero title="Sorting and Merging files" reading-time="27 min"></page-hero>
 						<hr />
 						<ul class="toc">
 							<li>

--- a/course/String.html
+++ b/course/String.html
@@ -99,7 +99,7 @@
 			<div class="page-wrapper">
 				<page-toc></page-toc>
 				<div class="page-content">
-					<page-hero title="The STRING verb"></page-hero>
+					<page-hero title="The STRING verb" reading-time="6 min"></page-hero>
 					<hr />
 					<ul class="toc">
 						<li>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -100,7 +100,7 @@
 			<div class="page-wrapper">
 				<page-toc></page-toc>
 				<div class="page-content">
-					<page-hero title="Subprograms"></page-hero>
+					<page-hero title="Subprograms" reading-time="22 min"></page-hero>
 					<hr />
 					<ul class="toc">
 						<li>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -100,7 +100,7 @@
 			<div class="page-wrapper">
 				<page-toc></page-toc>
 				<div class="page-content">
-					<page-hero title="Using Tables"></page-hero>
+					<page-hero title="Using Tables" reading-time="11 min"></page-hero>
 					<hr />
 					<ul class="toc">
 						<li>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -139,7 +139,7 @@
 				<page-toc></page-toc>
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="Creating Tables - syntax and semantics"></page-hero>
+						<page-hero title="Creating Tables - syntax and semantics" reading-time="27 min"></page-hero>
 						<hr />
 						<ul class="toc">
 							<li>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -99,7 +99,7 @@
 			<div class="page-wrapper">
 				<page-toc></page-toc>
 				<div class="page-content">
-					<page-hero title="The UNSTRING verb"></page-hero>
+					<page-hero title="The UNSTRING verb" reading-time="8 min"></page-hero>
 					<hr />
 					<ul class="toc">
 						<li>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -101,7 +101,7 @@
 				<page-toc></page-toc>
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="The USAGE clause"></page-hero>
+						<page-hero title="The USAGE clause" reading-time="12 min"></page-hero>
 						<hr />
 						<ul class="toc">
 							<li>

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
 		"a11y": "start-server-and-test serve http://localhost:8000 a11y:run",
 		"build:lesson-jsonld": "node scripts/generate-lesson-jsonld.js && prettier --write \"course/**/*.html\"",
 		"check:lesson-jsonld": "node scripts/generate-lesson-jsonld.js && prettier --write \"course/**/*.html\" && git diff --exit-code course/lesson-meta.json \"course/**/*.html\"",
+		"build:reading-time": "node scripts/add-reading-time.js && prettier --write \"course/**/*.html\"",
+		"check:reading-time": "node scripts/add-reading-time.js && prettier --write \"course/**/*.html\" && git diff --exit-code \"course/**/*.html\"",
 		"check:assets": "node scripts/check-assets.js",
 		"format:check": "prettier --check .",
 		"format:write": "prettier --write .",

--- a/scripts/add-reading-time.js
+++ b/scripts/add-reading-time.js
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * add-reading-time.js
+ *
+ * Estimates reading time for each course lesson from its body word count and
+ * stamps the result onto <page-hero reading-time="X min">. Re-running updates
+ * the existing attribute (idempotent).
+ *
+ * Reading speed: 200 wpm (appropriate for technical/tutorial content).
+ * Minimum displayed: 1 min.
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const COURSE_DIR = path.join(REPO_ROOT, "course");
+
+const WPM = 200;
+
+// Mirrors LESSON_SEQUENCE in generate-lesson-jsonld.js.
+const LESSON_FILES = [
+	"COBOLIntro.html",
+	"DataDeclaration.html",
+	"COBOLcommands.html",
+	"Selection.html",
+	"Iteration.html",
+	"SequentialFiles1.html",
+	"SequentialFiles2.html",
+	"EditedPics.html",
+	"Usage.html",
+	"SequentialFiles3.html",
+	"SortMerge.html",
+	"Intro2DirectAccess.html",
+	"RelativeFiles.html",
+	"IndexedFiles.html",
+	"Tables1.html",
+	"Tables2.html",
+	"Search.html",
+	"Subprograms.html",
+	"Copy.html",
+	"Inspect.html",
+	"String.html",
+	"Unstring.html",
+	"RefMod.html",
+	"ReportWriter.html",
+	"ReportWriterSS.html",
+];
+
+/** Extract visible text from the <body> element, stripping scripts and tags. */
+function extractBodyText(html) {
+	const bodyMatch = html.match(/<body[^>]*>([\s\S]*)<\/body>/i);
+	const body = bodyMatch ? bodyMatch[1] : html;
+	return body
+		.replace(/<script[\s\S]*?<\/script>/gi, " ")
+		.replace(/<style[\s\S]*?<\/style>/gi, " ")
+		.replace(/<!--[\s\S]*?-->/g, " ")
+		.replace(/<[^>]+>/g, " ")
+		.replace(/&[a-zA-Z]+;/g, " ")
+		.replace(/&#?\w+;/g, " ")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+function countWords(text) {
+	return text.split(/\s+/).filter(Boolean).length;
+}
+
+function readingMinutes(wordCount) {
+	return Math.max(1, Math.round(wordCount / WPM));
+}
+
+function main() {
+	for (const file of LESSON_FILES) {
+		const filePath = path.join(COURSE_DIR, file);
+		if (!fs.existsSync(filePath)) {
+			console.warn(`  SKIP  ${file} (not found)`);
+			continue;
+		}
+
+		let html = fs.readFileSync(filePath, "utf8");
+		const words = countWords(extractBodyText(html));
+		const mins = readingMinutes(words);
+		const label = `${mins} min`;
+
+		if (html.includes("reading-time=")) {
+			html = html.replace(/\breading-time="[^"]*"/, `reading-time="${label}"`);
+		} else {
+			html = html.replace(/(<page-hero\b[^>]*)>/, `$1 reading-time="${label}">`);
+		}
+
+		fs.writeFileSync(filePath, html, "utf8");
+		console.log(`  OK    ${file} — ${words} words → ${label}`);
+	}
+}
+
+main();


### PR DESCRIPTION
Closes #381

## Summary

- **`scripts/add-reading-time.js`** — new build script that walks all 25 course lessons, extracts body text (stripping `<script>`, `<style>`, tags, and HTML entities), counts words, and computes reading time at 200 wpm (min 1 min). Stamps `reading-time="X min"` onto each `<page-hero>` opening tag. Idempotent — re-running updates the existing attribute.
- **`components/page-hero.js`** — reads the `reading-time` attribute and conditionally renders `<p class="page-hero-reading-time">~X min read</p>` between the `<h1>` and the theme-toggle.
- **`course/Resources/css/course-components.css`** — adds `.page-hero-reading-time` at 0.8em / 65% opacity. Opacity handles both light and dark modes without theme-specific colour overrides.
- **`package.json`** — adds `build:reading-time` and `check:reading-time` scripts following the same pattern as the other build/check pairs.
- **25 course HTML files** — stamped with computed estimates (6–27 min range).

## Reading-time estimates

| Lesson | Words | Est. |
|---|---|---|
| COBOLIntro | 5109 | 26 min |
| DataDeclaration | 2288 | 11 min |
| COBOLcommands | 2750 | 14 min |
| Selection | 4114 | 21 min |
| Iteration | 4143 | 21 min |
| SequentialFiles1 | 3100 | 16 min |
| SequentialFiles2 | 1841 | 9 min |
| EditedPics | 2790 | 14 min |
| Usage | 2371 | 12 min |
| SequentialFiles3 | 3726 | 19 min |
| SortMerge | 5303 | 27 min |
| Intro2DirectAccess | 3093 | 15 min |
| RelativeFiles | 2499 | 12 min |
| IndexedFiles | 3883 | 19 min |
| Tables1 | 2175 | 11 min |
| Tables2 | 5392 | 27 min |
| Search | 4209 | 21 min |
| Subprograms | 4312 | 22 min |
| Copy | 2786 | 14 min |
| Inspect | 1549 | 8 min |
| String | 1222 | 6 min |
| Unstring | 1626 | 8 min |
| RefMod | 2948 | 15 min |
| ReportWriter | 3878 | 19 min |
| ReportWriterSS | 3962 | 20 min |

## Test plan

- [ ] `npm run build:reading-time` runs without errors
- [ ] `npm run check:reading-time` exits 0 (no diff after re-running)
- [ ] Badge renders below the lesson title on a course page
- [ ] Badge is absent on pages without a `reading-time` attribute (e.g. glossary)
- [ ] Dark-mode: badge remains readable at reduced opacity

🤖 Generated with [Claude Code](https://claude.ai/claude-code)