### PR TITLE
feat: add <link rel="prev"> and <link rel="next"> to lesson pages

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -44,6 +44,7 @@
 			content="To provide a brief introduction to the programming language COBOL. To provide a context in which its uses might be understood. To introduce the"
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/COBOLIntro.html" />
+		<link rel="next" href="https://bushidocodes.github.io/limerick-cobol/course/DataDeclaration.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="article" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/COBOLIntro.html" />

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -44,6 +44,8 @@
 			content="The PROCEDURE DIVISION contains the code used to manipulate the data described in the DATA DIVISION . This tutorial examines some of the basic COBOL"
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/COBOLcommands.html" />
+		<link rel="prev" href="https://bushidocodes.github.io/limerick-cobol/course/DataDeclaration.html" />
+		<link rel="next" href="https://bushidocodes.github.io/limerick-cobol/course/Selection.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="article" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/COBOLcommands.html" />

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -41,6 +41,8 @@
 		<title>The COPY verb</title>
 		<meta name="description" content="COBOL programming lesson on The COPY verb." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Copy.html" />
+		<link rel="prev" href="https://bushidocodes.github.io/limerick-cobol/course/Subprograms.html" />
+		<link rel="next" href="https://bushidocodes.github.io/limerick-cobol/course/Inspect.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="article" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/Copy.html" />

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -44,6 +44,8 @@
 			content="The aim of this unit is to give you an understanding of the different categories of data used in a COBOL program and to demonstrate how items of each"
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/DataDeclaration.html" />
+		<link rel="prev" href="https://bushidocodes.github.io/limerick-cobol/course/COBOLIntro.html" />
+		<link rel="next" href="https://bushidocodes.github.io/limerick-cobol/course/COBOLcommands.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="article" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/DataDeclaration.html" />

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -44,6 +44,8 @@
 			content="In a business-programming environment, the ability to print reports is an important property for a programming language. COBOL allows programmers to write"
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/EditedPics.html" />
+		<link rel="prev" href="https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles2.html" />
+		<link rel="next" href="https://bushidocodes.github.io/limerick-cobol/course/Usage.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="article" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/EditedPics.html" />

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -44,6 +44,8 @@
 			content="The aim of this unit is to provide you with a solid understanding of; the organization of Indexed files, the declarations required for them and the"
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/IndexedFiles.html" />
+		<link rel="prev" href="https://bushidocodes.github.io/limerick-cobol/course/RelativeFiles.html" />
+		<link rel="next" href="https://bushidocodes.github.io/limerick-cobol/course/Tables1.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="article" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/IndexedFiles.html" />

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -44,6 +44,8 @@
 			content="Many programming languages rely on library functions for string handling. COBOL too, uses Intrinsic Functions for some tasks but most string manipulation"
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Inspect.html" />
+		<link rel="prev" href="https://bushidocodes.github.io/limerick-cobol/course/Copy.html" />
+		<link rel="next" href="https://bushidocodes.github.io/limerick-cobol/course/String.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="article" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/Inspect.html" />

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -44,6 +44,8 @@
 			content="The aim of this unit is to provide a gentle introduction to COBOL's direct access file organizations and to equip you with a knowledge of the advantages"
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Intro2DirectAccess.html" />
+		<link rel="prev" href="https://bushidocodes.github.io/limerick-cobol/course/SortMerge.html" />
+		<link rel="next" href="https://bushidocodes.github.io/limerick-cobol/course/RelativeFiles.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="article" />
 		<meta

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -59,6 +59,8 @@
 			content="In almost every programming job, there is some task that needs to be done over and over again. For example: The job of processing a file of records is an"
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Iteration.html" />
+		<link rel="prev" href="https://bushidocodes.github.io/limerick-cobol/course/Selection.html" />
+		<link rel="next" href="https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles1.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="article" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/Iteration.html" />

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -44,6 +44,8 @@
 			content="The aim of this unit is to provide to provide you with a solid understanding of string manipulation using Reference Modification. It will also introduce"
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/RefMod.html" />
+		<link rel="prev" href="https://bushidocodes.github.io/limerick-cobol/course/Unstring.html" />
+		<link rel="next" href="https://bushidocodes.github.io/limerick-cobol/course/ReportWriter.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="article" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/RefMod.html" />

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -44,6 +44,8 @@
 			content="The aim of this unit is to provide you with a solid understanding of declarations required for Relative files and the Procedure Division verbs used to"
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/RelativeFiles.html" />
+		<link rel="prev" href="https://bushidocodes.github.io/limerick-cobol/course/Intro2DirectAccess.html" />
+		<link rel="next" href="https://bushidocodes.github.io/limerick-cobol/course/IndexedFiles.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="article" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/RelativeFiles.html" />

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -44,6 +44,8 @@
 			content="The aim of this unit is to provide you with a solid understanding of COBOL Report Writer. This unit introduces the report writer by -"
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/ReportWriter.html" />
+		<link rel="prev" href="https://bushidocodes.github.io/limerick-cobol/course/RefMod.html" />
+		<link rel="next" href="https://bushidocodes.github.io/limerick-cobol/course/ReportWriterSS.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="article" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/ReportWriter.html" />

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -44,6 +44,7 @@
 			content="The unit provides a Report Writer reference. The syntax elements of the Report Writer are presented and the semantics of their operation discussed."
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/ReportWriterSS.html" />
+		<link rel="prev" href="https://bushidocodes.github.io/limerick-cobol/course/ReportWriter.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="article" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/ReportWriterSS.html" />

--- a/course/Search.html
+++ b/course/Search.html
@@ -44,6 +44,8 @@
 			content="The task of searching a table to determine whether it contains a particular value is a common operation. The method used to search a table depends heavily"
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Search.html" />
+		<link rel="prev" href="https://bushidocodes.github.io/limerick-cobol/course/Tables2.html" />
+		<link rel="next" href="https://bushidocodes.github.io/limerick-cobol/course/Subprograms.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="article" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/Search.html" />

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -44,6 +44,8 @@
 			content="In most procedural languages, If and Case/Switch are the only selection constructs supported. COBOL supports advanced versions of both of these constructs,"
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Selection.html" />
+		<link rel="prev" href="https://bushidocodes.github.io/limerick-cobol/course/COBOLcommands.html" />
+		<link rel="next" href="https://bushidocodes.github.io/limerick-cobol/course/Iteration.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="article" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/Selection.html" />

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -44,6 +44,8 @@
 			content="Files are repositories of data that reside on backing storage (hard disk, magnetic tape or CD-ROM). Nowadays, files are used to store a variety of"
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles1.html" />
+		<link rel="prev" href="https://bushidocodes.github.io/limerick-cobol/course/Iteration.html" />
+		<link rel="next" href="https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles2.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="article" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles1.html" />

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -44,6 +44,8 @@
 			content="The records in a Sequential file are organized serially, one after another, but the records in the file may be ordered or unordered. The serial"
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles2.html" />
+		<link rel="prev" href="https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles1.html" />
+		<link rel="next" href="https://bushidocodes.github.io/limerick-cobol/course/EditedPics.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="article" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles2.html" />

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -44,6 +44,8 @@
 			content="This tutorial covers a number of topics including; COBOL print files, multiple record-type files, variable length records, and run-time file name"
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles3.html" />
+		<link rel="prev" href="https://bushidocodes.github.io/limerick-cobol/course/Usage.html" />
+		<link rel="next" href="https://bushidocodes.github.io/limerick-cobol/course/SortMerge.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="article" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles3.html" />

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -44,6 +44,8 @@
 			content="As we noted in the tutorial - Processing Sequential Files - it is possible to apply processing to an ordered sequential file that is difficult, or"
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/SortMerge.html" />
+		<link rel="prev" href="https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles3.html" />
+		<link rel="next" href="https://bushidocodes.github.io/limerick-cobol/course/Intro2DirectAccess.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="article" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/SortMerge.html" />

--- a/course/String.html
+++ b/course/String.html
@@ -44,6 +44,8 @@
 			content="The aim of this unit is to provide to provide you with a solid understanding of the STRING verb."
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/String.html" />
+		<link rel="prev" href="https://bushidocodes.github.io/limerick-cobol/course/Inspect.html" />
+		<link rel="next" href="https://bushidocodes.github.io/limerick-cobol/course/Unstring.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="article" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/String.html" />

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -44,6 +44,8 @@
 			content="To provide a brief introduction to building modular systems using separately compiled and/or contained subprograms."
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Subprograms.html" />
+		<link rel="prev" href="https://bushidocodes.github.io/limerick-cobol/course/Search.html" />
+		<link rel="next" href="https://bushidocodes.github.io/limerick-cobol/course/Copy.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="article" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/Subprograms.html" />

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -44,6 +44,8 @@
 			content='In most programming languages the term "array" is used to describe repeated, or multiple- occurrence, data-items. COBOL uses the term - "table".'
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Tables1.html" />
+		<link rel="prev" href="https://bushidocodes.github.io/limerick-cobol/course/IndexedFiles.html" />
+		<link rel="next" href="https://bushidocodes.github.io/limerick-cobol/course/Tables2.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="article" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/Tables1.html" />

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -44,6 +44,8 @@
 			content='In the "Using Tables" tutorial we examined why we might want to use tables as part of the solution to a programming problem.'
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Tables2.html" />
+		<link rel="prev" href="https://bushidocodes.github.io/limerick-cobol/course/Tables1.html" />
+		<link rel="next" href="https://bushidocodes.github.io/limerick-cobol/course/Search.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="article" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/Tables2.html" />

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -44,6 +44,8 @@
 			content="The aim of this unit is to provide to provide you with a solid understanding of the UNSTRING verb."
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/unstring.html" />
+		<link rel="prev" href="https://bushidocodes.github.io/limerick-cobol/course/String.html" />
+		<link rel="next" href="https://bushidocodes.github.io/limerick-cobol/course/RefMod.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="article" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/unstring.html" />

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -44,6 +44,8 @@
 			content="The internal representation of data can be an important consideration for program efficiency. Unfortunately the default representation used by COBOL for"
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/usage.html" />
+		<link rel="prev" href="https://bushidocodes.github.io/limerick-cobol/course/EditedPics.html" />
+		<link rel="next" href="https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles3.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="article" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/course/usage.html" />

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
 		"check:lesson-jsonld": "node scripts/generate-lesson-jsonld.js && prettier --write \"course/**/*.html\" && git diff --exit-code course/lesson-meta.json \"course/**/*.html\"",
 		"build:reading-time": "node scripts/add-reading-time.js && prettier --write \"course/**/*.html\"",
 		"check:reading-time": "node scripts/add-reading-time.js && prettier --write \"course/**/*.html\" && git diff --exit-code \"course/**/*.html\"",
+		"build:prev-next-links": "node scripts/add-prev-next-links.js && prettier --write \"course/**/*.html\"",
+		"check:prev-next-links": "node scripts/add-prev-next-links.js && prettier --write \"course/**/*.html\" && git diff --exit-code \"course/**/*.html\"",
 		"check:assets": "node scripts/check-assets.js",
 		"format:check": "prettier --check .",
 		"format:write": "prettier --write .",

--- a/scripts/add-prev-next-links.js
+++ b/scripts/add-prev-next-links.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * add-prev-next-links.js
+ *
+ * For each lesson page in course/, injects <link rel="prev"> and
+ * <link rel="next"> tags immediately after <link rel="canonical">.
+ *
+ * Uses absolute URLs matching the canonical href base so that crawlers
+ * and browsers treat them the same way they treat the canonical link.
+ *
+ * Idempotent — re-running replaces any existing prev/next link tags.
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const COURSE_DIR = path.join(REPO_ROOT, "course");
+const BASE_URL = "https://bushidocodes.github.io/limerick-cobol/course/";
+
+// Lesson sequence — mirrors the array in components/lesson-progress.js.
+const LESSON_SEQUENCE = [
+	{ file: "COBOLIntro.html" },
+	{ file: "DataDeclaration.html" },
+	{ file: "COBOLcommands.html" },
+	{ file: "Selection.html" },
+	{ file: "Iteration.html" },
+	{ file: "SequentialFiles1.html" },
+	{ file: "SequentialFiles2.html" },
+	{ file: "EditedPics.html" },
+	{ file: "Usage.html" },
+	{ file: "SequentialFiles3.html" },
+	{ file: "SortMerge.html" },
+	{ file: "Intro2DirectAccess.html" },
+	{ file: "RelativeFiles.html" },
+	{ file: "IndexedFiles.html" },
+	{ file: "Tables1.html" },
+	{ file: "Tables2.html" },
+	{ file: "Search.html" },
+	{ file: "Subprograms.html" },
+	{ file: "Copy.html" },
+	{ file: "Inspect.html" },
+	{ file: "String.html" },
+	{ file: "Unstring.html" },
+	{ file: "RefMod.html" },
+	{ file: "ReportWriter.html" },
+	{ file: "ReportWriterSS.html" },
+];
+
+/**
+ * Build the prev/next link tag block to inject.
+ * Returns only the tags that apply (first lesson has no prev, last has no next).
+ */
+function buildLinkBlock(prev, next) {
+	const lines = [];
+	if (prev) lines.push(`\t\t<link rel="prev" href="${BASE_URL}${prev.file}" />`);
+	if (next) lines.push(`\t\t<link rel="next" href="${BASE_URL}${next.file}" />`);
+	return lines.join("\n");
+}
+
+/**
+ * Remove any existing prev/next link tags, then inject new ones immediately
+ * after the <link rel="canonical"> tag.
+ */
+function injectPrevNextLinks(html, prev, next) {
+	// Strip existing prev/next tags (idempotency).
+	html = html.replace(/\t\t<link rel="(?:prev|next)"[^\n]+\n/g, "");
+
+	const block = buildLinkBlock(prev, next);
+	if (!block) return html;
+
+	// Insert after <link rel="canonical" ...>.
+	return html.replace(/(\t\t<link rel="canonical"[^\n]+\n)/, `$1${block}\n`);
+}
+
+function main() {
+	for (let i = 0; i < LESSON_SEQUENCE.length; i++) {
+		const { file } = LESSON_SEQUENCE[i];
+		const filePath = path.join(COURSE_DIR, file);
+
+		if (!fs.existsSync(filePath)) {
+			console.warn(`  SKIP  ${file} (not found)`);
+			continue;
+		}
+
+		const prev = i > 0 ? LESSON_SEQUENCE[i - 1] : null;
+		const next = i < LESSON_SEQUENCE.length - 1 ? LESSON_SEQUENCE[i + 1] : null;
+
+		let html = fs.readFileSync(filePath, "utf8");
+		html = injectPrevNextLinks(html, prev, next);
+		fs.writeFileSync(filePath, html, "utf8");
+		console.log(`  OK    ${file}`);
+	}
+}
+
+main();


### PR DESCRIPTION
## Summary

- Adds `scripts/add-prev-next-links.js` — an idempotent Node script that injects `<link rel="prev">` / `<link rel="next">` tags into each of the 25 lesson pages immediately after `<link rel="canonical">`
- Uses absolute URLs matching the existing canonical href base (`https://bushidocodes.github.io/limerick-cobol/course/`)
- First lesson gets only `rel="next"`; last lesson gets only `rel="prev"`; all others get both
- Adds `build:prev-next-links` and `check:prev-next-links` npm scripts following the same pattern as `build:lesson-jsonld` / `check:lesson-jsonld`

Closes #380.

## Test plan

- [ ] Spot-check `COBOLIntro.html` (first) — should have only `<link rel="next">`
- [ ] Spot-check a middle lesson (e.g. `Selection.html`) — should have both `<link rel="prev">` and `<link rel="next">`
- [ ] Spot-check `ReportWriterSS.html` (last) — should have only `<link rel="prev">`
- [ ] Run `npm run check:prev-next-links` — should exit clean (idempotency check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)