### PR TITLE
ci: wire check:lesson-index, pin action SHAs, restrict permissions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,15 +6,18 @@ on:
     push:
         branches: [master]
 
+permissions:
+    contents: read
+
 jobs:
     checks:
         name: Validate, links, and accessibility
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
                   fetch-depth: 0
-            - uses: actions/setup-node@v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: "22"
                   cache: "npm"
@@ -39,5 +42,5 @@ jobs:
         name: Spell check (typos)
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
             - uses: crate-ci/typos@v1.46.1

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -28,6 +28,7 @@ jobs:
                   github.event.pull_request.head.repo.full_name != github.repository
               run: npm run format:check
             - run: npm run validate
+            - run: npm run check:lesson-index
             - run: npm run check:assets
             - run: npm run check:img-dims
             - run: npm run links

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -22,11 +22,11 @@ jobs:
         if: github.event.pull_request.head.repo.full_name == github.repository
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
                   ref: ${{ github.head_ref }}
                   token: ${{ secrets.GITHUB_TOKEN }}
-            - uses: actions/setup-node@v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: "22"
                   cache: "npm"


### PR DESCRIPTION
## Summary

- Closes #398 — adds `check:lesson-index` step to CI so any PR that edits `lesson-manifest.json` without regenerating `course/index.html` fails
- Closes #411 — pins `actions/checkout` and `actions/setup-node` to their v6 commit SHAs in both workflow files
- Closes #412 — adds `permissions: contents: read` to `checks.yml`; `format.yml` already declares `contents: write` explicitly

## Context for #398

Issue #398 was filed before the `lesson-manifest.json` refactor landed. That refactor introduced `scripts/build-lesson-index.js` and a `check:lesson-index` npm script that rebuilds `course/index.html` from the manifest and runs `git diff --exit-code`. The only missing piece was wiring it into CI.

## Test plan

- [ ] CI passes on this branch
- [ ] Editing `lesson-manifest.json` without running `build:lesson-index` causes CI to fail
- [ ] Confirm workflow permissions are `contents: read` in checks.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)