### PR TITLE
fix: handle clipboard errors and missing API in copy-button

### DIFF
--- a/components/copy-button.js
+++ b/components/copy-button.js
@@ -16,14 +16,33 @@ document.addEventListener("DOMContentLoaded", () => {
 		btn.textContent = "Copy";
 
 		btn.addEventListener("click", () => {
-			navigator.clipboard.writeText(code.textContent).then(() => {
+			const onSuccess = () => {
 				btn.textContent = "Copied!";
 				btn.classList.add("is-success");
 				setTimeout(() => {
 					btn.textContent = "Copy";
 					btn.classList.remove("is-success");
 				}, 1500);
-			});
+			};
+			const onFailure = () => {
+				btn.textContent = "Copy failed";
+				setTimeout(() => {
+					btn.textContent = "Copy";
+				}, 1500);
+			};
+
+			if (navigator.clipboard) {
+				navigator.clipboard.writeText(code.textContent).then(onSuccess).catch(onFailure);
+			} else {
+				const selection = window.getSelection();
+				const range = document.createRange();
+				range.selectNodeContents(code);
+				selection.removeAllRanges();
+				selection.addRange(range);
+				const ok = document.execCommand("copy");
+				selection.removeAllRanges();
+				ok ? onSuccess() : onFailure();
+			}
 		});
 
 		pre.appendChild(btn);


### PR DESCRIPTION
## Summary

- Adds a `.catch()` handler so promise rejections (e.g. user denies clipboard permission, `file://` origin) show `"Copy failed"` instead of logging an unhandled rejection and silently failing — closes #346
- Feature-detects `navigator.clipboard` before use and falls back to `document.execCommand('copy')` on insecure-origin contexts (local IP dev on phones, older Safari) — closes #347

## What changed

`components/copy-button.js` — the click handler now:
1. Defines shared `onSuccess` / `onFailure` callbacks to avoid duplicating the label-toggle logic across both paths.
2. Checks `if (navigator.clipboard)` before calling the async API; if absent, selects the code text and calls the legacy `execCommand('copy')`, mapping its boolean return to the same callbacks.
3. Chains `.catch(onFailure)` on the `writeText` promise so any rejection surface as `"Copy failed"` rather than an unhandled rejection.

## Testing

Verified in the preview server against `course/COBOLIntro.html`:
- Mocked `writeText` to resolve → button shows `"Copied!"` and resets after 1.5 s ✓
- Mocked `writeText` to reject → button shows `"Copy failed"` and resets ✓
- Stubbed `navigator.clipboard` to `undefined` → `execCommand` path runs without throwing ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)