### PR TITLE
refactor: replace inline red styles with .cobol-highlight class in course pages

### DIFF
--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -662,7 +662,7 @@ The time is 14:41
 									<p><strong>PIC 9(3)V9</strong></p>
 								</td>
 								<td>
-									<b>123.2<span style="color: #ff0000">5</span></b>
+									<b>123.2<span class="cobol-highlight">5</span></b>
 								</td>
 								<td><b>123.2</b></td>
 								<td><b>123.3</b></td>
@@ -670,7 +670,7 @@ The time is 14:41
 							<tr>
 								<td><strong>PIC 9(3)V9</strong></td>
 								<td>
-									<b>123.2<span style="color: #ff0000">47</span></b>
+									<b>123.2<span class="cobol-highlight">47</span></b>
 								</td>
 								<td><b>123.2</b></td>
 								<td><b>123.2</b></td>
@@ -678,7 +678,7 @@ The time is 14:41
 							<tr>
 								<td><strong>PIC 9(3)</strong></td>
 								<td>
-									<b>123.<span style="color: #ff0000">25</span></b>
+									<b>123.<span class="cobol-highlight">25</span></b>
 								</td>
 								<td><b>123</b></td>
 								<td><b>123</b></td>
@@ -724,28 +724,28 @@ The time is 14:41
 								<th bgcolor="#FFFFCC" width="45%">
 									<div class="center-block">
 										<strong>
-											<span style="color: #ff0000">Receiving Field</span>
+											<span class="cobol-highlight">Receiving Field</span>
 										</strong>
 									</div>
 								</th>
 								<th bgcolor="#FFFFCC" width="19%">
 									<div class="center-block">
 										<strong>
-											<span style="color: #ff0000">Actual Result</span>
+											<span class="cobol-highlight">Actual Result</span>
 										</strong>
 									</div>
 								</th>
 								<th bgcolor="#FFFFCC" width="22%">
 									<div class="center-block">
 										<strong>
-											<span style="color: #ff0000">Truncated Result</span>
+											<span class="cobol-highlight">Truncated Result</span>
 										</strong>
 									</div>
 								</th>
 								<th bgcolor="#FFFFCC" width="14%">
 									<div class="center-block">
 										<strong>
-											<span style="color: #ff0000">Size Error?</span>
+											<span class="cobol-highlight">Size Error?</span>
 										</strong>
 									</div>
 								</th>
@@ -756,7 +756,7 @@ The time is 14:41
 									width="19%"
 									style="font-family: monospace; text-align: right; padding-inline-end: 0.5em"
 								>
-									<b>245.9<span style="color: #ff0000">6</span></b>
+									<b>245.9<span class="cobol-highlight">6</span></b>
 								</td>
 								<td
 									width="22%"
@@ -776,7 +776,7 @@ The time is 14:41
 									width="19%"
 									style="font-family: monospace; text-align: right; padding-inline-end: 0.5em"
 								>
-									<b><span style="color: #ff0000">3</span>245.9</b>
+									<b><span class="cobol-highlight">3</span>245.9</b>
 								</td>
 								<td
 									width="22%"
@@ -820,7 +820,7 @@ The time is 14:41
 									width="19%"
 									style="font-family: monospace; text-align: right; padding-inline-end: 0.5em"
 								>
-									<b><span style="color: #ff0000">5</span>324</b>
+									<b><span class="cobol-highlight">5</span>324</b>
 								</td>
 								<td
 									width="22%"
@@ -842,7 +842,7 @@ The time is 14:41
 									width="19%"
 									style="font-family: monospace; text-align: right; padding-inline-end: 0.5em"
 								>
-									<b>523.3<span style="color: #ff0000">5</span></b>
+									<b>523.3<span class="cobol-highlight">5</span></b>
 								</td>
 								<td
 									width="22%"
@@ -864,7 +864,7 @@ The time is 14:41
 									width="19%"
 									style="font-family: monospace; text-align: right; padding-inline-end: 0.5em"
 								>
-									<b>523.3<span style="color: #ff0000">5</span></b>
+									<b>523.3<span class="cobol-highlight">5</span></b>
 								</td>
 								<td
 									width="22%"
@@ -887,7 +887,7 @@ The time is 14:41
 									style="font-family: monospace; text-align: right; padding-inline-end: 0.5em"
 								>
 									<b
-										><span style="color: #ff0000">3</span>523.3<span style="color: #ff0000"
+										><span class="cobol-highlight">3</span>523.3<span class="cobol-highlight"
 											>5</span
 										></b
 									>

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -369,8 +369,8 @@
 									4 Text Words - <span style="color: #0000ff"><strong>MOVE</strong></span>
 									<strong>
 										<span style="color: #0000ff">
-											<span style="color: #ff0000">Total</span> TO
-											<span style="color: #ff0000">Print-Total</span>
+											<span class="cobol-highlight">Total</span> TO
+											<span class="cobol-highlight">Print-Total</span>
 										</span>
 									</strong>
 								</p>
@@ -378,9 +378,9 @@
 									<strong>MOVE Total TO Print-Total.</strong><br />
 									5 Text Words - <span style="color: #0000ff"><strong>MOVE</strong></span>
 									<strong>
-										<span style="color: #ff0000">Total</span>
+										<span class="cobol-highlight">Total</span>
 										<span style="color: #0000ff">TO</span>
-										<span style="color: #ff0000">Print-Total</span>
+										<span class="cobol-highlight">Print-Total</span>
 										<span style="color: #0000ff">.</span>
 									</strong>
 								</p>
@@ -390,10 +390,10 @@
 									<strong>
 										<span style="color: #0000ff">PIC</span>
 										<span style="color: #0000ff">
-											<span style="color: #ff0000">S9</span> (
-											<span style="color: #ff0000">4</span> )
-											<span style="color: #ff0000">V9</span> (
-											<span style="color: #ff0000">6</span> )
+											<span class="cobol-highlight">S9</span> (
+											<span class="cobol-highlight">4</span> )
+											<span class="cobol-highlight">V9</span> (
+											<span class="cobol-highlight">6</span> )
 										</span>
 									</strong>
 								</p>
@@ -515,7 +515,7 @@ COPY CopyFile4 IN EGLIB.</code></pre>
 						<p>
 							Text in
 							<strong>
-								<span style="color: #ff0000">red</span>
+								<span class="cobol-highlight">red</span>
 							</strong>
 							is the copied library text which may have been altered by the REPLACING phrase if one was
 							present and found matching text in the library file.

--- a/course/Resources/css/course.css
+++ b/course/Resources/css/course.css
@@ -25,6 +25,7 @@
 	--color-danger: #c00000;
 	--color-inline-warm: #993300;
 	--color-inline-green: #006600;
+	--color-syntax-highlight: #c00000;
 	--color-toc-marker: #2e7d32;
 
 	--prism-bg: #f5f2f0;
@@ -78,6 +79,7 @@
 		--color-danger: #ff8a8a;
 		--color-inline-warm: #ff9966;
 		--color-inline-green: #7ec47e;
+		--color-syntax-highlight: #ff8a8a;
 		--color-toc-marker: #66bb6a;
 
 		--prism-bg: #1f1f1f;
@@ -117,6 +119,7 @@
 	--color-danger: #ff8a8a;
 	--color-inline-warm: #ff9966;
 	--color-inline-green: #7ec47e;
+	--color-syntax-highlight: #ff8a8a;
 	--color-toc-marker: #66bb6a;
 
 	--prism-bg: #1f1f1f;
@@ -514,6 +517,10 @@ td[bgcolor="#ffffcc"] h4 {
 [style*="color:#CCCCCC"],
 [style*="color: #CCCCCC"] {
 	color: var(--color-text-muted) !important;
+}
+
+.cobol-highlight {
+	color: var(--color-syntax-highlight);
 }
 
 /* Legacy <span style="color: #ff0000"> fails 4.5:1 against light backgrounds

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -324,7 +324,7 @@ Statement6.</code></pre>
 						</p>
 						<div class="condition-types-box">
 							<div class="box-header">
-								<strong><span style="color: #ff0000">Condition Types</span></strong>
+								<strong><span class="cobol-highlight">Condition Types</span></strong>
 							</div>
 							<div class="box-body">
 								<ul>
@@ -520,13 +520,13 @@ END-IF</code></pre>
 							</colgroup>
 							<tr bgcolor="#FFFFCC">
 								<th style="text-align: center">
-									<span style="color: #ff0000"><strong>Precedence</strong></span>
+									<span class="cobol-highlight"><strong>Precedence</strong></span>
 								</th>
 								<th style="text-align: center">
-									<span style="color: #ff0000"><strong>Condition Value</strong></span>
+									<span class="cobol-highlight"><strong>Condition Value</strong></span>
 								</th>
 								<th style="text-align: center">
-									<span style="color: #ff0000"><strong>Arithmetic Equivalent</strong></span>
+									<span class="cobol-highlight"><strong>Arithmetic Equivalent</strong></span>
 								</th>
 							</tr>
 							<tr>
@@ -788,19 +788,19 @@ END-IF
 						>
 							<tr bgcolor="#FFFFCC">
 								<th width="13%" style="text-align: center">
-									<span style="color: #ff0000"><strong>VarA</strong></span>
+									<span class="cobol-highlight"><strong>VarA</strong></span>
 								</th>
 								<th width="13%" style="text-align: center">
-									<span style="color: #ff0000"><strong>VarB</strong></span>
+									<span class="cobol-highlight"><strong>VarB</strong></span>
 								</th>
 								<th width="13%" style="text-align: center">
-									<span style="color: #ff0000"><strong>VarC</strong></span>
+									<span class="cobol-highlight"><strong>VarC</strong></span>
 								</th>
 								<th width="12%" style="text-align: center">
-									<span style="color: #ff0000"><strong>VarG</strong></span>
+									<span class="cobol-highlight"><strong>VarG</strong></span>
 								</th>
 								<th bgcolor="#FFFFCC" width="49%" style="text-align: center">
-									<span style="color: #ff0000"
+									<span class="cobol-highlight"
 										><strong>
 											<code class="language-cobol">DISPLAY</code>
 										</strong></span

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -583,7 +583,7 @@ Begin.
 								<div class="center-block">
 									<strong>Example Runs<br /></strong>
 									The parameter value is shown in <span style="color: #0000ff">blue</span> and the
-									result displayed is shown in <span style="color: #ff0000">red</span>.<br />
+									result displayed is shown in <span class="cobol-highlight">red</span>.<br />
 								</div>
 								<hr />
 								<div class="center-block">First Run<br /></div>
@@ -591,7 +591,7 @@ Begin.
 									<span style="color: #0000ff"><b>12</b></span>
 									<b
 										><br />
-										<span style="color: #ff0000">Total = 62</span>
+										<span class="cobol-highlight">Total = 62</span>
 									</b>
 								</div>
 								<hr />
@@ -600,7 +600,7 @@ Begin.
 									<span style="color: #0000ff"><b>5</b></span>
 									<b
 										><br />
-										<span style="color: #ff0000">Total = 55</span>
+										<span class="cobol-highlight">Total = 55</span>
 									</b>
 								</div>
 								<hr />
@@ -609,7 +609,7 @@ Begin.
 									<span style="color: #0000ff"><b>12</b></span>
 									<b
 										><br />
-										<span style="color: #ff0000">Total = 62</span>
+										<span class="cobol-highlight">Total = 62</span>
 									</b>
 								</div>
 							</div>
@@ -645,7 +645,7 @@ Begin.
 								<div class="center-block">
 									<strong>Example Runs<br /></strong>
 									The parameter value is shown in <span style="color: #0000ff">blue</span> and the
-									result displayed is shown in <span style="color: #ff0000">red</span>.<br />
+									result displayed is shown in <span class="cobol-highlight">red</span>.<br />
 								</div>
 								<hr />
 								<div class="center-block">First Run<br /></div>
@@ -653,7 +653,7 @@ Begin.
 									<span style="color: #0000ff"><b>12</b></span>
 									<b
 										><br />
-										<span style="color: #ff0000">Total = 62</span>
+										<span class="cobol-highlight">Total = 62</span>
 									</b>
 								</div>
 								<hr />
@@ -663,7 +663,7 @@ Begin.
 										<span style="color: #0000ff"><b>5</b></span>
 										<b
 											><br />
-											<span style="color: #ff0000">Total = 67</span>
+											<span class="cobol-highlight">Total = 67</span>
 										</b>
 									</div>
 									<hr />
@@ -672,7 +672,7 @@ Begin.
 										<span style="color: #0000ff"><b>12</b></span>
 										<b
 											><br />
-											<span style="color: #ff0000">Total = 79</span>
+											<span class="cobol-highlight">Total = 79</span>
 										</b>
 									</div>
 								</div>
@@ -1145,7 +1145,7 @@ END PROGRAM Counter.</code></pre>
 								<p>
 									Numeric values entered by the user are shown in
 									<span style="color: #0000ff">blue</span> and values output by the computer are shown
-									in <span style="color: #ff0000">red</span>.
+									in <span class="cobol-highlight">red</span>.
 								</p>
 							</div>
 							<pre class="language-cobol"><code class="language-cobol">Enter value - 13

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -306,15 +306,15 @@ Begin.
 							If you examine the ASCII table below you will see that the digit 4 (the value in Num1) is
 							encoded as
 							<b>
-								<span style="color: #ff0000">00110100</span>
+								<span class="cobol-highlight">00110100</span>
 							</b>
-							and the digit 1 is encoded as <span style="color: #ff0000"><b>00110001</b></span
+							and the digit 1 is encoded as <span class="cobol-highlight"><b>00110001</b></span
 							>.
 						</p>
 						<p>
 							When these these binary numbers are added together the result is
 							<b>
-								<span style="color: #ff0000">01100101</span>
+								<span class="cobol-highlight">01100101</span>
 							</b>
 							which is the ASCII code for the lower case letter "e".
 						</p>
@@ -1037,28 +1037,28 @@ Begin.
 								<td width="114">
 									<p class="center-block">
 										<b>
-											<span style="color: #ff0000">1</span>
+											<span class="cobol-highlight">1</span>
 										</b>
 									</p>
 								</td>
 								<td width="66">
 									<p class="center-block">
 										<b>
-											<span style="color: #ff0000">49</span>
+											<span class="cobol-highlight">49</span>
 										</b>
 									</p>
 								</td>
 								<td width="60">
 									<p class="center-block">
 										<b>
-											<span style="color: #ff0000">31</span>
+											<span class="cobol-highlight">31</span>
 										</b>
 									</p>
 								</td>
 								<td width="108">
 									<p class="center-block">
 										<b>
-											<span style="color: #ff0000">00110001</span>
+											<span class="cobol-highlight">00110001</span>
 										</b>
 									</p>
 								</td>
@@ -1095,28 +1095,28 @@ Begin.
 								<td width="114">
 									<p class="center-block">
 										<b>
-											<span style="color: #ff0000">4</span>
+											<span class="cobol-highlight">4</span>
 										</b>
 									</p>
 								</td>
 								<td width="66">
 									<p class="center-block">
 										<b>
-											<span style="color: #ff0000">52</span>
+											<span class="cobol-highlight">52</span>
 										</b>
 									</p>
 								</td>
 								<td width="60">
 									<p class="center-block">
 										<b>
-											<span style="color: #ff0000">34</span>
+											<span class="cobol-highlight">34</span>
 										</b>
 									</p>
 								</td>
 								<td width="108">
 									<p class="center-block">
 										<b>
-											<span style="color: #ff0000">00110100</span>
+											<span class="cobol-highlight">00110100</span>
 										</b>
 									</p>
 								</td>
@@ -1797,28 +1797,28 @@ Begin.
 								<td width="114">
 									<p class="center-block">
 										<b>
-											<span style="color: #ff0000">e</span>
+											<span class="cobol-highlight">e</span>
 										</b>
 									</p>
 								</td>
 								<td width="66">
 									<p class="center-block">
 										<b>
-											<span style="color: #ff0000">101</span>
+											<span class="cobol-highlight">101</span>
 										</b>
 									</p>
 								</td>
 								<td width="60">
 									<p class="center-block">
 										<b>
-											<span style="color: #ff0000">65</span>
+											<span class="cobol-highlight">65</span>
 										</b>
 									</p>
 								</td>
 								<td width="108">
 									<p class="center-block">
 										<b>
-											<span style="color: #ff0000">01100101</span>
+											<span class="cobol-highlight">01100101</span>
 										</b>
 									</p>
 								</td>


### PR DESCRIPTION
Closes #372.

## Summary
- Adds `--color-syntax-highlight` CSS custom property to `course.css` (`#c00000` light / `#ff8a8a` dark) alongside the existing light/dark token blocks
- Adds `.cobol-highlight { color: var(--color-syntax-highlight); }` rule near the existing legacy inline-color corrections
- Replaces all 56 `style="color: #ff0000"` spans in `COBOLcommands.html` (14), `Copy.html` (9), `Selection.html` (9), `Subprograms.html` (9), and `Usage.html` (15) with `class="cobol-highlight"`

The existing `[style*="color:#ff0000"]` attribute-selector rules in `course.css` are intentionally kept — they still cover 7 files in `exercises/` and `lectures/` that use the same inline style.

## Test plan
- [ ] Verify red highlights are visible in light mode on all 5 course pages
- [ ] Toggle to dark mode — highlights should shift to `#ff8a8a` (soft pink-red) with good contrast
- [ ] Confirm no `style="color: #ff0000"` remains in `course/*.html` (`grep` should return empty)
- [ ] Confirm `exercises/` and `lectures/` red spans still render correctly (covered by the retained attribute-selector rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)