### PR TITLE
feat: add exercises-nav component (closes #389)

### DIFF
--- a/components/exercise-progress.js
+++ b/components/exercise-progress.js
@@ -1,0 +1,28 @@
+// Single source of truth for the exercise sequence.
+// Loaded before exercises-nav.js so the component can read window.COBOL_EXERCISES.
+// Paths are relative to the exercises/ root (subdir/file.html).
+
+window.COBOL_EXERCISES = Object.freeze([
+	// --- Programming Exam Specifications ---
+	{ file: "Exm-StudFeesRpt/Exm-StudPay.html", title: "Student Fees Report" },
+	{ file: "Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html", title: "Aromamora Summary Sales" },
+	{ file: "Exm-FlyByNightTravel/Exm-FlyByNight.html", title: "FlyByNight Summary File" },
+	{ file: "Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html", title: "AromamoraMaint&Report" },
+	{ file: "Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html", title: "Bookshop Lecturer Req Report" },
+	{ file: "Exm-AcmeStockReorder/Exm-AcmeStockReorder.html", title: "ACME Stock Reorder" },
+	{ file: "Exm-FileConversion/Exm-FileConversion.html", title: "File Conversion" },
+	{ file: "Exm-USSRshipRpt/Exm-USSRshipRpt.html", title: "USSR Ship Report" },
+	{ file: "Exm-SFbyMail/Exm-SFbyMail.html", title: "Science Fiction by Mail" },
+	{ file: "Exm-CSISEmailDomain/Exm-CSISEmailDomain.html", title: "CSIS Email Domain" },
+	{ file: "Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html", title: "Library Royalties Report" },
+	{ file: "Exm-TopSupplierRpt/Exm-TopSupplierRpt.html", title: "Top Supplier Report" },
+	{ file: "Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html", title: "Folio Best Sellers Report" },
+	{ file: "Exm-DueSubsRpt/Exm-DueSubsRpt.html", title: "Due Subscriptions Report" },
+	// --- Programming Project Specifications ---
+	{ file: "Proj-CSISEvalform/CSISEvalForm.html", title: "CSIS Evaluation Form Report" },
+	{ file: "Prj-AromaSalesRpt/Prj-AromaSalesRpt.html", title: "Aroma Sales Report" },
+	{ file: "Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html", title: "Newtronics File Maintenance" },
+	{ file: "Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html", title: "Aroma Invoices Report" },
+	{ file: "Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html", title: "Munster Surnames Frequency Report" },
+	{ file: "Prj-CAOPointsCalc/Prj-CAOcalculator.html", title: "CAO Points Calculator" },
+]);

--- a/components/exercises-nav.js
+++ b/components/exercises-nav.js
@@ -1,0 +1,39 @@
+// Exercise-level Prev / Next navigation bar. Mirrors lesson-nav.js for exercise
+// pages. Reads the exercise sequence from window.COBOL_EXERCISES (exercise-progress.js),
+// which must be loaded earlier in the page.
+//
+// All Exm-* and Prj-* pages live one directory below exercises/. Paths in
+// COBOL_EXERCISES are relative to that root (subdir/file.html), so hrefs are
+// constructed by prepending "../" to reach sibling exercise directories.
+
+class ExercisesNav extends HTMLElement {
+	connectedCallback() {
+		const EXERCISES = window.COBOL_EXERCISES;
+		if (!EXERCISES) return;
+
+		// Match against the last two path segments (subdir/file.html) since each
+		// exercise lives in its own subdirectory under exercises/.
+		const segments = window.location.pathname.split("/").filter(Boolean);
+		const currentFile = segments.slice(-2).join("/");
+
+		const index = EXERCISES.findIndex((e) => e.file === currentFile);
+		if (index === -1) return;
+
+		const prev = index > 0 ? EXERCISES[index - 1] : null;
+		const next = index < EXERCISES.length - 1 ? EXERCISES[index + 1] : null;
+
+		const prevHTML = prev
+			? `<a class="lesson-nav-prev" href="../${prev.file}">← Previous: ${prev.title}</a>`
+			: `<span></span>`;
+		const positionHTML = `<span class="lesson-nav-position">Exercise ${index + 1} of ${EXERCISES.length}</span>`;
+		const nextHTML = next
+			? `<a class="lesson-nav-next" href="../${next.file}">Next: ${next.title} →</a>`
+			: `<span></span>`;
+
+		this.innerHTML = `<nav class="lesson-nav" aria-label="Exercise navigation">${prevHTML}${positionHTML}${nextHTML}</nav>`;
+	}
+
+	disconnectedCallback() {}
+}
+
+customElements.define("exercises-nav", ExercisesNav);

--- a/exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html
+++ b/exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -48,6 +48,8 @@
 		<script src="../../components/back-to-top.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/exercise-progress.js" defer></script>
+		<script src="../../components/exercises-nav.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -543,6 +545,7 @@
 						</p>
 					</section>
 
+					<exercises-nav></exercises-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice type="exercises"></copyright-notice>
 					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>

--- a/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html
+++ b/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -48,6 +48,8 @@
 		<script src="../../components/back-to-top.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/exercise-progress.js" defer></script>
+		<script src="../../components/exercises-nav.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -358,6 +360,7 @@
 						</p>
 					</section>
 
+					<exercises-nav></exercises-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice type="exercises"></copyright-notice>
 					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>

--- a/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html
+++ b/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -48,6 +48,8 @@
 		<script src="../../components/back-to-top.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/exercise-progress.js" defer></script>
+		<script src="../../components/exercises-nav.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -224,6 +226,7 @@
 						</p>
 					</section>
 
+					<exercises-nav></exercises-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice type="exercises"></copyright-notice>
 					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>

--- a/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html
+++ b/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -48,6 +48,8 @@
 		<script src="../../components/back-to-top.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/exercise-progress.js" defer></script>
+		<script src="../../components/exercises-nav.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -227,6 +229,7 @@
 						</div>
 					</section>
 
+					<exercises-nav></exercises-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice type="exercises"></copyright-notice>
 					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>

--- a/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html
+++ b/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -48,6 +48,8 @@
 		<script src="../../components/back-to-top.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/exercise-progress.js" defer></script>
+		<script src="../../components/exercises-nav.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -310,6 +312,7 @@
 						</p>
 					</section>
 
+					<exercises-nav></exercises-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice type="exercises"></copyright-notice>
 					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>

--- a/exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html
+++ b/exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -48,6 +48,8 @@
 		<script src="../../components/back-to-top.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/exercise-progress.js" defer></script>
+		<script src="../../components/exercises-nav.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -353,6 +355,7 @@
 						</div>
 					</section>
 
+					<exercises-nav></exercises-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice type="exercises"></copyright-notice>
 					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>

--- a/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html
+++ b/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -48,6 +48,8 @@
 		<script src="../../components/back-to-top.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/exercise-progress.js" defer></script>
+		<script src="../../components/exercises-nav.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -323,6 +325,7 @@
 						</p>
 					</section>
 
+					<exercises-nav></exercises-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice type="exercises"></copyright-notice>
 					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>

--- a/exercises/Exm-FileConversion/Exm-FileConversion.html
+++ b/exercises/Exm-FileConversion/Exm-FileConversion.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -48,6 +48,8 @@
 		<script src="../../components/back-to-top.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/exercise-progress.js" defer></script>
+		<script src="../../components/exercises-nav.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -344,6 +346,7 @@ Ryan Michael Terence          34 Winchester Drive Dubline 7 Co. Dublin    090123
 						</div>
 					</section>
 
+					<exercises-nav></exercises-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice type="exercises"></copyright-notice>
 					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>

--- a/exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html
+++ b/exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -48,6 +48,8 @@
 		<script src="../../components/back-to-top.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/exercise-progress.js" defer></script>
+		<script src="../../components/exercises-nav.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -255,6 +257,7 @@
 						</blockquote>
 					</section>
 
+					<exercises-nav></exercises-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice type="exercises"></copyright-notice>
 					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>

--- a/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html
+++ b/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -48,6 +48,8 @@
 		<script src="../../components/back-to-top.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/exercise-progress.js" defer></script>
+		<script src="../../components/exercises-nav.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -345,6 +347,7 @@
 						</div>
 					</section>
 
+					<exercises-nav></exercises-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice type="exercises"></copyright-notice>
 					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>

--- a/exercises/Exm-SFbyMail/Exm-SFbyMail.html
+++ b/exercises/Exm-SFbyMail/Exm-SFbyMail.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -48,6 +48,8 @@
 		<script src="../../components/back-to-top.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/exercise-progress.js" defer></script>
+		<script src="../../components/exercises-nav.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -412,6 +414,7 @@
 						</blockquote>
 					</section>
 
+					<exercises-nav></exercises-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice type="exercises"></copyright-notice>
 					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>

--- a/exercises/Exm-StudFeesRpt/Exm-StudPay.html
+++ b/exercises/Exm-StudFeesRpt/Exm-StudPay.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -48,6 +48,8 @@
 		<script src="../../components/back-to-top.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/exercise-progress.js" defer></script>
+		<script src="../../components/exercises-nav.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -239,6 +241,7 @@
 						</p>
 					</section>
 
+					<exercises-nav></exercises-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice type="exercises"></copyright-notice>
 					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>

--- a/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html
+++ b/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -48,6 +48,8 @@
 		<script src="../../components/back-to-top.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/exercise-progress.js" defer></script>
+		<script src="../../components/exercises-nav.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -284,6 +286,7 @@
 						</p>
 					</section>
 
+					<exercises-nav></exercises-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice type="exercises"></copyright-notice>
 					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>

--- a/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html
+++ b/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -48,6 +48,8 @@
 		<script src="../../components/back-to-top.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/exercise-progress.js" defer></script>
+		<script src="../../components/exercises-nav.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -443,6 +445,7 @@
 						</p>
 					</section>
 
+					<exercises-nav></exercises-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice type="exercises"></copyright-notice>
 					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>

--- a/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html
+++ b/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html
@@ -64,6 +64,8 @@
 		<script src="../../components/back-to-top.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/exercise-progress.js" defer></script>
+		<script src="../../components/exercises-nav.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -387,6 +389,7 @@
 						</p>
 					</section>
 
+					<exercises-nav></exercises-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice type="project"></copyright-notice>
 					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>

--- a/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html
+++ b/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -64,6 +64,8 @@
 		<script src="../../components/back-to-top.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/exercise-progress.js" defer></script>
+		<script src="../../components/exercises-nav.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -418,6 +420,7 @@
 						</p>
 					</section>
 
+					<exercises-nav></exercises-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice type="project"></copyright-notice>
 					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>

--- a/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html
+++ b/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -64,6 +64,8 @@
 		<script src="../../components/back-to-top.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/exercise-progress.js" defer></script>
+		<script src="../../components/exercises-nav.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -997,6 +999,7 @@
 						</div>
 					</section>
 
+					<exercises-nav></exercises-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice type="project"></copyright-notice>
 					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>

--- a/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html
+++ b/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -64,6 +64,8 @@
 		<script src="../../components/back-to-top.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/exercise-progress.js" defer></script>
+		<script src="../../components/exercises-nav.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -210,6 +212,7 @@
 						</p>
 					</section>
 
+					<exercises-nav></exercises-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice type="project"></copyright-notice>
 					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>

--- a/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html
+++ b/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html
@@ -97,6 +97,8 @@
 		<script src="../../components/back-to-top.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/exercise-progress.js" defer></script>
+		<script src="../../components/exercises-nav.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -1122,6 +1124,7 @@ Check Digit       =            4</pre
 						</p>
 					</section>
 
+					<exercises-nav></exercises-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice type="project"></copyright-notice>
 					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>

--- a/exercises/Proj-CSISEvalform/CSISEvalForm.html
+++ b/exercises/Proj-CSISEvalform/CSISEvalForm.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en-GB">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -48,6 +48,8 @@
 		<script src="../../components/back-to-top.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/exercise-progress.js" defer></script>
+		<script src="../../components/exercises-nav.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -284,6 +286,7 @@
 <b>Overall Evaluation  - XXXXXXXXX</b></pre>
 					</section>
 
+					<exercises-nav></exercises-nav>
 					<back-to-top></back-to-top>
 					<copyright-notice type="project"></copyright-notice>
 					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>


### PR DESCRIPTION
## Summary

- Adds `components/exercise-progress.js` — defines `window.COBOL_EXERCISES`, a frozen array of 20 exercise pages (14 Exm-* exam specs + 6 Prj-* project specs) ordered as they appear in `exercises/index.html`
- Adds `components/exercises-nav.js` — `<exercises-nav>` custom element that mirrors `lesson-nav.js`; renders a Prev / Next bar reusing the existing `.lesson-nav` / `.lesson-nav-prev` / `.lesson-nav-next` / `.lesson-nav-position` CSS classes — no new CSS needed
- Updates all 20 Exm-* and Prj-* HTML pages: two `<script>` tags in `<head>` and `<exercises-nav></exercises-nav>` inserted before `<back-to-top>`

Because every exercise page lives exactly one directory below `exercises/`, relative hrefs are always `../subdir/file.html`. The component matches the current page by joining the last two URL path segments (`subdir/file.html`).

Closes #389

## Test plan

- [ ] Open any Exm-* or Prj-* page and confirm the nav bar appears showing "Exercise X of 20" with correct Prev/Next labels
- [ ] First exercise (Student Fees Report) has no Previous link
- [ ] Last exercise (CAO Points Calculator) has no Next link
- [ ] Clicking Prev/Next navigates to the correct sibling page
- [ ] Nav is absent on pages not in the sequence (simple exercises, COBOL source pages)