### PR TITLE
fix: restore missing section HRs, remove duplicate nav entry, and strip stale sidebar icons

### DIFF
--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -144,8 +144,10 @@
 					</div>
 				</div>
 
-				<div class="page-content">
-					<hr />
+				<div class="section-full">
+					<div>
+						<hr />
+					</div>
 				</div>
 
 				<!-- Part 1: Basic User Input and Output -->
@@ -336,9 +338,7 @@ DISPLAY PrinterSetupCodes UPON PrinterPort1.
 					</div>
 					<div class="section-sidebar">
 						<h3>ACCEPT and DISPLAY example program</h3>
-						<p class="center-block">
-							<img height="44" src="Resources/pics/program.gif" width="42" alt="" />
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>
@@ -421,8 +421,10 @@ The time is 14:41
 					</div>
 				</div>
 
-				<div class="page-content">
-					<hr />
+				<div class="section-full">
+					<div>
+						<hr />
+					</div>
 				</div>
 
 				<!-- Part 2: Assignment using the MOVE verb -->
@@ -538,8 +540,10 @@ The time is 14:41
 					</div>
 				</div>
 
-				<div class="page-content">
-					<hr />
+				<div class="section-full">
+					<div>
+						<hr />
+					</div>
 				</div>
 
 				<!-- Part 3: Arithmetic in COBOL -->

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -338,7 +338,6 @@ DISPLAY PrinterSetupCodes UPON PrinterPort1.
 					</div>
 					<div class="section-sidebar">
 						<h3>ACCEPT and DISPLAY example program</h3>
-
 					</div>
 					<div class="section-content">
 						<p>

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -391,9 +391,7 @@
 
 					<div class="section-sidebar">
 						<h3>Simple Insertion examples</h3>
-						<p class="center-block">
-							<img height="46" src="Resources/pics/i-SAQ2.svg" width="32" alt="" />
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>
@@ -580,9 +578,7 @@
 
 					<div class="section-sidebar">
 						<h3>Special Insertion examples</h3>
-						<p class="center-block">
-							<img height="46" src="Resources/pics/i-SAQ2.svg" width="32" alt="" />
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>
@@ -744,9 +740,7 @@
 
 					<div class="section-sidebar">
 						<h3>Fixed Insertion examples</h3>
-						<p class="center-block">
-							<img height="46" src="Resources/pics/i-SAQ2.svg" width="32" alt="" />
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>
@@ -1202,9 +1196,7 @@
 
 					<div class="section-sidebar">
 						<h3>Suppression and Replacement editing examples</h3>
-						<p class="center-block">
-							<img height="46" src="Resources/pics/i-SAQ2.svg" width="32" alt="" />
-						</p>
+
 					</div>
 					<div class="section-content">
 						<table

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -391,7 +391,6 @@
 
 					<div class="section-sidebar">
 						<h3>Simple Insertion examples</h3>
-
 					</div>
 					<div class="section-content">
 						<p>
@@ -578,7 +577,6 @@
 
 					<div class="section-sidebar">
 						<h3>Special Insertion examples</h3>
-
 					</div>
 					<div class="section-content">
 						<p>
@@ -740,7 +738,6 @@
 
 					<div class="section-sidebar">
 						<h3>Fixed Insertion examples</h3>
-
 					</div>
 					<div class="section-content">
 						<p>
@@ -1196,7 +1193,6 @@
 
 					<div class="section-sidebar">
 						<h3>Suppression and Replacement editing examples</h3>
-
 					</div>
 					<div class="section-content">
 						<table

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -188,7 +188,9 @@
 						</table>
 					</div>
 				</div>
-				<div class="section-full"></div>
+				<div class="section-full">
+					<hr />
+				</div>
 				<div class="section-header">
 					<h2 id="inspect">Using the INSPECT</h2>
 				</div>
@@ -306,7 +308,9 @@ Begin.
 						</p>
 					</div>
 				</div>
-				<div class="section-full"></div>
+				<div class="section-full">
+					<hr />
+				</div>
 				<div class="section-header">
 					<h2 id="count">The counting INSPECT</h2>
 				</div>
@@ -349,7 +353,9 @@ INSPECT SourceLine TALLYING ECount
                     BEFORE INITIAL "end".   </code></pre>
 					</div>
 				</div>
-				<div class="section-full"></div>
+				<div class="section-full">
+					<hr />
+				</div>
 				<div class="section-header">
 					<h2 id="replace">The replacing INSPECT</h2>
 				</div>
@@ -476,7 +482,9 @@ END-PERFORM</code></pre>
 						></iframe>
 					</div>
 				</div>
-				<div class="section-full"></div>
+				<div class="section-full">
+					<hr />
+				</div>
 				<div class="section-header">
 					<h2 id="combine">The combined INSPECT</h2>
 				</div>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -452,7 +452,6 @@
 					</div>
 					<div class="section-sidebar">
 						<h3>PERFORM..PROC example</h3>
-
 					</div>
 					<div class="section-content">
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
@@ -484,7 +483,6 @@ ThreeLevelsDown.
 					</div>
 					<div class="section-sidebar">
 						<h3>Self Assessment Questions</h3>
-
 					</div>
 					<div class="section-content">
 						<div>
@@ -606,7 +604,6 @@ Back in TopLevel.
 					</div>
 					<div class="section-sidebar">
 						<h3>Coping with errors</h3>
-
 					</div>
 					<div class="section-content">
 						<p>
@@ -651,7 +648,6 @@ SumSales.
 								paragraph prematurely.
 							</p>
 						</aside>
-
 					</div>
 					<div class="section-content">
 						<p>
@@ -830,7 +826,6 @@ OutOfLineEG.
 					</div>
 					<div class="section-sidebar">
 						<h3>Self Assessment Questions</h3>
-
 					</div>
 					<div class="section-content">
 						<p>Examine the program above and write out what it will display on the screen.</p>
@@ -1145,8 +1140,6 @@ END-PERFORM</code></pre>
 					</div>
 					<div class="section-sidebar">
 						<h3>PERFORM..VARYING Example Program</h3>
-
-
 					</div>
 					<div class="section-content">
 						<p>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -452,9 +452,7 @@
 					</div>
 					<div class="section-sidebar">
 						<h3>PERFORM..PROC example</h3>
-						<p class="center-block">
-							<img height="44" src="Resources/pics/program.gif" width="42" alt="" />
-						</p>
+
 					</div>
 					<div class="section-content">
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
@@ -486,9 +484,7 @@ ThreeLevelsDown.
 					</div>
 					<div class="section-sidebar">
 						<h3>Self Assessment Questions</h3>
-						<p class="center-block">
-							<img height="46" src="Resources/pics/i-SAQ2.svg" width="32" alt="" />
-						</p>
+
 					</div>
 					<div class="section-content">
 						<div>
@@ -610,14 +606,7 @@ Back in TopLevel.
 					</div>
 					<div class="section-sidebar">
 						<h3>Coping with errors</h3>
-						<p class="center-block">
-							<img
-								height="44"
-								src="Resources/pics/program-fragment.svg"
-								width="48"
-								alt="Program fragment"
-							/>
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>
@@ -662,14 +651,7 @@ SumSales.
 								paragraph prematurely.
 							</p>
 						</aside>
-						<p class="center-block">
-							<img
-								height="44"
-								src="Resources/pics/program-fragment.svg"
-								width="48"
-								alt="Program fragment"
-							/>
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>
@@ -848,9 +830,7 @@ OutOfLineEG.
 					</div>
 					<div class="section-sidebar">
 						<h3>Self Assessment Questions</h3>
-						<p class="center-block">
-							<img height="46" src="Resources/pics/i-SAQ2.svg" width="32" alt="" />
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>Examine the program above and write out what it will display on the screen.</p>
@@ -1165,12 +1145,8 @@ END-PERFORM</code></pre>
 					</div>
 					<div class="section-sidebar">
 						<h3>PERFORM..VARYING Example Program</h3>
-						<p class="center-block">
-							<img height="44" src="Resources/pics/program.gif" width="42" alt="" />
-						</p>
-						<p class="center-block">
-							<img height="46" src="Resources/pics/i-SAQ2.svg" width="32" alt="" />
-						</p>
+
+
 					</div>
 					<div class="section-content">
 						<p>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -152,7 +152,9 @@
 					</div>
 				</div>
 				<div class="section-grid"></div>
-				<div class="section-full"></div>
+				<div class="section-full">
+					<hr />
+				</div>
 				<div class="section-header">
 					<h2 id="progs">A look at some programs that use Relative files</h2>
 				</div>
@@ -234,7 +236,9 @@ Enter supplier key (2 digits)-&gt; 05
 						</p>
 					</div>
 				</div>
-				<div class="section-full"></div>
+				<div class="section-full">
+					<hr />
+				</div>
 				<div class="section-header">
 					<h2 id="declare">Relative file - Declarations</h2>
 				</div>
@@ -333,7 +337,9 @@ Enter supplier key (2 digits)-&gt; 05
 						</p>
 					</div>
 				</div>
-				<div class="section-full"></div>
+				<div class="section-full">
+					<hr />
+				</div>
 				<div class="section-header">
 					<h2 id="verbs">Relative file - file processing verbs</h2>
 				</div>
@@ -672,7 +678,9 @@ Enter supplier key (2 digits)-&gt; 05
 						</p>
 					</div>
 				</div>
-				<div class="section-full"></div>
+				<div class="section-full">
+					<hr />
+				</div>
 				<div class="section-header">
 					<h2 id="declaratives">Introduction to Declaratives</h2>
 				</div>

--- a/course/Search.html
+++ b/course/Search.html
@@ -173,7 +173,9 @@
 					</div>
 				</div>
 				<div class="section-grid"></div>
-				<div class="section-full"></div>
+				<div class="section-full">
+					<hr />
+				</div>
 				<div class="section-header">
 					<h2 id="part1">Occurs clause extensions</h2>
 				</div>
@@ -275,7 +277,9 @@
 						</p>
 					</div>
 				</div>
-				<div class="section-full"></div>
+				<div class="section-full">
+					<hr />
+				</div>
 				<div class="section-header">
 					<h2 id="part2">The SEARCH verb</h2>
 				</div>
@@ -403,9 +407,7 @@
 				<div class="section-grid">
 					<div class="section-sidebar">
 						<h3>SEARCH example 1</h3>
-						<p class="center-block">
-							<img height="44" src="Resources/pics/program.gif" width="42" alt="" />
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>
@@ -477,9 +479,7 @@ Begin.
 				<div class="section-grid">
 					<div class="section-sidebar">
 						<h3>Example program 2</h3>
-						<p class="center-block">
-							<img height="44" src="Resources/pics/program.gif" width="42" alt="" />
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>
@@ -598,7 +598,9 @@ DisplayCountyTaxes.
    END-IF.</code></pre>
 					</div>
 				</div>
-				<div class="section-full"></div>
+				<div class="section-full">
+					<hr />
+				</div>
 				<div class="section-header">
 					<h2 id="part3">Searching multi-dimension tables</h2>
 				</div>
@@ -660,9 +662,7 @@ DisplayCountyTaxes.
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<p class="center-block">
-							<img height="44" src="Resources/pics/program.gif" width="42" alt="" />
-						</p>
+
 					</div>
 					<div class="section-content">
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
@@ -768,9 +768,7 @@ LoadTable.
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<p class="center-block">
-							<img height="44" src="Resources/pics/program.gif" width="42" alt="" />
-						</p>
+
 					</div>
 					<div class="section-content">
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
@@ -863,7 +861,9 @@ SEARCH Race
 END-SEARCH</code></pre>
 					</div>
 				</div>
-				<div class="section-full"></div>
+				<div class="section-full">
+					<hr />
+				</div>
 				<div class="section-header">
 					<h2 id="part4">The SEARCH ALL verb</h2>
 				</div>
@@ -1005,9 +1005,7 @@ END-SEARCH.</code></pre>
 				</div>
 				<div class="section-grid">
 					<div class="section-sidebar">
-						<p class="center-block">
-							<img height="44" src="Resources/pics/program.gif" width="42" alt="" />
-						</p>
+
 					</div>
 					<div class="section-content">
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
@@ -1054,9 +1052,7 @@ Begin.
 				<div class="section-grid">
 					<div class="section-sidebar">
 						<h3>Example program</h3>
-						<p class="center-block">
-							<img height="44" src="Resources/pics/program.gif" width="42" alt="" />
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>

--- a/course/Search.html
+++ b/course/Search.html
@@ -407,7 +407,6 @@
 				<div class="section-grid">
 					<div class="section-sidebar">
 						<h3>SEARCH example 1</h3>
-
 					</div>
 					<div class="section-content">
 						<p>
@@ -479,7 +478,6 @@ Begin.
 				<div class="section-grid">
 					<div class="section-sidebar">
 						<h3>Example program 2</h3>
-
 					</div>
 					<div class="section-content">
 						<p>
@@ -661,9 +659,7 @@ DisplayCountyTaxes.
 					</div>
 				</div>
 				<div class="section-grid">
-					<div class="section-sidebar">
-
-					</div>
+					<div class="section-sidebar"></div>
 					<div class="section-content">
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
@@ -767,9 +763,7 @@ LoadTable.
 					</div>
 				</div>
 				<div class="section-grid">
-					<div class="section-sidebar">
-
-					</div>
+					<div class="section-sidebar"></div>
 					<div class="section-content">
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
@@ -1004,9 +998,7 @@ END-SEARCH.</code></pre>
 					</div>
 				</div>
 				<div class="section-grid">
-					<div class="section-sidebar">
-
-					</div>
+					<div class="section-sidebar"></div>
 					<div class="section-content">
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
@@ -1052,7 +1044,6 @@ Begin.
 				<div class="section-grid">
 					<div class="section-sidebar">
 						<h3>Example program</h3>
-
 					</div>
 					<div class="section-content">
 						<p>

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -717,9 +717,7 @@ END-IF
 
 					<div class="section-sidebar">
 						<h3>Nested Ifs</h3>
-						<p class="center-block">
-							<img height="46" src="Resources/pics/i-SAQ2.svg" width="32" alt="" />
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>COBOL allows nested <code class="language-cobol">IF</code> statements.</p>
@@ -1083,14 +1081,7 @@ END-IF
 
 					<div class="section-sidebar">
 						<h3>Using the SET verb with Sequential Files</h3>
-						<p class="center-block">
-							<img
-								height="44"
-								src="Resources/pics/program-fragment.svg"
-								width="48"
-								alt="Program fragment"
-							/>
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -717,7 +717,6 @@ END-IF
 
 					<div class="section-sidebar">
 						<h3>Nested Ifs</h3>
-
 					</div>
 					<div class="section-content">
 						<p>COBOL allows nested <code class="language-cobol">IF</code> statements.</p>
@@ -1081,7 +1080,6 @@ END-IF
 
 					<div class="section-sidebar">
 						<h3>Using the SET verb with Sequential Files</h3>
-
 					</div>
 					<div class="section-content">
 						<p>

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -268,9 +268,7 @@
 					</div>
 					<div class="section-sidebar">
 						<h3>Some implications of "buffers"</h3>
-						<p class="center-block">
-							<img height="44" src="Resources/pics/program.gif" width="42" alt="" />
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>If a program processes more than one file, a record buffer must be defined for each file.</p>
@@ -392,14 +390,7 @@
 					</div>
 					<div class="section-sidebar">
 						<h3>Declaring a record buffer in your program</h3>
-						<p class="center-block">
-							<img
-								height="44"
-								src="Resources/pics/program-fragment.svg"
-								width="48"
-								alt="Program fragment"
-							/>
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>
@@ -433,14 +424,7 @@ FD StudentFile.
 					</div>
 					<div class="section-sidebar">
 						<h3>The SELECT and ASSIGN clause</h3>
-						<p class="center-block">
-							<img
-								height="44"
-								src="Resources/pics/program-fragment.svg"
-								width="48"
-								alt="Program fragment"
-							/>
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>
@@ -784,9 +768,7 @@ SELECT StudentFile
 					</div>
 					<div class="section-sidebar">
 						<h3>Example Program</h3>
-						<p class="center-block">
-							<img height="44" src="Resources/pics/program.gif" width="42" alt="" />
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -268,7 +268,6 @@
 					</div>
 					<div class="section-sidebar">
 						<h3>Some implications of "buffers"</h3>
-
 					</div>
 					<div class="section-content">
 						<p>If a program processes more than one file, a record buffer must be defined for each file.</p>
@@ -390,7 +389,6 @@
 					</div>
 					<div class="section-sidebar">
 						<h3>Declaring a record buffer in your program</h3>
-
 					</div>
 					<div class="section-content">
 						<p>
@@ -424,7 +422,6 @@ FD StudentFile.
 					</div>
 					<div class="section-sidebar">
 						<h3>The SELECT and ASSIGN clause</h3>
-
 					</div>
 					<div class="section-content">
 						<p>
@@ -768,7 +765,6 @@ SELECT StudentFile
 					</div>
 					<div class="section-sidebar">
 						<h3>Example Program</h3>
-
 					</div>
 					<div class="section-content">
 						<p>

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -416,17 +416,8 @@
 					</div>
 					<div class="section-sidebar">
 						<h3>Self Assessment questions</h3>
-						<p class="center-block">
-							<img
-								height="44"
-								src="Resources/pics/program-fragment.svg"
-								width="48"
-								alt="Program fragment"
-							/>
-						</p>
-						<p class="center-block">
-							<img height="46" src="Resources/pics/i-SAQ2.svg" width="32" alt="" />
-						</p>
+
+
 					</div>
 					<div class="section-content">
 						<p>

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -416,8 +416,6 @@
 					</div>
 					<div class="section-sidebar">
 						<h3>Self Assessment questions</h3>
-
-
 					</div>
 					<div class="section-content">
 						<p>

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -197,14 +197,7 @@
 					</div>
 					<div class="section-sidebar">
 						<h3>Declaring a multiple record-type file</h3>
-						<p class="center-block">
-							<img
-								height="44"
-								src="Resources/pics/program-fragment.svg"
-								width="48"
-								alt="Program fragment"
-							/>
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>
@@ -672,9 +665,7 @@ FD TransFile.
 					</div>
 					<div class="section-sidebar">
 						<h3>Bringing it all together.</h3>
-						<p class="center-block">
-							<img height="44" src="Resources/pics/program.gif" width="42" alt="" />
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>The example program below implements the Student Details Report specified above;</p>

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -197,7 +197,6 @@
 					</div>
 					<div class="section-sidebar">
 						<h3>Declaring a multiple record-type file</h3>
-
 					</div>
 					<div class="section-content">
 						<p>
@@ -665,7 +664,6 @@ FD TransFile.
 					</div>
 					<div class="section-sidebar">
 						<h3>Bringing it all together.</h3>
-
 					</div>
 					<div class="section-content">
 						<p>The example program below implements the Student Details Report specified above;</p>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -310,7 +310,6 @@ END-IF</code></pre>
 								characters, but RECORD SEQUENTIAL files are organized as a simple stream of bytes.
 							</p>
 						</aside>
-
 					</div>
 					<div class="section-content">
 						<p>
@@ -832,7 +831,6 @@ CLOSE InFileName</code></pre>
 								table-based solution might also be viable.
 							</p>
 						</aside>
-
 					</div>
 					<div class="section-content">
 						<p>
@@ -981,7 +979,6 @@ PrintReportBody.
 					</div>
 					<div class="section-sidebar">
 						<h3>Feeding the SORT from the keyboard - example program</h3>
-
 					</div>
 					<div class="section-content">
 						<p>
@@ -1245,7 +1242,6 @@ CLOSE OutFile
 					</div>
 					<div class="section-sidebar">
 						<h3>Sales summary file - example program</h3>
-
 					</div>
 					<div class="section-content">
 						<p>
@@ -1317,7 +1313,6 @@ SummariseSales.
 					</div>
 					<div class="section-sidebar">
 						<h3>Revised Foreign Guests Report - example program</h3>
-
 					</div>
 					<div class="section-content">
 						<p>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -174,7 +174,9 @@
 							<li>Understand the significance of the merge keys.</li>
 						</ol>
 					</div>
-					<div class="section-full"></div>
+					<div class="section-full">
+						<hr />
+					</div>
 
 					<div class="section-header">
 						<h2 id="part1">Simple Sorting</h2>
@@ -308,14 +310,7 @@ END-IF</code></pre>
 								characters, but RECORD SEQUENTIAL files are organized as a simple stream of bytes.
 							</p>
 						</aside>
-						<p class="center-block">
-							<img
-								height="44"
-								src="Resources/pics/program-fragment.svg"
-								width="48"
-								alt="Program fragment"
-							/>
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>
@@ -837,9 +832,7 @@ CLOSE InFileName</code></pre>
 								table-based solution might also be viable.
 							</p>
 						</aside>
-						<p class="center-block">
-							<img height="44" src="Resources/pics/program.gif" width="42" alt="" />
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>
@@ -988,9 +981,7 @@ PrintReportBody.
 					</div>
 					<div class="section-sidebar">
 						<h3>Feeding the SORT from the keyboard - example program</h3>
-						<p class="center-block">
-							<img height="44" src="Resources/pics/program.gif" width="42" alt="" />
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>
@@ -1254,9 +1245,7 @@ CLOSE OutFile
 					</div>
 					<div class="section-sidebar">
 						<h3>Sales summary file - example program</h3>
-						<p class="center-block">
-							<img height="44" src="Resources/pics/program.gif" width="42" alt="" />
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>
@@ -1328,9 +1317,7 @@ SummariseSales.
 					</div>
 					<div class="section-sidebar">
 						<h3>Revised Foreign Guests Report - example program</h3>
-						<p class="center-block">
-							<img height="44" src="Resources/pics/program.gif" width="42" alt="" />
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -156,14 +156,7 @@
 					</div>
 					<div class="section-sidebar">
 						<h3>Introduction</h3>
-						<p class="center-block">
-							<img
-								height="44"
-								src="Resources/pics/program-fragment.svg"
-								width="48"
-								alt="Program fragment"
-							/>
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>
@@ -368,14 +361,7 @@ ADD TaxPaid TO CountyTax(CountyCode - 2)</code></pre>
 					</div>
 					<div class="section-sidebar">
 						<h3>The County Tax Report program</h3>
-						<p class="center-block">
-							<img
-								height="44"
-								src="Resources/pics/program-fragment.svg"
-								width="48"
-								alt="Program fragment"
-							/>
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>
@@ -436,14 +422,7 @@ Begin.
 					</div>
 					<div class="section-sidebar">
 						<h3>A table-based solution</h3>
-						<p class="center-block">
-							<img
-								height="44"
-								src="Resources/pics/program-fragment.svg"
-								width="48"
-								alt="Program fragment"
-							/>
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>
@@ -576,14 +555,7 @@ ADD TaxPaid TO CountyTax(CountyNum)</code></pre>
 					</div>
 					<div class="section-sidebar">
 						<h3>Using the subscript from one table as the index into another</h3>
-						<p class="center-block">
-							<img
-								height="44"
-								src="Resources/pics/program-fragment.svg"
-								width="48"
-								alt="Program fragment"
-							/>
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -156,7 +156,6 @@
 					</div>
 					<div class="section-sidebar">
 						<h3>Introduction</h3>
-
 					</div>
 					<div class="section-content">
 						<p>
@@ -361,7 +360,6 @@ ADD TaxPaid TO CountyTax(CountyCode - 2)</code></pre>
 					</div>
 					<div class="section-sidebar">
 						<h3>The County Tax Report program</h3>
-
 					</div>
 					<div class="section-content">
 						<p>
@@ -422,7 +420,6 @@ Begin.
 					</div>
 					<div class="section-sidebar">
 						<h3>A table-based solution</h3>
-
 					</div>
 					<div class="section-content">
 						<p>
@@ -555,7 +552,6 @@ ADD TaxPaid TO CountyTax(CountyNum)</code></pre>
 					</div>
 					<div class="section-sidebar">
 						<h3>Using the subscript from one table as the index into another</h3>
-
 					</div>
 					<div class="section-content">
 						<p>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -364,9 +364,7 @@
 					</div>
 					<div class="section-sidebar">
 						<h3>Table examples and some SAQ's</h3>
-						<p class="center-block">
-							<img height="46" src="Resources/pics/i-SAQ2.svg" width="32" alt="" />
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>
@@ -548,9 +546,7 @@
 					</div>
 					<div class="section-sidebar">
 						<h3>Self Assessment Questions and animated example</h3>
-						<p class="center-block">
-							<img height="46" src="Resources/pics/i-SAQ2.svg" width="32" alt="" />
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>
@@ -599,9 +595,7 @@ MOVE ZEROS TO CountyTaxTable</code></pre>
 					</div>
 					<div class="section-sidebar">
 						<h3>Example program</h3>
-						<p class="center-block">
-							<img height="44" src="Resources/pics/program.gif" width="42" alt="" />
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>
@@ -865,9 +859,7 @@ END-EVALUATE.
 					</div>
 					<div class="section-sidebar">
 						<h3>Self Assessment Questions and examples</h3>
-						<p class="center-block">
-							<img height="46" src="Resources/pics/i-SAQ2.svg" width="32" alt="" />
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>
@@ -1304,9 +1296,7 @@ END-EVALUATE </code></pre>
 					</div>
 					<div class="section-sidebar">
 						<h3>Example program</h3>
-						<p class="center-block">
-							<img height="44" src="Resources/pics/program.gif" width="42" alt="" />
-						</p>
+
 					</div>
 					<div class="section-content">
 						<p>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -364,7 +364,6 @@
 					</div>
 					<div class="section-sidebar">
 						<h3>Table examples and some SAQ's</h3>
-
 					</div>
 					<div class="section-content">
 						<p>
@@ -546,7 +545,6 @@
 					</div>
 					<div class="section-sidebar">
 						<h3>Self Assessment Questions and animated example</h3>
-
 					</div>
 					<div class="section-content">
 						<p>
@@ -595,7 +593,6 @@ MOVE ZEROS TO CountyTaxTable</code></pre>
 					</div>
 					<div class="section-sidebar">
 						<h3>Example program</h3>
-
 					</div>
 					<div class="section-content">
 						<p>
@@ -859,7 +856,6 @@ END-EVALUATE.
 					</div>
 					<div class="section-sidebar">
 						<h3>Self Assessment Questions and examples</h3>
-
 					</div>
 					<div class="section-content">
 						<p>
@@ -1296,7 +1292,6 @@ END-EVALUATE </code></pre>
 					</div>
 					<div class="section-sidebar">
 						<h3>Example program</h3>
-
 					</div>
 					<div class="section-content">
 						<p>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -154,7 +154,11 @@
 							</li>
 						</ol>
 					</div>
-					<div class="section-full"></div>
+					<div class="section-full">
+						<div>
+							<hr />
+						</div>
+					</div>
 					<div class="section-header">
 						<h2 id="part1">The USAGE clause</h2>
 					</div>
@@ -206,14 +210,7 @@
 					</div>
 					<div class="section-sidebar">
 						<h3><strong>Problems with USAGE IS DISPLAY</strong></h3>
-						<p class="center-block">
-							<img
-								height="44"
-								src="Resources/pics/program-fragment.svg"
-								width="48"
-								alt="Program fragment"
-							/>
-						</p>
+
 						<aside>
 							<p class="center-block">
 								<img height="44" src="Resources/pics/i-LightBulbTip.svg" width="42" alt="" />
@@ -2164,14 +2161,7 @@ Begin.
 						<p>
 							<b>USAGE syntax and notes</b>
 						</p>
-						<p class="center-block">
-							<img
-								height="44"
-								src="Resources/pics/program-fragment.svg"
-								width="48"
-								alt="Program fragment"
-							/>
-						</p>
+
 						<aside>
 							<p class="center-block">
 								<img height="62" src="Resources/pics/i-BugAlert.svg" width="56" alt="" />

--- a/course/index.html
+++ b/course/index.html
@@ -280,11 +280,6 @@
 							</div>
 							<div class="course-link">
 								<span class="course-link-icon"
-									><span class="icon-tut" aria-label="COBOL tutorial" role="img">T</span></span
-								><a href="COBOLcommands.html">Basic Procedure Division Commands</a>
-							</div>
-							<div class="course-link">
-								<span class="course-link-icon"
 									><span class="icon-exercise" aria-hidden="true">E</span></span
 								><a href="../exercises/SeqUpdate.html">Updating a Sequential File</a>
 							</div>

--- a/course/lesson-manifest.json
+++ b/course/lesson-manifest.json
@@ -125,12 +125,6 @@
 					"title": "Sorting and Merging"
 				},
 				{
-					"type": "tutorial",
-					"id": "COBOLcommands",
-					"file": "COBOLcommands.html",
-					"title": "Basic Procedure Division Commands"
-				},
-				{
 					"type": "exercise",
 					"file": "../exercises/SeqUpdate.html",
 					"title": "Updating a Sequential File"


### PR DESCRIPTION
## Summary

- **Missing section `<hr>` separators** restored across 6 lesson pages (`COBOLcommands`, `Usage`, `SortMerge`, `RelativeFiles`, `Search`, `Inspect`). These were either empty `<div class="section-full"></div>` elements or used the wrong wrapper class (`page-content` instead of `section-full`), causing sections to run together visually.
- **Duplicate nav entry removed** — `COBOLcommands.html` (Basic Procedure Division Commands) was incorrectly listed a second time under *Advanced Sequential Files* in both `course/index.html` and `course/lesson-manifest.json`. It belongs only under *Introduction to COBOL*. The duplicate was a historical copy-paste error present in the original site.
- **Stale sidebar icons stripped** — 44 decorative `<p class="center-block">` icon elements (`program.gif`, `i-SAQ2.svg`, `program-fragment.svg`) removed from 12 lesson pages. These were vestigial images that rendered as visual noise in the section sidebars.

## Test plan

- [ ] Visit each of the 6 fixed lesson pages and confirm horizontal rules appear between all major sections
- [ ] Open the course sidebar on any lesson page and confirm *Advanced Sequential Files* no longer lists "Basic Procedure Division Commands"
- [ ] Spot-check sidebar content on a few lesson pages (e.g. Iteration, Search, Tables2) to confirm no broken layout where icons were removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)