### PR TITLE
fix: modernize legacy HTML in exercises/Prj-* and Proj-CSISEvalform pages

### DIFF
--- a/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html
+++ b/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html
@@ -42,22 +42,6 @@
 		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
-		<style>
-			<!--
-			.Normal {
-			        font-size: 12.0pt;
-			        font-family: "Times New Roman";
-			}
-
-			.TableHead {
-			        text-align: center;
-			        font-size: 12.0pt;
-			        font-family: Times;
-			        font-variant: small-caps;
-			        font-weight: bold;
-			}
-			-->
-		</style>
 		<script src="../../components/theme-toggle.js" defer></script>
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/site-search.js" defer></script>
@@ -110,124 +94,56 @@
 							The Customer File holds details of all Aromamora customers. It is an indexed file with the
 							following record description.
 						</p>
-						<div style="text-align: center">
+						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
-									<td class="Normal" style="vertical-align: top">
-										<p class="TableHead"><span>&nbsp;</span>Field</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p class="TableHead">
-											<span style="font-variant: normal; text-transform: uppercase"
-												>Key type</span
-											>
-										</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p class="TableHead">
-											<span style="font-variant: normal; text-transform: uppercase">Type</span>
-										</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p class="TableHead">
-											<span style="font-variant: normal; text-transform: uppercase">Length</span>
-										</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p class="TableHead">
-											<span style="font-variant: normal; text-transform: uppercase">Value</span>
-										</p>
-									</td>
+								<tr>
+									<th>Field</th>
+									<th>Key type</th>
+									<th>Type</th>
+									<th>Length</th>
+									<th>Value</th>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Customer-Number</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">Primary</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">9</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">6</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">-</p>
-									</td>
+									<td>Customer-Number</td>
+									<td style="text-align: center">Primary</td>
+									<td style="text-align: center">9</td>
+									<td style="text-align: center">6</td>
+									<td style="text-align: center">-</td>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Customer-Name</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">ALT with Duplicates</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">X</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">25</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">Upper-Case</p>
-									</td>
+									<td>Customer-Name</td>
+									<td style="text-align: center">ALT with Duplicates</td>
+									<td style="text-align: center">X</td>
+									<td style="text-align: center">25</td>
+									<td style="text-align: center">Upper-Case</td>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Customer-Address</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">--</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">X</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">40</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">-</p>
-									</td>
+									<td>Customer-Address</td>
+									<td style="text-align: center">--</td>
+									<td style="text-align: center">X</td>
+									<td style="text-align: center">40</td>
+									<td style="text-align: center">-</td>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Country</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">ALT with Duplicates</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">X</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">15</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">Upper-Case</p>
-									</td>
+									<td>Country</td>
+									<td style="text-align: center">ALT with Duplicates</td>
+									<td style="text-align: center">X</td>
+									<td style="text-align: center">15</td>
+									<td style="text-align: center">Upper-Case</td>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Customer-Balance</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">--</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">9</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">7</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">-99999.99 - 0.0</p>
-									</td>
+									<td>Customer-Balance</td>
+									<td style="text-align: center">--</td>
+									<td style="text-align: center">9</td>
+									<td style="text-align: center">7</td>
+									<td style="text-align: center">-99999.99 - 0.0</td>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Date-Of-Last-Order</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">--</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">9</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">8</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">YYYYMMDD</p>
-									</td>
+									<td>Date-Of-Last-Order</td>
+									<td style="text-align: center">--</td>
+									<td style="text-align: center">9</td>
+									<td style="text-align: center">8</td>
+									<td style="text-align: center">YYYYMMDD</td>
 								</tr>
 							</table>
 						</div>
@@ -249,79 +165,35 @@
 							File.&nbsp; Aromamora customers always pay the exact amount specified on the invoice.
 						</p>
 						<p>The Invoice File is an Indexed file with the following record description;</p>
-						<div style="text-align: center">
+						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
-									<td class="Normal" style="vertical-align: top">
-										<p class="TableHead"><span>&nbsp;</span>Field</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p class="TableHead">
-											<span style="font-variant: normal; text-transform: uppercase"
-												>Key type</span
-											>
-										</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p class="TableHead">
-											<span style="font-variant: normal; text-transform: uppercase">Type</span>
-										</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p class="TableHead">
-											<span style="font-variant: normal; text-transform: uppercase">Length</span>
-										</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p class="TableHead">
-											<span style="font-variant: normal; text-transform: uppercase">Value</span>
-										</p>
-									</td>
+								<tr>
+									<th>Field</th>
+									<th>Key type</th>
+									<th>Type</th>
+									<th>Length</th>
+									<th>Value</th>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Order-Number</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">Primary</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">9</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">7</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">-</p>
-									</td>
+									<td>Order-Number</td>
+									<td style="text-align: center">Primary</td>
+									<td style="text-align: center">9</td>
+									<td style="text-align: center">7</td>
+									<td style="text-align: center">-</td>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Customer-Number</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">ALT with Duplicates</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">9</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">6</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">-</p>
-									</td>
+									<td>Customer-Number</td>
+									<td style="text-align: center">ALT with Duplicates</td>
+									<td style="text-align: center">9</td>
+									<td style="text-align: center">6</td>
+									<td style="text-align: center">-</td>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Invoice-Amount</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">--</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">9</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">7</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">0.01-9999.99</p>
-									</td>
+									<td>Invoice-Amount</td>
+									<td style="text-align: center">--</td>
+									<td style="text-align: center">9</td>
+									<td style="text-align: center">7</td>
+									<td style="text-align: center">0.01-9999.99</td>
 								</tr>
 							</table>
 						</div>
@@ -339,43 +211,43 @@
 							number should be zero suppressed.&nbsp; Change page after line 49 unless the Customer
 							Balance, the Total Amount Outstanding or report footing is the next thing to be printed.
 						</p>
-						<div style="text-align: center">
-							<table>
-								<tr style="vertical-align: top">
+						<div class="center-block">
+							<table class="data-table">
+								<tr>
 									<td><b>Line 1-8&nbsp;&nbsp;</b></td>
 									<td>
 										Page headings.&nbsp; To be printed at the top of each page.&nbsp; The programmer
 										field should contain your name.
 									</td>
 								</tr>
-								<tr style="vertical-align: top">
+								<tr>
 									<td><b>Line 10-15&nbsp;</b></td>
 									<td>
 										Customer Detail lines. Suppress the Customer Name and Customer Number after
 										their first occurrence.&nbsp; See also lines 21-27.
 									</td>
 								</tr>
-								<tr style="vertical-align: top">
+								<tr>
 									<td><b>Line 17&nbsp;</b></td>
 									<td>
 										Customer Balance Line. Amount owed by the customer.&nbsp; Printed at the end of
 										the Customer Detail lines. See also line 30.
 									</td>
 								</tr>
-								<tr style="vertical-align: top">
+								<tr>
 									<td><b>Line 33&nbsp;&nbsp;&nbsp;</b></td>
 									<td>
 										Total amount outstanding.&nbsp; Sum of the amounts owed by each customer.&nbsp;
 										Printed at the end of the report
 									</td>
 								</tr>
-								<tr style="vertical-align: top">
+								<tr>
 									<td><b>Line 36</b></td>
 									<td>Report footing.&nbsp; Printed at the end of the report.</td>
 								</tr>
 							</table>
 						</div>
-						<p style="text-align: center">
+						<p class="center-block">
 							<a href="Prj-AromaInvoicesRpt.gif"
 								><img
 									height="216"

--- a/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html
+++ b/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html
@@ -42,22 +42,6 @@
 		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
-		<style>
-			<!--
-			.Normal {
-			        font-size: 12.0pt;
-			        font-family: "Times New Roman";
-			}
-
-			.TableHead {
-			        text-align: center;
-			        font-size: 12.0pt;
-			        font-family: Times;
-			        font-variant: small-caps;
-			        font-weight: bold;
-			}
-			-->
-		</style>
 		<script src="../../components/theme-toggle.js" defer></script>
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/site-search.js" defer></script>
@@ -122,77 +106,37 @@
 							validated and has been sorted in ascending order on Customer-Id.&nbsp; The records in the
 							Sales File have the following description:
 						</p>
-						<div style="text-align: center">
+						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">
-											<b><span style="text-transform: uppercase">FieldName</span></b>
-										</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">
-											<b><span style="text-transform: uppercase">Type</span></b>
-										</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">
-											<b><span style="text-transform: uppercase">Length</span></b>
-										</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">
-											<b><span style="text-transform: uppercase">Value</span></b>
-										</p>
-									</td>
+								<tr>
+									<th>FieldName</th>
+									<th>Type</th>
+									<th>Length</th>
+									<th>Value</th>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Customer-Id</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">9</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">5</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">&nbsp;0-99999</p>
-									</td>
+									<td>Customer-Id</td>
+									<td style="text-align: center">9</td>
+									<td style="text-align: center">5</td>
+									<td style="text-align: center">0-99999</td>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Oil-Id</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">X</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">3</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">B01-B10 or E01-E30</p>
-									</td>
+									<td>Oil-Id</td>
+									<td style="text-align: center">X</td>
+									<td style="text-align: center">3</td>
+									<td style="text-align: center">B01-B10 or E01-E30</td>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Unit-Size</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">9</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">1</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">1-3</p>
-									</td>
+									<td>Unit-Size</td>
+									<td style="text-align: center">9</td>
+									<td style="text-align: center">1</td>
+									<td style="text-align: center">1-3</td>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Qty-Sold</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">9</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">3</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">1-999</p>
-									</td>
+									<td>Qty-Sold</td>
+									<td style="text-align: center">9</td>
+									<td style="text-align: center">3</td>
+									<td style="text-align: center">1-999</td>
 								</tr>
 							</table>
 						</div>
@@ -204,65 +148,31 @@
 							(CDF.dat).&nbsp;&nbsp; This file is a sequential file <b>ordered</b> on ascending
 							Customer-Id.&nbsp; The records in the Customer Details File have the following description:
 						</p>
-						<div style="text-align: center">
+						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
-									<td class="Normal" style="vertical-align: top">
-										<p class="TableHead">
-											<span style="font-variant: normal; text-transform: uppercase">Field</span>
-										</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p class="TableHead">
-											<span style="font-variant: normal; text-transform: uppercase">Type</span>
-										</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p class="TableHead">
-											<span style="font-variant: normal; text-transform: uppercase">Length</span>
-										</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p class="TableHead">
-											<span style="font-variant: normal; text-transform: uppercase">Value</span>
-										</p>
-									</td>
+								<tr>
+									<th>Field</th>
+									<th>Type</th>
+									<th>Length</th>
+									<th>Value</th>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Customer-Id</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">9</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">5</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">&nbsp;0-99999</p>
-									</td>
+									<td>Customer-Id</td>
+									<td style="text-align: center">9</td>
+									<td style="text-align: center">5</td>
+									<td style="text-align: center">0-99999</td>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Customer-Name</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">X</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">25</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">-</p>
-									</td>
+									<td>Customer-Name</td>
+									<td style="text-align: center">X</td>
+									<td style="text-align: center">25</td>
+									<td style="text-align: center">-</td>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Customer-Address</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">X</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">30</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">-</p>
-									</td>
+									<td>Customer-Address</td>
+									<td style="text-align: center">X</td>
+									<td style="text-align: center">30</td>
+									<td style="text-align: center">-</td>
 								</tr>
 							</table>
 						</div>
@@ -275,65 +185,31 @@
 							elements for the 30 essential oils.&nbsp; Records of the Oil Details File have the following
 							description;
 						</p>
-						<div style="text-align: center">
+						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
-									<td class="Normal" style="vertical-align: top">
-										<p class="TableHead">
-											<span style="font-variant: normal; text-transform: uppercase">Field</span>
-										</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p class="TableHead">
-											<span style="font-variant: normal; text-transform: uppercase">Type</span>
-										</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p class="TableHead">
-											<span style="font-variant: normal; text-transform: uppercase">Length</span>
-										</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p class="TableHead">
-											<span style="font-variant: normal; text-transform: uppercase">Value</span>
-										</p>
-									</td>
+								<tr>
+									<th>Field</th>
+									<th>Type</th>
+									<th>Length</th>
+									<th>Value</th>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Oil-Id</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">X</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">3</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">B01-B10 or E01-E30</p>
-									</td>
+									<td>Oil-Id</td>
+									<td style="text-align: center">X</td>
+									<td style="text-align: center">3</td>
+									<td style="text-align: center">B01-B10 or E01-E30</td>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Oil-Name</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">X</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">20</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">-</p>
-									</td>
+									<td>Oil-Name</td>
+									<td style="text-align: center">X</td>
+									<td style="text-align: center">20</td>
+									<td style="text-align: center">-</td>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Cost-Per-Ml</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">9</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">4</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">0.01-99.99</p>
-									</td>
+									<td>Cost-Per-Ml</td>
+									<td style="text-align: center">9</td>
+									<td style="text-align: center">4</td>
+									<td style="text-align: center">0.01-99.99</td>
 								</tr>
 							</table>
 						</div>
@@ -353,12 +229,12 @@
 							Numeric values must be printed using comma insertion and zero suppression or the floating
 							currency symbol.&nbsp; Change page after line 49 unless the Customer-Totals or the Final
 							Totals are the next thing to be printed.&nbsp; The Customer-Name should be suppressed after
-							its first occurrence unless a customer’s entries span more than one page, when the
+							its first occurrence unless a customer's entries span more than one page, when the
 							Customer-Name should again appear on the new page.
 						</p>
-						<div style="text-align: center">
-							<table>
-								<tr style="vertical-align: top">
+						<div class="center-block">
+							<table class="data-table">
+								<tr>
 									<td><b>Line 1&nbsp;&nbsp;&nbsp;</b></td>
 									<td>
 										Page Heading. To be printed at the top of each page.&nbsp; The programmer field
@@ -366,18 +242,18 @@
 										program.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 									</td>
 								</tr>
-								<tr style="vertical-align: top">
+								<tr>
 									<td><b>Line 3-5&nbsp;</b></td>
 									<td>Report Heading.&nbsp; To be printed on the first page of the report only.</td>
 								</tr>
-								<tr style="vertical-align: top">
+								<tr>
 									<td><b>Line 8&nbsp; &nbsp;</b></td>
 									<td>
 										SalesHeading. To be printed on line 8 for the first page and on lines 3 on each
 										succeeding page. &nbsp;&nbsp;
 									</td>
 								</tr>
-								<tr style="vertical-align: top">
+								<tr>
 									<td><b>Line 9&nbsp;&nbsp;&nbsp;&nbsp;</b></td>
 									<td>
 										&nbsp; Detail line showing the Customer-Name..&nbsp; Qty-Sold is the sum of the
@@ -386,18 +262,18 @@
 										is the value of the oils sold (Qty-Sold * Cost-Per-Ml).
 									</td>
 								</tr>
-								<tr style="vertical-align: top">
+								<tr>
 									<td><b>Line 10</b></td>
 									<td>Detail line with the Customer-Name suppressed.</td>
 								</tr>
-								<tr style="vertical-align: top">
+								<tr>
 									<td><b>Line 14-16&nbsp;&nbsp;&nbsp;</b></td>
 									<td>
 										&nbsp; Totals for the Customer. This is the sum of the Oil Totals. Preceded by
 										one blank line.
 									</td>
 								</tr>
-								<tr style="vertical-align: top">
+								<tr>
 									<td><b>Line 53-55&nbsp;</b></td>
 									<td>
 										Overall totals.&nbsp; This is the sum of the Customer-Totals.&nbsp; To be
@@ -406,7 +282,7 @@
 								</tr>
 							</table>
 						</div>
-						<p style="text-align: center">
+						<p class="center-block">
 							<a href="Prj-AromaOilSalesRpt.gif"
 								><img
 									height="301"

--- a/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html
+++ b/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html
@@ -42,22 +42,6 @@
 		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
-		<style>
-			<!--
-			.Normal {
-			        font-size: 12.0pt;
-			        font-family: "Times New Roman";
-			}
-
-			.TableHead {
-			        text-align: center;
-			        font-size: 12.0pt;
-			        font-family: Times;
-			        font-variant: small-caps;
-			        font-weight: bold;
-			}
-			-->
-		</style>
 		<script src="../../components/theme-toggle.js" defer></script>
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/site-search.js" defer></script>
@@ -139,84 +123,42 @@
 							10 element table.&nbsp; Note that the first two characters of the Course-Code represent the
 							institution. For instance, LM represents the University of Limerick.
 						</p>
-						<div style="text-align: center">
+						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
-									<td class="Normal" style="vertical-align: top">
-										<p><b>&nbsp;&nbsp; Field</b></p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center"><b>Type</b></p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center"><b>Length</b></p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center"><b>Occurrence</b></p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center"><b>Value</b></p>
-									</td>
+								<tr>
+									<th>Field</th>
+									<th>Type</th>
+									<th>Length</th>
+									<th>Occurrence</th>
+									<th>Value</th>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>CAO-Number</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">X</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">8</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">1</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">-</p>
-									</td>
+									<td>CAO-Number</td>
+									<td style="text-align: center">X</td>
+									<td style="text-align: center">8</td>
+									<td style="text-align: center">1</td>
+									<td style="text-align: center">-</td>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Applicant-Name</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">X</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">60</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">1</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">-</p>
-									</td>
+									<td>Applicant-Name</td>
+									<td style="text-align: center">X</td>
+									<td style="text-align: center">60</td>
+									<td style="text-align: center">1</td>
+									<td style="text-align: center">-</td>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Applicant-Address</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">X</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">100</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">1</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">-</p>
-									</td>
+									<td>Applicant-Address</td>
+									<td style="text-align: center">X</td>
+									<td style="text-align: center">100</td>
+									<td style="text-align: center">1</td>
+									<td style="text-align: center">-</td>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Course-Code</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">X</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">5</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">10</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">e.g LM051</p>
-									</td>
+									<td>Course-Code</td>
+									<td style="text-align: center">X</td>
+									<td style="text-align: center">5</td>
+									<td style="text-align: center">10</td>
+									<td style="text-align: center">e.g LM051</td>
 								</tr>
 							</table>
 						</div>
@@ -237,80 +179,42 @@
 							Leaving Certificate results are held in a 14 element table.&nbsp; Each element consists of
 							the Subject-Code and the Subject-Result.
 						</p>
-						<div style="text-align: center">
+						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
-									<td class="Normal" style="vertical-align: top">
-										<p><b>Field</b></p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center"><b>Type</b></p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center"><b>Length</b></p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center"><b>Occurrence</b></p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center"><b>Value</b></p>
-									</td>
+								<tr>
+									<th>Field</th>
+									<th>Type</th>
+									<th>Length</th>
+									<th>Occurrence</th>
+									<th>Value</th>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>CAO-Number</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">X</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">8</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">1</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">-</p>
-									</td>
+									<td>CAO-Number</td>
+									<td style="text-align: center">X</td>
+									<td style="text-align: center">8</td>
+									<td style="text-align: center">1</td>
+									<td style="text-align: center">-</td>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>LC-Result</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">Group</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">Group</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">14</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">-</p>
-									</td>
+									<td>LC-Result</td>
+									<td style="text-align: center">Group</td>
+									<td style="text-align: center">Group</td>
+									<td style="text-align: center">14</td>
+									<td style="text-align: center">-</td>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Subject-Code</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">X</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">3</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">&nbsp;</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">-</p>
-									</td>
+									<td>Subject-Code</td>
+									<td style="text-align: center">X</td>
+									<td style="text-align: center">3</td>
+									<td>&nbsp;</td>
+									<td style="text-align: center">-</td>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Subject-Result</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">X</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">3</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">&nbsp;</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">-</p>
-									</td>
+									<td>Subject-Result</td>
+									<td style="text-align: center">X</td>
+									<td style="text-align: center">3</td>
+									<td>&nbsp;</td>
+									<td style="text-align: center">-</td>
 								</tr>
 							</table>
 						</div>
@@ -320,69 +224,37 @@
 							The Course Points File is a sequential file ordered on ascending CAO-Number.&nbsp; It
 							contains the points awarded for each course application.
 						</p>
-						<div style="text-align: center">
+						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
-									<td class="Normal" style="vertical-align: top">
-										<p><b>&nbsp; Field</b></p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center"><b>Type</b></p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center"><b>Length</b></p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center"><b>Value</b></p>
-									</td>
+								<tr>
+									<th>Field</th>
+									<th>Type</th>
+									<th>Length</th>
+									<th>Value</th>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>CAO-Number</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">X</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">8</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">-&nbsp;&nbsp;&nbsp;</p>
-									</td>
+									<td>CAO-Number</td>
+									<td style="text-align: center">X</td>
+									<td style="text-align: center">8</td>
+									<td style="text-align: center">-</td>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Course-Code</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">X</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">5</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">&nbsp;-</p>
-									</td>
+									<td>Course-Code</td>
+									<td style="text-align: center">X</td>
+									<td style="text-align: center">5</td>
+									<td style="text-align: center">-</td>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Points</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">N</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">3</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">0-999</p>
-									</td>
+									<td>Points</td>
+									<td style="text-align: center">N</td>
+									<td style="text-align: center">3</td>
+									<td style="text-align: center">0-999</td>
 								</tr>
 								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Random-Number</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">N</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">3</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">0-999</p>
-									</td>
+									<td>Random-Number</td>
+									<td style="text-align: center">N</td>
+									<td style="text-align: center">3</td>
+									<td style="text-align: center">0-999</td>
 								</tr>
 							</table>
 						</div>
@@ -391,20 +263,11 @@
 					<section>
 						<h2>The Program</h2>
 						<p>Write a program that creates the Course Points File and generates a report showing;</p>
-						<blockquote>
-							<p>
-								1.<span style="font: 7pt &quot;Times New Roman&quot;">&nbsp;&nbsp;&nbsp;</span> The
-								number of applicants from each county.
-							</p>
-							<p>
-								2.<span style="font: 7pt &quot;Times New Roman&quot;">&nbsp;&nbsp;&nbsp;</span> The
-								number of first choices for each UL course.
-							</p>
-							<p>
-								3.<span style="font: 7pt &quot;Times New Roman&quot;">&nbsp;&nbsp;&nbsp;</span> The
-								number of first choices for the UL.
-							</p>
-						</blockquote>
+						<ol>
+							<li>The number of applicants from each county.</li>
+							<li>The number of first choices for each UL course.</li>
+							<li>The number of first choices for the UL.</li>
+						</ol>
 						<p>The format of the report is left to the programmers discretion.&nbsp;</p>
 						<p>The program should apply to the 26 counties only.</p>
 					</section>
@@ -432,108 +295,70 @@
 							satisfy additional requirements.&nbsp; Applicants who do not satisfy these requirements must
 							be awarded zero points.&nbsp; The additional requirements are as follows;
 						</p>
-						<blockquote>
-							<blockquote>
-								<blockquote>
-									<p>
-										LM020&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; OC3
-										Maths
-									</p>
-									<p>
-										LM021&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; HB3
-										French/German/Spanish/Irish & OB3 Maths
-									</p>
-									<p>
-										LM050&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; OC3
-										Maths
-									</p>
-									<p>
-										LM051&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; OB3/HD3
-										Maths
-									</p>
-								</blockquote>
-							</blockquote>
-						</blockquote>
+						<dl>
+							<dt>LM020</dt>
+							<dd>OC3 Maths</dd>
+							<dt>LM021</dt>
+							<dd>HB3 French/German/Spanish/Irish &amp; OB3 Maths</dd>
+							<dt>LM050</dt>
+							<dd>OC3 Maths</dd>
+							<dt>LM051</dt>
+							<dd>OB3/HD3 Maths</dd>
+						</dl>
 					</section>
 
 					<section>
 						<h2>Leaving Certificate Points System</h2>
 						<p>Standard points are calculated as follows;</p>
-						<div style="text-align: center">
+						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC" style="vertical-align: top">
-									<td>
-										<p><b>Grade&nbsp; &nbsp; Points</b></p>
-									</td>
-									<td>
-										<p><b>Grade&nbsp;&nbsp; Points</b></p>
-									</td>
+								<tr>
+									<th><b>Grade&nbsp; &nbsp; Points</b></th>
+									<th><b>Grade&nbsp;&nbsp; Points</b></th>
 								</tr>
 								<tr>
 									<td>&nbsp;HA1&nbsp; =&nbsp; 100&nbsp;</td>
-									<td>
-										<div style="text-align: left">&nbsp;OA1&nbsp; =&nbsp; 60&nbsp;&nbsp;</div>
-									</td>
+									<td>&nbsp;OA1&nbsp; =&nbsp; 60&nbsp;&nbsp;</td>
 								</tr>
 								<tr>
 									<td>&nbsp;HA2&nbsp; =&nbsp; 90&nbsp;</td>
-									<td>
-										<div style="text-align: left">&nbsp;OA2&nbsp; =&nbsp; 50</div>
-									</td>
+									<td>&nbsp;OA2&nbsp; =&nbsp; 50</td>
 								</tr>
 								<tr>
 									<td>&nbsp;HB1&nbsp; =&nbsp; 85</td>
-									<td>
-										<div style="text-align: left">&nbsp;OB1&nbsp; =&nbsp; 45</div>
-									</td>
+									<td>&nbsp;OB1&nbsp; =&nbsp; 45</td>
 								</tr>
 								<tr>
 									<td>&nbsp;HB2&nbsp; =&nbsp; 80</td>
-									<td>
-										<div style="text-align: left">&nbsp;OB2&nbsp; =&nbsp; 40</div>
-									</td>
+									<td>&nbsp;OB2&nbsp; =&nbsp; 40</td>
 								</tr>
 								<tr>
 									<td>&nbsp;HB3&nbsp; =&nbsp; 75&nbsp;</td>
-									<td>
-										<div style="text-align: left">&nbsp;OB3&nbsp; =&nbsp; 35</div>
-									</td>
+									<td>&nbsp;OB3&nbsp; =&nbsp; 35</td>
 								</tr>
 								<tr>
 									<td>&nbsp;HC1&nbsp; =&nbsp; 70&nbsp;</td>
-									<td>
-										<div style="text-align: left">&nbsp;OC1&nbsp; =&nbsp; 30</div>
-									</td>
+									<td>&nbsp;OC1&nbsp; =&nbsp; 30</td>
 								</tr>
 								<tr>
 									<td>&nbsp;HC2&nbsp; =&nbsp; 65&nbsp;</td>
-									<td>
-										<div style="text-align: left">&nbsp;OC2&nbsp; =&nbsp; 25</div>
-									</td>
+									<td>&nbsp;OC2&nbsp; =&nbsp; 25</td>
 								</tr>
 								<tr>
 									<td>&nbsp;HC3&nbsp; =&nbsp; 60</td>
-									<td>
-										<div style="text-align: left">&nbsp;OC3&nbsp; =&nbsp; 20</div>
-									</td>
+									<td>&nbsp;OC3&nbsp; =&nbsp; 20</td>
 								</tr>
 								<tr>
 									<td>&nbsp;HD1&nbsp; =&nbsp; 55</td>
-									<td>
-										<div style="text-align: left">&nbsp;OD1&nbsp; = 15</div>
-									</td>
+									<td>&nbsp;OD1&nbsp; = 15</td>
 								</tr>
 								<tr>
 									<td>&nbsp;HD2&nbsp; =&nbsp; 50&nbsp;</td>
-									<td>
-										<div style="text-align: left">&nbsp;OD2&nbsp; = 10</div>
-									</td>
+									<td>&nbsp;OD2&nbsp; = 10</td>
 								</tr>
 								<tr>
 									<td>&nbsp;HD3 &nbsp;=&nbsp; 45&nbsp;</td>
-									<td>
-										<div style="text-align: left">&nbsp;OD3&nbsp; =&nbsp; 5</div>
-									</td>
+									<td>&nbsp;OD3&nbsp; =&nbsp; 5</td>
 								</tr>
 							</table>
 						</div>
@@ -548,7 +373,7 @@
 					<section>
 						<h2>Processing</h2>
 						<p>
-							The overall points awarded to a candidate for a course is based on the candidate’s six best
+							The overall points awarded to a candidate for a course is based on the candidate's six best
 							Leaving Certificate subject points scores taking the bonus points into account.&nbsp;
 						</p>
 						<p>
@@ -572,429 +397,223 @@
 							to import the codes into your program.
 						</p>
 						<p>The list of UL courses and their Course Codes is given in the table below.</p>
-						<div style="text-align: center">
+						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#CCFFFF">
-									<td class="Normal" colspan="2" style="vertical-align: top">
-										<div style="text-align: center"><b>UL Courses and Course Codes</b></div>
-									</td>
-								</tr>
-								<tr bgcolor="#FFFFCC">
-									<td class="Normal" style="vertical-align: top">
-										<div style="text-align: center"><b>Course Code</b></div>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<div style="text-align: center"><b>Course Name</b></div>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM020</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.A. Law and Accounting</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM043</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.A. Insurance and European Studies</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM063</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Tech. Production Management</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM051</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Sc Computer Systems</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM059</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Sc. Computer Systems with French</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM060</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Sc Mathematical Sciences and Computing</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM069</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Eng.Computer Engineering</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM070</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Eng.Electronic Engineering</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM080</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Tech.Electronic Systems</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM083</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Tech.Information Technology and Telecommunications</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM062</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Sc. Biomedical & Advanced Materials</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM067</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Tech. Wood Science and Technology</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM071</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Eng. Biomedical Engineering</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM072</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Des. Industrial Design (Jointly with NCAD)</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM073</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Eng. Mechanical Engineering</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM074</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Eng. Computer Integrated Design</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM077</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Eng. Aeronautical Engineering</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM078</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Eng. Mechanical Engineering with a Language (German)</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM079</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Eng.Manufacturing Engineering</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM081</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Tech.Manufacturing Technology</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM050</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.B.S. Business Studies</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM052</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.B.S. Business Studies with French</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM053</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.B.S. Business Studies with German</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM054</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.B.S. Business Studies with Spanish</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM055</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.B.S. Business Studies with Japanese</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM090</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Sc. Physical Education</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM092</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Sc.(Education)</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM094</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Tech.(Education)- Materials and Construction</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM095</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Tech. (Education) – Materials and Engineering</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM096</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Sc. (Education) Physics & Chemistry</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM021</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.A. Languages with Computing</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM030</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.A. Irish Traditional Music and Dance</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM040</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.A. European Studies</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM041</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.A. Public Administration</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM042</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>LL.B. Law and European Studies</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM044</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.A. Applied Languages</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM045</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.A. Language and Cultural Studies</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM046</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.A. History</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM047</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.A. Arts (Offered at Mary Immaculate College)</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM048</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.A. Irish Studies</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM061</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Sc. Industrial Chemistry</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM064</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Sc. Industrial Biochemistry</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM065</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Sc. Applied Physics</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM066</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Sc. Environmental Science</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM068</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Sc. Food Technology</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM089</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Sc. Sports and Exercise Science</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM093</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Sc. Equine Science</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM150</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Sc. Nursing (General)</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM152</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Sc. Nursing (Mental Health)</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM154</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>B.Sc. Nursing (Intellectual Disability)</p>
-									</td>
-								</tr>
-								<tr>
-									<td bgcolor="#FFFFCC" class="Normal" style="vertical-align: top">
-										<p style="text-align: center">LM180</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p>Certificate/Diploma Equine Science</p>
-									</td>
-								</tr>
+								<thead>
+									<tr>
+										<th colspan="2">UL Courses and Course Codes</th>
+									</tr>
+									<tr>
+										<th>Course Code</th>
+										<th>Course Name</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<td style="text-align: center">LM020</td>
+										<td>B.A. Law and Accounting</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM043</td>
+										<td>B.A. Insurance and European Studies</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM063</td>
+										<td>B.Tech. Production Management</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM051</td>
+										<td>B.Sc Computer Systems</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM059</td>
+										<td>B.Sc. Computer Systems with French</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM060</td>
+										<td>B.Sc Mathematical Sciences and Computing</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM069</td>
+										<td>B.Eng.Computer Engineering</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM070</td>
+										<td>B.Eng.Electronic Engineering</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM080</td>
+										<td>B.Tech.Electronic Systems</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM083</td>
+										<td>B.Tech.Information Technology and Telecommunications</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM062</td>
+										<td>B.Sc. Biomedical &amp; Advanced Materials</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM067</td>
+										<td>B.Tech. Wood Science and Technology</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM071</td>
+										<td>B.Eng. Biomedical Engineering</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM072</td>
+										<td>B.Des. Industrial Design (Jointly with NCAD)</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM073</td>
+										<td>B.Eng. Mechanical Engineering</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM074</td>
+										<td>B.Eng. Computer Integrated Design</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM077</td>
+										<td>B.Eng. Aeronautical Engineering</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM078</td>
+										<td>B.Eng. Mechanical Engineering with a Language (German)</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM079</td>
+										<td>B.Eng.Manufacturing Engineering</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM081</td>
+										<td>B.Tech.Manufacturing Technology</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM050</td>
+										<td>B.B.S. Business Studies</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM052</td>
+										<td>B.B.S. Business Studies with French</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM053</td>
+										<td>B.B.S. Business Studies with German</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM054</td>
+										<td>B.B.S. Business Studies with Spanish</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM055</td>
+										<td>B.B.S. Business Studies with Japanese</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM090</td>
+										<td>B.Sc. Physical Education</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM092</td>
+										<td>B.Sc.(Education)</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM094</td>
+										<td>B.Tech.(Education)- Materials and Construction</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM095</td>
+										<td>B.Tech. (Education) – Materials and Engineering</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM096</td>
+										<td>B.Sc. (Education) Physics &amp; Chemistry</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM021</td>
+										<td>B.A. Languages with Computing</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM030</td>
+										<td>B.A. Irish Traditional Music and Dance</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM040</td>
+										<td>B.A. European Studies</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM041</td>
+										<td>B.A. Public Administration</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM042</td>
+										<td>LL.B. Law and European Studies</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM044</td>
+										<td>B.A. Applied Languages</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM045</td>
+										<td>B.A. Language and Cultural Studies</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM046</td>
+										<td>B.A. History</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM047</td>
+										<td>B.A. Arts (Offered at Mary Immaculate College)</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM048</td>
+										<td>B.A. Irish Studies</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM061</td>
+										<td>B.Sc. Industrial Chemistry</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM064</td>
+										<td>B.Sc. Industrial Biochemistry</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM065</td>
+										<td>B.Sc. Applied Physics</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM066</td>
+										<td>B.Sc. Environmental Science</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM068</td>
+										<td>B.Sc. Food Technology</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM089</td>
+										<td>B.Sc. Sports and Exercise Science</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM093</td>
+										<td>B.Sc. Equine Science</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM150</td>
+										<td>B.Sc. Nursing (General)</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM152</td>
+										<td>B.Sc. Nursing (Mental Health)</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM154</td>
+										<td>B.Sc. Nursing (Intellectual Disability)</td>
+									</tr>
+									<tr>
+										<td style="text-align: center">LM180</td>
+										<td>Certificate/Diploma Equine Science</td>
+									</tr>
+								</tbody>
 							</table>
 						</div>
 					</section>

--- a/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html
+++ b/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html
@@ -42,22 +42,6 @@
 		/>
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
-		<style>
-			<!--
-			.Normal {
-			  font-size: 12.0pt;
-			  font-family: "Times New Roman";
-			}
-
-			.TableHead {
-			  text-align: center;
-			  font-size: 12.0pt;
-			  font-family: Times;
-			  font-variant: small-caps;
-			  font-weight: bold;
-			}
-			-->
-		</style>
 		<script src="../../components/theme-toggle.js" defer></script>
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/site-search.js" defer></script>
@@ -120,38 +104,11 @@
 							from one another by commas.&nbsp; The file is unsorted.
 						</p>
 						<p>For your guidance;</p>
-						<blockquote>
-							<blockquote>
-								<blockquote>
-									<blockquote>
-										<p>
-											<span style="font-family: Symbol"
-												>·<span style="font: 7pt &quot;Times New Roman&quot;"
-													>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span
-												></span
-											>
-											the census number is 7 digits in size
-										</p>
-										<p>
-											<span style="font-family: Symbol"
-												>·<span style="font: 7pt &quot;Times New Roman&quot;"
-													>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span
-												></span
-											>
-											the surname is a maximum of 20 characters in size
-										</p>
-										<p>
-											<span style="font-family: Symbol"
-												>·<span style="font: 7pt &quot;Times New Roman&quot;"
-													>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span
-												></span
-											>
-											the county name is a maximum of 9 characters in size.
-										</p>
-									</blockquote>
-								</blockquote>
-							</blockquote>
-						</blockquote>
+						<ul>
+							<li>the census number is 7 digits in size</li>
+							<li>the surname is a maximum of 20 characters in size</li>
+							<li>the county name is a maximum of 9 characters in size.</li>
+						</ul>
 					</section>
 
 					<section>
@@ -170,13 +127,13 @@
 							after line 39 unless the End of Report line is the next line to be printed.
 						</p>
 						<p>See the print specification below for more report format details.&nbsp;</p>
-						<div style="text-align: center">
-							<table>
-								<tr style="vertical-align: top">
+						<div class="center-block">
+							<table class="data-table">
+								<tr>
 									<td>Line 2-5&nbsp;&nbsp;</td>
 									<td>Page Heading. To be printed at the top of each page.</td>
 								</tr>
-								<tr style="vertical-align: top">
+								<tr>
 									<td>Line 6-15</td>
 									<td>
 										Surname lines.&nbsp; The County name is printed only on the first
@@ -185,11 +142,11 @@
 										position 1, the next highest position 2 and so on.
 									</td>
 								</tr>
-								<tr style="vertical-align: top">
+								<tr>
 									<td>Line 44</td>
 									<td>Printed at the end of the report only.</td>
 								</tr>
-								<tr style="vertical-align: top">
+								<tr>
 									<td>Line 46-47</td>
 									<td>
 										Printed at the end of the report only.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The
@@ -199,7 +156,7 @@
 								</tr>
 							</table>
 						</div>
-						<p style="text-align: center">
+						<p class="center-block">
 							<a href="Prj-MunsterSurnamesFreqRpt.gif"
 								><img
 									height="333"

--- a/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html
+++ b/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html
@@ -43,22 +43,6 @@
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
 		<style>
-			<!--
-			.Normal {
-			    font-size: 12.0pt;
-			    font-family: "Times New Roman";
-			}
-
-			.TableHead {
-			    text-align: center;
-			    font-size: 12.0pt;
-			    font-family: Times;
-			    font-variant: small-caps;
-			    font-weight: bold;
-			}
-			-->
-		</style>
-		<style>
 			/* Page-specific: CSS grid layout for the spec body and the
 			   StockNumber check-digit calculation breakdown. Preserved from
 			   the partial modernization that pre-dated the shared theme. */
@@ -149,554 +133,256 @@
 							type code in the first character position.&nbsp; The following transaction types have been
 							identified :-
 						</p>
-						<div style="margin-left: 62px; text-align: left">
-							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">
-											<b><span style="text-transform: uppercase">Trans Type</span></b>
-										</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">
-											<b><span style="text-transform: uppercase">Description</span></b>
-										</p>
-									</td>
-								</tr>
-								<tr>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">1</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">Delete Stock Record</p>
-									</td>
-								</tr>
-								<tr>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">2</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">Insert Stock Record</p>
-									</td>
-								</tr>
-								<tr>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">3</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">Adjust Reorder Level</p>
-									</td>
-								</tr>
-								<tr>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">4</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">Adjust Reorder Qty</p>
-									</td>
-								</tr>
-								<tr>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">5</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">Adjust Price</p>
-									</td>
-								</tr>
-								<tr>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">6</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">Delete Supplier Record</p>
-									</td>
-								</tr>
-								<tr>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">7</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">Insert Supplier Record</p>
-									</td>
-								</tr>
-							</table>
-						</div>
+						<table class="data-table">
+							<tr>
+								<th>Trans Type</th>
+								<th>Description</th>
+							</tr>
+							<tr>
+								<td style="text-align: center">1</td>
+								<td style="text-align: center">Delete Stock Record</td>
+							</tr>
+							<tr>
+								<td style="text-align: center">2</td>
+								<td style="text-align: center">Insert Stock Record</td>
+							</tr>
+							<tr>
+								<td style="text-align: center">3</td>
+								<td style="text-align: center">Adjust Reorder Level</td>
+							</tr>
+							<tr>
+								<td style="text-align: center">4</td>
+								<td style="text-align: center">Adjust Reorder Qty</td>
+							</tr>
+							<tr>
+								<td style="text-align: center">5</td>
+								<td style="text-align: center">Adjust Price</td>
+							</tr>
+							<tr>
+								<td style="text-align: center">6</td>
+								<td style="text-align: center">Delete Supplier Record</td>
+							</tr>
+							<tr>
+								<td style="text-align: center">7</td>
+								<td style="text-align: center">Insert Supplier Record</td>
+							</tr>
+						</table>
 						<p>
 							<b>Transaction Record Descriptions</b><br />
 							Descriptions of the different types of transaction record are shown below.
 						</p>
 
-						<p style="text-align: left"><b>Delete Stock Record</b></p>
-						<div style="text-align: left">
-							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">
-											<b><span style="text-transform: uppercase">FieldName</span></b>
-										</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">
-											<b><span style="text-transform: uppercase">Type</span></b>
-										</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">
-											<b><span style="text-transform: uppercase">Length</span></b>
-										</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">
-											<b><span style="text-transform: uppercase">Format</span></b>
-										</p>
-									</td>
-								</tr>
-								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Transaction-Type</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">Numeric</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">1</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">Value 1</p>
-									</td>
-								</tr>
-								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Stock-Number</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">Character</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">7</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">9999999</p>
-									</td>
-								</tr>
-							</table>
-						</div>
+						<p><b>Delete Stock Record</b></p>
+						<table class="data-table">
+							<tr>
+								<th>FieldName</th>
+								<th>Type</th>
+								<th>Length</th>
+								<th>Format</th>
+							</tr>
+							<tr>
+								<td>Transaction-Type</td>
+								<td style="text-align: center">Numeric</td>
+								<td style="text-align: center">1</td>
+								<td style="text-align: center">Value 1</td>
+							</tr>
+							<tr>
+								<td>Stock-Number</td>
+								<td style="text-align: center">Character</td>
+								<td style="text-align: center">7</td>
+								<td style="text-align: center">9999999</td>
+							</tr>
+						</table>
 
 						<p><b>Insert Stock Record</b></p>
-						<div style="text-align: left">
-							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">
-											<b><span style="text-transform: uppercase">FieldName</span></b>
-										</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">
-											<b><span style="text-transform: uppercase">Type</span></b>
-										</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">
-											<b><span style="text-transform: uppercase">Length</span></b>
-										</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">
-											<b><span style="text-transform: uppercase">Format</span></b>
-										</p>
-									</td>
-								</tr>
-								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Transaction-Type</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">Numeric</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">1</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">Value 2</p>
-									</td>
-								</tr>
-								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Stock-Number</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">Numeric</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">7</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">9999999</p>
-									</td>
-								</tr>
-								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Qty-In-Stock</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">Numeric</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">5</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">99999</p>
-									</td>
-								</tr>
-								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Price</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">Numeric</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">6</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">9999.99</p>
-									</td>
-								</tr>
-								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Reorder-Level</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">Numeric</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">3</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">999</p>
-									</td>
-								</tr>
-								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Reorder-Qty</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">Numeric</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">5</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">99999</p>
-									</td>
-								</tr>
-								<tr>
-									<td class="Normal" style="vertical-align: top"><p>Supplier-Number</p></td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">Character</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">4</p>
-									</td>
-									<td class="Normal" style="vertical-align: top">
-										<p style="text-align: center">X999</p>
-									</td>
-								</tr>
-							</table>
-						</div>
+						<table class="data-table">
+							<tr>
+								<th>FieldName</th>
+								<th>Type</th>
+								<th>Length</th>
+								<th>Format</th>
+							</tr>
+							<tr>
+								<td>Transaction-Type</td>
+								<td style="text-align: center">Numeric</td>
+								<td style="text-align: center">1</td>
+								<td style="text-align: center">Value 2</td>
+							</tr>
+							<tr>
+								<td>Stock-Number</td>
+								<td style="text-align: center">Numeric</td>
+								<td style="text-align: center">7</td>
+								<td style="text-align: center">9999999</td>
+							</tr>
+							<tr>
+								<td>Qty-In-Stock</td>
+								<td style="text-align: center">Numeric</td>
+								<td style="text-align: center">5</td>
+								<td style="text-align: center">99999</td>
+							</tr>
+							<tr>
+								<td>Price</td>
+								<td style="text-align: center">Numeric</td>
+								<td style="text-align: center">6</td>
+								<td style="text-align: center">9999.99</td>
+							</tr>
+							<tr>
+								<td>Reorder-Level</td>
+								<td style="text-align: center">Numeric</td>
+								<td style="text-align: center">3</td>
+								<td style="text-align: center">999</td>
+							</tr>
+							<tr>
+								<td>Reorder-Qty</td>
+								<td style="text-align: center">Numeric</td>
+								<td style="text-align: center">5</td>
+								<td style="text-align: center">99999</td>
+							</tr>
+							<tr>
+								<td>Supplier-Number</td>
+								<td style="text-align: center">Character</td>
+								<td style="text-align: center">4</td>
+								<td style="text-align: center">X999</td>
+							</tr>
+						</table>
 
 						<p class="recorddesc"><b>Adjust Reorder Level</b></p>
 						<table class="data-table">
-							<tr bgcolor="#FFFFCC">
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">FieldName</span></b>
-									</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">Type</span></b>
-									</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">Length</span></b>
-									</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">Format</span></b>
-									</p>
-								</td>
+							<tr>
+								<th>FieldName</th>
+								<th>Type</th>
+								<th>Length</th>
+								<th>Format</th>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>Transaction-Type</p></td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">Numeric</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">1</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">Value 3</p>
-								</td>
+								<td>Transaction-Type</td>
+								<td style="text-align: center">Numeric</td>
+								<td style="text-align: center">1</td>
+								<td style="text-align: center">Value 3</td>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>Stock-Number</p></td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">Numeric</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">7</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">9999999</p>
-								</td>
+								<td>Stock-Number</td>
+								<td style="text-align: center">Numeric</td>
+								<td style="text-align: center">7</td>
+								<td style="text-align: center">9999999</td>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>Reorder-Level</p></td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">Numeric</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">3</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">999</p>
-								</td>
+								<td>Reorder-Level</td>
+								<td style="text-align: center">Numeric</td>
+								<td style="text-align: center">3</td>
+								<td style="text-align: center">999</td>
 							</tr>
 						</table>
 
 						<p class="recorddesc"><b>Adjust Reorder Qty</b></p>
 						<table class="data-table">
-							<tr bgcolor="#FFFFCC">
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">FieldName</span></b>
-									</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">Type</span></b>
-									</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">Length</span></b>
-									</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">Format</span></b>
-									</p>
-								</td>
+							<tr>
+								<th>FieldName</th>
+								<th>Type</th>
+								<th>Length</th>
+								<th>Format</th>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>Transaction-Type</p></td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">Numeric</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">1</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">Value 4</p>
-								</td>
+								<td>Transaction-Type</td>
+								<td style="text-align: center">Numeric</td>
+								<td style="text-align: center">1</td>
+								<td style="text-align: center">Value 4</td>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>Stock-Number</p></td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">Numeric</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">7</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">9999999</p>
-								</td>
+								<td>Stock-Number</td>
+								<td style="text-align: center">Numeric</td>
+								<td style="text-align: center">7</td>
+								<td style="text-align: center">9999999</td>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>Reorder-Qty</p></td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">Numeric</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">5</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">99999</p>
-								</td>
+								<td>Reorder-Qty</td>
+								<td style="text-align: center">Numeric</td>
+								<td style="text-align: center">5</td>
+								<td style="text-align: center">99999</td>
 							</tr>
 						</table>
 
 						<p class="recorddesc"><b>Adjust Price</b></p>
 						<table class="data-table">
-							<tr bgcolor="#FFFFCC">
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">FieldName</span></b>
-									</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">Type</span></b>
-									</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">Length</span></b>
-									</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">Format</span></b>
-									</p>
-								</td>
+							<tr>
+								<th>FieldName</th>
+								<th>Type</th>
+								<th>Length</th>
+								<th>Format</th>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>Transaction-Type</p></td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">Numeric</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">1</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">Value 5</p>
-								</td>
+								<td>Transaction-Type</td>
+								<td style="text-align: center">Numeric</td>
+								<td style="text-align: center">1</td>
+								<td style="text-align: center">Value 5</td>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>Stock-Number</p></td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">Numeric</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">7</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">9999999</p>
-								</td>
+								<td>Stock-Number</td>
+								<td style="text-align: center">Numeric</td>
+								<td style="text-align: center">7</td>
+								<td style="text-align: center">9999999</td>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>Price</p></td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">Numeric</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">6</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">9999.99</p>
-								</td>
+								<td>Price</td>
+								<td style="text-align: center">Numeric</td>
+								<td style="text-align: center">6</td>
+								<td style="text-align: center">9999.99</td>
 							</tr>
 						</table>
 
 						<p class="recorddesc"><b>Delete Supplier Record</b></p>
 						<table class="data-table">
-							<tr bgcolor="#FFFFCC">
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">FieldName</span></b>
-									</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">Type</span></b>
-									</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">Length</span></b>
-									</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">Format</span></b>
-									</p>
-								</td>
+							<tr>
+								<th>FieldName</th>
+								<th>Type</th>
+								<th>Length</th>
+								<th>Format</th>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>Transaction-Type</p></td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">Numeric</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">1</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">Value 6</p>
-								</td>
+								<td>Transaction-Type</td>
+								<td style="text-align: center">Numeric</td>
+								<td style="text-align: center">1</td>
+								<td style="text-align: center">Value 6</td>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>Supplier-Number</p></td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">Character</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">4</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">X999</p>
-								</td>
+								<td>Supplier-Number</td>
+								<td style="text-align: center">Character</td>
+								<td style="text-align: center">4</td>
+								<td style="text-align: center">X999</td>
 							</tr>
 						</table>
 
 						<p class="recorddesc"><b>Insert Supplier Record</b></p>
 						<table class="data-table">
-							<tr bgcolor="#FFFFCC">
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">FieldName</span></b>
-									</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">Type</span></b>
-									</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">Length</span></b>
-									</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">Format</span></b>
-									</p>
-								</td>
+							<tr>
+								<th>FieldName</th>
+								<th>Type</th>
+								<th>Length</th>
+								<th>Format</th>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>Transaction-Type</p></td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">9</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">1</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">Value 7</p>
-								</td>
+								<td>Transaction-Type</td>
+								<td style="text-align: center">9</td>
+								<td style="text-align: center">1</td>
+								<td style="text-align: center">Value 7</td>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>Supplier-Number</p></td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">X</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">4</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">X999</p>
-								</td>
+								<td>Supplier-Number</td>
+								<td style="text-align: center">X</td>
+								<td style="text-align: center">4</td>
+								<td style="text-align: center">X999</td>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>Supplier-Name</p></td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">X</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">20</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">-</p>
-								</td>
+								<td>Supplier-Name</td>
+								<td style="text-align: center">X</td>
+								<td style="text-align: center">20</td>
+								<td style="text-align: center">-</td>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>Supplier-Address</p></td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">X</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">35</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">-</p>
-								</td>
+								<td>Supplier-Address</td>
+								<td style="text-align: center">X</td>
+								<td style="text-align: center">35</td>
+								<td style="text-align: center">-</td>
 							</tr>
 						</table>
 					</section>
@@ -706,189 +392,87 @@
 						<h3>The Stock Master File</h3>
 						<p>The Stock Master File is an Indexed file with the following record description.</p>
 						<table class="data-table">
-							<tr bgcolor="#FFFFCC">
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">FieldName</span></b>
-									</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">Key type</span></b>
-									</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">Type</span></b>
-									</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">Length</span></b>
-									</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">Format</span></b>
-									</p>
-								</td>
+							<tr>
+								<th>FieldName</th>
+								<th>Key type</th>
+								<th>Type</th>
+								<th>Length</th>
+								<th>Format</th>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>StockNumber</p></td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">Primary</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">9</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">7</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">9999999</p>
-								</td>
+								<td>StockNumber</td>
+								<td style="text-align: center">Primary</td>
+								<td style="text-align: center">9</td>
+								<td style="text-align: center">7</td>
+								<td style="text-align: center">9999999</td>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>QtyInStock</p></td>
-								<td class="Normal" style="vertical-align: top">&nbsp;</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">9</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">5</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">99999</p>
-								</td>
+								<td>QtyInStock</td>
+								<td>&nbsp;</td>
+								<td style="text-align: center">9</td>
+								<td style="text-align: center">5</td>
+								<td style="text-align: center">99999</td>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>Price</p></td>
-								<td class="Normal" style="vertical-align: top">&nbsp;</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">9</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">6</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">9999.99</p>
-								</td>
+								<td>Price</td>
+								<td>&nbsp;</td>
+								<td style="text-align: center">9</td>
+								<td style="text-align: center">6</td>
+								<td style="text-align: center">9999.99</td>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>ReorderLevel</p></td>
-								<td class="Normal" style="vertical-align: top">&nbsp;</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">9</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">3</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">999</p>
-								</td>
+								<td>ReorderLevel</td>
+								<td>&nbsp;</td>
+								<td style="text-align: center">9</td>
+								<td style="text-align: center">3</td>
+								<td style="text-align: center">999</td>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>ReorderQty</p></td>
-								<td class="Normal" style="vertical-align: top">&nbsp;</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">9</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">5</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">99999</p>
-								</td>
+								<td>ReorderQty</td>
+								<td>&nbsp;</td>
+								<td style="text-align: center">9</td>
+								<td style="text-align: center">5</td>
+								<td style="text-align: center">99999</td>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>SupplierNumber</p></td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">ALT with Duplicates</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">X</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">4</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">X999</p>
-								</td>
+								<td>SupplierNumber</td>
+								<td style="text-align: center">ALT with Duplicates</td>
+								<td style="text-align: center">X</td>
+								<td style="text-align: center">4</td>
+								<td style="text-align: center">X999</td>
 							</tr>
 						</table>
 
 						<h3>The Supplier Master File</h3>
 						<p>The Supplier Master File is an Indexed file with the following record description.</p>
 						<table class="data-table">
-							<tr bgcolor="#FFFFCC">
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">FieldName</span></b>
-									</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">Key type</span></b>
-									</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">Type</span></b>
-									</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">Length</span></b>
-									</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">Format</span></b>
-									</p>
-								</td>
+							<tr>
+								<th>FieldName</th>
+								<th>Key type</th>
+								<th>Type</th>
+								<th>Length</th>
+								<th>Format</th>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>SupplierNumber</p></td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">Primary</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">X</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">4</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">X999</p>
-								</td>
+								<td>SupplierNumber</td>
+								<td style="text-align: center">Primary</td>
+								<td style="text-align: center">X</td>
+								<td style="text-align: center">4</td>
+								<td style="text-align: center">X999</td>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>SupplierName</p></td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">ALT with Duplicates</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">X</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">20</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">-</p>
-								</td>
+								<td>SupplierName</td>
+								<td style="text-align: center">ALT with Duplicates</td>
+								<td style="text-align: center">X</td>
+								<td style="text-align: center">20</td>
+								<td style="text-align: center">-</td>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>SupplierAddress</p></td>
-								<td class="Normal" style="vertical-align: top">&nbsp;</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">X</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">40</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">-</p>
-								</td>
+								<td>SupplierAddress</td>
+								<td>&nbsp;</td>
+								<td style="text-align: center">X</td>
+								<td style="text-align: center">40</td>
+								<td style="text-align: center">-</td>
 							</tr>
 						</table>
 					</section>
@@ -897,99 +481,47 @@
 						<h2>The Stock Archive File</h2>
 						<p>The Stock Archive File is a sequential file with the following record description.</p>
 						<table class="data-table">
-							<tr bgcolor="#FFFFCC">
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">FieldName</span></b>
-									</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">Type</span></b>
-									</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">Length</span></b>
-									</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">
-										<b><span style="text-transform: uppercase">Format</span></b>
-									</p>
-								</td>
+							<tr>
+								<th>FieldName</th>
+								<th>Type</th>
+								<th>Length</th>
+								<th>Format</th>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>StockNumber</p></td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">9</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">7</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">9999999</p>
-								</td>
+								<td>StockNumber</td>
+								<td style="text-align: center">9</td>
+								<td style="text-align: center">7</td>
+								<td style="text-align: center">9999999</td>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>QtyInStock</p></td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">9</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">5</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">99999</p>
-								</td>
+								<td>QtyInStock</td>
+								<td style="text-align: center">9</td>
+								<td style="text-align: center">5</td>
+								<td style="text-align: center">99999</td>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>Price</p></td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">9</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">6</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">9999.99</p>
-								</td>
+								<td>Price</td>
+								<td style="text-align: center">9</td>
+								<td style="text-align: center">6</td>
+								<td style="text-align: center">9999.99</td>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>ReorderLevel</p></td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">9</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">3</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">999</p>
-								</td>
+								<td>ReorderLevel</td>
+								<td style="text-align: center">9</td>
+								<td style="text-align: center">3</td>
+								<td style="text-align: center">999</td>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>ReorderQty</p></td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">9</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">5</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">99999</p>
-								</td>
+								<td>ReorderQty</td>
+								<td style="text-align: center">9</td>
+								<td style="text-align: center">5</td>
+								<td style="text-align: center">99999</td>
 							</tr>
 							<tr>
-								<td class="Normal" style="vertical-align: top"><p>SupplierNumber</p></td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">X</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">4</p>
-								</td>
-								<td class="Normal" style="vertical-align: top">
-									<p style="text-align: center">X999</p>
-								</td>
+								<td>SupplierNumber</td>
+								<td style="text-align: center">X</td>
+								<td style="text-align: center">4</td>
+								<td style="text-align: center">X999</td>
 							</tr>
 						</table>
 					</section>

--- a/exercises/Proj-CSISEvalform/CSISEvalForm.html
+++ b/exercises/Proj-CSISEvalform/CSISEvalForm.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en-GB">
+<html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
@@ -7,12 +7,22 @@
 		<script>
 			(function () {
 				var t = localStorage.getItem("lc-theme");
-				if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+				if (t === "dark" || t === "light") {
+					document.documentElement.setAttribute("data-theme", t);
+					var color = t === "dark" ? "#1a1a1a" : "#ffffff";
+					var meta = document.querySelector('meta[name="theme-color"]:not([media])');
+					if (!meta) {
+						meta = document.createElement("meta");
+						meta.name = "theme-color";
+						document.head.appendChild(meta);
+					}
+					meta.content = color;
+				}
 			})();
 		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
-		<title>Zoom taxis DP291 Cobol project</title>
+		<title>CSIS Web Site Evaluation Form Report</title>
 		<meta
 			name="description"
 			content="Visitors to the CSIS web site are asked to fill in an evaluation form. The form requests the name of the visitor, his/her country of origin, his/her"
@@ -27,7 +37,7 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/exercises/Proj-CSISEvalform/CSISEvalForm.html"
 		/>
-		<meta property="og:title" content="Zoom taxis DP291 Cobol project" />
+		<meta property="og:title" content="CSIS Web Site Evaluation Form Report" />
 		<meta
 			property="og:description"
 			content="Visitors to the CSIS web site are asked to fill in an evaluation form. The form requests the name of the visitor, his/her country of origin, his/her"
@@ -35,7 +45,7 @@
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/exercises.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Zoom taxis DP291 Cobol project" />
+		<meta name="twitter:title" content="CSIS Web Site Evaluation Form Report" />
 		<meta
 			name="twitter:description"
 			content="Visitors to the CSIS web site are asked to fill in an evaluation form. The form requests the name of the visitor, his/her country of origin, his/her"

--- a/search-index.json
+++ b/search-index.json
@@ -619,7 +619,7 @@
 	},
 	{
 		"p": "exercises/Proj-CSISEvalform/CSISEvalForm.html",
-		"t": "Zoom taxis DP291 Cobol project",
+		"t": "CSIS Web Site Evaluation Form Report",
 		"d": "Visitors to the CSIS web site are asked to fill in an evaluation form. The form requests the name of the visitor, his/her country of origin, his/her",
 		"s": "exercises"
 	},

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,690 +2,690 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/COBOLIntro.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/COBOLcommands.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Copy.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/DataDeclaration.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/EditedPics.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/IndexedFiles.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Inspect.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Intro2DirectAccess.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Iteration.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/RefMod.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/RelativeFiles.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/ReportWriter.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/ReportWriterSS.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/build-viewer.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/pdf-viewer.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Call.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro2.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro3.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro4.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro5.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro6.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Commands1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Commands2.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Condition1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Condition2.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Data1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Data2.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Perform1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Perform2.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Search2.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2a.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2b.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2c.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2d.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2e.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile3a.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables2.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables3.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables4.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables5.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables7.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables8.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Search.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Selection.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles2.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles3.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SortMerge.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/String.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Subprograms.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Tables1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Tables2.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Unstring.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Usage.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/glossary.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/index.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Accept/ACCEPT.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Accept/Multiplier.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Accept/Shortest.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Conditn/Conditions.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Conditn/IterIf.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Indexed/DirectReadIdx.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Indexed/Seq2Index.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Indexed/SeqReadIdx.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Merge/Merge.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/MileageCount.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform2.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform3.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform4.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Relative/ReadRel.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Relative/Seq2Rel.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteA.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteB.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteFull.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteSumm.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqIns/SEQINSERT.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREAD.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREADno88.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqRpt/SEQRPT.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqWrite/SEQWRITE.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Sort/InputSort.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Sort/MaleSort.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Strings/RefMod.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Strings/UnstringFileEg.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/DateDriver.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/ValiDate.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DayDiff/DayDiffDriver.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/DriverProg.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Fickle.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/MultiplyNums.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Steadfast.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Tables/MonthTable.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/index.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/COBOLExams/COBOLExams.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/CountDown.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FileConversion/Exm-FileConversion.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FileConversion/Prg-FileConversion.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-SFbyMail/Exm-SFbyMail.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-SFbyMail/Prg-SFbyMail.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-StudFeesRpt/Exm-StudPay.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-StudFeesRpt/Prg-StudPay.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/GettingStarted.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/MonthTable.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Proj-CSISEvalform/CSISEvalForm.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqInsert.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqRead.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqReadIf.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqUpdate.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqWrite.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SortIP.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/index.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/index.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/arithmetic.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/basics1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/basics2.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/call.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/cobintro.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/conditions.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/copy.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/cs4312topics.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/design.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/direct1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/dsr1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/genintro.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/index.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/indexed.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/inspect.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/perform.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/relative.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/reportwriterssweb.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/reportwriterweb.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/search.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/seqfile1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/seqfile2.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/seqfile3.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/sort.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/string.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/tables1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/tables2.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/unstring.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/usage.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
Closes #539

## Summary

- Removed dead `<style><!-- .Normal / .TableHead --></style>` blocks (Word-export HTML4 artifacts) from all 5 `Prj-*` files
- Converted `bgcolor`/`cellpadding`/`cellspacing` table header rows to semantic `<th>` elements with `class="data-table"` on tables and `<div class="center-block">` wrappers
- Converted nested `<blockquote>` bullet lists to `<ul><li>` and `<ol><li>` (CAO and Munster files)
- Converted Word-export course requirements (triple-nested blockquotes) to `<dl><dt><dd>` (CAO file)
- Stripped `class="Normal"`, `style="vertical-align: top"`, `<font>`, `<center>` tags throughout
- Fixed `CSISEvalForm.html`: wrong title "Zoom taxis DP291 Cobol project" → "CSIS Web Site Evaluation Form Report" (title, og:title, twitter:title) and `lang="en-GB"` → `lang="en"`
- Preserved the legitimate second `<style>` block in Newtronics (`.calc-steps` etc.) while removing only the dead first block
- All 6 files pass `npx html-validate` with no errors and are formatted with prettier

## Test plan

- [ ] `npx html-validate exercises/Prj-*/**.html exercises/Proj-CSISEvalform/CSISEvalForm.html` — no errors
- [ ] `npx prettier --check exercises/Prj-*/**.html exercises/Proj-CSISEvalform/CSISEvalForm.html` — all unchanged
- [ ] Visually verify each page renders correctly (tables, lists, images, links intact)
- [ ] Confirm CSISEvalForm.html shows correct title in browser tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)