### PR TITLE
feat: reorganize example page layout — toolbar above code, related links below

### DIFF
--- a/course/Resources/css/course-components.css
+++ b/course/Resources/css/course-components.css
@@ -869,7 +869,6 @@ body pre[class*="language-"] {
 	position: relative;
 }
 
-
 .copy-button {
 	position: absolute;
 	top: 0.4em;

--- a/course/Resources/css/course-components.css
+++ b/course/Resources/css/course-components.css
@@ -810,6 +810,54 @@ details[open].saq-reveal summary::before {
 }
 
 /* ============================================================================
+   Code toolbar — Download / Copy / Run buttons grouped above a code block.
+   Used on example pages; the .code-toolbar div sits immediately before <pre>.
+   ============================================================================ */
+
+.code-toolbar {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5em;
+	align-items: center;
+	margin-bottom: 0;
+}
+
+.download-btn {
+	display: inline-block;
+	padding: 0.4em 0.85em;
+	font-size: 0.9em;
+	line-height: 1.4;
+	cursor: pointer;
+	border-radius: 3px;
+	background-color: #f0f0f0;
+	color: #333;
+	border: 1px solid #bbb;
+	text-decoration: none;
+	transition: opacity 0.15s;
+}
+
+.download-btn:hover,
+.download-btn:focus {
+	opacity: 0.85;
+	outline: 2px solid currentColor;
+	outline-offset: 1px;
+}
+
+@media (prefers-color-scheme: dark) {
+	:root:not([data-theme="light"]) .download-btn {
+		background-color: #2e2e2e;
+		color: #ddd;
+		border-color: #555;
+	}
+}
+
+:root[data-theme="dark"] .download-btn {
+	background-color: #2e2e2e;
+	color: #ddd;
+	border-color: #555;
+}
+
+/* ============================================================================
    Copy-to-clipboard button (components/copy-button.js)
    The host <pre> gets position:relative so the button can sit top-right.
    The body prefix matches the specificity of the adjacent Prism overrides so
@@ -820,6 +868,7 @@ details[open].saq-reveal summary::before {
 body pre[class*="language-"] {
 	position: relative;
 }
+
 
 .copy-button {
 	position: absolute;

--- a/examples/Accept/ACCEPT.html
+++ b/examples/Accept/ACCEPT.html
@@ -11,18 +11,27 @@
 			})();
 		</script>
 		<title>ACCEPT and DISPLAY example program</title>
-		<meta name="description" content="The program accepts a simple student record from the user and displays the individual fields. Also shows how the ACCEPT may be used to get and DISPLAY the" />
+		<meta
+			name="description"
+			content="The program accepts a simple student record from the user and displays the individual fields. Also shows how the ACCEPT may be used to get and DISPLAY the"
+		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Accept/ACCEPT.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Accept/ACCEPT.html" />
 		<meta property="og:title" content="ACCEPT and DISPLAY example program" />
-		<meta property="og:description" content="The program accepts a simple student record from the user and displays the individual fields. Also shows how the ACCEPT may be used to get and DISPLAY the" />
+		<meta
+			property="og:description"
+			content="The program accepts a simple student record from the user and displays the individual fields. Also shows how the ACCEPT may be used to get and DISPLAY the"
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="ACCEPT and DISPLAY example program" />
-		<meta name="twitter:description" content="The program accepts a simple student record from the user and displays the individual fields. Also shows how the ACCEPT may be used to get and DISPLAY the" />
+		<meta
+			name="twitter:description"
+			content="The program accepts a simple student record from the user and displays the individual fields. Also shows how the ACCEPT may be used to get and DISPLAY the"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -46,9 +55,14 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>ACCEPT and DISPLAY</span>
 						</nav>
-						<p>The program accepts a simple student record from the user and displays the individual fields. Also shows how the ACCEPT may be used to get and DISPLAY the system time and date.</p>
-							<div class="code-toolbar">
-							<a href="AcceptAndDisplay.cbl" download class="download-btn">Download AcceptAndDisplay.cbl</a>
+						<p>
+							The program accepts a simple student record from the user and displays the individual
+							fields. Also shows how the ACCEPT may be used to get and DISPLAY the system time and date.
+						</p>
+						<div class="code-toolbar">
+							<a href="AcceptAndDisplay.cbl" download class="download-btn"
+								>Download AcceptAndDisplay.cbl</a
+							>
 							<run-in-ce></run-in-ce>
 						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE

--- a/examples/Accept/ACCEPT.html
+++ b/examples/Accept/ACCEPT.html
@@ -11,27 +11,18 @@
 			})();
 		</script>
 		<title>ACCEPT and DISPLAY example program</title>
-		<meta
-			name="description"
-			content="The program accepts a simple student record from the user and displays the individual fields. Also shows how the ACCEPT may be used to get and DISPLAY the"
-		/>
+		<meta name="description" content="The program accepts a simple student record from the user and displays the individual fields. Also shows how the ACCEPT may be used to get and DISPLAY the" />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Accept/ACCEPT.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Accept/ACCEPT.html" />
 		<meta property="og:title" content="ACCEPT and DISPLAY example program" />
-		<meta
-			property="og:description"
-			content="The program accepts a simple student record from the user and displays the individual fields. Also shows how the ACCEPT may be used to get and DISPLAY the"
-		/>
+		<meta property="og:description" content="The program accepts a simple student record from the user and displays the individual fields. Also shows how the ACCEPT may be used to get and DISPLAY the" />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="ACCEPT and DISPLAY example program" />
-		<meta
-			name="twitter:description"
-			content="The program accepts a simple student record from the user and displays the individual fields. Also shows how the ACCEPT may be used to get and DISPLAY the"
-		/>
+		<meta name="twitter:description" content="The program accepts a simple student record from the user and displays the individual fields. Also shows how the ACCEPT may be used to get and DISPLAY the" />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -55,17 +46,11 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>ACCEPT and DISPLAY</span>
 						</nav>
-						<p>
-							The program accepts a simple student record from the user and displays the individual
-							fields. Also shows how the ACCEPT may be used to get and DISPLAY the system time and date.
-						</p>
-						<p><a href="AcceptAndDisplay.cbl" download>Download AcceptAndDisplay.cbl</a></p>
-						<p><run-in-ce></run-in-ce></p>
-						<related-content
-							lectures="../../course/COBOLIntro.html|Introduction to COBOL, ../../course/COBOLcommands.html|Basic COBOL Commands, ../../course/DataDeclaration.html|Declaring Data in COBOL, ../../course/EditedPics.html|Edited PICs"
-							examples="Shortest.html|Shortest COBOL Program, Multiplier.html|ACCEPT, DISPLAY and MULTIPLY Example"
-							exercises="../../exercises/GettingStarted.html|Getting Started with VISOC"
-						></related-content>
+						<p>The program accepts a simple student record from the user and displays the individual fields. Also shows how the ACCEPT may be used to get and DISPLAY the system time and date.</p>
+							<div class="code-toolbar">
+							<a href="AcceptAndDisplay.cbl" download class="download-btn">Download AcceptAndDisplay.cbl</a>
+							<run-in-ce></run-in-ce>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  AcceptAndDisplay.
@@ -123,6 +108,11 @@ Begin.
     DISPLAY "The time is " CurrentHour ":" CurrentMinute.
     STOP RUN.
 </code></pre>
+						<related-content
+							lectures="../../course/COBOLIntro.html|Introduction to COBOL, ../../course/COBOLcommands.html|Basic COBOL Commands, ../../course/DataDeclaration.html|Declaring Data in COBOL, ../../course/EditedPics.html|Edited PICs"
+							examples="Shortest.html|Shortest COBOL Program, Multiplier.html|ACCEPT, DISPLAY and MULTIPLY Example"
+							exercises="../../exercises/GettingStarted.html|Getting Started with VISOC"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/Accept/Multiplier.html
+++ b/examples/Accept/Multiplier.html
@@ -11,18 +11,30 @@
 			})();
 		</script>
 		<title>ACCEPT, DISPLAY and MULTIPLY example program</title>
-		<meta name="description" content="Accepts two single digit numbers from the user, multiplies them together and displays the result." />
+		<meta
+			name="description"
+			content="Accepts two single digit numbers from the user, multiplies them together and displays the result."
+		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Accept/Multiplier.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Accept/Multiplier.html" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/Accept/Multiplier.html"
+		/>
 		<meta property="og:title" content="ACCEPT, DISPLAY and MULTIPLY example program" />
-		<meta property="og:description" content="Accepts two single digit numbers from the user, multiplies them together and displays the result." />
+		<meta
+			property="og:description"
+			content="Accepts two single digit numbers from the user, multiplies them together and displays the result."
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="ACCEPT, DISPLAY and MULTIPLY example program" />
-		<meta name="twitter:description" content="Accepts two single digit numbers from the user, multiplies them together and displays the result." />
+		<meta
+			name="twitter:description"
+			content="Accepts two single digit numbers from the user, multiplies them together and displays the result."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -41,13 +53,19 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="ACCEPT, DISPLAY and MULTIPLY example program" eyebrow="COBOL Example"></page-hero>
+						<page-hero
+							title="ACCEPT, DISPLAY and MULTIPLY example program"
+							eyebrow="COBOL Example"
+						></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../default.html">Example programs</a> ›
 							<span>Multiplier</span>
 						</nav>
-						<p>Accepts two single digit numbers from the user, multiplies them together and displays the result.</p>
-							<div class="code-toolbar">
+						<p>
+							Accepts two single digit numbers from the user, multiplies them together and displays the
+							result.
+						</p>
+						<div class="code-toolbar">
 							<a href="Multiplier.cbl" download class="download-btn">Download Multiplier.cbl</a>
 							<run-in-ce></run-in-ce>
 						</div>

--- a/examples/Accept/Multiplier.html
+++ b/examples/Accept/Multiplier.html
@@ -11,30 +11,18 @@
 			})();
 		</script>
 		<title>ACCEPT, DISPLAY and MULTIPLY example program</title>
-		<meta
-			name="description"
-			content="Accepts two single digit numbers from the user, multiplies them together and displays the result."
-		/>
+		<meta name="description" content="Accepts two single digit numbers from the user, multiplies them together and displays the result." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Accept/Multiplier.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta
-			property="og:url"
-			content="https://bushidocodes.github.io/limerick-cobol/examples/Accept/Multiplier.html"
-		/>
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Accept/Multiplier.html" />
 		<meta property="og:title" content="ACCEPT, DISPLAY and MULTIPLY example program" />
-		<meta
-			property="og:description"
-			content="Accepts two single digit numbers from the user, multiplies them together and displays the result."
-		/>
+		<meta property="og:description" content="Accepts two single digit numbers from the user, multiplies them together and displays the result." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="ACCEPT, DISPLAY and MULTIPLY example program" />
-		<meta
-			name="twitter:description"
-			content="Accepts two single digit numbers from the user, multiplies them together and displays the result."
-		/>
+		<meta name="twitter:description" content="Accepts two single digit numbers from the user, multiplies them together and displays the result." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -53,25 +41,16 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero
-							title="ACCEPT, DISPLAY and MULTIPLY example program"
-							eyebrow="COBOL Example"
-						></page-hero>
+						<page-hero title="ACCEPT, DISPLAY and MULTIPLY example program" eyebrow="COBOL Example"></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../default.html">Example programs</a> ›
 							<span>Multiplier</span>
 						</nav>
-						<p>
-							Accepts two single digit numbers from the user, multiplies them together and displays the
-							result.
-						</p>
-						<p><a href="Multiplier.cbl" download>Download Multiplier.cbl</a></p>
-						<p><run-in-ce></run-in-ce></p>
-						<related-content
-							lectures="../../course/COBOLcommands.html|Basic COBOL Commands, ../../course/DataDeclaration.html|Declaring Data in COBOL, ../../course/EditedPics.html|Edited PICs"
-							examples="ACCEPT.html|ACCEPT and DISPLAY Example"
-							exercises="../../exercises/GettingStarted.html|Getting Started with VISOC"
-						></related-content>
+						<p>Accepts two single digit numbers from the user, multiplies them together and displays the result.</p>
+							<div class="code-toolbar">
+							<a href="Multiplier.cbl" download class="download-btn">Download Multiplier.cbl</a>
+							<run-in-ce></run-in-ce>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  Multiplier.
@@ -95,6 +74,11 @@ PROCEDURE DIVISION.
     DISPLAY "Result is = ", Result.
     STOP RUN.
 </code></pre>
+						<related-content
+							lectures="../../course/COBOLcommands.html|Basic COBOL Commands, ../../course/DataDeclaration.html|Declaring Data in COBOL, ../../course/EditedPics.html|Edited PICs"
+							examples="ACCEPT.html|ACCEPT and DISPLAY Example"
+							exercises="../../exercises/GettingStarted.html|Getting Started with VISOC"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/Accept/Shortest.html
+++ b/examples/Accept/Shortest.html
@@ -11,18 +11,27 @@
 			})();
 		</script>
 		<title>The Shortest COBOL program we can have</title>
-		<meta name="description" content="This example program is almost the shortest COBOL program we can have. We could make it shorter still by leaving out the STOP RUN." />
+		<meta
+			name="description"
+			content="This example program is almost the shortest COBOL program we can have. We could make it shorter still by leaving out the STOP RUN."
+		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Accept/Shortest.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Accept/Shortest.html" />
 		<meta property="og:title" content="The Shortest COBOL program we can have" />
-		<meta property="og:description" content="This example program is almost the shortest COBOL program we can have. We could make it shorter still by leaving out the STOP RUN." />
+		<meta
+			property="og:description"
+			content="This example program is almost the shortest COBOL program we can have. We could make it shorter still by leaving out the STOP RUN."
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="The Shortest COBOL program we can have" />
-		<meta name="twitter:description" content="This example program is almost the shortest COBOL program we can have. We could make it shorter still by leaving out the STOP RUN." />
+		<meta
+			name="twitter:description"
+			content="This example program is almost the shortest COBOL program we can have. We could make it shorter still by leaving out the STOP RUN."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -46,8 +55,11 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>Shortest COBOL Program</span>
 						</nav>
-						<p>This example program is almost the shortest COBOL program we can have. We could make it shorter still by leaving out the STOP RUN.</p>
-							<div class="code-toolbar">
+						<p>
+							This example program is almost the shortest COBOL program we can have. We could make it
+							shorter still by leaving out the STOP RUN.
+						</p>
+						<div class="code-toolbar">
 							<a href="ShortestProgram.cbl" download class="download-btn">Download ShortestProgram.cbl</a>
 							<run-in-ce></run-in-ce>
 						</div>

--- a/examples/Accept/Shortest.html
+++ b/examples/Accept/Shortest.html
@@ -11,27 +11,18 @@
 			})();
 		</script>
 		<title>The Shortest COBOL program we can have</title>
-		<meta
-			name="description"
-			content="This example program is almost the shortest COBOL program we can have. We could make it shorter still by leaving out the STOP RUN."
-		/>
+		<meta name="description" content="This example program is almost the shortest COBOL program we can have. We could make it shorter still by leaving out the STOP RUN." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Accept/Shortest.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Accept/Shortest.html" />
 		<meta property="og:title" content="The Shortest COBOL program we can have" />
-		<meta
-			property="og:description"
-			content="This example program is almost the shortest COBOL program we can have. We could make it shorter still by leaving out the STOP RUN."
-		/>
+		<meta property="og:description" content="This example program is almost the shortest COBOL program we can have. We could make it shorter still by leaving out the STOP RUN." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="The Shortest COBOL program we can have" />
-		<meta
-			name="twitter:description"
-			content="This example program is almost the shortest COBOL program we can have. We could make it shorter still by leaving out the STOP RUN."
-		/>
+		<meta name="twitter:description" content="This example program is almost the shortest COBOL program we can have. We could make it shorter still by leaving out the STOP RUN." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -55,17 +46,11 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>Shortest COBOL Program</span>
 						</nav>
-						<p>
-							This example program is almost the shortest COBOL program we can have. We could make it
-							shorter still by leaving out the STOP RUN.
-						</p>
-						<p><a href="ShortestProgram.cbl" download>Download ShortestProgram.cbl</a></p>
-						<p><run-in-ce></run-in-ce></p>
-						<related-content
-							lectures="../../course/COBOLIntro.html|Introduction to COBOL"
-							examples="ACCEPT.html|ACCEPT and DISPLAY Example"
-							exercises="../../exercises/GettingStarted.html|Getting Started with VISOC"
-						></related-content>
+						<p>This example program is almost the shortest COBOL program we can have. We could make it shorter still by leaving out the STOP RUN.</p>
+							<div class="code-toolbar">
+							<a href="ShortestProgram.cbl" download class="download-btn">Download ShortestProgram.cbl</a>
+							<run-in-ce></run-in-ce>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  ShortestProgram.
@@ -75,6 +60,11 @@ DisplayPrompt.
     DISPLAY "I did it".
     STOP RUN.
 </code></pre>
+						<related-content
+							lectures="../../course/COBOLIntro.html|Introduction to COBOL"
+							examples="ACCEPT.html|ACCEPT and DISPLAY Example"
+							exercises="../../exercises/GettingStarted.html|Getting Started with VISOC"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/Conditn/Conditions.html
+++ b/examples/Conditn/Conditions.html
@@ -15,23 +15,14 @@
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Conditn/Conditions.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta
-			property="og:url"
-			content="https://bushidocodes.github.io/limerick-cobol/examples/Conditn/Conditions.html"
-		/>
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Conditn/Conditions.html" />
 		<meta property="og:title" content="Condition Names (level 88) example program" />
-		<meta
-			property="og:description"
-			content="An example program demonstrating the use of Condition Names (level 88's)."
-		/>
+		<meta property="og:description" content="An example program demonstrating the use of Condition Names (level 88's)." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Condition Names (level 88) example program" />
-		<meta
-			name="twitter:description"
-			content="An example program demonstrating the use of Condition Names (level 88's)."
-		/>
+		<meta name="twitter:description" content="An example program demonstrating the use of Condition Names (level 88's)." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -50,21 +41,16 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero
-							title="Condition Names (level 88) example program"
-							eyebrow="COBOL Example"
-						></page-hero>
+						<page-hero title="Condition Names (level 88) example program" eyebrow="COBOL Example"></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../default.html">Example programs</a> ›
 							<span>Condition Names</span>
 						</nav>
 						<p>An example program demonstrating the use of Condition Names (level 88's).</p>
-						<p><a href="CONDITIONS.cbl" download>Download CONDITIONS.cbl</a></p>
-						<p><run-in-ce></run-in-ce></p>
-						<related-content
-							lectures="../../course/Selection.html|Selection in COBOL"
-							examples="IterIf.html|Iteration with IF Example"
-						></related-content>
+							<div class="code-toolbar">
+							<a href="CONDITIONS.cbl" download class="download-btn">Download CONDITIONS.cbl</a>
+							<run-in-ce></run-in-ce>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  Conditions.
@@ -96,6 +82,10 @@ Begin.
     END-PERFORM
     STOP RUN.
 </code></pre>
+						<related-content
+							lectures="../../course/Selection.html|Selection in COBOL"
+							examples="IterIf.html|Iteration with IF Example"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/Conditn/Conditions.html
+++ b/examples/Conditn/Conditions.html
@@ -15,14 +15,23 @@
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Conditn/Conditions.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Conditn/Conditions.html" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/Conditn/Conditions.html"
+		/>
 		<meta property="og:title" content="Condition Names (level 88) example program" />
-		<meta property="og:description" content="An example program demonstrating the use of Condition Names (level 88's)." />
+		<meta
+			property="og:description"
+			content="An example program demonstrating the use of Condition Names (level 88's)."
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Condition Names (level 88) example program" />
-		<meta name="twitter:description" content="An example program demonstrating the use of Condition Names (level 88's)." />
+		<meta
+			name="twitter:description"
+			content="An example program demonstrating the use of Condition Names (level 88's)."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -41,13 +50,16 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="Condition Names (level 88) example program" eyebrow="COBOL Example"></page-hero>
+						<page-hero
+							title="Condition Names (level 88) example program"
+							eyebrow="COBOL Example"
+						></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../default.html">Example programs</a> ›
 							<span>Condition Names</span>
 						</nav>
 						<p>An example program demonstrating the use of Condition Names (level 88's).</p>
-							<div class="code-toolbar">
+						<div class="code-toolbar">
 							<a href="CONDITIONS.cbl" download class="download-btn">Download CONDITIONS.cbl</a>
 							<run-in-ce></run-in-ce>
 						</div>

--- a/examples/Conditn/IterIf.html
+++ b/examples/Conditn/IterIf.html
@@ -11,27 +11,18 @@
 			})();
 		</script>
 		<title>Iteration with IF example program</title>
-		<meta
-			name="description"
-			content="An example program that implements a primitive calculator. The calculator only does additions and multiplications."
-		/>
+		<meta name="description" content="An example program that implements a primitive calculator. The calculator only does additions and multiplications." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Conditn/IterIf.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Conditn/IterIf.html" />
 		<meta property="og:title" content="Iteration with IF example program" />
-		<meta
-			property="og:description"
-			content="An example program that implements a primitive calculator. The calculator only does additions and multiplications."
-		/>
+		<meta property="og:description" content="An example program that implements a primitive calculator. The calculator only does additions and multiplications." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Iteration with IF example program" />
-		<meta
-			name="twitter:description"
-			content="An example program that implements a primitive calculator. The calculator only does additions and multiplications."
-		/>
+		<meta name="twitter:description" content="An example program that implements a primitive calculator. The calculator only does additions and multiplications." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -55,17 +46,11 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>Iteration with IF</span>
 						</nav>
-						<p>
-							An example program that implements a primitive calculator. The calculator only does
-							additions and multiplications.
-						</p>
-						<p><a href="Iteration-If.cbl" download>Download Iteration-If.cbl</a></p>
-						<p><run-in-ce></run-in-ce></p>
-						<related-content
-							lectures="../../course/Selection.html|Selection in COBOL, ../../course/Iteration.html|Iteration in COBOL"
-							examples="Conditions.html|Condition Names Example, ../Perform/Perform1.html|PERFORM – Format 1, ../Perform/Perform2.html|PERFORM – Format 2, ../Perform/Perform3.html|PERFORM – Format 3"
-							exercises="../../exercises/CountDown.html|Calculator and Countdown"
-						></related-content>
+						<p>An example program that implements a primitive calculator. The calculator only does additions and multiplications.</p>
+							<div class="code-toolbar">
+							<a href="Iteration-If.cbl" download class="download-btn">Download Iteration-If.cbl</a>
+							<run-in-ce></run-in-ce>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  Iteration-If.
@@ -97,6 +82,11 @@ Calculator.
     END-PERFORM.
     STOP RUN.
 </code></pre>
+						<related-content
+							lectures="../../course/Selection.html|Selection in COBOL, ../../course/Iteration.html|Iteration in COBOL"
+							examples="Conditions.html|Condition Names Example, ../Perform/Perform1.html|PERFORM – Format 1, ../Perform/Perform2.html|PERFORM – Format 2, ../Perform/Perform3.html|PERFORM – Format 3"
+							exercises="../../exercises/CountDown.html|Calculator and Countdown"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/Conditn/IterIf.html
+++ b/examples/Conditn/IterIf.html
@@ -11,18 +11,27 @@
 			})();
 		</script>
 		<title>Iteration with IF example program</title>
-		<meta name="description" content="An example program that implements a primitive calculator. The calculator only does additions and multiplications." />
+		<meta
+			name="description"
+			content="An example program that implements a primitive calculator. The calculator only does additions and multiplications."
+		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Conditn/IterIf.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Conditn/IterIf.html" />
 		<meta property="og:title" content="Iteration with IF example program" />
-		<meta property="og:description" content="An example program that implements a primitive calculator. The calculator only does additions and multiplications." />
+		<meta
+			property="og:description"
+			content="An example program that implements a primitive calculator. The calculator only does additions and multiplications."
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Iteration with IF example program" />
-		<meta name="twitter:description" content="An example program that implements a primitive calculator. The calculator only does additions and multiplications." />
+		<meta
+			name="twitter:description"
+			content="An example program that implements a primitive calculator. The calculator only does additions and multiplications."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -46,8 +55,11 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>Iteration with IF</span>
 						</nav>
-						<p>An example program that implements a primitive calculator. The calculator only does additions and multiplications.</p>
-							<div class="code-toolbar">
+						<p>
+							An example program that implements a primitive calculator. The calculator only does
+							additions and multiplications.
+						</p>
+						<div class="code-toolbar">
 							<a href="Iteration-If.cbl" download class="download-btn">Download Iteration-If.cbl</a>
 							<run-in-ce></run-in-ce>
 						</div>

--- a/examples/Indexed/DirectReadIdx.html
+++ b/examples/Indexed/DirectReadIdx.html
@@ -11,33 +11,18 @@
 			})();
 		</script>
 		<title>Reading an Indexed file directly by key</title>
-		<meta
-			name="description"
-			content="Does a direct read on the Indexed file. Allows the user to choose which of the keys to use for the direct read."
-		/>
-		<link
-			rel="canonical"
-			href="https://bushidocodes.github.io/limerick-cobol/examples/Indexed/DirectReadIdx.html"
-		/>
+		<meta name="description" content="Does a direct read on the Indexed file. Allows the user to choose which of the keys to use for the direct read." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Indexed/DirectReadIdx.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta
-			property="og:url"
-			content="https://bushidocodes.github.io/limerick-cobol/examples/Indexed/DirectReadIdx.html"
-		/>
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Indexed/DirectReadIdx.html" />
 		<meta property="og:title" content="Reading an Indexed file directly by key" />
-		<meta
-			property="og:description"
-			content="Does a direct read on the Indexed file. Allows the user to choose which of the keys to use for the direct read."
-		/>
+		<meta property="og:description" content="Does a direct read on the Indexed file. Allows the user to choose which of the keys to use for the direct read." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Reading an Indexed file directly by key" />
-		<meta
-			name="twitter:description"
-			content="Does a direct read on the Indexed file. Allows the user to choose which of the keys to use for the direct read."
-		/>
+		<meta name="twitter:description" content="Does a direct read on the Indexed file. Allows the user to choose which of the keys to use for the direct read." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -60,15 +45,10 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>Direct Read on Indexed File</span>
 						</nav>
-						<p>
-							Does a direct read on the Indexed file. Allows the user to choose which of the keys to use
-							for the direct read.
-						</p>
-						<p><a href="DirectReadIdx.cbl" download>Download DirectReadIdx.cbl</a></p>
-						<related-content
-							lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access"
-							examples="Seq2Index.html|Sequential to Indexed File, SeqReadIdx.html|Reading an Indexed File Sequentially"
-						></related-content>
+						<p>Does a direct read on the Indexed file. Allows the user to choose which of the keys to use for the direct read.</p>
+							<div class="code-toolbar">
+							<a href="DirectReadIdx.cbl" download class="download-btn">Download DirectReadIdx.cbl</a>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  DirectReadIdx.
@@ -147,6 +127,10 @@ Begin.
    CLOSE VideoFile.
    STOP RUN.
 </code></pre>
+						<related-content
+							lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access"
+							examples="Seq2Index.html|Sequential to Indexed File, SeqReadIdx.html|Reading an Indexed File Sequentially"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/Indexed/DirectReadIdx.html
+++ b/examples/Indexed/DirectReadIdx.html
@@ -11,18 +11,33 @@
 			})();
 		</script>
 		<title>Reading an Indexed file directly by key</title>
-		<meta name="description" content="Does a direct read on the Indexed file. Allows the user to choose which of the keys to use for the direct read." />
-		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Indexed/DirectReadIdx.html" />
+		<meta
+			name="description"
+			content="Does a direct read on the Indexed file. Allows the user to choose which of the keys to use for the direct read."
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/examples/Indexed/DirectReadIdx.html"
+		/>
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Indexed/DirectReadIdx.html" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/Indexed/DirectReadIdx.html"
+		/>
 		<meta property="og:title" content="Reading an Indexed file directly by key" />
-		<meta property="og:description" content="Does a direct read on the Indexed file. Allows the user to choose which of the keys to use for the direct read." />
+		<meta
+			property="og:description"
+			content="Does a direct read on the Indexed file. Allows the user to choose which of the keys to use for the direct read."
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Reading an Indexed file directly by key" />
-		<meta name="twitter:description" content="Does a direct read on the Indexed file. Allows the user to choose which of the keys to use for the direct read." />
+		<meta
+			name="twitter:description"
+			content="Does a direct read on the Indexed file. Allows the user to choose which of the keys to use for the direct read."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -45,8 +60,11 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>Direct Read on Indexed File</span>
 						</nav>
-						<p>Does a direct read on the Indexed file. Allows the user to choose which of the keys to use for the direct read.</p>
-							<div class="code-toolbar">
+						<p>
+							Does a direct read on the Indexed file. Allows the user to choose which of the keys to use
+							for the direct read.
+						</p>
+						<div class="code-toolbar">
 							<a href="DirectReadIdx.cbl" download class="download-btn">Download DirectReadIdx.cbl</a>
 						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE

--- a/examples/Indexed/Seq2Index.html
+++ b/examples/Indexed/Seq2Index.html
@@ -15,10 +15,7 @@
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Indexed/Seq2Index.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta
-			property="og:url"
-			content="https://bushidocodes.github.io/limerick-cobol/examples/Indexed/Seq2Index.html"
-		/>
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Indexed/Seq2Index.html" />
 		<meta property="og:title" content="Creating an Indexed file from a sequential file" />
 		<meta property="og:description" content="Creates a direct access Indexed file from a Sequential file." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
@@ -43,20 +40,15 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero
-							title="Creating an Indexed file from a sequential file"
-							eyebrow="COBOL Example"
-						></page-hero>
+						<page-hero title="Creating an Indexed file from a sequential file" eyebrow="COBOL Example"></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../default.html">Example programs</a> ›
 							<span>Sequential to Indexed</span>
 						</nav>
 						<p>Creates a direct access Indexed file from a Sequential file.</p>
-						<p><a href="Seq2Index.cbl" download>Download Seq2Index.cbl</a></p>
-						<related-content
-							lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access"
-							examples="SeqReadIdx.html|Reading an Indexed File Sequentially, DirectReadIdx.html|Reading an Indexed File Directly"
-						></related-content>
+							<div class="code-toolbar">
+							<a href="Seq2Index.cbl" download class="download-btn">Download Seq2Index.cbl</a>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  Seq2Index.
@@ -119,6 +111,10 @@ Begin.
    CLOSE VideoFile, SeqVideoFile.
    STOP RUN.
 </code></pre>
+						<related-content
+							lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access"
+							examples="SeqReadIdx.html|Reading an Indexed File Sequentially, DirectReadIdx.html|Reading an Indexed File Directly"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/Indexed/Seq2Index.html
+++ b/examples/Indexed/Seq2Index.html
@@ -15,7 +15,10 @@
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Indexed/Seq2Index.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Indexed/Seq2Index.html" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/Indexed/Seq2Index.html"
+		/>
 		<meta property="og:title" content="Creating an Indexed file from a sequential file" />
 		<meta property="og:description" content="Creates a direct access Indexed file from a Sequential file." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
@@ -40,13 +43,16 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="Creating an Indexed file from a sequential file" eyebrow="COBOL Example"></page-hero>
+						<page-hero
+							title="Creating an Indexed file from a sequential file"
+							eyebrow="COBOL Example"
+						></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../default.html">Example programs</a> ›
 							<span>Sequential to Indexed</span>
 						</nav>
 						<p>Creates a direct access Indexed file from a Sequential file.</p>
-							<div class="code-toolbar">
+						<div class="code-toolbar">
 							<a href="Seq2Index.cbl" download class="download-btn">Download Seq2Index.cbl</a>
 						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE

--- a/examples/Indexed/SeqReadIdx.html
+++ b/examples/Indexed/SeqReadIdx.html
@@ -11,30 +11,18 @@
 			})();
 		</script>
 		<title>Reading an Indexed file sequentially on any of its keys</title>
-		<meta
-			name="description"
-			content="Reads the Indexed file sequentially on whichever key is chosen by the user. Displays all the records in the file."
-		/>
+		<meta name="description" content="Reads the Indexed file sequentially on whichever key is chosen by the user. Displays all the records in the file." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Indexed/SeqReadIdx.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta
-			property="og:url"
-			content="https://bushidocodes.github.io/limerick-cobol/examples/Indexed/SeqReadIdx.html"
-		/>
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Indexed/SeqReadIdx.html" />
 		<meta property="og:title" content="Reading an Indexed file sequentially on any of its keys" />
-		<meta
-			property="og:description"
-			content="Reads the Indexed file sequentially on whichever key is chosen by the user. Displays all the records in the file."
-		/>
+		<meta property="og:description" content="Reads the Indexed file sequentially on whichever key is chosen by the user. Displays all the records in the file." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Reading an Indexed file sequentially on any of its keys" />
-		<meta
-			name="twitter:description"
-			content="Reads the Indexed file sequentially on whichever key is chosen by the user. Displays all the records in the file."
-		/>
+		<meta name="twitter:description" content="Reads the Indexed file sequentially on whichever key is chosen by the user. Displays all the records in the file." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -52,23 +40,15 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero
-							title="Reading an Indexed file sequentially on any of its keys"
-							eyebrow="COBOL Example"
-						></page-hero>
+						<page-hero title="Reading an Indexed file sequentially on any of its keys" eyebrow="COBOL Example"></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../default.html">Example programs</a> ›
 							<span>Sequential Read of Indexed File</span>
 						</nav>
-						<p>
-							Reads the Indexed file sequentially on whichever key is chosen by the user. Displays all the
-							records in the file.
-						</p>
-						<p><a href="SeqReadIdx.cbl" download>Download SeqReadIdx.cbl</a></p>
-						<related-content
-							lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access"
-							examples="Seq2Index.html|Sequential to Indexed File, DirectReadIdx.html|Reading an Indexed File Directly"
-						></related-content>
+						<p>Reads the Indexed file sequentially on whichever key is chosen by the user. Displays all the records in the file.</p>
+							<div class="code-toolbar">
+							<a href="SeqReadIdx.cbl" download class="download-btn">Download SeqReadIdx.cbl</a>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  SeqReadIdx.
@@ -151,6 +131,10 @@ Begin.
    CLOSE VideoFile.
    STOP RUN.
 </code></pre>
+						<related-content
+							lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access"
+							examples="Seq2Index.html|Sequential to Indexed File, DirectReadIdx.html|Reading an Indexed File Directly"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/Indexed/SeqReadIdx.html
+++ b/examples/Indexed/SeqReadIdx.html
@@ -11,18 +11,30 @@
 			})();
 		</script>
 		<title>Reading an Indexed file sequentially on any of its keys</title>
-		<meta name="description" content="Reads the Indexed file sequentially on whichever key is chosen by the user. Displays all the records in the file." />
+		<meta
+			name="description"
+			content="Reads the Indexed file sequentially on whichever key is chosen by the user. Displays all the records in the file."
+		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Indexed/SeqReadIdx.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Indexed/SeqReadIdx.html" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/Indexed/SeqReadIdx.html"
+		/>
 		<meta property="og:title" content="Reading an Indexed file sequentially on any of its keys" />
-		<meta property="og:description" content="Reads the Indexed file sequentially on whichever key is chosen by the user. Displays all the records in the file." />
+		<meta
+			property="og:description"
+			content="Reads the Indexed file sequentially on whichever key is chosen by the user. Displays all the records in the file."
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Reading an Indexed file sequentially on any of its keys" />
-		<meta name="twitter:description" content="Reads the Indexed file sequentially on whichever key is chosen by the user. Displays all the records in the file." />
+		<meta
+			name="twitter:description"
+			content="Reads the Indexed file sequentially on whichever key is chosen by the user. Displays all the records in the file."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -40,13 +52,19 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="Reading an Indexed file sequentially on any of its keys" eyebrow="COBOL Example"></page-hero>
+						<page-hero
+							title="Reading an Indexed file sequentially on any of its keys"
+							eyebrow="COBOL Example"
+						></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../default.html">Example programs</a> ›
 							<span>Sequential Read of Indexed File</span>
 						</nav>
-						<p>Reads the Indexed file sequentially on whichever key is chosen by the user. Displays all the records in the file.</p>
-							<div class="code-toolbar">
+						<p>
+							Reads the Indexed file sequentially on whichever key is chosen by the user. Displays all the
+							records in the file.
+						</p>
+						<div class="code-toolbar">
 							<a href="SeqReadIdx.cbl" download class="download-btn">Download SeqReadIdx.cbl</a>
 						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE

--- a/examples/Merge/Merge.html
+++ b/examples/Merge/Merge.html
@@ -11,18 +11,27 @@
 			})();
 		</script>
 		<title>Merge Files - Example Program</title>
-		<meta name="description" content="Uses the MERGE to insert records from a transaction file into a sequential master file." />
+		<meta
+			name="description"
+			content="Uses the MERGE to insert records from a transaction file into a sequential master file."
+		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Merge/Merge.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Merge/Merge.html" />
 		<meta property="og:title" content="Merge Files - Example Program" />
-		<meta property="og:description" content="Uses the MERGE to insert records from a transaction file into a sequential master file." />
+		<meta
+			property="og:description"
+			content="Uses the MERGE to insert records from a transaction file into a sequential master file."
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Merge Files - Example Program" />
-		<meta name="twitter:description" content="Uses the MERGE to insert records from a transaction file into a sequential master file." />
+		<meta
+			name="twitter:description"
+			content="Uses the MERGE to insert records from a transaction file into a sequential master file."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -46,7 +55,7 @@
 							<span>Merge Files</span>
 						</nav>
 						<p>Uses the MERGE to insert records from a transaction file into a sequential master file.</p>
-							<div class="code-toolbar">
+						<div class="code-toolbar">
 							<a href="MergeFiles.cbl" download class="download-btn">Download MergeFiles.cbl</a>
 						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE

--- a/examples/Merge/Merge.html
+++ b/examples/Merge/Merge.html
@@ -11,27 +11,18 @@
 			})();
 		</script>
 		<title>Merge Files - Example Program</title>
-		<meta
-			name="description"
-			content="Uses the MERGE to insert records from a transaction file into a sequential master file."
-		/>
+		<meta name="description" content="Uses the MERGE to insert records from a transaction file into a sequential master file." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Merge/Merge.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Merge/Merge.html" />
 		<meta property="og:title" content="Merge Files - Example Program" />
-		<meta
-			property="og:description"
-			content="Uses the MERGE to insert records from a transaction file into a sequential master file."
-		/>
+		<meta property="og:description" content="Uses the MERGE to insert records from a transaction file into a sequential master file." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Merge Files - Example Program" />
-		<meta
-			name="twitter:description"
-			content="Uses the MERGE to insert records from a transaction file into a sequential master file."
-		/>
+		<meta name="twitter:description" content="Uses the MERGE to insert records from a transaction file into a sequential master file." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -55,12 +46,9 @@
 							<span>Merge Files</span>
 						</nav>
 						<p>Uses the MERGE to insert records from a transaction file into a sequential master file.</p>
-						<p><a href="MergeFiles.cbl" download>Download MergeFiles.cbl</a></p>
-						<related-content
-							lectures="../../course/SortMerge.html|SORT and MERGE"
-							examples="../Sort/InputSort.html|SORT with Input Procedure, ../Sort/MaleSort.html|SORT with Output Procedure"
-							exercises="../../exercises/SortIP.html|Sorting a Sequential File"
-						></related-content>
+							<div class="code-toolbar">
+							<a href="MergeFiles.cbl" download class="download-btn">Download MergeFiles.cbl</a>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. MergeFiles.
@@ -111,6 +99,11 @@ Begin.
        GIVING NewStudentFile.
     STOP RUN.
 </code></pre>
+						<related-content
+							lectures="../../course/SortMerge.html|SORT and MERGE"
+							examples="../Sort/InputSort.html|SORT with Input Procedure, ../Sort/MaleSort.html|SORT with Output Procedure"
+							exercises="../../exercises/SortIP.html|Sorting a Sequential File"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/Perform/MileageCount.html
+++ b/examples/Perform/MileageCount.html
@@ -11,30 +11,18 @@
 			})();
 		</script>
 		<title>Mileage counter simulation</title>
-		<meta
-			name="description"
-			content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used to simulate a mileage counter."
-		/>
+		<meta name="description" content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used to simulate a mileage counter." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Perform/MileageCount.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta
-			property="og:url"
-			content="https://bushidocodes.github.io/limerick-cobol/examples/Perform/MileageCount.html"
-		/>
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Perform/MileageCount.html" />
 		<meta property="og:title" content="Mileage counter simulation" />
-		<meta
-			property="og:description"
-			content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used to simulate a mileage counter."
-		/>
+		<meta property="og:description" content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used to simulate a mileage counter." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Mileage counter simulation" />
-		<meta
-			name="twitter:description"
-			content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used to simulate a mileage counter."
-		/>
+		<meta name="twitter:description" content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used to simulate a mileage counter." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -58,17 +46,11 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>Mileage Counter</span>
 						</nav>
-						<p>
-							Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be
-							used to simulate a mileage counter.
-						</p>
-						<p><a href="MileageCounter.cbl" download>Download MileageCounter.cbl</a></p>
-						<p><run-in-ce></run-in-ce></p>
-						<related-content
-							lectures="../../course/Iteration.html|Iteration in COBOL"
-							examples="Perform1.html|PERFORM – Format 1, Perform2.html|PERFORM – Format 2, Perform3.html|PERFORM – Format 3, Perform4.html|PERFORM – Format 4"
-							exercises="../../exercises/CountDown.html|Calculator and Countdown"
-						></related-content>
+						<p>Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used to simulate a mileage counter.</p>
+							<div class="code-toolbar">
+							<a href="MileageCounter.cbl" download class="download-btn">Download MileageCounter.cbl</a>
+							<run-in-ce></run-in-ce>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  MileageCounter.
@@ -120,6 +102,11 @@ CountMileage.
    MOVE UnitsCount    TO PrnUnits
    DISPLAY PrnHunds "-" PrnTens "-" PrnUnits.
 </code></pre>
+						<related-content
+							lectures="../../course/Iteration.html|Iteration in COBOL"
+							examples="Perform1.html|PERFORM – Format 1, Perform2.html|PERFORM – Format 2, Perform3.html|PERFORM – Format 3, Perform4.html|PERFORM – Format 4"
+							exercises="../../exercises/CountDown.html|Calculator and Countdown"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/Perform/MileageCount.html
+++ b/examples/Perform/MileageCount.html
@@ -11,18 +11,30 @@
 			})();
 		</script>
 		<title>Mileage counter simulation</title>
-		<meta name="description" content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used to simulate a mileage counter." />
+		<meta
+			name="description"
+			content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used to simulate a mileage counter."
+		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Perform/MileageCount.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Perform/MileageCount.html" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/Perform/MileageCount.html"
+		/>
 		<meta property="og:title" content="Mileage counter simulation" />
-		<meta property="og:description" content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used to simulate a mileage counter." />
+		<meta
+			property="og:description"
+			content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used to simulate a mileage counter."
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Mileage counter simulation" />
-		<meta name="twitter:description" content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used to simulate a mileage counter." />
+		<meta
+			name="twitter:description"
+			content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used to simulate a mileage counter."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -46,8 +58,11 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>Mileage Counter</span>
 						</nav>
-						<p>Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used to simulate a mileage counter.</p>
-							<div class="code-toolbar">
+						<p>
+							Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be
+							used to simulate a mileage counter.
+						</p>
+						<div class="code-toolbar">
 							<a href="MileageCounter.cbl" download class="download-btn">Download MileageCounter.cbl</a>
 							<run-in-ce></run-in-ce>
 						</div>

--- a/examples/Perform/Perform1.html
+++ b/examples/Perform/Perform1.html
@@ -11,18 +11,30 @@
 			})();
 		</script>
 		<title>Perform - Format 1 example program</title>
-		<meta name="description" content="An example program demonstrating how the first format of the PERFORM may be used to change the flow of control through a program." />
+		<meta
+			name="description"
+			content="An example program demonstrating how the first format of the PERFORM may be used to change the flow of control through a program."
+		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform1.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform1.html" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform1.html"
+		/>
 		<meta property="og:title" content="Perform - Format 1 example program" />
-		<meta property="og:description" content="An example program demonstrating how the first format of the PERFORM may be used to change the flow of control through a program." />
+		<meta
+			property="og:description"
+			content="An example program demonstrating how the first format of the PERFORM may be used to change the flow of control through a program."
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Perform - Format 1 example program" />
-		<meta name="twitter:description" content="An example program demonstrating how the first format of the PERFORM may be used to change the flow of control through a program." />
+		<meta
+			name="twitter:description"
+			content="An example program demonstrating how the first format of the PERFORM may be used to change the flow of control through a program."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -46,8 +58,11 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>PERFORM Format 1</span>
 						</nav>
-						<p>An example program demonstrating how the first format of the PERFORM may be used to change the flow of control through a program.</p>
-							<div class="code-toolbar">
+						<p>
+							An example program demonstrating how the first format of the PERFORM may be used to change
+							the flow of control through a program.
+						</p>
+						<div class="code-toolbar">
 							<a href="PerformFormat1.cbl" download class="download-btn">Download PerformFormat1.cbl</a>
 							<run-in-ce></run-in-ce>
 						</div>

--- a/examples/Perform/Perform1.html
+++ b/examples/Perform/Perform1.html
@@ -11,30 +11,18 @@
 			})();
 		</script>
 		<title>Perform - Format 1 example program</title>
-		<meta
-			name="description"
-			content="An example program demonstrating how the first format of the PERFORM may be used to change the flow of control through a program."
-		/>
+		<meta name="description" content="An example program demonstrating how the first format of the PERFORM may be used to change the flow of control through a program." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform1.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta
-			property="og:url"
-			content="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform1.html"
-		/>
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform1.html" />
 		<meta property="og:title" content="Perform - Format 1 example program" />
-		<meta
-			property="og:description"
-			content="An example program demonstrating how the first format of the PERFORM may be used to change the flow of control through a program."
-		/>
+		<meta property="og:description" content="An example program demonstrating how the first format of the PERFORM may be used to change the flow of control through a program." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Perform - Format 1 example program" />
-		<meta
-			name="twitter:description"
-			content="An example program demonstrating how the first format of the PERFORM may be used to change the flow of control through a program."
-		/>
+		<meta name="twitter:description" content="An example program demonstrating how the first format of the PERFORM may be used to change the flow of control through a program." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -58,17 +46,11 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>PERFORM Format 1</span>
 						</nav>
-						<p>
-							An example program demonstrating how the first format of the PERFORM may be used to change
-							the flow of control through a program.
-						</p>
-						<p><a href="PerformFormat1.cbl" download>Download PerformFormat1.cbl</a></p>
-						<p><run-in-ce></run-in-ce></p>
-						<related-content
-							lectures="../../course/Iteration.html|Iteration in COBOL"
-							examples="Perform2.html|PERFORM – Format 2, Perform3.html|PERFORM – Format 3, Perform4.html|PERFORM – Format 4, MileageCount.html|Mileage Counter"
-							exercises="../../exercises/CountDown.html|Calculator and Countdown"
-						></related-content>
+						<p>An example program demonstrating how the first format of the PERFORM may be used to change the flow of control through a program.</p>
+							<div class="code-toolbar">
+							<a href="PerformFormat1.cbl" download class="download-btn">Download PerformFormat1.cbl</a>
+							<run-in-ce></run-in-ce>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  PerformFormat1.
@@ -101,6 +83,11 @@ OneLevelDown.
 ThreeLevelsDown.
     DISPLAY "&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; Now in ThreeLevelsDown".
 </code></pre>
+						<related-content
+							lectures="../../course/Iteration.html|Iteration in COBOL"
+							examples="Perform2.html|PERFORM – Format 2, Perform3.html|PERFORM – Format 3, Perform4.html|PERFORM – Format 4, MileageCount.html|Mileage Counter"
+							exercises="../../exercises/CountDown.html|Calculator and Countdown"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/Perform/Perform2.html
+++ b/examples/Perform/Perform2.html
@@ -11,30 +11,18 @@
 			})();
 		</script>
 		<title>Perform - Format 2 example program</title>
-		<meta
-			name="description"
-			content="Demonstrates the second format of the PERFORM. The PERFORM..TIMES may be used to execute a block of code x number of times."
-		/>
+		<meta name="description" content="Demonstrates the second format of the PERFORM. The PERFORM..TIMES may be used to execute a block of code x number of times." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform2.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta
-			property="og:url"
-			content="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform2.html"
-		/>
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform2.html" />
 		<meta property="og:title" content="Perform - Format 2 example program" />
-		<meta
-			property="og:description"
-			content="Demonstrates the second format of the PERFORM. The PERFORM..TIMES may be used to execute a block of code x number of times."
-		/>
+		<meta property="og:description" content="Demonstrates the second format of the PERFORM. The PERFORM..TIMES may be used to execute a block of code x number of times." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Perform - Format 2 example program" />
-		<meta
-			name="twitter:description"
-			content="Demonstrates the second format of the PERFORM. The PERFORM..TIMES may be used to execute a block of code x number of times."
-		/>
+		<meta name="twitter:description" content="Demonstrates the second format of the PERFORM. The PERFORM..TIMES may be used to execute a block of code x number of times." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -58,17 +46,11 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>PERFORM Format 2</span>
 						</nav>
-						<p>
-							Demonstrates the second format of the PERFORM. The PERFORM..TIMES may be used to execute a
-							block of code x number of times.
-						</p>
-						<p><a href="PerformFormat2.cbl" download>Download PerformFormat2.cbl</a></p>
-						<p><run-in-ce></run-in-ce></p>
-						<related-content
-							lectures="../../course/Iteration.html|Iteration in COBOL"
-							examples="Perform1.html|PERFORM – Format 1, Perform3.html|PERFORM – Format 3, Perform4.html|PERFORM – Format 4, MileageCount.html|Mileage Counter"
-							exercises="../../exercises/CountDown.html|Calculator and Countdown"
-						></related-content>
+						<p>Demonstrates the second format of the PERFORM. The PERFORM..TIMES may be used to execute a block of code x number of times.</p>
+							<div class="code-toolbar">
+							<a href="PerformFormat2.cbl" download class="download-btn">Download PerformFormat2.cbl</a>
+							<run-in-ce></run-in-ce>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  PerformFormat2.
@@ -95,6 +77,11 @@ Begin.
 OutOfLineEG.
     DISPLAY "&gt;&gt;&gt;&gt; This is an out of line Perform".
 </code></pre>
+						<related-content
+							lectures="../../course/Iteration.html|Iteration in COBOL"
+							examples="Perform1.html|PERFORM – Format 1, Perform3.html|PERFORM – Format 3, Perform4.html|PERFORM – Format 4, MileageCount.html|Mileage Counter"
+							exercises="../../exercises/CountDown.html|Calculator and Countdown"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/Perform/Perform2.html
+++ b/examples/Perform/Perform2.html
@@ -11,18 +11,30 @@
 			})();
 		</script>
 		<title>Perform - Format 2 example program</title>
-		<meta name="description" content="Demonstrates the second format of the PERFORM. The PERFORM..TIMES may be used to execute a block of code x number of times." />
+		<meta
+			name="description"
+			content="Demonstrates the second format of the PERFORM. The PERFORM..TIMES may be used to execute a block of code x number of times."
+		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform2.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform2.html" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform2.html"
+		/>
 		<meta property="og:title" content="Perform - Format 2 example program" />
-		<meta property="og:description" content="Demonstrates the second format of the PERFORM. The PERFORM..TIMES may be used to execute a block of code x number of times." />
+		<meta
+			property="og:description"
+			content="Demonstrates the second format of the PERFORM. The PERFORM..TIMES may be used to execute a block of code x number of times."
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Perform - Format 2 example program" />
-		<meta name="twitter:description" content="Demonstrates the second format of the PERFORM. The PERFORM..TIMES may be used to execute a block of code x number of times." />
+		<meta
+			name="twitter:description"
+			content="Demonstrates the second format of the PERFORM. The PERFORM..TIMES may be used to execute a block of code x number of times."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -46,8 +58,11 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>PERFORM Format 2</span>
 						</nav>
-						<p>Demonstrates the second format of the PERFORM. The PERFORM..TIMES may be used to execute a block of code x number of times.</p>
-							<div class="code-toolbar">
+						<p>
+							Demonstrates the second format of the PERFORM. The PERFORM..TIMES may be used to execute a
+							block of code x number of times.
+						</p>
+						<div class="code-toolbar">
 							<a href="PerformFormat2.cbl" download class="download-btn">Download PerformFormat2.cbl</a>
 							<run-in-ce></run-in-ce>
 						</div>

--- a/examples/Perform/Perform3.html
+++ b/examples/Perform/Perform3.html
@@ -11,30 +11,18 @@
 			})();
 		</script>
 		<title>Perform - Format 3 example program</title>
-		<meta
-			name="description"
-			content="Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values where the length of the stream cannot be determined in"
-		/>
+		<meta name="description" content="Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values where the length of the stream cannot be determined in" />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform3.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta
-			property="og:url"
-			content="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform3.html"
-		/>
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform3.html" />
 		<meta property="og:title" content="Perform - Format 3 example program" />
-		<meta
-			property="og:description"
-			content="Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values where the length of the stream cannot be determined in"
-		/>
+		<meta property="og:description" content="Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values where the length of the stream cannot be determined in" />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Perform - Format 3 example program" />
-		<meta
-			name="twitter:description"
-			content="Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values where the length of the stream cannot be determined in"
-		/>
+		<meta name="twitter:description" content="Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values where the length of the stream cannot be determined in" />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -58,17 +46,11 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>PERFORM Format 3</span>
 						</nav>
-						<p>
-							Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values
-							where the length of the stream cannot be determined in advance.
-						</p>
-						<p><a href="PerformFormat3.cbl" download>Download PerformFormat3.cbl</a></p>
-						<p><run-in-ce></run-in-ce></p>
-						<related-content
-							lectures="../../course/Iteration.html|Iteration in COBOL"
-							examples="Perform1.html|PERFORM – Format 1, Perform2.html|PERFORM – Format 2, Perform4.html|PERFORM – Format 4, MileageCount.html|Mileage Counter"
-							exercises="../../exercises/CountDown.html|Calculator and Countdown"
-						></related-content>
+						<p>Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values where the length of the stream cannot be determined in advance.</p>
+							<div class="code-toolbar">
+							<a href="PerformFormat3.cbl" download class="download-btn">Download PerformFormat3.cbl</a>
+							<run-in-ce></run-in-ce>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  PerformFormat3.
@@ -127,6 +109,11 @@ GetUserInput.
     DISPLAY "Enter number :- " WITH NO ADVANCING
     ACCEPT UserInput.
 </code></pre>
+						<related-content
+							lectures="../../course/Iteration.html|Iteration in COBOL"
+							examples="Perform1.html|PERFORM – Format 1, Perform2.html|PERFORM – Format 2, Perform4.html|PERFORM – Format 4, MileageCount.html|Mileage Counter"
+							exercises="../../exercises/CountDown.html|Calculator and Countdown"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/Perform/Perform3.html
+++ b/examples/Perform/Perform3.html
@@ -11,18 +11,30 @@
 			})();
 		</script>
 		<title>Perform - Format 3 example program</title>
-		<meta name="description" content="Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values where the length of the stream cannot be determined in" />
+		<meta
+			name="description"
+			content="Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values where the length of the stream cannot be determined in"
+		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform3.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform3.html" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform3.html"
+		/>
 		<meta property="og:title" content="Perform - Format 3 example program" />
-		<meta property="og:description" content="Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values where the length of the stream cannot be determined in" />
+		<meta
+			property="og:description"
+			content="Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values where the length of the stream cannot be determined in"
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Perform - Format 3 example program" />
-		<meta name="twitter:description" content="Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values where the length of the stream cannot be determined in" />
+		<meta
+			name="twitter:description"
+			content="Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values where the length of the stream cannot be determined in"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -46,8 +58,11 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>PERFORM Format 3</span>
 						</nav>
-						<p>Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values where the length of the stream cannot be determined in advance.</p>
-							<div class="code-toolbar">
+						<p>
+							Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values
+							where the length of the stream cannot be determined in advance.
+						</p>
+						<div class="code-toolbar">
 							<a href="PerformFormat3.cbl" download class="download-btn">Download PerformFormat3.cbl</a>
 							<run-in-ce></run-in-ce>
 						</div>

--- a/examples/Perform/Perform4.html
+++ b/examples/Perform/Perform4.html
@@ -11,18 +11,30 @@
 			})();
 		</script>
 		<title>Perform - Format 4 example program</title>
-		<meta name="description" content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used for counting iteration. Also introduces the WITH TEST" />
+		<meta
+			name="description"
+			content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used for counting iteration. Also introduces the WITH TEST"
+		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform4.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform4.html" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform4.html"
+		/>
 		<meta property="og:title" content="Perform - Format 4 example program" />
-		<meta property="og:description" content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used for counting iteration. Also introduces the WITH TEST" />
+		<meta
+			property="og:description"
+			content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used for counting iteration. Also introduces the WITH TEST"
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Perform - Format 4 example program" />
-		<meta name="twitter:description" content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used for counting iteration. Also introduces the WITH TEST" />
+		<meta
+			name="twitter:description"
+			content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used for counting iteration. Also introduces the WITH TEST"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -46,8 +58,12 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>PERFORM Format 4</span>
 						</nav>
-						<p>Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used for counting iteration. Also introduces the WITH TEST BEFORE and WITH TEST AFTER phrases.</p>
-							<div class="code-toolbar">
+						<p>
+							Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be
+							used for counting iteration. Also introduces the WITH TEST BEFORE and WITH TEST AFTER
+							phrases.
+						</p>
+						<div class="code-toolbar">
 							<a href="PerformFormat4.cbl" download class="download-btn">Download PerformFormat4.cbl</a>
 							<run-in-ce></run-in-ce>
 						</div>

--- a/examples/Perform/Perform4.html
+++ b/examples/Perform/Perform4.html
@@ -11,30 +11,18 @@
 			})();
 		</script>
 		<title>Perform - Format 4 example program</title>
-		<meta
-			name="description"
-			content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used for counting iteration. Also introduces the WITH TEST"
-		/>
+		<meta name="description" content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used for counting iteration. Also introduces the WITH TEST" />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform4.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta
-			property="og:url"
-			content="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform4.html"
-		/>
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform4.html" />
 		<meta property="og:title" content="Perform - Format 4 example program" />
-		<meta
-			property="og:description"
-			content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used for counting iteration. Also introduces the WITH TEST"
-		/>
+		<meta property="og:description" content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used for counting iteration. Also introduces the WITH TEST" />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Perform - Format 4 example program" />
-		<meta
-			name="twitter:description"
-			content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used for counting iteration. Also introduces the WITH TEST"
-		/>
+		<meta name="twitter:description" content="Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used for counting iteration. Also introduces the WITH TEST" />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -58,18 +46,11 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>PERFORM Format 4</span>
 						</nav>
-						<p>
-							Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be
-							used for counting iteration. Also introduces the WITH TEST BEFORE and WITH TEST AFTER
-							phrases.
-						</p>
-						<p><a href="PerformFormat4.cbl" download>Download PerformFormat4.cbl</a></p>
-						<p><run-in-ce></run-in-ce></p>
-						<related-content
-							lectures="../../course/Iteration.html|Iteration in COBOL"
-							examples="Perform1.html|PERFORM – Format 1, Perform2.html|PERFORM – Format 2, Perform3.html|PERFORM – Format 3, MileageCount.html|Mileage Counter"
-							exercises="../../exercises/CountDown.html|Calculator and Countdown"
-						></related-content>
+						<p>Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be used for counting iteration. Also introduces the WITH TEST BEFORE and WITH TEST AFTER phrases.</p>
+							<div class="code-toolbar">
+							<a href="PerformFormat4.cbl" download class="download-btn">Download PerformFormat4.cbl</a>
+							<run-in-ce></run-in-ce>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  PerformFormat4.
@@ -124,6 +105,11 @@ LoopBody.
     DISPLAY "LoopBody " WITH NO ADVANCING
     DISPLAY "LoopCount = " LoopCount " LoopCount2 = " LoopCount2.
 </code></pre>
+						<related-content
+							lectures="../../course/Iteration.html|Iteration in COBOL"
+							examples="Perform1.html|PERFORM – Format 1, Perform2.html|PERFORM – Format 2, Perform3.html|PERFORM – Format 3, MileageCount.html|Mileage Counter"
+							exercises="../../exercises/CountDown.html|Calculator and Countdown"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/Relative/ReadRel.html
+++ b/examples/Relative/ReadRel.html
@@ -11,30 +11,18 @@
 			})();
 		</script>
 		<title>Read Relative File example program</title>
-		<meta
-			name="description"
-			content="Reads the Relative file and displays the records. Allows the user to choose to read sequentially through all the records or to use a key to read a single"
-		/>
+		<meta name="description" content="Reads the Relative file and displays the records. Allows the user to choose to read sequentially through all the records or to use a key to read a single" />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Relative/ReadRel.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta
-			property="og:url"
-			content="https://bushidocodes.github.io/limerick-cobol/examples/Relative/ReadRel.html"
-		/>
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Relative/ReadRel.html" />
 		<meta property="og:title" content="Read Relative File example program" />
-		<meta
-			property="og:description"
-			content="Reads the Relative file and displays the records. Allows the user to choose to read sequentially through all the records or to use a key to read a single"
-		/>
+		<meta property="og:description" content="Reads the Relative file and displays the records. Allows the user to choose to read sequentially through all the records or to use a key to read a single" />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Read Relative File example program" />
-		<meta
-			name="twitter:description"
-			content="Reads the Relative file and displays the records. Allows the user to choose to read sequentially through all the records or to use a key to read a single"
-		/>
+		<meta name="twitter:description" content="Reads the Relative file and displays the records. Allows the user to choose to read sequentially through all the records or to use a key to read a single" />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -57,15 +45,10 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>Read Relative File</span>
 						</nav>
-						<p>
-							Reads the Relative file and displays the records. Allows the user to choose to read
-							sequentially through all the records or to use a key to read a single record directly.
-						</p>
-						<p><a href="ReadRelative.cbl" download>Download ReadRelative.cbl</a></p>
-						<related-content
-							lectures="../../course/RelativeFiles.html|Relative Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access"
-							examples="Seq2Rel.html|Sequential to Relative File"
-						></related-content>
+						<p>Reads the Relative file and displays the records. Allows the user to choose to read sequentially through all the records or to use a key to read a single record directly.</p>
+							<div class="code-toolbar">
+							<a href="ReadRelative.cbl" download class="download-btn">Download ReadRelative.cbl</a>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  ReadRelative.
@@ -147,6 +130,10 @@ DisplayRecord.
         DISPLAY PrnSupplierRecord
     END-IF.
 </code></pre>
+						<related-content
+							lectures="../../course/RelativeFiles.html|Relative Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access"
+							examples="Seq2Rel.html|Sequential to Relative File"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/Relative/ReadRel.html
+++ b/examples/Relative/ReadRel.html
@@ -11,18 +11,30 @@
 			})();
 		</script>
 		<title>Read Relative File example program</title>
-		<meta name="description" content="Reads the Relative file and displays the records. Allows the user to choose to read sequentially through all the records or to use a key to read a single" />
+		<meta
+			name="description"
+			content="Reads the Relative file and displays the records. Allows the user to choose to read sequentially through all the records or to use a key to read a single"
+		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Relative/ReadRel.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Relative/ReadRel.html" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/Relative/ReadRel.html"
+		/>
 		<meta property="og:title" content="Read Relative File example program" />
-		<meta property="og:description" content="Reads the Relative file and displays the records. Allows the user to choose to read sequentially through all the records or to use a key to read a single" />
+		<meta
+			property="og:description"
+			content="Reads the Relative file and displays the records. Allows the user to choose to read sequentially through all the records or to use a key to read a single"
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Read Relative File example program" />
-		<meta name="twitter:description" content="Reads the Relative file and displays the records. Allows the user to choose to read sequentially through all the records or to use a key to read a single" />
+		<meta
+			name="twitter:description"
+			content="Reads the Relative file and displays the records. Allows the user to choose to read sequentially through all the records or to use a key to read a single"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -45,8 +57,11 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>Read Relative File</span>
 						</nav>
-						<p>Reads the Relative file and displays the records. Allows the user to choose to read sequentially through all the records or to use a key to read a single record directly.</p>
-							<div class="code-toolbar">
+						<p>
+							Reads the Relative file and displays the records. Allows the user to choose to read
+							sequentially through all the records or to use a key to read a single record directly.
+						</p>
+						<div class="code-toolbar">
 							<a href="ReadRelative.cbl" download class="download-btn">Download ReadRelative.cbl</a>
 						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE

--- a/examples/Relative/Seq2Rel.html
+++ b/examples/Relative/Seq2Rel.html
@@ -15,10 +15,7 @@
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Relative/Seq2Rel.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta
-			property="og:url"
-			content="https://bushidocodes.github.io/limerick-cobol/examples/Relative/Seq2Rel.html"
-		/>
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Relative/Seq2Rel.html" />
 		<meta property="og:title" content="Sequential to Relative File example program" />
 		<meta property="og:description" content="Creates a direct access Relative file from a Sequential File." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
@@ -43,20 +40,15 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero
-							title="Sequential to Relative File example program"
-							eyebrow="COBOL Example"
-						></page-hero>
+						<page-hero title="Sequential to Relative File example program" eyebrow="COBOL Example"></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../default.html">Example programs</a> ›
 							<span>Sequential to Relative</span>
 						</nav>
 						<p>Creates a direct access Relative file from a Sequential File.</p>
-						<p><a href="Seq2Rel.cbl" download>Download Seq2Rel.cbl</a></p>
-						<related-content
-							lectures="../../course/RelativeFiles.html|Relative Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access"
-							examples="ReadRel.html|Reading a Relative File"
-						></related-content>
+							<div class="code-toolbar">
+							<a href="Seq2Rel.cbl" download class="download-btn">Download Seq2Rel.cbl</a>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  Seq2Rel.
@@ -122,6 +114,10 @@ Begin.
     CLOSE  SupplierFile, SupplierFileSeq.
     STOP RUN.
 </code></pre>
+						<related-content
+							lectures="../../course/RelativeFiles.html|Relative Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access"
+							examples="ReadRel.html|Reading a Relative File"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/Relative/Seq2Rel.html
+++ b/examples/Relative/Seq2Rel.html
@@ -15,7 +15,10 @@
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Relative/Seq2Rel.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Relative/Seq2Rel.html" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/Relative/Seq2Rel.html"
+		/>
 		<meta property="og:title" content="Sequential to Relative File example program" />
 		<meta property="og:description" content="Creates a direct access Relative file from a Sequential File." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
@@ -40,13 +43,16 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="Sequential to Relative File example program" eyebrow="COBOL Example"></page-hero>
+						<page-hero
+							title="Sequential to Relative File example program"
+							eyebrow="COBOL Example"
+						></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../default.html">Example programs</a> ›
 							<span>Sequential to Relative</span>
 						</nav>
 						<p>Creates a direct access Relative file from a Sequential File.</p>
-							<div class="code-toolbar">
+						<div class="code-toolbar">
 							<a href="Seq2Rel.cbl" download class="download-btn">Download Seq2Rel.cbl</a>
 						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE

--- a/examples/ReportWriter/RepWriteA.html
+++ b/examples/ReportWriter/RepWriteA.html
@@ -11,18 +11,33 @@
 			})();
 		</script>
 		<title>One control break version of full Report Writer example Program</title>
-		<meta name="description" content="A simplified version of the full report program using only one control break. Uses the GBsales.dat data file." />
-		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteA.html" />
+		<meta
+			name="description"
+			content="A simplified version of the full report program using only one control break. Uses the GBsales.dat data file."
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteA.html"
+		/>
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteA.html" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteA.html"
+		/>
 		<meta property="og:title" content="One control break version of full Report Writer example Program" />
-		<meta property="og:description" content="A simplified version of the full report program using only one control break. Uses the GBsales.dat data file." />
+		<meta
+			property="og:description"
+			content="A simplified version of the full report program using only one control break. Uses the GBsales.dat data file."
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="One control break version of full Report Writer example Program" />
-		<meta name="twitter:description" content="A simplified version of the full report program using only one control break. Uses the GBsales.dat data file." />
+		<meta
+			name="twitter:description"
+			content="A simplified version of the full report program using only one control break. Uses the GBsales.dat data file."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -40,13 +55,19 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="One control break version of full Report Writer example Program" eyebrow="COBOL Example"></page-hero>
+						<page-hero
+							title="One control break version of full Report Writer example Program"
+							eyebrow="COBOL Example"
+						></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../default.html">Example programs</a> ›
 							<span>Report Writer Example A</span>
 						</nav>
-						<p>A simplified version of the full report program using only one control break. Uses the GBsales.dat data file.</p>
-							<div class="code-toolbar">
+						<p>
+							A simplified version of the full report program using only one control break. Uses the
+							GBsales.dat data file.
+						</p>
+						<div class="code-toolbar">
 							<a href="ReportExampleA.cbl" download class="download-btn">Download ReportExampleA.cbl</a>
 						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE

--- a/examples/ReportWriter/RepWriteA.html
+++ b/examples/ReportWriter/RepWriteA.html
@@ -11,33 +11,18 @@
 			})();
 		</script>
 		<title>One control break version of full Report Writer example Program</title>
-		<meta
-			name="description"
-			content="A simplified version of the full report program using only one control break. Uses the GBsales.dat data file."
-		/>
-		<link
-			rel="canonical"
-			href="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteA.html"
-		/>
+		<meta name="description" content="A simplified version of the full report program using only one control break. Uses the GBsales.dat data file." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteA.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta
-			property="og:url"
-			content="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteA.html"
-		/>
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteA.html" />
 		<meta property="og:title" content="One control break version of full Report Writer example Program" />
-		<meta
-			property="og:description"
-			content="A simplified version of the full report program using only one control break. Uses the GBsales.dat data file."
-		/>
+		<meta property="og:description" content="A simplified version of the full report program using only one control break. Uses the GBsales.dat data file." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="One control break version of full Report Writer example Program" />
-		<meta
-			name="twitter:description"
-			content="A simplified version of the full report program using only one control break. Uses the GBsales.dat data file."
-		/>
+		<meta name="twitter:description" content="A simplified version of the full report program using only one control break. Uses the GBsales.dat data file." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -55,23 +40,15 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero
-							title="One control break version of full Report Writer example Program"
-							eyebrow="COBOL Example"
-						></page-hero>
+						<page-hero title="One control break version of full Report Writer example Program" eyebrow="COBOL Example"></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../default.html">Example programs</a> ›
 							<span>Report Writer Example A</span>
 						</nav>
-						<p>
-							A simplified version of the full report program using only one control break. Uses the
-							GBsales.dat data file.
-						</p>
-						<p><a href="ReportExampleA.cbl" download>Download ReportExampleA.cbl</a></p>
-						<related-content
-							lectures="../../course/ReportWriter.html|Report Writer, ../../course/ReportWriterSS.html|Report Writer – Syntax and Semantics"
-							examples="RepWriteFull.html|Full Report Writer, RepWriteB.html|Report Writer – No Declaratives, RepWriteSumm.html|Report Writer Summary"
-						></related-content>
+						<p>A simplified version of the full report program using only one control break. Uses the GBsales.dat data file.</p>
+							<div class="code-toolbar">
+							<a href="ReportExampleA.cbl" download class="download-btn">Download ReportExampleA.cbl</a>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  ReportExampleA.
@@ -185,6 +162,10 @@ PrintSalaryReport.
           AT END SET EndOfFile TO TRUE
     END-READ.
 </code></pre>
+						<related-content
+							lectures="../../course/ReportWriter.html|Report Writer, ../../course/ReportWriterSS.html|Report Writer – Syntax and Semantics"
+							examples="RepWriteFull.html|Full Report Writer, RepWriteB.html|Report Writer – No Declaratives, RepWriteSumm.html|Report Writer Summary"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/ReportWriter/RepWriteB.html
+++ b/examples/ReportWriter/RepWriteB.html
@@ -11,18 +11,33 @@
 			})();
 		</script>
 		<title>No Declaratives version of full Report Writer example program</title>
-		<meta name="description" content="A simplified version of the full report program containing all the control breaks but not using Declaratives. Uses the GBsales.dat data file." />
-		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteB.html" />
+		<meta
+			name="description"
+			content="A simplified version of the full report program containing all the control breaks but not using Declaratives. Uses the GBsales.dat data file."
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteB.html"
+		/>
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteB.html" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteB.html"
+		/>
 		<meta property="og:title" content="No Declaratives version of full Report Writer example program" />
-		<meta property="og:description" content="A simplified version of the full report program containing all the control breaks but not using Declaratives. Uses the GBsales.dat data file." />
+		<meta
+			property="og:description"
+			content="A simplified version of the full report program containing all the control breaks but not using Declaratives. Uses the GBsales.dat data file."
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="No Declaratives version of full Report Writer example program" />
-		<meta name="twitter:description" content="A simplified version of the full report program containing all the control breaks but not using Declaratives. Uses the GBsales.dat data file." />
+		<meta
+			name="twitter:description"
+			content="A simplified version of the full report program containing all the control breaks but not using Declaratives. Uses the GBsales.dat data file."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -40,13 +55,19 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="No Declaratives version of full Report Writer example program" eyebrow="COBOL Example"></page-hero>
+						<page-hero
+							title="No Declaratives version of full Report Writer example program"
+							eyebrow="COBOL Example"
+						></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../default.html">Example programs</a> ›
 							<span>Report Writer Example B</span>
 						</nav>
-						<p>A simplified version of the full report program containing all the control breaks but not using Declaratives. Uses the GBsales.dat data file.</p>
-							<div class="code-toolbar">
+						<p>
+							A simplified version of the full report program containing all the control breaks but not
+							using Declaratives. Uses the GBsales.dat data file.
+						</p>
+						<div class="code-toolbar">
 							<a href="ReportExampleB.cbl" download class="download-btn">Download ReportExampleB.cbl</a>
 						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE

--- a/examples/ReportWriter/RepWriteB.html
+++ b/examples/ReportWriter/RepWriteB.html
@@ -11,33 +11,18 @@
 			})();
 		</script>
 		<title>No Declaratives version of full Report Writer example program</title>
-		<meta
-			name="description"
-			content="A simplified version of the full report program containing all the control breaks but not using Declaratives. Uses the GBsales.dat data file."
-		/>
-		<link
-			rel="canonical"
-			href="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteB.html"
-		/>
+		<meta name="description" content="A simplified version of the full report program containing all the control breaks but not using Declaratives. Uses the GBsales.dat data file." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteB.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta
-			property="og:url"
-			content="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteB.html"
-		/>
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteB.html" />
 		<meta property="og:title" content="No Declaratives version of full Report Writer example program" />
-		<meta
-			property="og:description"
-			content="A simplified version of the full report program containing all the control breaks but not using Declaratives. Uses the GBsales.dat data file."
-		/>
+		<meta property="og:description" content="A simplified version of the full report program containing all the control breaks but not using Declaratives. Uses the GBsales.dat data file." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="No Declaratives version of full Report Writer example program" />
-		<meta
-			name="twitter:description"
-			content="A simplified version of the full report program containing all the control breaks but not using Declaratives. Uses the GBsales.dat data file."
-		/>
+		<meta name="twitter:description" content="A simplified version of the full report program containing all the control breaks but not using Declaratives. Uses the GBsales.dat data file." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -55,23 +40,15 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero
-							title="No Declaratives version of full Report Writer example program"
-							eyebrow="COBOL Example"
-						></page-hero>
+						<page-hero title="No Declaratives version of full Report Writer example program" eyebrow="COBOL Example"></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../default.html">Example programs</a> ›
 							<span>Report Writer Example B</span>
 						</nav>
-						<p>
-							A simplified version of the full report program containing all the control breaks but not
-							using Declaratives. Uses the GBsales.dat data file.
-						</p>
-						<p><a href="ReportExampleB.cbl" download>Download ReportExampleB.cbl</a></p>
-						<related-content
-							lectures="../../course/ReportWriter.html|Report Writer, ../../course/ReportWriterSS.html|Report Writer – Syntax and Semantics"
-							examples="RepWriteFull.html|Full Report Writer, RepWriteA.html|Report Writer – One Control Break, RepWriteSumm.html|Report Writer Summary"
-						></related-content>
+						<p>A simplified version of the full report program containing all the control breaks but not using Declaratives. Uses the GBsales.dat data file.</p>
+							<div class="code-toolbar">
+							<a href="ReportExampleB.cbl" download class="download-btn">Download ReportExampleB.cbl</a>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  ReportExampleB.
@@ -204,6 +181,10 @@ PrintSalaryReport.
           AT END SET EndOfFile TO TRUE
     END-READ.
 </code></pre>
+						<related-content
+							lectures="../../course/ReportWriter.html|Report Writer, ../../course/ReportWriterSS.html|Report Writer – Syntax and Semantics"
+							examples="RepWriteFull.html|Full Report Writer, RepWriteA.html|Report Writer – One Control Break, RepWriteSumm.html|Report Writer Summary"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/ReportWriter/RepWriteFull.html
+++ b/examples/ReportWriter/RepWriteFull.html
@@ -11,18 +11,33 @@
 			})();
 		</script>
 		<title>Full Report Writer example program - includes Declaratives</title>
-		<meta name="description" content="The full version of the report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission." />
-		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteFull.html" />
+		<meta
+			name="description"
+			content="The full version of the report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission."
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteFull.html"
+		/>
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteFull.html" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteFull.html"
+		/>
 		<meta property="og:title" content="Full Report Writer example program - includes Declaratives" />
-		<meta property="og:description" content="The full version of the report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission." />
+		<meta
+			property="og:description"
+			content="The full version of the report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission."
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Full Report Writer example program - includes Declaratives" />
-		<meta name="twitter:description" content="The full version of the report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission." />
+		<meta
+			name="twitter:description"
+			content="The full version of the report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -40,14 +55,22 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="Full Report Writer example program - includes Declaratives" eyebrow="COBOL Example"></page-hero>
+						<page-hero
+							title="Full Report Writer example program - includes Declaratives"
+							eyebrow="COBOL Example"
+						></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../default.html">Example programs</a> ›
 							<span>Report Writer Full Example</span>
 						</nav>
-						<p>The full version of the report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission.</p>
-							<div class="code-toolbar">
-							<a href="ReportExampleFull.cbl" download class="download-btn">Download ReportExampleFull.cbl</a>
+						<p>
+							The full version of the report program containing all the control breaks and using
+							Declaratives to calculate the salesperson salary and commission.
+						</p>
+						<div class="code-toolbar">
+							<a href="ReportExampleFull.cbl" download class="download-btn"
+								>Download ReportExampleFull.cbl</a
+							>
 						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.

--- a/examples/ReportWriter/RepWriteFull.html
+++ b/examples/ReportWriter/RepWriteFull.html
@@ -11,33 +11,18 @@
 			})();
 		</script>
 		<title>Full Report Writer example program - includes Declaratives</title>
-		<meta
-			name="description"
-			content="The full version of the report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission."
-		/>
-		<link
-			rel="canonical"
-			href="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteFull.html"
-		/>
+		<meta name="description" content="The full version of the report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteFull.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta
-			property="og:url"
-			content="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteFull.html"
-		/>
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteFull.html" />
 		<meta property="og:title" content="Full Report Writer example program - includes Declaratives" />
-		<meta
-			property="og:description"
-			content="The full version of the report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission."
-		/>
+		<meta property="og:description" content="The full version of the report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Full Report Writer example program - includes Declaratives" />
-		<meta
-			name="twitter:description"
-			content="The full version of the report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission."
-		/>
+		<meta name="twitter:description" content="The full version of the report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -55,23 +40,15 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero
-							title="Full Report Writer example program - includes Declaratives"
-							eyebrow="COBOL Example"
-						></page-hero>
+						<page-hero title="Full Report Writer example program - includes Declaratives" eyebrow="COBOL Example"></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../default.html">Example programs</a> ›
 							<span>Report Writer Full Example</span>
 						</nav>
-						<p>
-							The full version of the report program containing all the control breaks and using
-							Declaratives to calculate the salesperson salary and commission.
-						</p>
-						<p><a href="ReportExampleFull.cbl" download>Download ReportExampleFull.cbl</a></p>
-						<related-content
-							lectures="../../course/ReportWriter.html|Report Writer, ../../course/ReportWriterSS.html|Report Writer – Syntax and Semantics"
-							examples="RepWriteA.html|Report Writer – One Control Break, RepWriteB.html|Report Writer – No Declaratives, RepWriteSumm.html|Report Writer Summary"
-						></related-content>
+						<p>The full version of the report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission.</p>
+							<div class="code-toolbar">
+							<a href="ReportExampleFull.cbl" download class="download-btn">Download ReportExampleFull.cbl</a>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  ReportExampleFull.
@@ -281,6 +258,10 @@ PrintSalaryReport.
           AT END SET EndOfFile TO TRUE
     END-READ.
 </code></pre>
+						<related-content
+							lectures="../../course/ReportWriter.html|Report Writer, ../../course/ReportWriterSS.html|Report Writer – Syntax and Semantics"
+							examples="RepWriteA.html|Report Writer – One Control Break, RepWriteB.html|Report Writer – No Declaratives, RepWriteSumm.html|Report Writer Summary"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/ReportWriter/RepWriteSumm.html
+++ b/examples/ReportWriter/RepWriteSumm.html
@@ -11,33 +11,18 @@
 			})();
 		</script>
 		<title>Summary version of the full Report Writer program</title>
-		<meta
-			name="description"
-			content="The summary version of the full report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission."
-		/>
-		<link
-			rel="canonical"
-			href="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteSumm.html"
-		/>
+		<meta name="description" content="The summary version of the full report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteSumm.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta
-			property="og:url"
-			content="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteSumm.html"
-		/>
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteSumm.html" />
 		<meta property="og:title" content="Summary version of the full Report Writer program" />
-		<meta
-			property="og:description"
-			content="The summary version of the full report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission."
-		/>
+		<meta property="og:description" content="The summary version of the full report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Summary version of the full Report Writer program" />
-		<meta
-			name="twitter:description"
-			content="The summary version of the full report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission."
-		/>
+		<meta name="twitter:description" content="The summary version of the full report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -55,23 +40,15 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero
-							title="Summary version of the full Report Writer program"
-							eyebrow="COBOL Example"
-						></page-hero>
+						<page-hero title="Summary version of the full Report Writer program" eyebrow="COBOL Example"></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../default.html">Example programs</a> ›
 							<span>Report Writer Summary</span>
 						</nav>
-						<p>
-							The summary version of the full report program containing all the control breaks and using
-							Declaratives to calculate the salesperson salary and commission.
-						</p>
-						<p><a href="ReportExampleSummary.cbl" download>Download ReportExampleSummary.cbl</a></p>
-						<related-content
-							lectures="../../course/ReportWriter.html|Report Writer, ../../course/ReportWriterSS.html|Report Writer – Syntax and Semantics"
-							examples="RepWriteFull.html|Full Report Writer, RepWriteA.html|Report Writer – One Control Break, RepWriteB.html|Report Writer – No Declaratives"
-						></related-content>
+						<p>The summary version of the full report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission.</p>
+							<div class="code-toolbar">
+							<a href="ReportExampleSummary.cbl" download class="download-btn">Download ReportExampleSummary.cbl</a>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  ReportExampleSummary.
@@ -281,6 +258,10 @@ PrintSalaryReport.
           AT END SET EndOfFile TO TRUE
     END-READ.
 </code></pre>
+						<related-content
+							lectures="../../course/ReportWriter.html|Report Writer, ../../course/ReportWriterSS.html|Report Writer – Syntax and Semantics"
+							examples="RepWriteFull.html|Full Report Writer, RepWriteA.html|Report Writer – One Control Break, RepWriteB.html|Report Writer – No Declaratives"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/ReportWriter/RepWriteSumm.html
+++ b/examples/ReportWriter/RepWriteSumm.html
@@ -11,18 +11,33 @@
 			})();
 		</script>
 		<title>Summary version of the full Report Writer program</title>
-		<meta name="description" content="The summary version of the full report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission." />
-		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteSumm.html" />
+		<meta
+			name="description"
+			content="The summary version of the full report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission."
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteSumm.html"
+		/>
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteSumm.html" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteSumm.html"
+		/>
 		<meta property="og:title" content="Summary version of the full Report Writer program" />
-		<meta property="og:description" content="The summary version of the full report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission." />
+		<meta
+			property="og:description"
+			content="The summary version of the full report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission."
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Summary version of the full Report Writer program" />
-		<meta name="twitter:description" content="The summary version of the full report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission." />
+		<meta
+			name="twitter:description"
+			content="The summary version of the full report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -40,14 +55,22 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="Summary version of the full Report Writer program" eyebrow="COBOL Example"></page-hero>
+						<page-hero
+							title="Summary version of the full Report Writer program"
+							eyebrow="COBOL Example"
+						></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../default.html">Example programs</a> ›
 							<span>Report Writer Summary</span>
 						</nav>
-						<p>The summary version of the full report program containing all the control breaks and using Declaratives to calculate the salesperson salary and commission.</p>
-							<div class="code-toolbar">
-							<a href="ReportExampleSummary.cbl" download class="download-btn">Download ReportExampleSummary.cbl</a>
+						<p>
+							The summary version of the full report program containing all the control breaks and using
+							Declaratives to calculate the salesperson salary and commission.
+						</p>
+						<div class="code-toolbar">
+							<a href="ReportExampleSummary.cbl" download class="download-btn"
+								>Download ReportExampleSummary.cbl</a
+							>
 						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.

--- a/examples/SeqIns/SEQINSERT.html
+++ b/examples/SeqIns/SEQINSERT.html
@@ -11,30 +11,18 @@
 			})();
 		</script>
 		<title>Inserting records in a Sequential File</title>
-		<meta
-			name="description"
-			content="Demonstrates how to insert records into a sequential file from a file of transaction records. A new file is created which contains the inserted records."
-		/>
+		<meta name="description" content="Demonstrates how to insert records into a sequential file from a file of transaction records. A new file is created which contains the inserted records." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SeqIns/SEQINSERT.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta
-			property="og:url"
-			content="https://bushidocodes.github.io/limerick-cobol/examples/SeqIns/SEQINSERT.html"
-		/>
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/SeqIns/SEQINSERT.html" />
 		<meta property="og:title" content="Inserting records in a Sequential File" />
-		<meta
-			property="og:description"
-			content="Demonstrates how to insert records into a sequential file from a file of transaction records. A new file is created which contains the inserted records."
-		/>
+		<meta property="og:description" content="Demonstrates how to insert records into a sequential file from a file of transaction records. A new file is created which contains the inserted records." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Inserting records in a Sequential File" />
-		<meta
-			name="twitter:description"
-			content="Demonstrates how to insert records into a sequential file from a file of transaction records. A new file is created which contains the inserted records."
-		/>
+		<meta name="twitter:description" content="Demonstrates how to insert records into a sequential file from a file of transaction records. A new file is created which contains the inserted records." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -57,16 +45,10 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>Insert Records</span>
 						</nav>
-						<p>
-							Demonstrates how to insert records into a sequential file from a file of transaction
-							records. A new file is created which contains the inserted records.
-						</p>
-						<p><a href="InsertRecords.cbl" download>Download InsertRecords.cbl</a></p>
-						<related-content
-							lectures="../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3"
-							examples="../SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../SeqRead/SEQREAD.html|Reading a Sequential File, ../SeqRead/SEQREADno88.html|Reading a Sequential File (no 88), ../SeqRpt/SEQRPT.html|Sequential Student Number Report"
-							exercises="../../exercises/SeqWrite.html|Writing Records, ../../exercises/SeqRead.html|Reading Sequential Files, ../../exercises/SeqReadIf.html|Counting Records, ../../exercises/SeqInsert.html|Inserting Records"
-						></related-content>
+						<p>Demonstrates how to insert records into a sequential file from a file of transaction records. A new file is created which contains the inserted records.</p>
+							<div class="code-toolbar">
+							<a href="InsertRecords.cbl" download class="download-btn">Download InsertRecords.cbl</a>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. InsertRecords.
@@ -152,6 +134,11 @@ BEGIN.
     CLOSE NewStudentRecords
     STOP RUN.
 </code></pre>
+						<related-content
+							lectures="../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3"
+							examples="../SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../SeqRead/SEQREAD.html|Reading a Sequential File, ../SeqRead/SEQREADno88.html|Reading a Sequential File (no 88), ../SeqRpt/SEQRPT.html|Sequential Student Number Report"
+							exercises="../../exercises/SeqWrite.html|Writing Records, ../../exercises/SeqRead.html|Reading Sequential Files, ../../exercises/SeqReadIf.html|Counting Records, ../../exercises/SeqInsert.html|Inserting Records"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/SeqIns/SEQINSERT.html
+++ b/examples/SeqIns/SEQINSERT.html
@@ -11,18 +11,30 @@
 			})();
 		</script>
 		<title>Inserting records in a Sequential File</title>
-		<meta name="description" content="Demonstrates how to insert records into a sequential file from a file of transaction records. A new file is created which contains the inserted records." />
+		<meta
+			name="description"
+			content="Demonstrates how to insert records into a sequential file from a file of transaction records. A new file is created which contains the inserted records."
+		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SeqIns/SEQINSERT.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/SeqIns/SEQINSERT.html" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/SeqIns/SEQINSERT.html"
+		/>
 		<meta property="og:title" content="Inserting records in a Sequential File" />
-		<meta property="og:description" content="Demonstrates how to insert records into a sequential file from a file of transaction records. A new file is created which contains the inserted records." />
+		<meta
+			property="og:description"
+			content="Demonstrates how to insert records into a sequential file from a file of transaction records. A new file is created which contains the inserted records."
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Inserting records in a Sequential File" />
-		<meta name="twitter:description" content="Demonstrates how to insert records into a sequential file from a file of transaction records. A new file is created which contains the inserted records." />
+		<meta
+			name="twitter:description"
+			content="Demonstrates how to insert records into a sequential file from a file of transaction records. A new file is created which contains the inserted records."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -45,8 +57,11 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>Insert Records</span>
 						</nav>
-						<p>Demonstrates how to insert records into a sequential file from a file of transaction records. A new file is created which contains the inserted records.</p>
-							<div class="code-toolbar">
+						<p>
+							Demonstrates how to insert records into a sequential file from a file of transaction
+							records. A new file is created which contains the inserted records.
+						</p>
+						<div class="code-toolbar">
 							<a href="InsertRecords.cbl" download class="download-btn">Download InsertRecords.cbl</a>
 						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE

--- a/examples/SeqRead/SEQREAD.html
+++ b/examples/SeqRead/SEQREAD.html
@@ -11,18 +11,27 @@
 			})();
 		</script>
 		<title>Reading a Sequential File</title>
-		<meta name="description" content="An example program that reads a sequential file and displays the records. Uses the Condition Name (level 88) &quot;EndOfFile&quot; to signal when the end of the file" />
+		<meta
+			name="description"
+			content='An example program that reads a sequential file and displays the records. Uses the Condition Name (level 88) "EndOfFile" to signal when the end of the file'
+		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREAD.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREAD.html" />
 		<meta property="og:title" content="Reading a Sequential File" />
-		<meta property="og:description" content="An example program that reads a sequential file and displays the records. Uses the Condition Name (level 88) &quot;EndOfFile&quot; to signal when the end of the file" />
+		<meta
+			property="og:description"
+			content='An example program that reads a sequential file and displays the records. Uses the Condition Name (level 88) "EndOfFile" to signal when the end of the file'
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Reading a Sequential File" />
-		<meta name="twitter:description" content="An example program that reads a sequential file and displays the records. Uses the Condition Name (level 88) &quot;EndOfFile&quot; to signal when the end of the file" />
+		<meta
+			name="twitter:description"
+			content='An example program that reads a sequential file and displays the records. Uses the Condition Name (level 88) "EndOfFile" to signal when the end of the file'
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -45,8 +54,11 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>Sequential Read</span>
 						</nav>
-						<p>An example program that reads a sequential file and displays the records. Uses the Condition Name (level 88) "EndOfFile" to signal when the end of the file has been reached.</p>
-							<div class="code-toolbar">
+						<p>
+							An example program that reads a sequential file and displays the records. Uses the Condition
+							Name (level 88) "EndOfFile" to signal when the end of the file has been reached.
+						</p>
+						<div class="code-toolbar">
 							<a href="Seqread.cbl" download class="download-btn">Download Seqread.cbl</a>
 						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE

--- a/examples/SeqRead/SEQREAD.html
+++ b/examples/SeqRead/SEQREAD.html
@@ -11,27 +11,18 @@
 			})();
 		</script>
 		<title>Reading a Sequential File</title>
-		<meta
-			name="description"
-			content='An example program that reads a sequential file and displays the records. Uses the Condition Name (level 88) "EndOfFile" to signal when the end of the file'
-		/>
+		<meta name="description" content="An example program that reads a sequential file and displays the records. Uses the Condition Name (level 88) &quot;EndOfFile&quot; to signal when the end of the file" />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREAD.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREAD.html" />
 		<meta property="og:title" content="Reading a Sequential File" />
-		<meta
-			property="og:description"
-			content='An example program that reads a sequential file and displays the records. Uses the Condition Name (level 88) "EndOfFile" to signal when the end of the file'
-		/>
+		<meta property="og:description" content="An example program that reads a sequential file and displays the records. Uses the Condition Name (level 88) &quot;EndOfFile&quot; to signal when the end of the file" />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Reading a Sequential File" />
-		<meta
-			name="twitter:description"
-			content='An example program that reads a sequential file and displays the records. Uses the Condition Name (level 88) "EndOfFile" to signal when the end of the file'
-		/>
+		<meta name="twitter:description" content="An example program that reads a sequential file and displays the records. Uses the Condition Name (level 88) &quot;EndOfFile&quot; to signal when the end of the file" />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -54,16 +45,10 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>Sequential Read</span>
 						</nav>
-						<p>
-							An example program that reads a sequential file and displays the records. Uses the Condition
-							Name (level 88) "EndOfFile" to signal when the end of the file has been reached.
-						</p>
-						<p><a href="Seqread.cbl" download>Download Seqread.cbl</a></p>
-						<related-content
-							lectures="../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3"
-							examples="../SeqWrite/SEQWRITE.html|Writing to a Sequential File, SEQREADno88.html|Reading a Sequential File (no 88), ../SeqIns/SEQINSERT.html|Inserting Records in a Sequential File, ../SeqRpt/SEQRPT.html|Sequential Student Number Report"
-							exercises="../../exercises/SeqWrite.html|Writing Records, ../../exercises/SeqRead.html|Reading Sequential Files, ../../exercises/SeqReadIf.html|Counting Records, ../../exercises/SeqInsert.html|Inserting Records"
-						></related-content>
+						<p>An example program that reads a sequential file and displays the records. Uses the Condition Name (level 88) "EndOfFile" to signal when the end of the file has been reached.</p>
+							<div class="code-toolbar">
+							<a href="Seqread.cbl" download class="download-btn">Download Seqread.cbl</a>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  SeqRead.
@@ -108,6 +93,11 @@ Begin.
    CLOSE StudentFile
    STOP RUN.
 </code></pre>
+						<related-content
+							lectures="../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3"
+							examples="../SeqWrite/SEQWRITE.html|Writing to a Sequential File, SEQREADno88.html|Reading a Sequential File (no 88), ../SeqIns/SEQINSERT.html|Inserting Records in a Sequential File, ../SeqRpt/SEQRPT.html|Sequential Student Number Report"
+							exercises="../../exercises/SeqWrite.html|Writing Records, ../../exercises/SeqRead.html|Reading Sequential Files, ../../exercises/SeqReadIf.html|Counting Records, ../../exercises/SeqInsert.html|Inserting Records"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/SeqRead/SEQREADno88.html
+++ b/examples/SeqRead/SEQREADno88.html
@@ -11,18 +11,30 @@
 			})();
 		</script>
 		<title>Reading a Sequential File</title>
-		<meta name="description" content="An example program that reads a sequential file and displays the records. This version does not use level 88's to signal when the end of the file has been" />
+		<meta
+			name="description"
+			content="An example program that reads a sequential file and displays the records. This version does not use level 88's to signal when the end of the file has been"
+		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREADno88.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREADno88.html" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREADno88.html"
+		/>
 		<meta property="og:title" content="Reading a Sequential File" />
-		<meta property="og:description" content="An example program that reads a sequential file and displays the records. This version does not use level 88's to signal when the end of the file has been" />
+		<meta
+			property="og:description"
+			content="An example program that reads a sequential file and displays the records. This version does not use level 88's to signal when the end of the file has been"
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Reading a Sequential File" />
-		<meta name="twitter:description" content="An example program that reads a sequential file and displays the records. This version does not use level 88's to signal when the end of the file has been" />
+		<meta
+			name="twitter:description"
+			content="An example program that reads a sequential file and displays the records. This version does not use level 88's to signal when the end of the file has been"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -45,8 +57,11 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>Sequential Read (without level 88s)</span>
 						</nav>
-						<p>An example program that reads a sequential file and displays the records. This version does not use level 88's to signal when the end of the file has been reached.</p>
-							<div class="code-toolbar">
+						<p>
+							An example program that reads a sequential file and displays the records. This version does
+							not use level 88's to signal when the end of the file has been reached.
+						</p>
+						<div class="code-toolbar">
 							<a href="SeqreadNo88.cbl" download class="download-btn">Download SeqreadNo88.cbl</a>
 						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE

--- a/examples/SeqRead/SEQREADno88.html
+++ b/examples/SeqRead/SEQREADno88.html
@@ -11,30 +11,18 @@
 			})();
 		</script>
 		<title>Reading a Sequential File</title>
-		<meta
-			name="description"
-			content="An example program that reads a sequential file and displays the records. This version does not use level 88's to signal when the end of the file has been"
-		/>
+		<meta name="description" content="An example program that reads a sequential file and displays the records. This version does not use level 88's to signal when the end of the file has been" />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREADno88.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta
-			property="og:url"
-			content="https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREADno88.html"
-		/>
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREADno88.html" />
 		<meta property="og:title" content="Reading a Sequential File" />
-		<meta
-			property="og:description"
-			content="An example program that reads a sequential file and displays the records. This version does not use level 88's to signal when the end of the file has been"
-		/>
+		<meta property="og:description" content="An example program that reads a sequential file and displays the records. This version does not use level 88's to signal when the end of the file has been" />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Reading a Sequential File" />
-		<meta
-			name="twitter:description"
-			content="An example program that reads a sequential file and displays the records. This version does not use level 88's to signal when the end of the file has been"
-		/>
+		<meta name="twitter:description" content="An example program that reads a sequential file and displays the records. This version does not use level 88's to signal when the end of the file has been" />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -57,16 +45,10 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>Sequential Read (without level 88s)</span>
 						</nav>
-						<p>
-							An example program that reads a sequential file and displays the records. This version does
-							not use level 88's to signal when the end of the file has been reached.
-						</p>
-						<p><a href="SeqreadNo88.cbl" download>Download SeqreadNo88.cbl</a></p>
-						<related-content
-							lectures="../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3"
-							examples="../SeqWrite/SEQWRITE.html|Writing to a Sequential File, SEQREAD.html|Reading a Sequential File, ../SeqIns/SEQINSERT.html|Inserting Records in a Sequential File, ../SeqRpt/SEQRPT.html|Sequential Student Number Report"
-							exercises="../../exercises/SeqWrite.html|Writing Records, ../../exercises/SeqRead.html|Reading Sequential Files, ../../exercises/SeqReadIf.html|Counting Records, ../../exercises/SeqInsert.html|Inserting Records"
-						></related-content>
+						<p>An example program that reads a sequential file and displays the records. This version does not use level 88's to signal when the end of the file has been reached.</p>
+							<div class="code-toolbar">
+							<a href="SeqreadNo88.cbl" download class="download-btn">Download SeqreadNo88.cbl</a>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  SeqReadNo88.
@@ -112,6 +94,11 @@ Begin.
    CLOSE StudentFile
    STOP RUN.
 </code></pre>
+						<related-content
+							lectures="../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3"
+							examples="../SeqWrite/SEQWRITE.html|Writing to a Sequential File, SEQREAD.html|Reading a Sequential File, ../SeqIns/SEQINSERT.html|Inserting Records in a Sequential File, ../SeqRpt/SEQRPT.html|Sequential Student Number Report"
+							exercises="../../exercises/SeqWrite.html|Writing Records, ../../exercises/SeqRead.html|Reading Sequential Files, ../../exercises/SeqReadIf.html|Counting Records, ../../exercises/SeqInsert.html|Inserting Records"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/SeqRpt/SEQRPT.html
+++ b/examples/SeqRpt/SEQRPT.html
@@ -11,18 +11,27 @@
 			})();
 		</script>
 		<title>Sequential Student Number Report</title>
-		<meta name="description" content="Reads records from the student file, counts the total number of student records and the number of records for females and males, and prints the results in" />
+		<meta
+			name="description"
+			content="Reads records from the student file, counts the total number of student records and the number of records for females and males, and prints the results in"
+		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SeqRpt/SEQRPT.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/SeqRpt/SEQRPT.html" />
 		<meta property="og:title" content="Sequential Student Number Report" />
-		<meta property="og:description" content="Reads records from the student file, counts the total number of student records and the number of records for females and males, and prints the results in" />
+		<meta
+			property="og:description"
+			content="Reads records from the student file, counts the total number of student records and the number of records for females and males, and prints the results in"
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Sequential Student Number Report" />
-		<meta name="twitter:description" content="Reads records from the student file, counts the total number of student records and the number of records for females and males, and prints the results in" />
+		<meta
+			name="twitter:description"
+			content="Reads records from the student file, counts the total number of student records and the number of records for females and males, and prints the results in"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -45,9 +54,14 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>Student Numbers Report</span>
 						</nav>
-						<p>Reads records from the student file, counts the total number of student records and the number of records for females and males, and prints the results in a short report.</p>
-							<div class="code-toolbar">
-							<a href="StudentNumbersReport.cbl" download class="download-btn">Download StudentNumbersReport.cbl</a>
+						<p>
+							Reads records from the student file, counts the total number of student records and the
+							number of records for females and males, and prints the results in a short report.
+						</p>
+						<div class="code-toolbar">
+							<a href="StudentNumbersReport.cbl" download class="download-btn"
+								>Download StudentNumbersReport.cbl</a
+							>
 						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION. 

--- a/examples/SeqRpt/SEQRPT.html
+++ b/examples/SeqRpt/SEQRPT.html
@@ -11,27 +11,18 @@
 			})();
 		</script>
 		<title>Sequential Student Number Report</title>
-		<meta
-			name="description"
-			content="Reads records from the student file, counts the total number of student records and the number of records for females and males, and prints the results in"
-		/>
+		<meta name="description" content="Reads records from the student file, counts the total number of student records and the number of records for females and males, and prints the results in" />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SeqRpt/SEQRPT.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/SeqRpt/SEQRPT.html" />
 		<meta property="og:title" content="Sequential Student Number Report" />
-		<meta
-			property="og:description"
-			content="Reads records from the student file, counts the total number of student records and the number of records for females and males, and prints the results in"
-		/>
+		<meta property="og:description" content="Reads records from the student file, counts the total number of student records and the number of records for females and males, and prints the results in" />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Sequential Student Number Report" />
-		<meta
-			name="twitter:description"
-			content="Reads records from the student file, counts the total number of student records and the number of records for females and males, and prints the results in"
-		/>
+		<meta name="twitter:description" content="Reads records from the student file, counts the total number of student records and the number of records for females and males, and prints the results in" />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -54,16 +45,10 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>Student Numbers Report</span>
 						</nav>
-						<p>
-							Reads records from the student file, counts the total number of student records and the
-							number of records for females and males, and prints the results in a short report.
-						</p>
-						<p><a href="StudentNumbersReport.cbl" download>Download StudentNumbersReport.cbl</a></p>
-						<related-content
-							lectures="../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3"
-							examples="../SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../SeqRead/SEQREAD.html|Reading a Sequential File, ../SeqRead/SEQREADno88.html|Reading a Sequential File (no 88), ../SeqIns/SEQINSERT.html|Inserting Records in a Sequential File"
-							exercises="../../exercises/SeqWrite.html|Writing Records, ../../exercises/SeqRead.html|Reading Sequential Files, ../../exercises/SeqReadIf.html|Counting Records, ../../exercises/SeqInsert.html|Inserting Records"
-						></related-content>
+						<p>Reads records from the student file, counts the total number of student records and the number of records for females and males, and prints the results in a short report.</p>
+							<div class="code-toolbar">
+							<a href="StudentNumbersReport.cbl" download class="download-btn">Download StudentNumbersReport.cbl</a>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION. 
 PROGRAM-ID.  StudentNumbersReport . 
@@ -166,6 +151,11 @@ PrintReportLines.
     WRITE PrintLine FROM FemaleTotalLine 
             AFTER ADVANCING 2 LINES.
 </code></pre>
+						<related-content
+							lectures="../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3"
+							examples="../SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../SeqRead/SEQREAD.html|Reading a Sequential File, ../SeqRead/SEQREADno88.html|Reading a Sequential File (no 88), ../SeqIns/SEQINSERT.html|Inserting Records in a Sequential File"
+							exercises="../../exercises/SeqWrite.html|Writing Records, ../../exercises/SeqRead.html|Reading Sequential Files, ../../exercises/SeqReadIf.html|Counting Records, ../../exercises/SeqInsert.html|Inserting Records"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/SeqWrite/SEQWRITE.html
+++ b/examples/SeqWrite/SEQWRITE.html
@@ -11,30 +11,18 @@
 			})();
 		</script>
 		<title>Writing to a Sequential File</title>
-		<meta
-			name="description"
-			content="Example program demonstrating how to create a sequential file from data input by the user."
-		/>
+		<meta name="description" content="Example program demonstrating how to create a sequential file from data input by the user." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SeqWrite/SEQWRITE.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta
-			property="og:url"
-			content="https://bushidocodes.github.io/limerick-cobol/examples/SeqWrite/SEQWRITE.html"
-		/>
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/SeqWrite/SEQWRITE.html" />
 		<meta property="og:title" content="Writing to a Sequential File" />
-		<meta
-			property="og:description"
-			content="Example program demonstrating how to create a sequential file from data input by the user."
-		/>
+		<meta property="og:description" content="Example program demonstrating how to create a sequential file from data input by the user." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Writing to a Sequential File" />
-		<meta
-			name="twitter:description"
-			content="Example program demonstrating how to create a sequential file from data input by the user."
-		/>
+		<meta name="twitter:description" content="Example program demonstrating how to create a sequential file from data input by the user." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -57,15 +45,10 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>Sequential Write</span>
 						</nav>
-						<p>
-							Example program demonstrating how to create a sequential file from data input by the user.
-						</p>
-						<p><a href="SEQWRITE.cbl" download>Download SEQWRITE.cbl</a></p>
-						<related-content
-							lectures="../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3"
-							examples="../SeqRead/SEQREAD.html|Reading a Sequential File, ../SeqRead/SEQREADno88.html|Reading a Sequential File (no 88), ../SeqIns/SEQINSERT.html|Inserting Records in a Sequential File, ../SeqRpt/SEQRPT.html|Sequential Student Number Report"
-							exercises="../../exercises/SeqWrite.html|Writing Records, ../../exercises/SeqRead.html|Reading Sequential Files, ../../exercises/SeqReadIf.html|Counting Records, ../../exercises/SeqInsert.html|Inserting Records"
-						></related-content>
+						<p>Example program demonstrating how to create a sequential file from data input by the user.</p>
+							<div class="code-toolbar">
+							<a href="SEQWRITE.cbl" download class="download-btn">Download SEQWRITE.cbl</a>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  SeqWrite.
@@ -116,6 +99,11 @@ GetStudentDetails.
     DISPLAY "NNNNNNNSSSSSSSSIIYYYYMMDDCCCCG"
     ACCEPT  StudentDetails.
 </code></pre>
+						<related-content
+							lectures="../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3"
+							examples="../SeqRead/SEQREAD.html|Reading a Sequential File, ../SeqRead/SEQREADno88.html|Reading a Sequential File (no 88), ../SeqIns/SEQINSERT.html|Inserting Records in a Sequential File, ../SeqRpt/SEQRPT.html|Sequential Student Number Report"
+							exercises="../../exercises/SeqWrite.html|Writing Records, ../../exercises/SeqRead.html|Reading Sequential Files, ../../exercises/SeqReadIf.html|Counting Records, ../../exercises/SeqInsert.html|Inserting Records"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/SeqWrite/SEQWRITE.html
+++ b/examples/SeqWrite/SEQWRITE.html
@@ -11,18 +11,30 @@
 			})();
 		</script>
 		<title>Writing to a Sequential File</title>
-		<meta name="description" content="Example program demonstrating how to create a sequential file from data input by the user." />
+		<meta
+			name="description"
+			content="Example program demonstrating how to create a sequential file from data input by the user."
+		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SeqWrite/SEQWRITE.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/SeqWrite/SEQWRITE.html" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/SeqWrite/SEQWRITE.html"
+		/>
 		<meta property="og:title" content="Writing to a Sequential File" />
-		<meta property="og:description" content="Example program demonstrating how to create a sequential file from data input by the user." />
+		<meta
+			property="og:description"
+			content="Example program demonstrating how to create a sequential file from data input by the user."
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Writing to a Sequential File" />
-		<meta name="twitter:description" content="Example program demonstrating how to create a sequential file from data input by the user." />
+		<meta
+			name="twitter:description"
+			content="Example program demonstrating how to create a sequential file from data input by the user."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -45,8 +57,10 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>Sequential Write</span>
 						</nav>
-						<p>Example program demonstrating how to create a sequential file from data input by the user.</p>
-							<div class="code-toolbar">
+						<p>
+							Example program demonstrating how to create a sequential file from data input by the user.
+						</p>
+						<div class="code-toolbar">
 							<a href="SEQWRITE.cbl" download class="download-btn">Download SEQWRITE.cbl</a>
 						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE

--- a/examples/Sort/InputSort.html
+++ b/examples/Sort/InputSort.html
@@ -11,27 +11,18 @@
 			})();
 		</script>
 		<title>SORT with Input Procedure to get recs from user</title>
-		<meta
-			name="description"
-			content="Uses the SORT and an INPUT PROCEDURE to accept records from the user and sort them on ascending StudentId."
-		/>
+		<meta name="description" content="Uses the SORT and an INPUT PROCEDURE to accept records from the user and sort them on ascending StudentId." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Sort/InputSort.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Sort/InputSort.html" />
 		<meta property="og:title" content="SORT with Input Procedure to get recs from user" />
-		<meta
-			property="og:description"
-			content="Uses the SORT and an INPUT PROCEDURE to accept records from the user and sort them on ascending StudentId."
-		/>
+		<meta property="og:description" content="Uses the SORT and an INPUT PROCEDURE to accept records from the user and sort them on ascending StudentId." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="SORT with Input Procedure to get recs from user" />
-		<meta
-			name="twitter:description"
-			content="Uses the SORT and an INPUT PROCEDURE to accept records from the user and sort them on ascending StudentId."
-		/>
+		<meta name="twitter:description" content="Uses the SORT and an INPUT PROCEDURE to accept records from the user and sort them on ascending StudentId." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -49,24 +40,15 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero
-							title="SORT with Input Procedure to get recs from user"
-							eyebrow="COBOL Example"
-						></page-hero>
+						<page-hero title="SORT with Input Procedure to get recs from user" eyebrow="COBOL Example"></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../default.html">Example programs</a> ›
 							<span>Input Sort</span>
 						</nav>
-						<p>
-							Uses the SORT and an INPUT PROCEDURE to accept records from the user and sort them on
-							ascending StudentId.
-						</p>
-						<p><a href="InputSORT.cbl" download>Download InputSORT.cbl</a></p>
-						<related-content
-							lectures="../../course/SortMerge.html|SORT and MERGE"
-							examples="MaleSort.html|SORT with Output Procedure, ../Merge/Merge.html|Merging Files"
-							exercises="../../exercises/SortIP.html|Sorting a Sequential File"
-						></related-content>
+						<p>Uses the SORT and an INPUT PROCEDURE to accept records from the user and sort them on ascending StudentId.</p>
+							<div class="code-toolbar">
+							<a href="InputSORT.cbl" download class="download-btn">Download InputSORT.cbl</a>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  InputSort.
@@ -132,6 +114,11 @@ GetStudentDetails.
        ACCEPT WorkRec
     END-PERFORM.
 </code></pre>
+						<related-content
+							lectures="../../course/SortMerge.html|SORT and MERGE"
+							examples="MaleSort.html|SORT with Output Procedure, ../Merge/Merge.html|Merging Files"
+							exercises="../../exercises/SortIP.html|Sorting a Sequential File"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/Sort/InputSort.html
+++ b/examples/Sort/InputSort.html
@@ -11,18 +11,27 @@
 			})();
 		</script>
 		<title>SORT with Input Procedure to get recs from user</title>
-		<meta name="description" content="Uses the SORT and an INPUT PROCEDURE to accept records from the user and sort them on ascending StudentId." />
+		<meta
+			name="description"
+			content="Uses the SORT and an INPUT PROCEDURE to accept records from the user and sort them on ascending StudentId."
+		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Sort/InputSort.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Sort/InputSort.html" />
 		<meta property="og:title" content="SORT with Input Procedure to get recs from user" />
-		<meta property="og:description" content="Uses the SORT and an INPUT PROCEDURE to accept records from the user and sort them on ascending StudentId." />
+		<meta
+			property="og:description"
+			content="Uses the SORT and an INPUT PROCEDURE to accept records from the user and sort them on ascending StudentId."
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="SORT with Input Procedure to get recs from user" />
-		<meta name="twitter:description" content="Uses the SORT and an INPUT PROCEDURE to accept records from the user and sort them on ascending StudentId." />
+		<meta
+			name="twitter:description"
+			content="Uses the SORT and an INPUT PROCEDURE to accept records from the user and sort them on ascending StudentId."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -40,13 +49,19 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="SORT with Input Procedure to get recs from user" eyebrow="COBOL Example"></page-hero>
+						<page-hero
+							title="SORT with Input Procedure to get recs from user"
+							eyebrow="COBOL Example"
+						></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../default.html">Example programs</a> ›
 							<span>Input Sort</span>
 						</nav>
-						<p>Uses the SORT and an INPUT PROCEDURE to accept records from the user and sort them on ascending StudentId.</p>
-							<div class="code-toolbar">
+						<p>
+							Uses the SORT and an INPUT PROCEDURE to accept records from the user and sort them on
+							ascending StudentId.
+						</p>
+						<div class="code-toolbar">
 							<a href="InputSORT.cbl" download class="download-btn">Download InputSORT.cbl</a>
 						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE

--- a/examples/Sort/MaleSort.html
+++ b/examples/Sort/MaleSort.html
@@ -11,18 +11,27 @@
 			})();
 		</script>
 		<title>SORT file and select only male records</title>
-		<meta name="description" content="Sorts the student masterfile and produces a new file, sorted on ascending student name, containing only the records of male students." />
+		<meta
+			name="description"
+			content="Sorts the student masterfile and produces a new file, sorted on ascending student name, containing only the records of male students."
+		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Sort/MaleSort.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Sort/MaleSort.html" />
 		<meta property="og:title" content="SORT file and select only male records" />
-		<meta property="og:description" content="Sorts the student masterfile and produces a new file, sorted on ascending student name, containing only the records of male students." />
+		<meta
+			property="og:description"
+			content="Sorts the student masterfile and produces a new file, sorted on ascending student name, containing only the records of male students."
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="SORT file and select only male records" />
-		<meta name="twitter:description" content="Sorts the student masterfile and produces a new file, sorted on ascending student name, containing only the records of male students." />
+		<meta
+			name="twitter:description"
+			content="Sorts the student masterfile and produces a new file, sorted on ascending student name, containing only the records of male students."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -45,8 +54,11 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>Male Sort</span>
 						</nav>
-						<p>Sorts the student masterfile and produces a new file, sorted on ascending student name, containing only the records of male students.</p>
-							<div class="code-toolbar">
+						<p>
+							Sorts the student masterfile and produces a new file, sorted on ascending student name,
+							containing only the records of male students.
+						</p>
+						<div class="code-toolbar">
 							<a href="MaleSORT.cbl" download class="download-btn">Download MaleSORT.cbl</a>
 						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE

--- a/examples/Sort/MaleSort.html
+++ b/examples/Sort/MaleSort.html
@@ -11,27 +11,18 @@
 			})();
 		</script>
 		<title>SORT file and select only male records</title>
-		<meta
-			name="description"
-			content="Sorts the student masterfile and produces a new file, sorted on ascending student name, containing only the records of male students."
-		/>
+		<meta name="description" content="Sorts the student masterfile and produces a new file, sorted on ascending student name, containing only the records of male students." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Sort/MaleSort.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Sort/MaleSort.html" />
 		<meta property="og:title" content="SORT file and select only male records" />
-		<meta
-			property="og:description"
-			content="Sorts the student masterfile and produces a new file, sorted on ascending student name, containing only the records of male students."
-		/>
+		<meta property="og:description" content="Sorts the student masterfile and produces a new file, sorted on ascending student name, containing only the records of male students." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="SORT file and select only male records" />
-		<meta
-			name="twitter:description"
-			content="Sorts the student masterfile and produces a new file, sorted on ascending student name, containing only the records of male students."
-		/>
+		<meta name="twitter:description" content="Sorts the student masterfile and produces a new file, sorted on ascending student name, containing only the records of male students." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -54,16 +45,10 @@
 							<a href="../default.html">Example programs</a> ›
 							<span>Male Sort</span>
 						</nav>
-						<p>
-							Sorts the student masterfile and produces a new file, sorted on ascending student name,
-							containing only the records of male students.
-						</p>
-						<p><a href="MaleSORT.cbl" download>Download MaleSORT.cbl</a></p>
-						<related-content
-							lectures="../../course/SortMerge.html|SORT and MERGE"
-							examples="InputSort.html|SORT with Input Procedure, ../Merge/Merge.html|Merging Files"
-							exercises="../../exercises/SortIP.html|Sorting a Sequential File"
-						></related-content>
+						<p>Sorts the student masterfile and produces a new file, sorted on ascending student name, containing only the records of male students.</p>
+							<div class="code-toolbar">
+							<a href="MaleSORT.cbl" download class="download-btn">Download MaleSORT.cbl</a>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  MaleSort.
@@ -127,6 +112,11 @@ GetMaleStudents.
    END-PERFORM
    CLOSE StudentFile.
 </code></pre>
+						<related-content
+							lectures="../../course/SortMerge.html|SORT and MERGE"
+							examples="InputSort.html|SORT with Input Procedure, ../Merge/Merge.html|Merging Files"
+							exercises="../../exercises/SortIP.html|Sorting a Sequential File"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/Strings/RefMod.html
+++ b/examples/Strings/RefMod.html
@@ -11,27 +11,18 @@
 			})();
 		</script>
 		<title>String handling - Reference Modification examples</title>
-		<meta
-			name="description"
-			content="Solves a number of string handling tasks such as extracting substrings, removing leading or trailing blanks, and finding the location of the first"
-		/>
+		<meta name="description" content="Solves a number of string handling tasks such as extracting substrings, removing leading or trailing blanks, and finding the location of the first" />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Strings/RefMod.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Strings/RefMod.html" />
 		<meta property="og:title" content="String handling - Reference Modification examples" />
-		<meta
-			property="og:description"
-			content="Solves a number of string handling tasks such as extracting substrings, removing leading or trailing blanks, and finding the location of the first"
-		/>
+		<meta property="og:description" content="Solves a number of string handling tasks such as extracting substrings, removing leading or trailing blanks, and finding the location of the first" />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="String handling - Reference Modification examples" />
-		<meta
-			name="twitter:description"
-			content="Solves a number of string handling tasks such as extracting substrings, removing leading or trailing blanks, and finding the location of the first"
-		/>
+		<meta name="twitter:description" content="Solves a number of string handling tasks such as extracting substrings, removing leading or trailing blanks, and finding the location of the first" />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -50,25 +41,16 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero
-							title="String handling - Reference Modification examples"
-							eyebrow="COBOL Example"
-						></page-hero>
+						<page-hero title="String handling - Reference Modification examples" eyebrow="COBOL Example"></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../default.html">Example programs</a> ›
 							<span>Reference Modification</span>
 						</nav>
-						<p>
-							Solves a number of string handling tasks such as extracting substrings, removing leading or
-							trailing blanks, and finding the location of the first occurrence of a character in a
-							string.
-						</p>
-						<p><a href="RefModification.cbl" download>Download RefModification.cbl</a></p>
-						<p><run-in-ce></run-in-ce></p>
-						<related-content
-							lectures="../../course/String.html|STRING Verb, ../../course/Unstring.html|UNSTRING Verb, ../../course/RefMod.html|Reference Modification"
-							examples="UnstringFileEg.html|Unpacking Comma-Separated Records"
-						></related-content>
+						<p>Solves a number of string handling tasks such as extracting substrings, removing leading or trailing blanks, and finding the location of the first occurrence of a character in a string.</p>
+							<div class="code-toolbar">
+							<a href="RefModification.cbl" download class="download-btn">Download RefModification.cbl</a>
+							<run-in-ce></run-in-ce>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  RefModification.
@@ -177,6 +159,10 @@ Begin.
     DISPLAY "The character is " xStr(EndCount:1)
     STOP RUN.
 </code></pre>
+						<related-content
+							lectures="../../course/String.html|STRING Verb, ../../course/Unstring.html|UNSTRING Verb, ../../course/RefMod.html|Reference Modification"
+							examples="UnstringFileEg.html|Unpacking Comma-Separated Records"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/Strings/RefMod.html
+++ b/examples/Strings/RefMod.html
@@ -11,18 +11,27 @@
 			})();
 		</script>
 		<title>String handling - Reference Modification examples</title>
-		<meta name="description" content="Solves a number of string handling tasks such as extracting substrings, removing leading or trailing blanks, and finding the location of the first" />
+		<meta
+			name="description"
+			content="Solves a number of string handling tasks such as extracting substrings, removing leading or trailing blanks, and finding the location of the first"
+		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Strings/RefMod.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Strings/RefMod.html" />
 		<meta property="og:title" content="String handling - Reference Modification examples" />
-		<meta property="og:description" content="Solves a number of string handling tasks such as extracting substrings, removing leading or trailing blanks, and finding the location of the first" />
+		<meta
+			property="og:description"
+			content="Solves a number of string handling tasks such as extracting substrings, removing leading or trailing blanks, and finding the location of the first"
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="String handling - Reference Modification examples" />
-		<meta name="twitter:description" content="Solves a number of string handling tasks such as extracting substrings, removing leading or trailing blanks, and finding the location of the first" />
+		<meta
+			name="twitter:description"
+			content="Solves a number of string handling tasks such as extracting substrings, removing leading or trailing blanks, and finding the location of the first"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -41,13 +50,20 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="String handling - Reference Modification examples" eyebrow="COBOL Example"></page-hero>
+						<page-hero
+							title="String handling - Reference Modification examples"
+							eyebrow="COBOL Example"
+						></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../default.html">Example programs</a> ›
 							<span>Reference Modification</span>
 						</nav>
-						<p>Solves a number of string handling tasks such as extracting substrings, removing leading or trailing blanks, and finding the location of the first occurrence of a character in a string.</p>
-							<div class="code-toolbar">
+						<p>
+							Solves a number of string handling tasks such as extracting substrings, removing leading or
+							trailing blanks, and finding the location of the first occurrence of a character in a
+							string.
+						</p>
+						<div class="code-toolbar">
 							<a href="RefModification.cbl" download class="download-btn">Download RefModification.cbl</a>
 							<run-in-ce></run-in-ce>
 						</div>

--- a/examples/Strings/UnstringFileEg.html
+++ b/examples/Strings/UnstringFileEg.html
@@ -11,18 +11,33 @@
 			})();
 		</script>
 		<title>String handling - Unpacking and size-validating comma separated records</title>
-		<meta name="description" content="An example showing the unpacking of comma-separated records and the size validation of the unpacked fields." />
-		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Strings/UnstringFileEg.html" />
+		<meta
+			name="description"
+			content="An example showing the unpacking of comma-separated records and the size validation of the unpacked fields."
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/examples/Strings/UnstringFileEg.html"
+		/>
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Strings/UnstringFileEg.html" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/Strings/UnstringFileEg.html"
+		/>
 		<meta property="og:title" content="String handling - Unpacking and size-validating comma separated records" />
-		<meta property="og:description" content="An example showing the unpacking of comma-separated records and the size validation of the unpacked fields." />
+		<meta
+			property="og:description"
+			content="An example showing the unpacking of comma-separated records and the size validation of the unpacked fields."
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="String handling - Unpacking and size-validating comma separated records" />
-		<meta name="twitter:description" content="An example showing the unpacking of comma-separated records and the size validation of the unpacked fields." />
+		<meta
+			name="twitter:description"
+			content="An example showing the unpacking of comma-separated records and the size validation of the unpacked fields."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -40,13 +55,19 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="String handling - Unpacking and size-validating comma separated records" eyebrow="COBOL Example"></page-hero>
+						<page-hero
+							title="String handling - Unpacking and size-validating comma separated records"
+							eyebrow="COBOL Example"
+						></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../default.html">Example programs</a> ›
 							<span>UNSTRING File Example</span>
 						</nav>
-						<p>An example showing the unpacking of comma-separated records and the size validation of the unpacked fields.</p>
-							<div class="code-toolbar">
+						<p>
+							An example showing the unpacking of comma-separated records and the size validation of the
+							unpacked fields.
+						</p>
+						<div class="code-toolbar">
 							<a href="UnstringFileEg.cbl" download class="download-btn">Download UnstringFileEg.cbl</a>
 						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE

--- a/examples/Strings/UnstringFileEg.html
+++ b/examples/Strings/UnstringFileEg.html
@@ -11,33 +11,18 @@
 			})();
 		</script>
 		<title>String handling - Unpacking and size-validating comma separated records</title>
-		<meta
-			name="description"
-			content="An example showing the unpacking of comma-separated records and the size validation of the unpacked fields."
-		/>
-		<link
-			rel="canonical"
-			href="https://bushidocodes.github.io/limerick-cobol/examples/Strings/UnstringFileEg.html"
-		/>
+		<meta name="description" content="An example showing the unpacking of comma-separated records and the size validation of the unpacked fields." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Strings/UnstringFileEg.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta
-			property="og:url"
-			content="https://bushidocodes.github.io/limerick-cobol/examples/Strings/UnstringFileEg.html"
-		/>
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Strings/UnstringFileEg.html" />
 		<meta property="og:title" content="String handling - Unpacking and size-validating comma separated records" />
-		<meta
-			property="og:description"
-			content="An example showing the unpacking of comma-separated records and the size validation of the unpacked fields."
-		/>
+		<meta property="og:description" content="An example showing the unpacking of comma-separated records and the size validation of the unpacked fields." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="String handling - Unpacking and size-validating comma separated records" />
-		<meta
-			name="twitter:description"
-			content="An example showing the unpacking of comma-separated records and the size validation of the unpacked fields."
-		/>
+		<meta name="twitter:description" content="An example showing the unpacking of comma-separated records and the size validation of the unpacked fields." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -55,23 +40,15 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero
-							title="String handling - Unpacking and size-validating comma separated records"
-							eyebrow="COBOL Example"
-						></page-hero>
+						<page-hero title="String handling - Unpacking and size-validating comma separated records" eyebrow="COBOL Example"></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../default.html">Example programs</a> ›
 							<span>UNSTRING File Example</span>
 						</nav>
-						<p>
-							An example showing the unpacking of comma-separated records and the size validation of the
-							unpacked fields.
-						</p>
-						<p><a href="UnstringFileEg.cbl" download>Download UnstringFileEg.cbl</a></p>
-						<related-content
-							lectures="../../course/String.html|STRING Verb, ../../course/Unstring.html|UNSTRING Verb, ../../course/RefMod.html|Reference Modification"
-							examples="RefMod.html|Reference Modification Examples"
-						></related-content>
+						<p>An example showing the unpacking of comma-separated records and the size validation of the unpacked fields.</p>
+							<div class="code-toolbar">
+							<a href="UnstringFileEg.cbl" download class="download-btn">Download UnstringFileEg.cbl</a>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  UnstringFileEg.
@@ -168,6 +145,10 @@ CheckForErrors.
    IF NOT ValidSuppName DISPLAY "Supplier name Error"    END-IF
    IF NOT ValidSuppAdr  DISPLAY "Supplier address Error" END-IF.
 </code></pre>
+						<related-content
+							lectures="../../course/String.html|STRING Verb, ../../course/Unstring.html|UNSTRING Verb, ../../course/RefMod.html|Reference Modification"
+							examples="RefMod.html|Reference Modification Examples"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/SubProg/DateValid/DateDriver.html
+++ b/examples/SubProg/DateValid/DateDriver.html
@@ -11,18 +11,33 @@
 			})();
 		</script>
 		<title>Driver program for date validation sub-program</title>
-		<meta name="description" content="A driver program for the date validation sub-program. Accepts a date from the user, passes it to the date validation sub-program and interprets and" />
-		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/DateDriver.html" />
+		<meta
+			name="description"
+			content="A driver program for the date validation sub-program. Accepts a date from the user, passes it to the date validation sub-program and interprets and"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/DateDriver.html"
+		/>
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/DateDriver.html" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/DateDriver.html"
+		/>
 		<meta property="og:title" content="Driver program for date validation sub-program" />
-		<meta property="og:description" content="A driver program for the date validation sub-program. Accepts a date from the user, passes it to the date validation sub-program and interprets and" />
+		<meta
+			property="og:description"
+			content="A driver program for the date validation sub-program. Accepts a date from the user, passes it to the date validation sub-program and interprets and"
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Driver program for date validation sub-program" />
-		<meta name="twitter:description" content="A driver program for the date validation sub-program. Accepts a date from the user, passes it to the date validation sub-program and interprets and" />
+		<meta
+			name="twitter:description"
+			content="A driver program for the date validation sub-program. Accepts a date from the user, passes it to the date validation sub-program and interprets and"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -40,13 +55,19 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="Driver program for date validation sub-program" eyebrow="COBOL Example"></page-hero>
+						<page-hero
+							title="Driver program for date validation sub-program"
+							eyebrow="COBOL Example"
+						></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../../default.html">Example programs</a> ›
 							<span>Date Driver Program</span>
 						</nav>
-						<p>A driver program for the date validation sub-program. Accepts a date from the user, passes it to the date validation sub-program and interprets and displays the result.</p>
-							<div class="code-toolbar">
+						<p>
+							A driver program for the date validation sub-program. Accepts a date from the user, passes
+							it to the date validation sub-program and interprets and displays the result.
+						</p>
+						<div class="code-toolbar">
 							<a href="DateDriver.cbl" download class="download-btn">Download DateDriver.cbl</a>
 						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE

--- a/examples/SubProg/DateValid/DateDriver.html
+++ b/examples/SubProg/DateValid/DateDriver.html
@@ -11,33 +11,18 @@
 			})();
 		</script>
 		<title>Driver program for date validation sub-program</title>
-		<meta
-			name="description"
-			content="A driver program for the date validation sub-program. Accepts a date from the user, passes it to the date validation sub-program and interprets and"
-		/>
-		<link
-			rel="canonical"
-			href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/DateDriver.html"
-		/>
+		<meta name="description" content="A driver program for the date validation sub-program. Accepts a date from the user, passes it to the date validation sub-program and interprets and" />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/DateDriver.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta
-			property="og:url"
-			content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/DateDriver.html"
-		/>
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/DateDriver.html" />
 		<meta property="og:title" content="Driver program for date validation sub-program" />
-		<meta
-			property="og:description"
-			content="A driver program for the date validation sub-program. Accepts a date from the user, passes it to the date validation sub-program and interprets and"
-		/>
+		<meta property="og:description" content="A driver program for the date validation sub-program. Accepts a date from the user, passes it to the date validation sub-program and interprets and" />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Driver program for date validation sub-program" />
-		<meta
-			name="twitter:description"
-			content="A driver program for the date validation sub-program. Accepts a date from the user, passes it to the date validation sub-program and interprets and"
-		/>
+		<meta name="twitter:description" content="A driver program for the date validation sub-program. Accepts a date from the user, passes it to the date validation sub-program and interprets and" />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -55,23 +40,15 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero
-							title="Driver program for date validation sub-program"
-							eyebrow="COBOL Example"
-						></page-hero>
+						<page-hero title="Driver program for date validation sub-program" eyebrow="COBOL Example"></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../../default.html">Example programs</a> ›
 							<span>Date Driver Program</span>
 						</nav>
-						<p>
-							A driver program for the date validation sub-program. Accepts a date from the user, passes
-							it to the date validation sub-program and interprets and displays the result.
-						</p>
-						<p><a href="DateDriver.cbl" download>Download DateDriver.cbl</a></p>
-						<related-content
-							lectures="../../../course/Subprograms.html|Subprograms"
-							examples="../Multiply/DriverProg.html|Subprogram Driver, ../Multiply/MultiplyNums.html|MultiplyNums Subprogram, ../Multiply/Fickle.html|Fickle Subprogram (State Memory), ../Multiply/Steadfast.html|Steadfast Subprogram (IS INITIAL)"
-						></related-content>
+						<p>A driver program for the date validation sub-program. Accepts a date from the user, passes it to the date validation sub-program and interprets and displays the result.</p>
+							<div class="code-toolbar">
+							<a href="DateDriver.cbl" download class="download-btn">Download DateDriver.cbl</a>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. DateDriver.
@@ -117,6 +94,10 @@ Begin.
 
     STOP RUN.
 </code></pre>
+						<related-content
+							lectures="../../../course/Subprograms.html|Subprograms"
+							examples="../Multiply/DriverProg.html|Subprogram Driver, ../Multiply/MultiplyNums.html|MultiplyNums Subprogram, ../Multiply/Fickle.html|Fickle Subprogram (State Memory), ../Multiply/Steadfast.html|Steadfast Subprogram (IS INITIAL)"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/SubProg/DateValid/ValiDate.html
+++ b/examples/SubProg/DateValid/ValiDate.html
@@ -11,33 +11,18 @@
 			})();
 		</script>
 		<title>Date validation sub-program</title>
-		<meta
-			name="description"
-			content="A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a code indicating whether the date was valid, and if not, why it was"
-		/>
-		<link
-			rel="canonical"
-			href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/ValiDate.html"
-		/>
+		<meta name="description" content="A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a code indicating whether the date was valid, and if not, why it was" />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/ValiDate.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta
-			property="og:url"
-			content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/ValiDate.html"
-		/>
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/ValiDate.html" />
 		<meta property="og:title" content="Date validation sub-program" />
-		<meta
-			property="og:description"
-			content="A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a code indicating whether the date was valid, and if not, why it was"
-		/>
+		<meta property="og:description" content="A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a code indicating whether the date was valid, and if not, why it was" />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Date validation sub-program" />
-		<meta
-			name="twitter:description"
-			content="A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a code indicating whether the date was valid, and if not, why it was"
-		/>
+		<meta name="twitter:description" content="A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a code indicating whether the date was valid, and if not, why it was" />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -60,15 +45,10 @@
 							<a href="../../default.html">Example programs</a> ›
 							<span>Date Validation Sub-program</span>
 						</nav>
-						<p>
-							A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a
-							code indicating whether the date was valid, and if not, why it was invalid.
-						</p>
-						<p><a href="Validate.cbl" download>Download Validate.cbl</a></p>
-						<related-content
-							lectures="../../../course/Subprograms.html|Subprograms"
-							examples="../Multiply/DriverProg.html|Subprogram Driver, ../Multiply/MultiplyNums.html|MultiplyNums Subprogram, ../Multiply/Fickle.html|Fickle Subprogram (State Memory), ../Multiply/Steadfast.html|Steadfast Subprogram (IS INITIAL)"
-						></related-content>
+						<p>A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a code indicating whether the date was valid, and if not, why it was invalid.</p>
+							<div class="code-toolbar">
+							<a href="Validate.cbl" download class="download-btn">Download Validate.cbl</a>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. Validate IS INITIAL.
@@ -151,6 +131,10 @@ CheckForValidDay.
      SET DateIsValid TO TRUE
   END-IF.
 </code></pre>
+						<related-content
+							lectures="../../../course/Subprograms.html|Subprograms"
+							examples="../Multiply/DriverProg.html|Subprogram Driver, ../Multiply/MultiplyNums.html|MultiplyNums Subprogram, ../Multiply/Fickle.html|Fickle Subprogram (State Memory), ../Multiply/Steadfast.html|Steadfast Subprogram (IS INITIAL)"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/SubProg/DateValid/ValiDate.html
+++ b/examples/SubProg/DateValid/ValiDate.html
@@ -11,18 +11,33 @@
 			})();
 		</script>
 		<title>Date validation sub-program</title>
-		<meta name="description" content="A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a code indicating whether the date was valid, and if not, why it was" />
-		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/ValiDate.html" />
+		<meta
+			name="description"
+			content="A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a code indicating whether the date was valid, and if not, why it was"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/ValiDate.html"
+		/>
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/ValiDate.html" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/ValiDate.html"
+		/>
 		<meta property="og:title" content="Date validation sub-program" />
-		<meta property="og:description" content="A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a code indicating whether the date was valid, and if not, why it was" />
+		<meta
+			property="og:description"
+			content="A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a code indicating whether the date was valid, and if not, why it was"
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Date validation sub-program" />
-		<meta name="twitter:description" content="A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a code indicating whether the date was valid, and if not, why it was" />
+		<meta
+			name="twitter:description"
+			content="A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a code indicating whether the date was valid, and if not, why it was"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -45,8 +60,11 @@
 							<a href="../../default.html">Example programs</a> ›
 							<span>Date Validation Sub-program</span>
 						</nav>
-						<p>A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a code indicating whether the date was valid, and if not, why it was invalid.</p>
-							<div class="code-toolbar">
+						<p>
+							A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a
+							code indicating whether the date was valid, and if not, why it was invalid.
+						</p>
+						<div class="code-toolbar">
 							<a href="Validate.cbl" download class="download-btn">Download Validate.cbl</a>
 						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE

--- a/examples/SubProg/DayDiff/DayDiffDriver.html
+++ b/examples/SubProg/DayDiff/DayDiffDriver.html
@@ -11,18 +11,33 @@
 			})();
 		</script>
 		<title>Get difference between dates driver program</title>
-		<meta name="description" content="A driver program that accepts two dates from the user and displays the difference in days between them. Uses the Validate sub-program and also contains a" />
-		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DayDiff/DayDiffDriver.html" />
+		<meta
+			name="description"
+			content="A driver program that accepts two dates from the user and displays the difference in days between them. Uses the Validate sub-program and also contains a"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DayDiff/DayDiffDriver.html"
+		/>
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DayDiff/DayDiffDriver.html" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DayDiff/DayDiffDriver.html"
+		/>
 		<meta property="og:title" content="Get difference between dates driver program" />
-		<meta property="og:description" content="A driver program that accepts two dates from the user and displays the difference in days between them. Uses the Validate sub-program and also contains a" />
+		<meta
+			property="og:description"
+			content="A driver program that accepts two dates from the user and displays the difference in days between them. Uses the Validate sub-program and also contains a"
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Get difference between dates driver program" />
-		<meta name="twitter:description" content="A driver program that accepts two dates from the user and displays the difference in days between them. Uses the Validate sub-program and also contains a" />
+		<meta
+			name="twitter:description"
+			content="A driver program that accepts two dates from the user and displays the difference in days between them. Uses the Validate sub-program and also contains a"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -40,13 +55,20 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="Get difference between dates driver program" eyebrow="COBOL Example"></page-hero>
+						<page-hero
+							title="Get difference between dates driver program"
+							eyebrow="COBOL Example"
+						></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../../default.html">Example programs</a> ›
 							<span>Day Difference Driver</span>
 						</nav>
-						<p>A driver program that accepts two dates from the user and displays the difference in days between them. Uses the Validate sub-program and also contains a number of contained sub-programs.</p>
-							<div class="code-toolbar">
+						<p>
+							A driver program that accepts two dates from the user and displays the difference in days
+							between them. Uses the Validate sub-program and also contains a number of contained
+							sub-programs.
+						</p>
+						<div class="code-toolbar">
 							<a href="DayDiffDriver.cbl" download class="download-btn">Download DayDiffDriver.cbl</a>
 						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE

--- a/examples/SubProg/DayDiff/DayDiffDriver.html
+++ b/examples/SubProg/DayDiff/DayDiffDriver.html
@@ -11,33 +11,18 @@
 			})();
 		</script>
 		<title>Get difference between dates driver program</title>
-		<meta
-			name="description"
-			content="A driver program that accepts two dates from the user and displays the difference in days between them. Uses the Validate sub-program and also contains a"
-		/>
-		<link
-			rel="canonical"
-			href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DayDiff/DayDiffDriver.html"
-		/>
+		<meta name="description" content="A driver program that accepts two dates from the user and displays the difference in days between them. Uses the Validate sub-program and also contains a" />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DayDiff/DayDiffDriver.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta
-			property="og:url"
-			content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DayDiff/DayDiffDriver.html"
-		/>
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DayDiff/DayDiffDriver.html" />
 		<meta property="og:title" content="Get difference between dates driver program" />
-		<meta
-			property="og:description"
-			content="A driver program that accepts two dates from the user and displays the difference in days between them. Uses the Validate sub-program and also contains a"
-		/>
+		<meta property="og:description" content="A driver program that accepts two dates from the user and displays the difference in days between them. Uses the Validate sub-program and also contains a" />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Get difference between dates driver program" />
-		<meta
-			name="twitter:description"
-			content="A driver program that accepts two dates from the user and displays the difference in days between them. Uses the Validate sub-program and also contains a"
-		/>
+		<meta name="twitter:description" content="A driver program that accepts two dates from the user and displays the difference in days between them. Uses the Validate sub-program and also contains a" />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -55,24 +40,15 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero
-							title="Get difference between dates driver program"
-							eyebrow="COBOL Example"
-						></page-hero>
+						<page-hero title="Get difference between dates driver program" eyebrow="COBOL Example"></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../../default.html">Example programs</a> ›
 							<span>Day Difference Driver</span>
 						</nav>
-						<p>
-							A driver program that accepts two dates from the user and displays the difference in days
-							between them. Uses the Validate sub-program and also contains a number of contained
-							sub-programs.
-						</p>
-						<p><a href="DayDiffDriver.cbl" download>Download DayDiffDriver.cbl</a></p>
-						<related-content
-							lectures="../../../course/Subprograms.html|Subprograms"
-							examples="../Multiply/DriverProg.html|Subprogram Driver, ../Multiply/MultiplyNums.html|MultiplyNums Subprogram, ../Multiply/Fickle.html|Fickle Subprogram (State Memory), ../Multiply/Steadfast.html|Steadfast Subprogram (IS INITIAL)"
-						></related-content>
+						<p>A driver program that accepts two dates from the user and displays the difference in days between them. Uses the Validate sub-program and also contains a number of contained sub-programs.</p>
+							<div class="code-toolbar">
+							<a href="DayDiffDriver.cbl" download class="download-btn">Download DayDiffDriver.cbl</a>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. DayDiffDriver.
@@ -269,6 +245,10 @@ END PROGRAM GetDayDiff.
 
 END PROGRAM DayDiffDriver.
 </code></pre>
+						<related-content
+							lectures="../../../course/Subprograms.html|Subprograms"
+							examples="../Multiply/DriverProg.html|Subprogram Driver, ../Multiply/MultiplyNums.html|MultiplyNums Subprogram, ../Multiply/Fickle.html|Fickle Subprogram (State Memory), ../Multiply/Steadfast.html|Steadfast Subprogram (IS INITIAL)"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/SubProg/Multiply/DriverProg.html
+++ b/examples/SubProg/Multiply/DriverProg.html
@@ -11,33 +11,18 @@
 			})();
 		</script>
 		<title>A driver for the MultiplyNums, Fickle and Steafast sub-programs</title>
-		<meta
-			name="description"
-			content="Demonstrates the CALL verb by calling three external sub-programs that illustrate flow of control, parameter passing, and state memory."
-		/>
-		<link
-			rel="canonical"
-			href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/DriverProg.html"
-		/>
+		<meta name="description" content="Demonstrates the CALL verb by calling three external sub-programs that illustrate flow of control, parameter passing, and state memory." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/DriverProg.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta
-			property="og:url"
-			content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/DriverProg.html"
-		/>
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/DriverProg.html" />
 		<meta property="og:title" content="A driver for the MultiplyNums, Fickle and Steafast sub-programs" />
-		<meta
-			property="og:description"
-			content="Demonstrates the CALL verb by calling three external sub-programs that illustrate flow of control, parameter passing, and state memory."
-		/>
+		<meta property="og:description" content="Demonstrates the CALL verb by calling three external sub-programs that illustrate flow of control, parameter passing, and state memory." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="A driver for the MultiplyNums, Fickle and Steafast sub-programs" />
-		<meta
-			name="twitter:description"
-			content="Demonstrates the CALL verb by calling three external sub-programs that illustrate flow of control, parameter passing, and state memory."
-		/>
+		<meta name="twitter:description" content="Demonstrates the CALL verb by calling three external sub-programs that illustrate flow of control, parameter passing, and state memory." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -55,23 +40,15 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero
-							title="A driver for the MultiplyNums, Fickle and Steafast sub-programs"
-							eyebrow="COBOL Example"
-						></page-hero>
+						<page-hero title="A driver for the MultiplyNums, Fickle and Steafast sub-programs" eyebrow="COBOL Example"></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../../default.html">Example programs</a> ›
 							<span>Sub-program Driver</span>
 						</nav>
-						<p>
-							Demonstrates the CALL verb by calling three external sub-programs that illustrate flow of
-							control, parameter passing, and state memory.
-						</p>
-						<p><a href="DriverProg.cbl" download>Download DriverProg.cbl</a></p>
-						<related-content
-							lectures="../../../course/Subprograms.html|Subprograms"
-							examples="MultiplyNums.html|MultiplyNums Subprogram, Fickle.html|Fickle Subprogram (State Memory), Steadfast.html|Steadfast Subprogram (IS INITIAL), ../DateValid/DateDriver.html|Date Validation Driver"
-						></related-content>
+						<p>Demonstrates the CALL verb by calling three external sub-programs that illustrate flow of control, parameter passing, and state memory.</p>
+							<div class="code-toolbar">
+							<a href="DriverProg.cbl" download class="download-btn">Download DriverProg.cbl</a>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. DriverProg.
@@ -205,6 +182,10 @@ MakeFickleSteadfast.
 *&gt;   the CANCEL verb to set it into its initial state
 *&gt;   each time we call it
 </code></pre>
+						<related-content
+							lectures="../../../course/Subprograms.html|Subprograms"
+							examples="MultiplyNums.html|MultiplyNums Subprogram, Fickle.html|Fickle Subprogram (State Memory), Steadfast.html|Steadfast Subprogram (IS INITIAL), ../DateValid/DateDriver.html|Date Validation Driver"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/SubProg/Multiply/DriverProg.html
+++ b/examples/SubProg/Multiply/DriverProg.html
@@ -11,18 +11,33 @@
 			})();
 		</script>
 		<title>A driver for the MultiplyNums, Fickle and Steafast sub-programs</title>
-		<meta name="description" content="Demonstrates the CALL verb by calling three external sub-programs that illustrate flow of control, parameter passing, and state memory." />
-		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/DriverProg.html" />
+		<meta
+			name="description"
+			content="Demonstrates the CALL verb by calling three external sub-programs that illustrate flow of control, parameter passing, and state memory."
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/DriverProg.html"
+		/>
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/DriverProg.html" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/DriverProg.html"
+		/>
 		<meta property="og:title" content="A driver for the MultiplyNums, Fickle and Steafast sub-programs" />
-		<meta property="og:description" content="Demonstrates the CALL verb by calling three external sub-programs that illustrate flow of control, parameter passing, and state memory." />
+		<meta
+			property="og:description"
+			content="Demonstrates the CALL verb by calling three external sub-programs that illustrate flow of control, parameter passing, and state memory."
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="A driver for the MultiplyNums, Fickle and Steafast sub-programs" />
-		<meta name="twitter:description" content="Demonstrates the CALL verb by calling three external sub-programs that illustrate flow of control, parameter passing, and state memory." />
+		<meta
+			name="twitter:description"
+			content="Demonstrates the CALL verb by calling three external sub-programs that illustrate flow of control, parameter passing, and state memory."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -40,13 +55,19 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="A driver for the MultiplyNums, Fickle and Steafast sub-programs" eyebrow="COBOL Example"></page-hero>
+						<page-hero
+							title="A driver for the MultiplyNums, Fickle and Steafast sub-programs"
+							eyebrow="COBOL Example"
+						></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../../default.html">Example programs</a> ›
 							<span>Sub-program Driver</span>
 						</nav>
-						<p>Demonstrates the CALL verb by calling three external sub-programs that illustrate flow of control, parameter passing, and state memory.</p>
-							<div class="code-toolbar">
+						<p>
+							Demonstrates the CALL verb by calling three external sub-programs that illustrate flow of
+							control, parameter passing, and state memory.
+						</p>
+						<div class="code-toolbar">
 							<a href="DriverProg.cbl" download class="download-btn">Download DriverProg.cbl</a>
 						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE

--- a/examples/SubProg/Multiply/Fickle.html
+++ b/examples/SubProg/Multiply/Fickle.html
@@ -11,33 +11,18 @@
 			})();
 		</script>
 		<title>The Fickle sub-program demonstrates State Memory</title>
-		<meta
-			name="description"
-			content="A sub-program that demonstrates State Memory — each time it is called it remembers its state from the previous call."
-		/>
-		<link
-			rel="canonical"
-			href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Fickle.html"
-		/>
+		<meta name="description" content="A sub-program that demonstrates State Memory — each time it is called it remembers its state from the previous call." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Fickle.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta
-			property="og:url"
-			content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Fickle.html"
-		/>
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Fickle.html" />
 		<meta property="og:title" content="The Fickle sub-program demonstrates State Memory" />
-		<meta
-			property="og:description"
-			content="A sub-program that demonstrates State Memory — each time it is called it remembers its state from the previous call."
-		/>
+		<meta property="og:description" content="A sub-program that demonstrates State Memory — each time it is called it remembers its state from the previous call." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="The Fickle sub-program demonstrates State Memory" />
-		<meta
-			name="twitter:description"
-			content="A sub-program that demonstrates State Memory — each time it is called it remembers its state from the previous call."
-		/>
+		<meta name="twitter:description" content="A sub-program that demonstrates State Memory — each time it is called it remembers its state from the previous call." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -55,23 +40,15 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero
-							title="The Fickle sub-program demonstrates State Memory"
-							eyebrow="COBOL Example"
-						></page-hero>
+						<page-hero title="The Fickle sub-program demonstrates State Memory" eyebrow="COBOL Example"></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../../default.html">Example programs</a> ›
 							<span>Fickle Sub-program</span>
 						</nav>
-						<p>
-							A sub-program that demonstrates State Memory — each time it is called it remembers its state
-							from the previous call.
-						</p>
-						<p><a href="Fickle.cbl" download>Download Fickle.cbl</a></p>
-						<related-content
-							lectures="../../../course/Subprograms.html|Subprograms"
-							examples="DriverProg.html|Subprogram Driver, MultiplyNums.html|MultiplyNums Subprogram, Steadfast.html|Steadfast Subprogram (IS INITIAL), ../DateValid/DateDriver.html|Date Validation Driver"
-						></related-content>
+						<p>A sub-program that demonstrates State Memory — each time it is called it remembers its state from the previous call.</p>
+							<div class="code-toolbar">
+							<a href="Fickle.cbl" download class="download-btn">Download Fickle.cbl</a>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. Fickle.
@@ -97,6 +74,10 @@ Begin.
 
     EXIT PROGRAM.
 </code></pre>
+						<related-content
+							lectures="../../../course/Subprograms.html|Subprograms"
+							examples="DriverProg.html|Subprogram Driver, MultiplyNums.html|MultiplyNums Subprogram, Steadfast.html|Steadfast Subprogram (IS INITIAL), ../DateValid/DateDriver.html|Date Validation Driver"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/SubProg/Multiply/Fickle.html
+++ b/examples/SubProg/Multiply/Fickle.html
@@ -11,18 +11,33 @@
 			})();
 		</script>
 		<title>The Fickle sub-program demonstrates State Memory</title>
-		<meta name="description" content="A sub-program that demonstrates State Memory — each time it is called it remembers its state from the previous call." />
-		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Fickle.html" />
+		<meta
+			name="description"
+			content="A sub-program that demonstrates State Memory — each time it is called it remembers its state from the previous call."
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Fickle.html"
+		/>
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Fickle.html" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Fickle.html"
+		/>
 		<meta property="og:title" content="The Fickle sub-program demonstrates State Memory" />
-		<meta property="og:description" content="A sub-program that demonstrates State Memory — each time it is called it remembers its state from the previous call." />
+		<meta
+			property="og:description"
+			content="A sub-program that demonstrates State Memory — each time it is called it remembers its state from the previous call."
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="The Fickle sub-program demonstrates State Memory" />
-		<meta name="twitter:description" content="A sub-program that demonstrates State Memory — each time it is called it remembers its state from the previous call." />
+		<meta
+			name="twitter:description"
+			content="A sub-program that demonstrates State Memory — each time it is called it remembers its state from the previous call."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -40,13 +55,19 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="The Fickle sub-program demonstrates State Memory" eyebrow="COBOL Example"></page-hero>
+						<page-hero
+							title="The Fickle sub-program demonstrates State Memory"
+							eyebrow="COBOL Example"
+						></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../../default.html">Example programs</a> ›
 							<span>Fickle Sub-program</span>
 						</nav>
-						<p>A sub-program that demonstrates State Memory — each time it is called it remembers its state from the previous call.</p>
-							<div class="code-toolbar">
+						<p>
+							A sub-program that demonstrates State Memory — each time it is called it remembers its state
+							from the previous call.
+						</p>
+						<div class="code-toolbar">
 							<a href="Fickle.cbl" download class="download-btn">Download Fickle.cbl</a>
 						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE

--- a/examples/SubProg/Multiply/MultiplyNums.html
+++ b/examples/SubProg/Multiply/MultiplyNums.html
@@ -11,33 +11,18 @@
 			})();
 		</script>
 		<title>The MultiplyNums sub-program</title>
-		<meta
-			name="description"
-			content="The MultiplyNums sub-program demonstrates flow of control from a driver program and the use of numeric and string parameters with BY REFERENCE and BY"
-		/>
-		<link
-			rel="canonical"
-			href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/MultiplyNums.html"
-		/>
+		<meta name="description" content="The MultiplyNums sub-program demonstrates flow of control from a driver program and the use of numeric and string parameters with BY REFERENCE and BY" />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/MultiplyNums.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta
-			property="og:url"
-			content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/MultiplyNums.html"
-		/>
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/MultiplyNums.html" />
 		<meta property="og:title" content="The MultiplyNums sub-program" />
-		<meta
-			property="og:description"
-			content="The MultiplyNums sub-program demonstrates flow of control from a driver program and the use of numeric and string parameters with BY REFERENCE and BY"
-		/>
+		<meta property="og:description" content="The MultiplyNums sub-program demonstrates flow of control from a driver program and the use of numeric and string parameters with BY REFERENCE and BY" />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="The MultiplyNums sub-program" />
-		<meta
-			name="twitter:description"
-			content="The MultiplyNums sub-program demonstrates flow of control from a driver program and the use of numeric and string parameters with BY REFERENCE and BY"
-		/>
+		<meta name="twitter:description" content="The MultiplyNums sub-program demonstrates flow of control from a driver program and the use of numeric and string parameters with BY REFERENCE and BY" />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -60,15 +45,10 @@
 							<a href="../../default.html">Example programs</a> ›
 							<span>MultiplyNums Sub-program</span>
 						</nav>
-						<p>
-							The MultiplyNums sub-program demonstrates flow of control from a driver program and the use
-							of numeric and string parameters with BY REFERENCE and BY CONTENT.
-						</p>
-						<p><a href="MultiplyNums.cbl" download>Download MultiplyNums.cbl</a></p>
-						<related-content
-							lectures="../../../course/Subprograms.html|Subprograms"
-							examples="DriverProg.html|Subprogram Driver, Fickle.html|Fickle Subprogram (State Memory), Steadfast.html|Steadfast Subprogram (IS INITIAL), ../DateValid/DateDriver.html|Date Validation Driver"
-						></related-content>
+						<p>The MultiplyNums sub-program demonstrates flow of control from a driver program and the use of numeric and string parameters with BY REFERENCE and BY CONTENT.</p>
+							<div class="code-toolbar">
+							<a href="MultiplyNums.cbl" download class="download-btn">Download MultiplyNums.cbl</a>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. MultiplyNums.
@@ -123,6 +103,10 @@ Begin.
     DISPLAY "&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt; Leaving sub-program now".
     EXIT PROGRAM.
 </code></pre>
+						<related-content
+							lectures="../../../course/Subprograms.html|Subprograms"
+							examples="DriverProg.html|Subprogram Driver, Fickle.html|Fickle Subprogram (State Memory), Steadfast.html|Steadfast Subprogram (IS INITIAL), ../DateValid/DateDriver.html|Date Validation Driver"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/SubProg/Multiply/MultiplyNums.html
+++ b/examples/SubProg/Multiply/MultiplyNums.html
@@ -11,18 +11,33 @@
 			})();
 		</script>
 		<title>The MultiplyNums sub-program</title>
-		<meta name="description" content="The MultiplyNums sub-program demonstrates flow of control from a driver program and the use of numeric and string parameters with BY REFERENCE and BY" />
-		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/MultiplyNums.html" />
+		<meta
+			name="description"
+			content="The MultiplyNums sub-program demonstrates flow of control from a driver program and the use of numeric and string parameters with BY REFERENCE and BY"
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/MultiplyNums.html"
+		/>
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/MultiplyNums.html" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/MultiplyNums.html"
+		/>
 		<meta property="og:title" content="The MultiplyNums sub-program" />
-		<meta property="og:description" content="The MultiplyNums sub-program demonstrates flow of control from a driver program and the use of numeric and string parameters with BY REFERENCE and BY" />
+		<meta
+			property="og:description"
+			content="The MultiplyNums sub-program demonstrates flow of control from a driver program and the use of numeric and string parameters with BY REFERENCE and BY"
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="The MultiplyNums sub-program" />
-		<meta name="twitter:description" content="The MultiplyNums sub-program demonstrates flow of control from a driver program and the use of numeric and string parameters with BY REFERENCE and BY" />
+		<meta
+			name="twitter:description"
+			content="The MultiplyNums sub-program demonstrates flow of control from a driver program and the use of numeric and string parameters with BY REFERENCE and BY"
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -45,8 +60,11 @@
 							<a href="../../default.html">Example programs</a> ›
 							<span>MultiplyNums Sub-program</span>
 						</nav>
-						<p>The MultiplyNums sub-program demonstrates flow of control from a driver program and the use of numeric and string parameters with BY REFERENCE and BY CONTENT.</p>
-							<div class="code-toolbar">
+						<p>
+							The MultiplyNums sub-program demonstrates flow of control from a driver program and the use
+							of numeric and string parameters with BY REFERENCE and BY CONTENT.
+						</p>
+						<div class="code-toolbar">
 							<a href="MultiplyNums.cbl" download class="download-btn">Download MultiplyNums.cbl</a>
 						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE

--- a/examples/SubProg/Multiply/Steadfast.html
+++ b/examples/SubProg/Multiply/Steadfast.html
@@ -11,33 +11,18 @@
 			})();
 		</script>
 		<title>The Steadfast sub-program demonstrates the IS INITIAL phrase</title>
-		<meta
-			name="description"
-			content="A sub-program identical to Fickle except that it uses the IS INITIAL phrase to avoid State Memory — it always produces the same result for the same input."
-		/>
-		<link
-			rel="canonical"
-			href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Steadfast.html"
-		/>
+		<meta name="description" content="A sub-program identical to Fickle except that it uses the IS INITIAL phrase to avoid State Memory — it always produces the same result for the same input." />
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Steadfast.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta
-			property="og:url"
-			content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Steadfast.html"
-		/>
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Steadfast.html" />
 		<meta property="og:title" content="The Steadfast sub-program demonstrates the IS INITIAL phrase" />
-		<meta
-			property="og:description"
-			content="A sub-program identical to Fickle except that it uses the IS INITIAL phrase to avoid State Memory — it always produces the same result for the same input."
-		/>
+		<meta property="og:description" content="A sub-program identical to Fickle except that it uses the IS INITIAL phrase to avoid State Memory — it always produces the same result for the same input." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="The Steadfast sub-program demonstrates the IS INITIAL phrase" />
-		<meta
-			name="twitter:description"
-			content="A sub-program identical to Fickle except that it uses the IS INITIAL phrase to avoid State Memory — it always produces the same result for the same input."
-		/>
+		<meta name="twitter:description" content="A sub-program identical to Fickle except that it uses the IS INITIAL phrase to avoid State Memory — it always produces the same result for the same input." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -55,23 +40,15 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero
-							title="The Steadfast sub-program demonstrates the IS INITIAL phrase"
-							eyebrow="COBOL Example"
-						></page-hero>
+						<page-hero title="The Steadfast sub-program demonstrates the IS INITIAL phrase" eyebrow="COBOL Example"></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../../default.html">Example programs</a> ›
 							<span>Steadfast Sub-program</span>
 						</nav>
-						<p>
-							A sub-program identical to Fickle except that it uses the IS INITIAL phrase to avoid State
-							Memory — it always produces the same result for the same input.
-						</p>
-						<p><a href="Steadfast.cbl" download>Download Steadfast.cbl</a></p>
-						<related-content
-							lectures="../../../course/Subprograms.html|Subprograms"
-							examples="DriverProg.html|Subprogram Driver, MultiplyNums.html|MultiplyNums Subprogram, Fickle.html|Fickle Subprogram (State Memory), ../DateValid/DateDriver.html|Date Validation Driver"
-						></related-content>
+						<p>A sub-program identical to Fickle except that it uses the IS INITIAL phrase to avoid State Memory — it always produces the same result for the same input.</p>
+							<div class="code-toolbar">
+							<a href="Steadfast.cbl" download class="download-btn">Download Steadfast.cbl</a>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID. Steadfast IS INITIAL.
@@ -97,6 +74,10 @@ Begin.
 
     EXIT PROGRAM.
 </code></pre>
+						<related-content
+							lectures="../../../course/Subprograms.html|Subprograms"
+							examples="DriverProg.html|Subprogram Driver, MultiplyNums.html|MultiplyNums Subprogram, Fickle.html|Fickle Subprogram (State Memory), ../DateValid/DateDriver.html|Date Validation Driver"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/examples/SubProg/Multiply/Steadfast.html
+++ b/examples/SubProg/Multiply/Steadfast.html
@@ -11,18 +11,33 @@
 			})();
 		</script>
 		<title>The Steadfast sub-program demonstrates the IS INITIAL phrase</title>
-		<meta name="description" content="A sub-program identical to Fickle except that it uses the IS INITIAL phrase to avoid State Memory — it always produces the same result for the same input." />
-		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Steadfast.html" />
+		<meta
+			name="description"
+			content="A sub-program identical to Fickle except that it uses the IS INITIAL phrase to avoid State Memory — it always produces the same result for the same input."
+		/>
+		<link
+			rel="canonical"
+			href="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Steadfast.html"
+		/>
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Steadfast.html" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Steadfast.html"
+		/>
 		<meta property="og:title" content="The Steadfast sub-program demonstrates the IS INITIAL phrase" />
-		<meta property="og:description" content="A sub-program identical to Fickle except that it uses the IS INITIAL phrase to avoid State Memory — it always produces the same result for the same input." />
+		<meta
+			property="og:description"
+			content="A sub-program identical to Fickle except that it uses the IS INITIAL phrase to avoid State Memory — it always produces the same result for the same input."
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="The Steadfast sub-program demonstrates the IS INITIAL phrase" />
-		<meta name="twitter:description" content="A sub-program identical to Fickle except that it uses the IS INITIAL phrase to avoid State Memory — it always produces the same result for the same input." />
+		<meta
+			name="twitter:description"
+			content="A sub-program identical to Fickle except that it uses the IS INITIAL phrase to avoid State Memory — it always produces the same result for the same input."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -40,13 +55,19 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="The Steadfast sub-program demonstrates the IS INITIAL phrase" eyebrow="COBOL Example"></page-hero>
+						<page-hero
+							title="The Steadfast sub-program demonstrates the IS INITIAL phrase"
+							eyebrow="COBOL Example"
+						></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../../default.html">Example programs</a> ›
 							<span>Steadfast Sub-program</span>
 						</nav>
-						<p>A sub-program identical to Fickle except that it uses the IS INITIAL phrase to avoid State Memory — it always produces the same result for the same input.</p>
-							<div class="code-toolbar">
+						<p>
+							A sub-program identical to Fickle except that it uses the IS INITIAL phrase to avoid State
+							Memory — it always produces the same result for the same input.
+						</p>
+						<div class="code-toolbar">
 							<a href="Steadfast.cbl" download class="download-btn">Download Steadfast.cbl</a>
 						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE

--- a/examples/Tables/MonthTable.html
+++ b/examples/Tables/MonthTable.html
@@ -11,18 +11,30 @@
 			})();
 		</script>
 		<title>Tables - Counts number of students born in each month</title>
-		<meta name="description" content="Counts the number of students born in each month using a pre-filled table of month names and displays the result." />
+		<meta
+			name="description"
+			content="Counts the number of students born in each month using a pre-filled table of month names and displays the result."
+		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Tables/MonthTable.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Tables/MonthTable.html" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/Tables/MonthTable.html"
+		/>
 		<meta property="og:title" content="Tables - Counts number of students born in each month" />
-		<meta property="og:description" content="Counts the number of students born in each month using a pre-filled table of month names and displays the result." />
+		<meta
+			property="og:description"
+			content="Counts the number of students born in each month using a pre-filled table of month names and displays the result."
+		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Tables - Counts number of students born in each month" />
-		<meta name="twitter:description" content="Counts the number of students born in each month using a pre-filled table of month names and displays the result." />
+		<meta
+			name="twitter:description"
+			content="Counts the number of students born in each month using a pre-filled table of month names and displays the result."
+		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -40,13 +52,19 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="Tables - Counts number of students born in each month" eyebrow="COBOL Example"></page-hero>
+						<page-hero
+							title="Tables - Counts number of students born in each month"
+							eyebrow="COBOL Example"
+						></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../default.html">Example programs</a> ›
 							<span>Month Table</span>
 						</nav>
-						<p>Counts the number of students born in each month using a pre-filled table of month names and displays the result.</p>
-							<div class="code-toolbar">
+						<p>
+							Counts the number of students born in each month using a pre-filled table of month names and
+							displays the result.
+						</p>
+						<div class="code-toolbar">
 							<a href="MonthTable.cbl" download class="download-btn">Download MonthTable.cbl</a>
 						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE

--- a/examples/Tables/MonthTable.html
+++ b/examples/Tables/MonthTable.html
@@ -11,30 +11,18 @@
 			})();
 		</script>
 		<title>Tables - Counts number of students born in each month</title>
-		<meta
-			name="description"
-			content="Counts the number of students born in each month using a pre-filled table of month names and displays the result."
-		/>
+		<meta name="description" content="Counts the number of students born in each month using a pre-filled table of month names and displays the result." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Tables/MonthTable.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
-		<meta
-			property="og:url"
-			content="https://bushidocodes.github.io/limerick-cobol/examples/Tables/MonthTable.html"
-		/>
+		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/Tables/MonthTable.html" />
 		<meta property="og:title" content="Tables - Counts number of students born in each month" />
-		<meta
-			property="og:description"
-			content="Counts the number of students born in each month using a pre-filled table of month names and displays the result."
-		/>
+		<meta property="og:description" content="Counts the number of students born in each month using a pre-filled table of month names and displays the result." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Tables - Counts number of students born in each month" />
-		<meta
-			name="twitter:description"
-			content="Counts the number of students born in each month using a pre-filled table of month names and displays the result."
-		/>
+		<meta name="twitter:description" content="Counts the number of students born in each month using a pre-filled table of month names and displays the result." />
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
@@ -52,23 +40,15 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero
-							title="Tables - Counts number of students born in each month"
-							eyebrow="COBOL Example"
-						></page-hero>
+						<page-hero title="Tables - Counts number of students born in each month" eyebrow="COBOL Example"></page-hero>
 						<nav aria-label="Breadcrumb">
 							<a href="../default.html">Example programs</a> ›
 							<span>Month Table</span>
 						</nav>
-						<p>
-							Counts the number of students born in each month using a pre-filled table of month names and
-							displays the result.
-						</p>
-						<p><a href="MonthTable.cbl" download>Download MonthTable.cbl</a></p>
-						<related-content
-							lectures="../../course/Tables1.html|Tables 1, ../../course/Tables2.html|Tables 2, ../../course/Search.html|SEARCH and SEARCH ALL"
-							exercises="../../exercises/MonthTable.html|Using Tables Exercise"
-						></related-content>
+						<p>Counts the number of students born in each month using a pre-filled table of month names and displays the result.</p>
+							<div class="code-toolbar">
+							<a href="MonthTable.cbl" download class="download-btn">Download MonthTable.cbl</a>
+						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
 PROGRAM-ID.  MonthTable.
@@ -145,6 +125,10 @@ Begin.
    CLOSE StudentFile
    STOP RUN.
 </code></pre>
+						<related-content
+							lectures="../../course/Tables1.html|Tables 1, ../../course/Tables2.html|Tables 2, ../../course/Search.html|SEARCH and SEARCH ALL"
+							exercises="../../exercises/MonthTable.html|Using Tables Exercise"
+						></related-content>
 					</div>
 				</div>
 			</div>

--- a/scripts/build-examples.js
+++ b/scripts/build-examples.js
@@ -441,7 +441,7 @@ function buildPage(entry) {
 	const relatedEl = relatedContentHtml(entry.file);
 
 	const runInCeScript = entry.runInCe ? `\t\t<script src="${pfx}components/run-in-ce.js" defer></script>\n` : "";
-	const runInCeEl = entry.runInCe ? `\t\t\t\t\t\t<p><run-in-ce></run-in-ce></p>\n` : "";
+	const runInCeToolbarEl = entry.runInCe ? `\t\t\t\t\t\t\t<run-in-ce></run-in-ce>\n` : "";
 
 	return `<!doctype html>
 <html lang="en">
@@ -491,10 +491,12 @@ ${runInCeScript}\t</head>
 \t\t\t\t\t\t\t<span>${entry.crumb}</span>
 \t\t\t\t\t\t</nav>
 \t\t\t\t\t\t<p>${entry.desc}</p>
-\t\t\t\t\t\t<p><a href="${entry.cbl}" download>Download ${entry.cbl}</a></p>
-${runInCeEl}${relatedEl}\t\t\t\t\t\t<pre class="language-cobol"><code class="language-cobol">${escapedSource}
+\t\t\t\t\t\t\t<div class="code-toolbar">
+\t\t\t\t\t\t\t<a href="${entry.cbl}" download class="download-btn">Download ${entry.cbl}</a>
+${runInCeToolbarEl}\t\t\t\t\t\t</div>
+\t\t\t\t\t\t<pre class="language-cobol"><code class="language-cobol">${escapedSource}
 </code></pre>
-\t\t\t\t\t</div>
+${relatedEl}\t\t\t\t\t</div>
 \t\t\t\t</div>
 \t\t\t</div>
 \t\t</main>


### PR DESCRIPTION
## Summary

- **Download + Run buttons** are now grouped in a `div.code-toolbar` rendered directly above the `<pre>` block instead of being scattered as separate paragraphs before the related sidebar
- **Related links** moved from above the code to below it, appearing at the bottom of the page after the source listing
- **Copy button** is unchanged — still injected by `copy-button.js` and positioned absolutely over the top-right corner of the `<pre>`

## What changed

| File | Change |
|---|---|
| `scripts/build-examples.js` | New `code-toolbar` div wrapping Download + Run, `relatedEl` moved after `</pre>` |
| `course/Resources/css/course-components.css` | Added `.code-toolbar` (flex row, gap) and `.download-btn` (mirrors existing `.run-in-ce` styling, with dark-mode variants) |
| `examples/**/*.html` | All 37 example pages regenerated from the updated template |

## Reviewer notes

The `components/copy-button.js` file is **not changed** — it still appends the button inside the `<pre>` as an absolutely-positioned overlay. The toolbar only contains Download and Run on Compiler Explorer.