### PR TITLE
fix: replace back-to-top emoji with an inline SVG

### DIFF
--- a/components/back-to-top.js
+++ b/components/back-to-top.js
@@ -14,7 +14,7 @@ class BackToTop extends HTMLElement {
 	connectedCallback() {
 		this.innerHTML = `
 			<div class="back-to-top">
-				<p><a href="#top"><span class="i-pagetop" aria-hidden="true">🔝</span></a></p>
+				<p><a href="#top"><svg class="i-pagetop" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><line x1="3" y1="3" x2="21" y2="3" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/><line x1="12" y1="7" x2="12" y2="21" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/><polyline points="6,13 12,7 18,13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/></svg><span class="visually-hidden">Back to top</span></a></p>
 			</div>
 		`;
 	}

--- a/course/Resources/css/course-components.css
+++ b/course/Resources/css/course-components.css
@@ -107,16 +107,14 @@ nav[aria-label="Breadcrumb"] {
 }
 
 /* Back-to-top marker. Replaces the legacy 132×38 px i-pagetop.gif "to top of
-   page" link with the 🔝 emoji. font-size 36px keeps the glyph close to the
-   original GIF height (38px) without overshooting; line-height 1 prevents the
-   emoji from inflating the line box; vertical-align: middle centres the glyph
-   against neighbouring text the same way it does for .i-detail.
-   display: inline-block makes the span an atomic inline so the parent
-   anchor's a:link underline doesn't extend through the emoji. */
+   page" link with an inline SVG arrow. width/height 38px matches the original
+   GIF height; vertical-align: middle centres the icon against neighbouring
+   text. currentColor inherits the parent anchor's link/visited colour so dark-
+   and light-mode styles apply automatically without extra rules. */
 .i-pagetop {
 	display: inline-block;
-	font-size: 36px;
-	line-height: 1;
+	width: 38px;
+	height: 38px;
 	vertical-align: middle;
 }
 


### PR DESCRIPTION
## What changed

- **`components/back-to-top.js`** — replaces `<span aria-hidden="true">🔝</span>` with an inline SVG (upward arrow + top bar) and adds `<span class="visually-hidden">Back to top</span>` inside the anchor.
- **`course/Resources/css/course-components.css`** — updates `.i-pagetop` to size the SVG via `width: 38px; height: 38px` instead of the emoji-oriented `font-size: 36px; line-height: 1`.

## Why

On systems without an emoji font (older Linux distros, some terminal-based browsers, certain corporate-managed browsers), `🔝` renders as a tofu box, making the link unrecognisable. An inline SVG renders reliably everywhere and uses `currentColor` to automatically inherit the anchor's link/visited colour in both light and dark mode.

As a bonus, the change fixes a pre-existing accessibility gap: the emoji span was `aria-hidden="true"` with no other label, so the anchor had zero accessible text. The new `visually-hidden` span gives screen readers a proper "Back to top" label.

Closes #353