### PR TITLE
feat: add description meta and standard chrome to lectures/index.html

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -61,3 +61,5 @@ Alph = "Alph"
 PERFOR = "PERFOR"
 # cpy — COBOL copybook file extension (.cpy); appears in href attributes and inline filenames
 cpy = "cpy"
+# PN — prefix of "PNGs" (plural of the PNG image format); typos splits the word and flags "PN" as "ON"
+PN = "PN"

--- a/lectures/index.html
+++ b/lectures/index.html
@@ -12,8 +12,16 @@
 		</script>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
-		<meta content="COBOL,lectures, tutorials" name="keywords" />
 		<title>COBOL Lectures and Tutorials</title>
+		<meta name="resource-type" content="document" />
+		<meta name="description" content="COBOL lecture notes and tutorials covering core COBOL programming concepts." />
+		<meta name="keywords" content="COBOL, lectures, tutorials" />
+		<meta name="revisit-after" content="15 days" />
+		<meta name="distribution" content="Global" />
+		<meta name="copyright" content="Michael Coughlan" />
+		<meta name="author" content="Michael Coughlan" />
+		<meta name="robots" content="All" />
+		<meta name="rating" content="General" />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/index.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />

--- a/lectures/index.html
+++ b/lectures/index.html
@@ -14,7 +14,10 @@
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
 		<title>COBOL Lectures and Tutorials</title>
 		<meta name="resource-type" content="document" />
-		<meta name="description" content="COBOL lecture notes and tutorials covering core COBOL programming concepts." />
+		<meta
+			name="description"
+			content="COBOL lecture notes and tutorials covering core COBOL programming concepts."
+		/>
 		<meta name="keywords" content="COBOL, lectures, tutorials" />
 		<meta name="revisit-after" content="15 days" />
 		<meta name="distribution" content="Global" />

--- a/search-index.json
+++ b/search-index.json
@@ -734,7 +734,7 @@
 	{
 		"p": "lectures/index.html",
 		"t": "COBOL Lectures and Tutorials",
-		"d": "",
+		"d": "COBOL lecture notes and tutorials covering core COBOL programming concepts.",
 		"s": "lectures"
 	},
 	{


### PR DESCRIPTION
## Summary

- Adds `<meta name="description">` (standard, not just OG) to `lectures/index.html`
- Adds the full standard meta block (`resource-type`, `revisit-after`, `distribution`, `copyright`, `author`, `robots`, `rating`) matching the pattern already used in `index.html` and `course/index.html`
- Moves `<title>` before the meta block and expands the minimal `keywords` content
- All new tags are inserted between the existing favicon link and `<link rel="canonical">`, consistent with sibling pages

Closes #369.

## Test plan

- [ ] Verify `lectures/index.html` head now includes `<meta name="description">`, `<meta name="author" content="Michael Coughlan">`, and `<meta name="copyright" content="Michael Coughlan">`
- [ ] Confirm the page renders correctly and no visual regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)