### PR TITLE
feat: add MDN-style sidebar, nav, breadcrumbs, and footer panel

### DIFF
--- a/components/breadcrumbs.js
+++ b/components/breadcrumbs.js
@@ -1,0 +1,163 @@
+// Light-DOM custom element <breadcrumbs>: renders a hierarchical trail from
+// the site home down to the current page, derived from the URL pathname.
+// Mirrors MDN's "Learn › Core › CSS styling basics" pattern.
+//
+// Auto-injection: an IIFE at the bottom inserts <breadcrumbs> as the first
+// child of .page-wrapper (so it lands in the content column of the grid
+// layout) or of <main> if no .page-wrapper exists. Pages can also place the
+// tag manually.
+//
+// Scope: skipped on the site home page (where the trail would be just "Home"
+// alone) and on viewer shells that don't have a <main>.
+//
+// Labels: top-level directories (course, exercises, examples, lectures) map
+// to friendly titles via SECTION_LABELS. The leaf page uses document.title
+// stripped at the first " - " / " — " / " | " separator.
+
+(function () {
+	function computeBaseUrl() {
+		const scripts = document.querySelectorAll("script[src]");
+		for (const s of scripts) {
+			if (/components\/breadcrumbs\.js(\?|$)/.test(s.src)) {
+				return s.src.replace(/components\/breadcrumbs\.js(\?.*)?$/, "");
+			}
+		}
+		return "";
+	}
+
+	const baseUrl = computeBaseUrl();
+	const homeUrl = baseUrl + "index.html";
+	const sitePath = new URL(baseUrl || "./", location.href).pathname;
+
+	// Top-level sections: friendly label plus the path of their entry page
+	// (relative to the site base). Deeper directories don't get linked
+	// because they don't have index pages — clicking them would 404.
+	const TOP_LEVEL_SECTIONS = {
+		course: { label: "Course", entry: "course/index.html" },
+		exercises: { label: "Exercises", entry: "exercises/index.html" },
+		examples: { label: "Examples", entry: "examples/default.html" },
+		lectures: { label: "Lectures", entry: "lectures/index.html" },
+	};
+
+	function tidyLeafLabel() {
+		const t = (document.title || "").trim();
+		const parts = t.split(/\s+[-—–|]\s+/);
+		return parts[0] || t;
+	}
+
+	function buildCrumbs() {
+		const here = currentPath();
+		if (!here.startsWith(sitePath)) return null;
+
+		let rel = here.slice(sitePath.length).replace(/^\/+/, "");
+		// A bare "" or "index.html" at site root means the home page.
+		if (rel === "" || rel === "index.html") return null;
+		rel = rel.replace(/\/index\.html$/, "/");
+
+		const parts = rel.split("/").filter(Boolean);
+		if (parts.length === 0) return null;
+
+		const crumbs = [{ href: homeUrl, label: "Home" }];
+
+		parts.forEach((part, i) => {
+			const isLeaf = i === parts.length - 1 && !rel.endsWith("/");
+			let label, href;
+			if (isLeaf) {
+				label = tidyLeafLabel();
+				href = null;
+			} else if (i === 0 && TOP_LEVEL_SECTIONS[part]) {
+				// Top-level section: link to its known entry page.
+				const sec = TOP_LEVEL_SECTIONS[part];
+				label = sec.label;
+				href = baseUrl + sec.entry;
+			} else {
+				// Intermediate directory with no guaranteed index page —
+				// render as plain text rather than a 404-prone link.
+				label = part.replace(/[-_]/g, " ");
+				href = null;
+			}
+			crumbs.push({ href, label });
+		});
+
+		return crumbs;
+	}
+
+	function currentPath() {
+		return new URL(location.href).pathname;
+	}
+
+	function render(host, crumbs) {
+		const nav = document.createElement("nav");
+		nav.className = "page-breadcrumbs";
+		nav.setAttribute("aria-label", "Breadcrumb");
+
+		const ol = document.createElement("ol");
+		ol.className = "breadcrumbs-list";
+
+		crumbs.forEach((c) => {
+			const li = document.createElement("li");
+			li.className = "breadcrumbs-item";
+			if (c.href) {
+				const a = document.createElement("a");
+				a.href = c.href;
+				a.textContent = c.label;
+				li.appendChild(a);
+			} else {
+				const span = document.createElement("span");
+				span.className = "breadcrumbs-current";
+				span.textContent = c.label;
+				span.setAttribute("aria-current", "page");
+				li.appendChild(span);
+			}
+			ol.appendChild(li);
+		});
+
+		nav.appendChild(ol);
+		host.appendChild(nav);
+	}
+
+	class PageBreadcrumbs extends HTMLElement {
+		connectedCallback() {
+			if (this.childElementCount > 0) return;
+			const crumbs = buildCrumbs();
+			if (!crumbs || crumbs.length < 2) {
+				this.remove();
+				return;
+			}
+			render(this, crumbs);
+		}
+	}
+
+	if (!customElements.get("page-breadcrumbs")) {
+		customElements.define("page-breadcrumbs", PageBreadcrumbs);
+	}
+
+	function autoInject() {
+		if (document.querySelector("page-breadcrumbs")) return;
+		const el = document.createElement("page-breadcrumbs");
+
+		// Preferred insertion point: inside the content column, immediately
+		// before <page-hero>. This keeps breadcrumbs visually aligned with
+		// the lesson content (matching MDN's pattern) without becoming a
+		// direct grid child of .page-wrapper, which would force the wrapper
+		// grid into multiple rows and inflate row sizing for sticky
+		// sidebar siblings.
+		const hero = document.querySelector("page-hero");
+		if (hero && hero.parentNode) {
+			hero.parentNode.insertBefore(el, hero);
+			return;
+		}
+
+		// Fallback for pages without a page-hero (e.g. index, glossary,
+		// 404): insert at top of <main>.
+		const main = document.getElementById("main-content") || document.querySelector("main");
+		if (!main) return;
+		main.insertBefore(el, main.firstChild);
+	}
+
+	if (document.readyState === "loading") {
+		document.addEventListener("DOMContentLoaded", autoInject);
+	} else {
+		autoInject();
+	}
+})();

--- a/components/course-sidebar.js
+++ b/components/course-sidebar.js
@@ -1,0 +1,153 @@
+// Light-DOM custom element <course-sidebar>: renders the full COBOL course
+// outline on the left rail of every page that belongs to the course. Mirrors
+// MDN's left sidebar pattern — from any lesson the learner can see the whole
+// module with the current page highlighted, and jump anywhere without
+// backtracking through the course index.
+//
+// Data source: course/lesson-manifest.json (fetched once; same request
+// lesson-progress.js makes, so the browser cache absorbs the cost).
+//
+// Auto-injection: an IIFE at the bottom inserts <course-sidebar> as the first
+// child of .page-wrapper if it isn't already present. Pages can also place
+// the tag manually — the connectedCallback handles both paths.
+//
+// Scope: the sidebar renders only when the current page is part of the
+// course — either its pathname is listed in the manifest, or it lives under
+// the /course/ directory (so the course index and glossary also show it).
+// Outside that scope, connectedCallback removes the element silently.
+//
+// Layout: a sibling rule in course-components.css gives .page-wrapper a grid
+// when :has(course-sidebar) matches. Hidden below ~1100px so narrow viewports
+// fall back to the existing top-of-page lesson-toc.
+
+(function () {
+	function computeBaseUrl() {
+		const scripts = document.querySelectorAll("script[src]");
+		for (const s of scripts) {
+			if (/components\/course-sidebar\.js(\?|$)/.test(s.src)) {
+				return s.src.replace(/components\/course-sidebar\.js(\?.*)?$/, "");
+			}
+		}
+		return "";
+	}
+
+	const baseUrl = computeBaseUrl();
+	const manifestUrl = baseUrl + "course/lesson-manifest.json";
+	const courseHomeUrl = baseUrl + "course/index.html";
+
+	function resolvePath(file) {
+		return new URL(file, manifestUrl).pathname;
+	}
+
+	function currentPath() {
+		return new URL(location.href).pathname;
+	}
+
+	function isInCourseScope(manifest) {
+		const cur = currentPath();
+		if (/\/course\//.test(cur)) return true;
+		for (const topic of manifest.topics) {
+			for (const link of topic.links) {
+				if (resolvePath(link.file) === cur) return true;
+			}
+		}
+		return false;
+	}
+
+	function render(host, manifest) {
+		const cur = currentPath();
+
+		const nav = document.createElement("nav");
+		nav.className = "course-sidebar";
+		nav.setAttribute("aria-label", "Course outline");
+
+		const heading = document.createElement("p");
+		heading.className = "course-sidebar-heading";
+		const headingLink = document.createElement("a");
+		headingLink.href = courseHomeUrl;
+		headingLink.textContent = "COBOL Course";
+		heading.appendChild(headingLink);
+		nav.appendChild(heading);
+
+		const list = document.createElement("ol");
+		list.className = "course-sidebar-topics";
+
+		for (const topic of manifest.topics) {
+			const topicLi = document.createElement("li");
+			topicLi.className = "course-sidebar-topic";
+
+			const topicLabel = document.createElement("p");
+			topicLabel.className = "course-sidebar-topic-label";
+			topicLabel.textContent = topic.label;
+			topicLi.appendChild(topicLabel);
+
+			const linksUl = document.createElement("ul");
+			linksUl.className = "course-sidebar-links";
+
+			let topicHasActive = false;
+			for (const link of topic.links) {
+				const li = document.createElement("li");
+				li.className = `course-sidebar-link course-sidebar-link--${link.type}`;
+				const a = document.createElement("a");
+				a.href = new URL(link.file, manifestUrl).toString();
+				a.textContent = link.title;
+				if (resolvePath(link.file) === cur) {
+					a.setAttribute("data-active", "");
+					a.setAttribute("aria-current", "page");
+					topicHasActive = true;
+				}
+				li.appendChild(a);
+				linksUl.appendChild(li);
+			}
+
+			if (topicHasActive) topicLi.setAttribute("data-active-topic", "");
+			topicLi.appendChild(linksUl);
+			list.appendChild(topicLi);
+		}
+
+		nav.appendChild(list);
+		host.appendChild(nav);
+	}
+
+	class CourseSidebar extends HTMLElement {
+		connectedCallback() {
+			if (this.childElementCount > 0) return;
+			fetch(manifestUrl)
+				.then((r) => r.json())
+				.then((manifest) => {
+					if (!this.isConnected) return;
+					if (!isInCourseScope(manifest)) {
+						this.remove();
+						return;
+					}
+					render(this, manifest);
+				})
+				.catch(() => {
+					// Fail silently — no sidebar.
+				});
+		}
+	}
+
+	if (!customElements.get("course-sidebar")) {
+		customElements.define("course-sidebar", CourseSidebar);
+	}
+
+	function autoInject() {
+		if (document.querySelector("course-sidebar")) return;
+		// Gate by URL so non-course pages don't get an empty sidebar inserted
+		// and then removed after the manifest fetch (avoids a layout flash).
+		// Exercise/example pages can still opt in by adding <course-sidebar>
+		// manually if desired.
+		if (!/\/course\//.test(location.pathname)) return;
+		const pageWrapper = document.querySelector(".page-wrapper");
+		if (!pageWrapper) return;
+		const el = document.createElement("course-sidebar");
+		pageWrapper.insertBefore(el, pageWrapper.firstChild);
+	}
+
+	if (document.readyState === "loading") {
+		document.addEventListener("DOMContentLoaded", autoInject);
+	} else {
+		autoInject();
+	}
+})();

--- a/components/edit-on-github.js
+++ b/components/edit-on-github.js
@@ -1,5 +1,7 @@
-// Light-DOM custom element. Renders a subtle "Edit this page on GitHub" footer
-// link whose URL is derived from window.location.pathname (issue #402).
+// Light-DOM custom element. Renders MDN's "Help improve this page" footer
+// block (issue #402): a bordered panel offering two contribution paths —
+// directly editing the file on GitHub, or opening an issue with the page
+// path pre-filled. Both URLs are derived from window.location.pathname.
 //
 // Path normalization handles the two deployment surfaces:
 //   - GitHub Pages: /limerick-cobol/course/COBOLIntro.html → course/COBOLIntro.html
@@ -8,9 +10,10 @@
 // edit link still points at a real source file.
 //
 // Light DOM (not shadow DOM) so the .edit-on-github rule in course-components.css
-// applies and the inner <a> picks up the same a:link / a:visited colours as the
-// rest of the page.
+// applies and the inner <a>s pick up the same link colours as the rest of
+// the page.
 const REPO_EDIT_URL = "https://github.com/bushidocodes/limerick-cobol/edit/master/";
+const REPO_ISSUES_URL = "https://github.com/bushidocodes/limerick-cobol/issues/new";
 const GH_PAGES_BASE = "/limerick-cobol/";
 
 function computePagePath() {
@@ -28,12 +31,21 @@ function computePagePath() {
 
 class EditOnGithub extends HTMLElement {
 	connectedCallback() {
-		const href = REPO_EDIT_URL + computePagePath();
+		const pagePath = computePagePath();
+		const editHref = REPO_EDIT_URL + pagePath;
+		const issueParams = new URLSearchParams({
+			title: `Issue on ${pagePath}`,
+			body: `Found a problem with [${pagePath}](https://bushidocodes.github.io/limerick-cobol/${pagePath}):\n\n_describe the issue_\n`,
+		});
+		const issueHref = `${REPO_ISSUES_URL}?${issueParams}`;
 		this.innerHTML = `
-			<p class="edit-on-github">
-				Found a typo or broken link?
-				<a href="${href}" rel="noopener" target="_blank">Edit this page on GitHub</a>.
-			</p>
+			<div class="edit-on-github">
+				<p class="edit-on-github-heading">Help improve this page</p>
+				<ul class="edit-on-github-links">
+					<li><a href="${editHref}" rel="noopener" target="_blank">Edit on GitHub</a></li>
+					<li><a href="${issueHref}" rel="noopener" target="_blank">Report a problem</a></li>
+				</ul>
+			</div>
 		`;
 	}
 }

--- a/components/site-header.js
+++ b/components/site-header.js
@@ -29,6 +29,8 @@
 
 	ensureScript("theme-toggle.js");
 	ensureScript("site-search.js");
+	ensureScript("breadcrumbs.js");
+	ensureScript("course-sidebar.js");
 
 	function inject() {
 		if (document.querySelector(".site-header")) return;

--- a/components/site-header.js
+++ b/components/site-header.js
@@ -19,6 +19,17 @@
 	const homeUrl = baseUrl + "index.html";
 	const faviconUrl = baseUrl + "favicon.svg";
 
+	// Primary nav verticals exposed in the header — mirrors MDN's top tabs.
+	// `dir` is the first URL segment used to detect the active section.
+	// `entry` is the section's known entry page (some use default.html, not
+	// index.html). Keep in sync with TOP_LEVEL_SECTIONS in breadcrumbs.js.
+	const NAV_SECTIONS = [
+		{ label: "Course", dir: "course", entry: "course/index.html" },
+		{ label: "Exercises", dir: "exercises", entry: "exercises/index.html" },
+		{ label: "Examples", dir: "examples", entry: "examples/default.html" },
+		{ label: "Lectures", dir: "lectures", entry: "lectures/index.html" },
+	];
+
 	function ensureScript(filename) {
 		if (document.querySelector(`script[src*="components/${filename}"]`)) return;
 		const s = document.createElement("script");
@@ -32,6 +43,16 @@
 	ensureScript("breadcrumbs.js");
 	ensureScript("course-sidebar.js");
 
+	function buildNavHTML() {
+		const path = location.pathname;
+		const items = NAV_SECTIONS.map((s) => {
+			const isActive = new RegExp("/" + s.dir + "/").test(path);
+			const attrs = isActive ? ' data-active aria-current="page"' : "";
+			return `<li><a href="${baseUrl}${s.entry}"${attrs}>${s.label}</a></li>`;
+		}).join("");
+		return `<nav class="site-nav" aria-label="Primary"><ul>${items}</ul></nav>`;
+	}
+
 	function inject() {
 		if (document.querySelector(".site-header")) return;
 		const header = document.createElement("header");
@@ -39,7 +60,7 @@
 		header.innerHTML =
 			`<a class="site-header__logo" href="${homeUrl}">` +
 			`<img src="${faviconUrl}" alt="COBOL Tutorial" width="32" height="28">` +
-			`</a><theme-toggle></theme-toggle><site-search></site-search>`;
+			`</a>${buildNavHTML()}<theme-toggle></theme-toggle><site-search></site-search>`;
 		const skipLink = document.body.querySelector("a.skip-link");
 		if (skipLink) {
 			skipLink.insertAdjacentElement("afterend", header);

--- a/course/Resources/css/course-components.css
+++ b/course/Resources/css/course-components.css
@@ -3,16 +3,17 @@
    a recurring chunk of legacy presentational HTML (<center>, align="...",
    <table border cellspacing cellpadding>) without changing the rendered output. */
 
-/* Sticky site-wide toolbar — injected by page-hero.js before <main>.
-   Contains theme-toggle and site-search. */
+/* Sticky site-wide toolbar — injected by site-header.js before <main>.
+   Contains the site logo, primary section nav, site-search, and
+   theme-toggle. */
 .site-header {
 	position: sticky;
 	top: 0;
 	z-index: 200;
 	display: grid;
-	grid-template-columns: auto 1fr auto;
+	grid-template-columns: auto auto 1fr auto;
 	align-items: center;
-	column-gap: 0.5em;
+	column-gap: 0.75em;
 	padding: 0.25em 0.5em;
 	background-color: var(--color-bg);
 	border-bottom: 1px solid var(--color-border-mute);
@@ -32,19 +33,92 @@
 	display: block;
 }
 
-.site-header site-search {
+.site-header .site-nav {
 	grid-column: 2;
 	grid-row: 1;
 	display: flex;
 	align-items: center;
 }
 
-.site-header theme-toggle {
+.site-header site-search {
 	grid-column: 3;
+	grid-row: 1;
+	display: flex;
+	align-items: center;
+}
+
+.site-header theme-toggle {
+	grid-column: 4;
 	grid-row: 1;
 	justify-self: end;
 	display: flex;
 	align-items: center;
+}
+
+/* Primary nav — horizontal list of top-level sections (Course, Exercises,
+   Examples, Lectures). Active section gets a bottom-border accent and bold
+   text so the reader always knows which silo they're in (MDN's tab pattern).
+   Hidden below ~720px so the mobile header stays compact — logo + search
+   still reach everything. */
+.site-nav ul {
+	display: flex;
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	gap: 0.25em;
+}
+
+.site-nav li {
+	margin: 0;
+}
+
+.site-nav a {
+	display: inline-block;
+	padding: 0.25em 0.6em;
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 0.9em;
+	text-decoration: none;
+	color: var(--color-text);
+	border-bottom: 2px solid transparent;
+	border-radius: 2px 2px 0 0;
+	line-height: 1.4;
+}
+
+.site-nav a:hover {
+	background-color: var(--color-border-mute);
+}
+
+.site-nav a[data-active] {
+	font-weight: bold;
+	border-bottom-color: var(--color-header-bg);
+}
+
+@media (prefers-color-scheme: dark) {
+	:root:not([data-theme="light"]) .site-nav a[data-active] {
+		border-bottom-color: #ff9966;
+	}
+}
+
+:root[data-theme="dark"] .site-nav a[data-active] {
+	border-bottom-color: #ff9966;
+}
+
+@media (max-width: 720px) {
+	.site-header {
+		grid-template-columns: auto 1fr auto;
+	}
+
+	.site-header .site-nav {
+		display: none;
+	}
+
+	.site-header site-search {
+		grid-column: 2;
+	}
+
+	.site-header theme-toggle {
+		grid-column: 3;
+	}
 }
 
 .site-header .theme-toggle {

--- a/course/Resources/css/course-components.css
+++ b/course/Resources/css/course-components.css
@@ -1763,7 +1763,9 @@ copyright-notice .left {
 
 /* ============================================================================
    edit-on-github custom element (issue #402).
-   Subtle "Edit this page on GitHub" footer affordance. Sits below the
+   MDN-style "Help improve this page" footer panel: a small bordered card
+   offering two contribution paths — edit the file directly on GitHub, or
+   open an issue with the page path pre-filled. Sits below the
    copyright-notice block on content pages; standalone on index pages.
    Light DOM — link colours come from course.css.
    ============================================================================ */
@@ -1773,19 +1775,45 @@ edit-on-github {
 }
 
 .edit-on-github {
-	text-align: center;
 	font-size: 0.85em;
 	margin: 1em 0 0.25em;
-	opacity: 0.75;
-}
-
-.edit-on-github a {
-	text-decoration: underline;
+	padding: 0.5em 0.75em;
+	border: 1px solid var(--color-border-soft);
+	border-radius: 4px;
+	background-color: var(--color-panel-bg);
+	opacity: 0.85;
 }
 
 .edit-on-github:hover,
 .edit-on-github:focus-within {
 	opacity: 1;
+}
+
+.edit-on-github-heading {
+	margin: 0 0 0.25em;
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 0.9em;
+	font-weight: bold;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	color: var(--color-text-muted);
+}
+
+.edit-on-github-links {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.3em 1em;
+}
+
+.edit-on-github-links li {
+	margin: 0;
+}
+
+.edit-on-github-links a {
+	text-decoration: underline;
 }
 
 /* ============================================================================

--- a/course/Resources/css/course-components.css
+++ b/course/Resources/css/course-components.css
@@ -854,15 +854,35 @@ details[open].saq-reveal summary::before {
 	width: 100%;
 }
 
+/* Topic-label is rendered as <h2> by build-lesson-index.js so each topic
+   group becomes an anchorable section (#introduction-to-cobol etc.) and
+   has proper heading semantics. The selector targets both the old div
+   form and the new h2 to keep the build script's output flexible. */
 .topic-label {
 	background-color: var(--color-panel-bg);
 	padding: 4px;
+	margin: 0;
+	font-size: 1em;
+	font-weight: bold;
+	font-family: inherit;
+	line-height: 1.3;
 }
 
 .topic-links {
 	background-color: var(--color-bg);
 	display: flex;
 	flex-direction: column;
+}
+
+/* One-line context blurb rendered above each topic's links. Sits at the
+   top of the topic-links column so it visually pairs with the label on
+   the left without crowding the narrow 225px label column. */
+.topic-description {
+	margin: 0 0 0.5em;
+	padding: 4px 4px 0;
+	font-size: 0.9em;
+	color: var(--color-text-muted);
+	line-height: 1.35;
 }
 
 /* Flexbox rows replace each icon+link layout table */

--- a/course/Resources/css/course-components.css
+++ b/course/Resources/css/course-components.css
@@ -1710,3 +1710,283 @@ last-updated {
 	margin: 0.75em 0 0;
 	opacity: 0.75;
 }
+
+/* ============================================================================
+   breadcrumbs custom element (MDN-style trail above page-hero).
+   Light DOM. Auto-injected by components/breadcrumbs.js. Renders as a small
+   muted-text row with › separators; the current page is non-linked.
+   ============================================================================ */
+
+page-breadcrumbs {
+	display: block;
+	margin: 0 0 0.5em;
+}
+
+.breadcrumbs {
+	font-size: 0.85em;
+	color: var(--color-text-muted);
+}
+
+.breadcrumbs-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0 0.4em;
+}
+
+.breadcrumbs-item {
+	display: inline-flex;
+	align-items: center;
+}
+
+.breadcrumbs-item + .breadcrumbs-item::before {
+	content: "›";
+	margin-right: 0.4em;
+	color: var(--color-text-muted);
+	opacity: 0.6;
+}
+
+.breadcrumbs-item a {
+	text-decoration: none;
+}
+
+.breadcrumbs-item a:hover {
+	text-decoration: underline;
+}
+
+.breadcrumbs-current {
+	color: var(--color-text-muted);
+}
+
+/* ============================================================================
+   course-sidebar custom element (MDN-style left rail).
+   Light DOM. Auto-injected by components/course-sidebar.js on pages within
+   the COBOL course. Renders the full course outline grouped by topic, with
+   the current page highlighted via the same data-active pattern page-toc
+   uses for its scroll-spy.
+
+   Layout interaction:
+   - Below 1100px: hidden. The inline lesson-toc at the top of each page
+     handles per-page navigation; the course index is reachable via the
+     site-header logo link.
+   - 1100-1399px: course-sidebar takes the left rail. If page-toc is also
+     present in the DOM, it is hidden at this width (and lesson-toc is
+     re-shown at the top of the page so the reader still has an in-page
+     index).
+   - 1400px+: three-column layout — course-sidebar left, content middle,
+     page-toc right (mirrors MDN's CSS docs).
+   ============================================================================ */
+
+course-sidebar {
+	display: none;
+}
+
+.course-sidebar {
+	font-size: 0.85em;
+	line-height: 1.4;
+}
+
+.course-sidebar-heading {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 0.9em;
+	font-weight: bold;
+	text-transform: uppercase;
+	letter-spacing: 0.06em;
+	margin: 0 0 0.5em;
+	padding-bottom: 0.3em;
+	border-bottom: 1px solid var(--color-border-soft);
+}
+
+.course-sidebar-heading a {
+	text-decoration: none;
+	color: inherit;
+}
+
+.course-sidebar-heading a:hover {
+	text-decoration: underline;
+}
+
+.course-sidebar-topics {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+}
+
+.course-sidebar-topic {
+	margin: 0 0 1em;
+}
+
+.course-sidebar-topic-label {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 0.85em;
+	font-weight: bold;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	margin: 0 0 0.25em;
+	color: var(--color-text-muted);
+}
+
+.course-sidebar-topic[data-active-topic] .course-sidebar-topic-label {
+	color: var(--color-text);
+}
+
+.course-sidebar-links {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+}
+
+.course-sidebar-link {
+	margin: 0;
+}
+
+.course-sidebar-link a {
+	display: block;
+	padding: 0.25em 0 0.25em 0.7em;
+	border-left: 2px solid transparent;
+	text-decoration: none;
+	line-height: 1.3;
+}
+
+.course-sidebar-link a:hover {
+	border-left-color: var(--color-border-soft);
+}
+
+.course-sidebar-link a[data-active] {
+	border-left-color: var(--color-header-bg);
+	font-weight: bold;
+}
+
+@media (prefers-color-scheme: dark) {
+	:root:not([data-theme="light"]) .course-sidebar-link a[data-active] {
+		border-left-color: #ff9966;
+	}
+}
+
+:root[data-theme="dark"] .course-sidebar-link a[data-active] {
+	border-left-color: #ff9966;
+}
+
+/* Subtle type marker so the reader can tell tutorials from exercises and
+   self-assessment questions at a glance. Matches the icon legend on
+   course/index.html. */
+.course-sidebar-link--exercise a::after,
+.course-sidebar-link--saq a::after,
+.course-sidebar-link--reference a::after {
+	margin-left: 0.4em;
+	font-size: 0.85em;
+	color: var(--color-text-muted);
+	font-weight: normal;
+}
+
+.course-sidebar-link--exercise a::after {
+	content: "ex";
+}
+
+.course-sidebar-link--saq a::after {
+	content: "saq";
+}
+
+.course-sidebar-link--reference a::after {
+	content: "ref";
+}
+
+/* Narrow-desktop band: course-sidebar is the only sidebar visible.
+   The page-wrapper grid is identical in shape to the existing page-toc
+   layout, just keyed on :has(course-sidebar). When :has(page-toc) ALSO
+   matches at this width, the override block further down hides page-toc
+   and re-shows the inline lesson-toc so the reader still has an in-page
+   index. */
+@media (min-width: 1100px) {
+	.page-wrapper:has(course-sidebar) {
+		display: grid;
+		grid-template-columns: 220px minmax(0, 715px);
+		column-gap: 2em;
+		max-width: 967px;
+		border: none;
+		align-items: start;
+	}
+
+	.page-wrapper:has(course-sidebar) > *:not(course-sidebar):not(page-toc) {
+		grid-column: 2;
+		min-width: 0;
+	}
+
+	/* Take course-sidebar out of grid flow with position: fixed.
+	   Why: with grid-row: 1 / -1 (needed for sticky to work over the full
+	   page), the sidebar's tall content (~820px clamped by max-height)
+	   gets distributed across the grid's row tracks. On pages with many
+	   direct .page-wrapper children (RelativeFiles has 36, Iteration has
+	   2), the algorithm inflates one or more rows by hundreds of pixels,
+	   leaving large empty bands in the content column.
+	   Fixed positioning bypasses grid sizing entirely. The grid still
+	   reserves the 220px first column track (empty); the sidebar visually
+	   fills it via viewport-coordinate left/top. Horizontal position
+	   tracks the wrapper's centered left edge:
+	     wrapper-left = max(0, (viewport-width - max-width) / 2)
+	   The 2-col layout uses max-width 967px so the offset is
+	   `max(0px, (50vw - 967px / 2))`. The 3-col layout below overrides
+	   for max-width 1199px. */
+	.page-wrapper:has(course-sidebar) > course-sidebar {
+		display: block;
+		position: fixed;
+		top: calc(var(--site-header-height) + 1em);
+		left: max(0px, calc(50vw - 967px / 2));
+		width: 220px;
+		max-height: calc(100vh - var(--site-header-height) - 2em);
+		overflow-y: auto;
+		padding: 0.5em 0.25em;
+		box-sizing: border-box;
+	}
+}
+
+/* Narrow desktop with both sidebars in the DOM: hide page-toc (no room),
+   re-show the inline lesson-toc / ul.toc so the reader can still jump
+   between page sections. The existing :has(page-toc) rule hides those by
+   default; this override (more specific via the extra :has clause) wins. */
+@media (min-width: 1100px) and (max-width: 1399px) {
+	.page-wrapper:has(course-sidebar):has(page-toc) > page-toc {
+		display: none;
+	}
+
+	.page-wrapper:has(course-sidebar):has(page-toc) lesson-toc,
+	.page-wrapper:has(course-sidebar):has(page-toc) ul.toc {
+		display: block;
+	}
+
+	.page-wrapper:has(course-sidebar):has(page-toc) lesson-toc + hr,
+	.page-wrapper:has(course-sidebar):has(page-toc) ul.toc + hr {
+		display: block;
+	}
+}
+
+/* Wide-desktop three-column layout: course-sidebar left, content middle,
+   page-toc right. Mirrors MDN's CSS reference pages. */
+@media (min-width: 1400px) {
+	.page-wrapper:has(course-sidebar):has(page-toc) {
+		grid-template-columns: 220px minmax(0, 715px) 200px;
+		max-width: 1199px;
+	}
+
+	/* Override the 2-col left offset for the wider 3-col max-width. */
+	.page-wrapper:has(course-sidebar):has(page-toc) > course-sidebar {
+		left: max(0px, calc(50vw - 1199px / 2));
+	}
+
+	.page-wrapper:has(course-sidebar):has(page-toc) > page-toc {
+		grid-column: 3;
+	}
+
+	.page-wrapper:has(course-sidebar):has(page-toc) > *:not(course-sidebar):not(page-toc) {
+		grid-column: 2;
+	}
+}
+
+@media print {
+	course-sidebar,
+	page-breadcrumbs {
+		display: none !important;
+	}
+}

--- a/course/index.html
+++ b/course/index.html
@@ -156,10 +156,13 @@
 				<div class="course-content">
 					<div class="course-topics">
 						<!-- BEGIN:lesson-topics -->
-						<div class="topic-label">
-							<span class="ball-red" aria-hidden="true"></span><strong>Introduction to COBOL</strong>
-						</div>
+						<h2 class="topic-label" id="introduction-to-cobol">
+							<span class="ball-red" aria-hidden="true"></span>Introduction to COBOL
+						</h2>
 						<div class="topic-links">
+							<p class="topic-description">
+								Get your bearings: program structure, data declaration, and the four divisions.
+							</p>
 							<div class="course-link">
 								<span class="course-link-icon"
 									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
@@ -186,10 +189,13 @@
 							</div>
 						</div>
 						<div class="topic-divider"></div>
-						<div class="topic-label">
-							<span class="ball-red" aria-hidden="true"></span><strong>COBOL Control structures</strong>
-						</div>
+						<h2 class="topic-label" id="cobol-control-structures">
+							<span class="ball-red" aria-hidden="true"></span>COBOL Control structures
+						</h2>
 						<div class="topic-links">
+							<p class="topic-description">
+								Branch and loop: IF, EVALUATE, and PERFORM in all its forms.
+							</p>
 							<div class="course-link">
 								<span class="course-link-icon"
 									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
@@ -211,10 +217,14 @@
 							</div>
 						</div>
 						<div class="topic-divider"></div>
-						<div class="topic-label">
-							<span class="ball-red" aria-hidden="true"></span><strong>Simple Sequential Files</strong>
-						</div>
+						<h2 class="topic-label" id="simple-sequential-files">
+							<span class="ball-red" aria-hidden="true"></span>Simple Sequential Files
+						</h2>
 						<div class="topic-links">
+							<p class="topic-description">
+								Read and process file records one at a time — the bread-and-butter pattern for batch
+								COBOL.
+							</p>
 							<div class="course-link">
 								<span class="course-link-icon"
 									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
@@ -237,10 +247,13 @@
 							</div>
 						</div>
 						<div class="topic-divider"></div>
-						<div class="topic-label">
-							<span class="ball-red" aria-hidden="true"></span><strong>Advanced data declaration</strong>
-						</div>
+						<h2 class="topic-label" id="advanced-data-declaration">
+							<span class="ball-red" aria-hidden="true"></span>Advanced data declaration
+						</h2>
 						<div class="topic-links">
+							<p class="topic-description">
+								Edited PICTURE strings and the USAGE clause for richer data representations.
+							</p>
 							<div class="course-link">
 								<span class="course-link-icon"
 									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
@@ -263,10 +276,13 @@
 							</div>
 						</div>
 						<div class="topic-divider"></div>
-						<div class="topic-label">
-							<span class="ball-red" aria-hidden="true"></span><strong>Advanced Sequential Files</strong>
-						</div>
+						<h2 class="topic-label" id="advanced-sequential-files">
+							<span class="ball-red" aria-hidden="true"></span>Advanced Sequential Files
+						</h2>
 						<div class="topic-links">
+							<p class="topic-description">
+								Print files, variable-length records, sorting, merging, and in-place updates.
+							</p>
 							<div class="course-link">
 								<span class="course-link-icon"
 									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
@@ -294,10 +310,13 @@
 							</div>
 						</div>
 						<div class="topic-divider"></div>
-						<div class="topic-label">
-							<span class="ball-red" aria-hidden="true"></span><strong>Direct access files</strong>
-						</div>
+						<h2 class="topic-label" id="direct-access-files">
+							<span class="ball-red" aria-hidden="true"></span>Direct access files
+						</h2>
 						<div class="topic-links">
+							<p class="topic-description">
+								Random-access alternatives to sequential files: relative and indexed organisations.
+							</p>
 							<div class="course-link">
 								<span class="course-link-icon"
 									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
@@ -315,10 +334,14 @@
 							</div>
 						</div>
 						<div class="topic-divider"></div>
-						<div class="topic-label">
-							<span class="ball-red" aria-hidden="true"></span><strong>COBOL tables</strong>
-						</div>
+						<h2 class="topic-label" id="cobol-tables">
+							<span class="ball-red" aria-hidden="true"></span>COBOL tables
+						</h2>
 						<div class="topic-links">
+							<p class="topic-description">
+								Arrays in COBOL — declaring tables, accessing them, and searching with SEARCH / SEARCH
+								ALL.
+							</p>
 							<div class="course-link">
 								<span class="course-link-icon"
 									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
@@ -341,10 +364,13 @@
 							</div>
 						</div>
 						<div class="topic-divider"></div>
-						<div class="topic-label">
-							<span class="ball-red" aria-hidden="true"></span><strong>Constructing large systems</strong>
-						</div>
+						<h2 class="topic-label" id="constructing-large-systems">
+							<span class="ball-red" aria-hidden="true"></span>Constructing large systems
+						</h2>
 						<div class="topic-links">
+							<p class="topic-description">
+								Splitting a program across source files: sub-programs and the COPY verb.
+							</p>
 							<div class="course-link">
 								<span class="course-link-icon"
 									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
@@ -357,10 +383,14 @@
 							</div>
 						</div>
 						<div class="topic-divider"></div>
-						<div class="topic-label">
-							<span class="ball-red" aria-hidden="true"></span><strong>COBOL string handling</strong>
-						</div>
+						<h2 class="topic-label" id="cobol-string-handling">
+							<span class="ball-red" aria-hidden="true"></span>COBOL string handling
+						</h2>
 						<div class="topic-links">
+							<p class="topic-description">
+								Operate on character data: INSPECT, STRING, UNSTRING, reference modification, and
+								intrinsic functions.
+							</p>
 							<div class="course-link">
 								<span class="course-link-icon"
 									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
@@ -383,10 +413,13 @@
 							</div>
 						</div>
 						<div class="topic-divider"></div>
-						<div class="topic-label">
-							<span class="ball-red" aria-hidden="true"></span><strong>The COBOL Report Writer</strong>
-						</div>
+						<h2 class="topic-label" id="the-cobol-report-writer">
+							<span class="ball-red" aria-hidden="true"></span>The COBOL Report Writer
+						</h2>
 						<div class="topic-links">
+							<p class="topic-description">
+								COBOL's built-in reporting facility — by example first, then by syntax and semantics.
+							</p>
 							<div class="course-link">
 								<span class="course-link-icon"
 									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
@@ -399,10 +432,13 @@
 							</div>
 						</div>
 						<div class="topic-divider"></div>
-						<div class="topic-label">
-							<span class="ball-red" aria-hidden="true"></span><strong>Reference</strong>
-						</div>
+						<h2 class="topic-label" id="reference">
+							<span class="ball-red" aria-hidden="true"></span>Reference
+						</h2>
 						<div class="topic-links">
+							<p class="topic-description">
+								Quick lookup for keywords and concepts encountered across the course.
+							</p>
 							<div class="course-link">
 								<span class="course-link-icon"
 									><span class="icon-ref" aria-label="COBOL reference" role="img">R</span></span

--- a/course/lesson-manifest.json
+++ b/course/lesson-manifest.json
@@ -2,6 +2,7 @@
 	"topics": [
 		{
 			"label": "Introduction to COBOL",
+			"description": "Get your bearings: program structure, data declaration, and the four divisions.",
 			"links": [
 				{
 					"type": "tutorial",
@@ -31,6 +32,7 @@
 		},
 		{
 			"label": "COBOL Control structures",
+			"description": "Branch and loop: IF, EVALUATE, and PERFORM in all its forms.",
 			"links": [
 				{ "type": "tutorial", "id": "Selection", "file": "Selection.html", "title": "Selection in COBOL" },
 				{ "type": "tutorial", "id": "Iteration", "file": "Iteration.html", "title": "Iteration in COBOL" },
@@ -48,6 +50,7 @@
 		},
 		{
 			"label": "Simple Sequential Files",
+			"description": "Read and process file records one at a time — the bread-and-butter pattern for batch COBOL.",
 			"links": [
 				{
 					"type": "tutorial",
@@ -71,6 +74,7 @@
 		},
 		{
 			"label": "Advanced data declaration",
+			"description": "Edited PICTURE strings and the USAGE clause for richer data representations.",
 			"links": [
 				{ "type": "tutorial", "id": "EditedPics", "file": "EditedPics.html", "title": "Edited Pictures" },
 				{ "type": "tutorial", "id": "Usage", "file": "Usage.html", "title": "The USAGE clause" },
@@ -88,6 +92,7 @@
 		},
 		{
 			"label": "Advanced Sequential Files",
+			"description": "Print files, variable-length records, sorting, merging, and in-place updates.",
 			"links": [
 				{
 					"type": "tutorial",
@@ -108,6 +113,7 @@
 		},
 		{
 			"label": "Direct access files",
+			"description": "Random-access alternatives to sequential files: relative and indexed organisations.",
 			"links": [
 				{
 					"type": "tutorial",
@@ -121,6 +127,7 @@
 		},
 		{
 			"label": "COBOL tables",
+			"description": "Arrays in COBOL — declaring tables, accessing them, and searching with SEARCH / SEARCH ALL.",
 			"links": [
 				{ "type": "tutorial", "id": "Tables1", "file": "Tables1.html", "title": "Using tables" },
 				{
@@ -135,6 +142,7 @@
 		},
 		{
 			"label": "Constructing large systems",
+			"description": "Splitting a program across source files: sub-programs and the COPY verb.",
 			"links": [
 				{
 					"type": "tutorial",
@@ -147,6 +155,7 @@
 		},
 		{
 			"label": "COBOL string handling",
+			"description": "Operate on character data: INSPECT, STRING, UNSTRING, reference modification, and intrinsic functions.",
 			"links": [
 				{ "type": "tutorial", "id": "Inspect", "file": "Inspect.html", "title": "Inspect" },
 				{ "type": "tutorial", "id": "String", "file": "String.html", "title": "String" },
@@ -161,6 +170,7 @@
 		},
 		{
 			"label": "The COBOL Report Writer",
+			"description": "COBOL's built-in reporting facility — by example first, then by syntax and semantics.",
 			"links": [
 				{
 					"type": "tutorial",
@@ -178,6 +188,7 @@
 		},
 		{
 			"label": "Reference",
+			"description": "Quick lookup for keywords and concepts encountered across the course.",
 			"links": [
 				{ "type": "reference", "file": "glossary.html", "title": "Glossary of COBOL keywords and concepts" }
 			]

--- a/examples/Accept/ACCEPT.html
+++ b/examples/Accept/ACCEPT.html
@@ -43,6 +43,7 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Accept/ACCEPT.html
+++ b/examples/Accept/ACCEPT.html
@@ -43,7 +43,6 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Accept/ACCEPT.html
+++ b/examples/Accept/ACCEPT.html
@@ -42,6 +42,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
 	</head>
 	<body>

--- a/examples/Accept/Multiplier.html
+++ b/examples/Accept/Multiplier.html
@@ -46,6 +46,7 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Accept/Multiplier.html
+++ b/examples/Accept/Multiplier.html
@@ -45,6 +45,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
 	</head>
 	<body>

--- a/examples/Accept/Multiplier.html
+++ b/examples/Accept/Multiplier.html
@@ -46,7 +46,6 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Accept/Shortest.html
+++ b/examples/Accept/Shortest.html
@@ -43,6 +43,7 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Accept/Shortest.html
+++ b/examples/Accept/Shortest.html
@@ -43,7 +43,6 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Accept/Shortest.html
+++ b/examples/Accept/Shortest.html
@@ -42,6 +42,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
 	</head>
 	<body>

--- a/examples/Conditn/Conditions.html
+++ b/examples/Conditn/Conditions.html
@@ -43,6 +43,7 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Conditn/Conditions.html
+++ b/examples/Conditn/Conditions.html
@@ -43,7 +43,6 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Conditn/Conditions.html
+++ b/examples/Conditn/Conditions.html
@@ -42,6 +42,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
 	</head>
 	<body>

--- a/examples/Conditn/IterIf.html
+++ b/examples/Conditn/IterIf.html
@@ -43,6 +43,7 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Conditn/IterIf.html
+++ b/examples/Conditn/IterIf.html
@@ -43,7 +43,6 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Conditn/IterIf.html
+++ b/examples/Conditn/IterIf.html
@@ -42,6 +42,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
 	</head>
 	<body>

--- a/examples/Indexed/DirectReadIdx.html
+++ b/examples/Indexed/DirectReadIdx.html
@@ -48,7 +48,6 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Indexed/DirectReadIdx.html
+++ b/examples/Indexed/DirectReadIdx.html
@@ -48,6 +48,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Indexed/Seq2Index.html
+++ b/examples/Indexed/Seq2Index.html
@@ -36,7 +36,6 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Indexed/Seq2Index.html
+++ b/examples/Indexed/Seq2Index.html
@@ -36,6 +36,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Indexed/SeqReadIdx.html
+++ b/examples/Indexed/SeqReadIdx.html
@@ -45,6 +45,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Indexed/SeqReadIdx.html
+++ b/examples/Indexed/SeqReadIdx.html
@@ -45,7 +45,6 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Merge/Merge.html
+++ b/examples/Merge/Merge.html
@@ -42,7 +42,6 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Merge/Merge.html
+++ b/examples/Merge/Merge.html
@@ -42,6 +42,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Perform/MileageCount.html
+++ b/examples/Perform/MileageCount.html
@@ -46,6 +46,7 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Perform/MileageCount.html
+++ b/examples/Perform/MileageCount.html
@@ -45,6 +45,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
 	</head>
 	<body>

--- a/examples/Perform/MileageCount.html
+++ b/examples/Perform/MileageCount.html
@@ -46,7 +46,6 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Perform/Perform1.html
+++ b/examples/Perform/Perform1.html
@@ -46,6 +46,7 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Perform/Perform1.html
+++ b/examples/Perform/Perform1.html
@@ -45,6 +45,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
 	</head>
 	<body>

--- a/examples/Perform/Perform1.html
+++ b/examples/Perform/Perform1.html
@@ -46,7 +46,6 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Perform/Perform2.html
+++ b/examples/Perform/Perform2.html
@@ -46,6 +46,7 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Perform/Perform2.html
+++ b/examples/Perform/Perform2.html
@@ -45,6 +45,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
 	</head>
 	<body>

--- a/examples/Perform/Perform2.html
+++ b/examples/Perform/Perform2.html
@@ -46,7 +46,6 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Perform/Perform3.html
+++ b/examples/Perform/Perform3.html
@@ -46,6 +46,7 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Perform/Perform3.html
+++ b/examples/Perform/Perform3.html
@@ -45,6 +45,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
 	</head>
 	<body>

--- a/examples/Perform/Perform3.html
+++ b/examples/Perform/Perform3.html
@@ -46,7 +46,6 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Perform/Perform4.html
+++ b/examples/Perform/Perform4.html
@@ -46,6 +46,7 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Perform/Perform4.html
+++ b/examples/Perform/Perform4.html
@@ -45,6 +45,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
 	</head>
 	<body>

--- a/examples/Perform/Perform4.html
+++ b/examples/Perform/Perform4.html
@@ -46,7 +46,6 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Relative/ReadRel.html
+++ b/examples/Relative/ReadRel.html
@@ -45,6 +45,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Relative/ReadRel.html
+++ b/examples/Relative/ReadRel.html
@@ -45,7 +45,6 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Relative/Seq2Rel.html
+++ b/examples/Relative/Seq2Rel.html
@@ -36,7 +36,6 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Relative/Seq2Rel.html
+++ b/examples/Relative/Seq2Rel.html
@@ -36,6 +36,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/ReportWriter/RepWriteA.html
+++ b/examples/ReportWriter/RepWriteA.html
@@ -48,7 +48,6 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/ReportWriter/RepWriteA.html
+++ b/examples/ReportWriter/RepWriteA.html
@@ -48,6 +48,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/ReportWriter/RepWriteB.html
+++ b/examples/ReportWriter/RepWriteB.html
@@ -48,7 +48,6 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/ReportWriter/RepWriteB.html
+++ b/examples/ReportWriter/RepWriteB.html
@@ -48,6 +48,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/ReportWriter/RepWriteFull.html
+++ b/examples/ReportWriter/RepWriteFull.html
@@ -48,7 +48,6 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/ReportWriter/RepWriteFull.html
+++ b/examples/ReportWriter/RepWriteFull.html
@@ -48,6 +48,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/ReportWriter/RepWriteSumm.html
+++ b/examples/ReportWriter/RepWriteSumm.html
@@ -48,7 +48,6 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/ReportWriter/RepWriteSumm.html
+++ b/examples/ReportWriter/RepWriteSumm.html
@@ -48,6 +48,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/SeqIns/SEQINSERT.html
+++ b/examples/SeqIns/SEQINSERT.html
@@ -45,6 +45,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/SeqIns/SEQINSERT.html
+++ b/examples/SeqIns/SEQINSERT.html
@@ -45,7 +45,6 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/SeqRead/SEQREAD.html
+++ b/examples/SeqRead/SEQREAD.html
@@ -42,7 +42,6 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/SeqRead/SEQREAD.html
+++ b/examples/SeqRead/SEQREAD.html
@@ -42,6 +42,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/SeqRead/SEQREADno88.html
+++ b/examples/SeqRead/SEQREADno88.html
@@ -45,6 +45,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/SeqRead/SEQREADno88.html
+++ b/examples/SeqRead/SEQREADno88.html
@@ -45,7 +45,6 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/SeqRpt/SEQRPT.html
+++ b/examples/SeqRpt/SEQRPT.html
@@ -42,7 +42,6 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/SeqRpt/SEQRPT.html
+++ b/examples/SeqRpt/SEQRPT.html
@@ -42,6 +42,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/SeqWrite/SEQWRITE.html
+++ b/examples/SeqWrite/SEQWRITE.html
@@ -45,6 +45,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/SeqWrite/SEQWRITE.html
+++ b/examples/SeqWrite/SEQWRITE.html
@@ -45,7 +45,6 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Sort/InputSort.html
+++ b/examples/Sort/InputSort.html
@@ -42,7 +42,6 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Sort/InputSort.html
+++ b/examples/Sort/InputSort.html
@@ -42,6 +42,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Sort/MaleSort.html
+++ b/examples/Sort/MaleSort.html
@@ -42,7 +42,6 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Sort/MaleSort.html
+++ b/examples/Sort/MaleSort.html
@@ -42,6 +42,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Strings/RefMod.html
+++ b/examples/Strings/RefMod.html
@@ -43,6 +43,7 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Strings/RefMod.html
+++ b/examples/Strings/RefMod.html
@@ -43,7 +43,6 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Strings/RefMod.html
+++ b/examples/Strings/RefMod.html
@@ -42,6 +42,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 		<script src="../../components/run-in-ce.js" defer></script>
 	</head>
 	<body>

--- a/examples/Strings/UnstringFileEg.html
+++ b/examples/Strings/UnstringFileEg.html
@@ -48,7 +48,6 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Strings/UnstringFileEg.html
+++ b/examples/Strings/UnstringFileEg.html
@@ -48,6 +48,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/SubProg/DateValid/DateDriver.html
+++ b/examples/SubProg/DateValid/DateDriver.html
@@ -48,6 +48,7 @@
 		<script src="../../../components/page-hero.js" defer></script>
 		<script src="../../../components/related-content.js" defer></script>
 		<script src="../../../components/copy-button.js" defer></script>
+		<script src="../../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/SubProg/DateValid/DateDriver.html
+++ b/examples/SubProg/DateValid/DateDriver.html
@@ -48,7 +48,6 @@
 		<script src="../../../components/page-hero.js" defer></script>
 		<script src="../../../components/related-content.js" defer></script>
 		<script src="../../../components/copy-button.js" defer></script>
-		<script src="../../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/SubProg/DateValid/ValiDate.html
+++ b/examples/SubProg/DateValid/ValiDate.html
@@ -48,6 +48,7 @@
 		<script src="../../../components/page-hero.js" defer></script>
 		<script src="../../../components/related-content.js" defer></script>
 		<script src="../../../components/copy-button.js" defer></script>
+		<script src="../../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/SubProg/DateValid/ValiDate.html
+++ b/examples/SubProg/DateValid/ValiDate.html
@@ -48,7 +48,6 @@
 		<script src="../../../components/page-hero.js" defer></script>
 		<script src="../../../components/related-content.js" defer></script>
 		<script src="../../../components/copy-button.js" defer></script>
-		<script src="../../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/SubProg/DayDiff/DayDiffDriver.html
+++ b/examples/SubProg/DayDiff/DayDiffDriver.html
@@ -48,6 +48,7 @@
 		<script src="../../../components/page-hero.js" defer></script>
 		<script src="../../../components/related-content.js" defer></script>
 		<script src="../../../components/copy-button.js" defer></script>
+		<script src="../../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/SubProg/DayDiff/DayDiffDriver.html
+++ b/examples/SubProg/DayDiff/DayDiffDriver.html
@@ -48,7 +48,6 @@
 		<script src="../../../components/page-hero.js" defer></script>
 		<script src="../../../components/related-content.js" defer></script>
 		<script src="../../../components/copy-button.js" defer></script>
-		<script src="../../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/SubProg/Multiply/DriverProg.html
+++ b/examples/SubProg/Multiply/DriverProg.html
@@ -48,6 +48,7 @@
 		<script src="../../../components/page-hero.js" defer></script>
 		<script src="../../../components/related-content.js" defer></script>
 		<script src="../../../components/copy-button.js" defer></script>
+		<script src="../../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/SubProg/Multiply/DriverProg.html
+++ b/examples/SubProg/Multiply/DriverProg.html
@@ -48,7 +48,6 @@
 		<script src="../../../components/page-hero.js" defer></script>
 		<script src="../../../components/related-content.js" defer></script>
 		<script src="../../../components/copy-button.js" defer></script>
-		<script src="../../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/SubProg/Multiply/Fickle.html
+++ b/examples/SubProg/Multiply/Fickle.html
@@ -48,6 +48,7 @@
 		<script src="../../../components/page-hero.js" defer></script>
 		<script src="../../../components/related-content.js" defer></script>
 		<script src="../../../components/copy-button.js" defer></script>
+		<script src="../../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/SubProg/Multiply/Fickle.html
+++ b/examples/SubProg/Multiply/Fickle.html
@@ -48,7 +48,6 @@
 		<script src="../../../components/page-hero.js" defer></script>
 		<script src="../../../components/related-content.js" defer></script>
 		<script src="../../../components/copy-button.js" defer></script>
-		<script src="../../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/SubProg/Multiply/MultiplyNums.html
+++ b/examples/SubProg/Multiply/MultiplyNums.html
@@ -48,6 +48,7 @@
 		<script src="../../../components/page-hero.js" defer></script>
 		<script src="../../../components/related-content.js" defer></script>
 		<script src="../../../components/copy-button.js" defer></script>
+		<script src="../../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/SubProg/Multiply/MultiplyNums.html
+++ b/examples/SubProg/Multiply/MultiplyNums.html
@@ -48,7 +48,6 @@
 		<script src="../../../components/page-hero.js" defer></script>
 		<script src="../../../components/related-content.js" defer></script>
 		<script src="../../../components/copy-button.js" defer></script>
-		<script src="../../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/SubProg/Multiply/Steadfast.html
+++ b/examples/SubProg/Multiply/Steadfast.html
@@ -48,6 +48,7 @@
 		<script src="../../../components/page-hero.js" defer></script>
 		<script src="../../../components/related-content.js" defer></script>
 		<script src="../../../components/copy-button.js" defer></script>
+		<script src="../../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/SubProg/Multiply/Steadfast.html
+++ b/examples/SubProg/Multiply/Steadfast.html
@@ -48,7 +48,6 @@
 		<script src="../../../components/page-hero.js" defer></script>
 		<script src="../../../components/related-content.js" defer></script>
 		<script src="../../../components/copy-button.js" defer></script>
-		<script src="../../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Tables/MonthTable.html
+++ b/examples/Tables/MonthTable.html
@@ -45,6 +45,7 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/examples/Tables/MonthTable.html
+++ b/examples/Tables/MonthTable.html
@@ -45,7 +45,6 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/scripts/build-examples.js
+++ b/scripts/build-examples.js
@@ -478,6 +478,7 @@ function buildPage(entry) {
 \t\t<script src="${pfx}components/page-hero.js" defer></script>
 \t\t<script src="${pfx}components/related-content.js" defer></script>
 \t\t<script src="${pfx}components/copy-button.js" defer></script>
+\t\t<script src="${pfx}components/site-header.js" defer></script>
 ${runInCeScript}\t</head>
 \t<body>
 \t\t<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/scripts/build-lesson-index.js
+++ b/scripts/build-lesson-index.js
@@ -28,10 +28,25 @@ const ICON_MAP = {
 	reference: `<span class="icon-ref" aria-label="COBOL reference" role="img">R</span>`,
 };
 
+function slugify(s) {
+	return s
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+}
+
+function escapeHTML(s) {
+	return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
 function buildTopicsHTML(topics) {
 	return topics
 		.map((topic, i) => {
 			const isLast = i === topics.length - 1;
+			const slug = slugify(topic.label);
+			const description = topic.description
+				? `<p class="topic-description">${escapeHTML(topic.description)}</p>`
+				: "";
 			const links = topic.links
 				.map(
 					(link) =>
@@ -39,7 +54,7 @@ function buildTopicsHTML(topics) {
 				)
 				.join("");
 			const divider = isLast ? "" : `<div class="topic-divider"></div>`;
-			return `<div class="topic-label"><span class="ball-red" aria-hidden="true"></span><strong>${topic.label}</strong></div><div class="topic-links">${links}</div>${divider}`;
+			return `<h2 class="topic-label" id="${slug}"><span class="ball-red" aria-hidden="true"></span>${escapeHTML(topic.label)}</h2><div class="topic-links">${description}${links}</div>${divider}`;
 		})
 		.join("");
 }


### PR DESCRIPTION
## Summary

Adds the navigation patterns from MDN's Learn Web Development docs to the COBOL site:

- **Course outline sidebar** (`components/course-sidebar.js`) — left rail on every `/course/` page showing all 25 lessons grouped by topic, with the current page highlighted. Driven by `course/lesson-manifest.json`. Hidden below 1100px (mobile falls back to the existing inline lesson-toc).
- **Breadcrumbs** (`components/breadcrumbs.js`) — hierarchical trail above the page-hero on every non-home page. Top-level sections link to their entry pages; deeper directories render as plain text to avoid 404s.
- **Primary site nav** (`components/site-header.js`) — Course / Exercises / Examples / Lectures tabs in the sticky site header, with the active section highlighted.
- **Anchorable topic sections** (`course/index.html`) — each of the 11 course topics is now an `<h2 id="...">` with a short description, so URLs like `course/index.html#cobol-tables` work and the index is more scannable. Descriptions live in `lesson-manifest.json`; reword whatever doesn't fit.
- **"Help improve this page" footer panel** (`components/edit-on-github.js`) — replaces the inline edit link with an MDN-style bordered panel offering both "Edit on GitHub" and "Report a problem" (the latter opens a pre-filled GitHub issue).

Also propagated `site-header.js` to 38 example pages that were missing it — pre-existing inconsistency, surfaced because the new sidebar/breadcrumb scripts route through site-header's loader chain.

Skipped from the original MDN-inspired suggestion list: admonition callouts (no Note/Warning content to wrap), intro-card (lessons use 3 different structural layouts so a unified card needs careful per-layout handling), lesson-type badges (clean follow-up if you want it).

## Screenshots

Run \`npm run serve\` and visit \`/course/COBOLIntro.html\` — at 1440px the full 3-column MDN-style layout appears (course-sidebar left, content middle, page-toc right); at 1200px page-toc hides and the inline lesson-toc re-shows; below 720px the site-header nav collapses.

Course-sidebar uses \`position: fixed\` rather than \`position: sticky\` with \`grid-row: 1 / -1\` — the latter would distribute its tall content height across grid row tracks, inflating row 1 by hundreds of pixels on pages with many direct \`.page-wrapper\` children (RelativeFiles has 36, Inspect has 21). Bug surfaced and fixed during testing; commit \`768e7d4\` body has the detail.

## Test plan

- [x] \`npm run validate\` passes
- [x] \`npm run links\` passes (spot-checked on COBOLIntro)
- [x] \`npm run format:check\` clean for the files I touched (264 pre-existing CRLF warnings across the repo are unrelated)
- [x] \`npx pa11y\` passes individually on COBOLIntro / Iteration / exercises index (the bulk \`npm run a11y\` hits a port conflict with the dev preview, not actual a11y failures)
- [x] Visually verified at 1440 / 1200 / 700px, light + dark themes, on COBOLIntro (single section-grid), Iteration (page-content + section-grid), and RelativeFiles / Inspect (many section-grids — the row-sizing edge case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)