### PR TITLE
Remove duplicate example breadcrumbs from generated pages

### DIFF
--- a/examples/Accept/ACCEPT.html
+++ b/examples/Accept/ACCEPT.html
@@ -52,10 +52,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="ACCEPT and DISPLAY example program"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>ACCEPT and DISPLAY</span>
-						</nav>
 						<p>
 							The program accepts a simple student record from the user and displays the individual
 							fields. Also shows how the ACCEPT may be used to get and DISPLAY the system time and date.

--- a/examples/Accept/Multiplier.html
+++ b/examples/Accept/Multiplier.html
@@ -55,10 +55,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="ACCEPT, DISPLAY and MULTIPLY example program"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>Multiplier</span>
-						</nav>
 						<p>
 							Accepts two single digit numbers from the user, multiplies them together and displays the
 							result.

--- a/examples/Accept/Shortest.html
+++ b/examples/Accept/Shortest.html
@@ -52,10 +52,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="The Shortest COBOL program we can have"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>Shortest COBOL Program</span>
-						</nav>
 						<p>
 							This example program is almost the shortest COBOL program we can have. We could make it
 							shorter still by leaving out the STOP RUN.

--- a/examples/Conditn/Conditions.html
+++ b/examples/Conditn/Conditions.html
@@ -52,10 +52,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="Condition Names (level 88) example program"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>Condition Names</span>
-						</nav>
 						<p>An example program demonstrating the use of Condition Names (level 88's).</p>
 						<div class="code-toolbar">
 							<a href="CONDITIONS.cbl" download class="download-btn">Download CONDITIONS.cbl</a>

--- a/examples/Conditn/IterIf.html
+++ b/examples/Conditn/IterIf.html
@@ -52,10 +52,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="Iteration with IF example program"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>Iteration with IF</span>
-						</nav>
 						<p>
 							An example program that implements a primitive calculator. The calculator only does
 							additions and multiplications.

--- a/examples/Indexed/DirectReadIdx.html
+++ b/examples/Indexed/DirectReadIdx.html
@@ -57,10 +57,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="Reading an Indexed file directly by key"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>Direct Read on Indexed File</span>
-						</nav>
 						<p>
 							Does a direct read on the Indexed file. Allows the user to choose which of the keys to use
 							for the direct read.

--- a/examples/Indexed/Seq2Index.html
+++ b/examples/Indexed/Seq2Index.html
@@ -45,10 +45,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="Creating an Indexed file from a sequential file"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>Sequential to Indexed</span>
-						</nav>
 						<p>Creates a direct access Indexed file from a Sequential file.</p>
 						<div class="code-toolbar">
 							<a href="Seq2Index.cbl" download class="download-btn">Download Seq2Index.cbl</a>

--- a/examples/Indexed/SeqReadIdx.html
+++ b/examples/Indexed/SeqReadIdx.html
@@ -54,10 +54,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="Reading an Indexed file sequentially on any of its keys"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>Sequential Read of Indexed File</span>
-						</nav>
 						<p>
 							Reads the Indexed file sequentially on whichever key is chosen by the user. Displays all the
 							records in the file.

--- a/examples/Merge/Merge.html
+++ b/examples/Merge/Merge.html
@@ -51,10 +51,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="Merge Files - Example Program"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>Merge Files</span>
-						</nav>
 						<p>Uses the MERGE to insert records from a transaction file into a sequential master file.</p>
 						<div class="code-toolbar">
 							<a href="MergeFiles.cbl" download class="download-btn">Download MergeFiles.cbl</a>

--- a/examples/Perform/MileageCount.html
+++ b/examples/Perform/MileageCount.html
@@ -55,10 +55,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="Mileage counter simulation"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>Mileage Counter</span>
-						</nav>
 						<p>
 							Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be
 							used to simulate a mileage counter.

--- a/examples/Perform/Perform1.html
+++ b/examples/Perform/Perform1.html
@@ -55,10 +55,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="Perform - Format 1 example program"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>PERFORM Format 1</span>
-						</nav>
 						<p>
 							An example program demonstrating how the first format of the PERFORM may be used to change
 							the flow of control through a program.

--- a/examples/Perform/Perform2.html
+++ b/examples/Perform/Perform2.html
@@ -55,10 +55,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="Perform - Format 2 example program"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>PERFORM Format 2</span>
-						</nav>
 						<p>
 							Demonstrates the second format of the PERFORM. The PERFORM..TIMES may be used to execute a
 							block of code x number of times.

--- a/examples/Perform/Perform3.html
+++ b/examples/Perform/Perform3.html
@@ -55,10 +55,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="Perform - Format 3 example program"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>PERFORM Format 3</span>
-						</nav>
 						<p>
 							Demonstrates how the PERFORM..UNTIL (third format) may be used to process a stream of values
 							where the length of the stream cannot be determined in advance.

--- a/examples/Perform/Perform4.html
+++ b/examples/Perform/Perform4.html
@@ -55,10 +55,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="Perform - Format 4 example program"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>PERFORM Format 4</span>
-						</nav>
 						<p>
 							Demonstrates how the PERFORM..VARYING and the PERFORM..VARYING..AFTER (fourth format) may be
 							used for counting iteration. Also introduces the WITH TEST BEFORE and WITH TEST AFTER

--- a/examples/Relative/ReadRel.html
+++ b/examples/Relative/ReadRel.html
@@ -54,10 +54,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="Read Relative File example program"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>Read Relative File</span>
-						</nav>
 						<p>
 							Reads the Relative file and displays the records. Allows the user to choose to read
 							sequentially through all the records or to use a key to read a single record directly.

--- a/examples/Relative/Seq2Rel.html
+++ b/examples/Relative/Seq2Rel.html
@@ -45,10 +45,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="Sequential to Relative File example program"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>Sequential to Relative</span>
-						</nav>
 						<p>Creates a direct access Relative file from a Sequential File.</p>
 						<div class="code-toolbar">
 							<a href="Seq2Rel.cbl" download class="download-btn">Download Seq2Rel.cbl</a>

--- a/examples/ReportWriter/RepWriteA.html
+++ b/examples/ReportWriter/RepWriteA.html
@@ -57,10 +57,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="One control break version of full Report Writer example Program"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>Report Writer Example A</span>
-						</nav>
 						<p>
 							A simplified version of the full report program using only one control break. Uses the
 							GBsales.dat data file.

--- a/examples/ReportWriter/RepWriteB.html
+++ b/examples/ReportWriter/RepWriteB.html
@@ -57,10 +57,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="No Declaratives version of full Report Writer example program"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>Report Writer Example B</span>
-						</nav>
 						<p>
 							A simplified version of the full report program containing all the control breaks but not
 							using Declaratives. Uses the GBsales.dat data file.

--- a/examples/ReportWriter/RepWriteFull.html
+++ b/examples/ReportWriter/RepWriteFull.html
@@ -57,10 +57,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="Full Report Writer example program - includes Declaratives"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>Report Writer Full Example</span>
-						</nav>
 						<p>
 							The full version of the report program containing all the control breaks and using
 							Declaratives to calculate the salesperson salary and commission.

--- a/examples/ReportWriter/RepWriteSumm.html
+++ b/examples/ReportWriter/RepWriteSumm.html
@@ -57,10 +57,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="Summary version of the full Report Writer program"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>Report Writer Summary</span>
-						</nav>
 						<p>
 							The summary version of the full report program containing all the control breaks and using
 							Declaratives to calculate the salesperson salary and commission.

--- a/examples/SeqIns/SEQINSERT.html
+++ b/examples/SeqIns/SEQINSERT.html
@@ -54,10 +54,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="Inserting records in a Sequential File"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>Insert Records</span>
-						</nav>
 						<p>
 							Demonstrates how to insert records into a sequential file from a file of transaction
 							records. A new file is created which contains the inserted records.

--- a/examples/SeqRead/SEQREAD.html
+++ b/examples/SeqRead/SEQREAD.html
@@ -51,10 +51,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="Reading a Sequential File"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>Sequential Read</span>
-						</nav>
 						<p>
 							An example program that reads a sequential file and displays the records. Uses the Condition
 							Name (level 88) "EndOfFile" to signal when the end of the file has been reached.

--- a/examples/SeqRead/SEQREADno88.html
+++ b/examples/SeqRead/SEQREADno88.html
@@ -54,10 +54,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="Reading a Sequential File"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>Sequential Read (without level 88s)</span>
-						</nav>
 						<p>
 							An example program that reads a sequential file and displays the records. This version does
 							not use level 88's to signal when the end of the file has been reached.

--- a/examples/SeqRpt/SEQRPT.html
+++ b/examples/SeqRpt/SEQRPT.html
@@ -51,10 +51,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="Sequential Student Number Report"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>Student Numbers Report</span>
-						</nav>
 						<p>
 							Reads records from the student file, counts the total number of student records and the
 							number of records for females and males, and prints the results in a short report.

--- a/examples/SeqWrite/SEQWRITE.html
+++ b/examples/SeqWrite/SEQWRITE.html
@@ -54,10 +54,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="Writing to a Sequential File"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>Sequential Write</span>
-						</nav>
 						<p>
 							Example program demonstrating how to create a sequential file from data input by the user.
 						</p>

--- a/examples/Sort/InputSort.html
+++ b/examples/Sort/InputSort.html
@@ -51,10 +51,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="SORT with Input Procedure to get recs from user"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>Input Sort</span>
-						</nav>
 						<p>
 							Uses the SORT and an INPUT PROCEDURE to accept records from the user and sort them on
 							ascending StudentId.

--- a/examples/Sort/MaleSort.html
+++ b/examples/Sort/MaleSort.html
@@ -51,10 +51,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="SORT file and select only male records"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>Male Sort</span>
-						</nav>
 						<p>
 							Sorts the student masterfile and produces a new file, sorted on ascending student name,
 							containing only the records of male students.

--- a/examples/Strings/RefMod.html
+++ b/examples/Strings/RefMod.html
@@ -52,10 +52,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="String handling - Reference Modification examples"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>Reference Modification</span>
-						</nav>
 						<p>
 							Solves a number of string handling tasks such as extracting substrings, removing leading or
 							trailing blanks, and finding the location of the first occurrence of a character in a

--- a/examples/Strings/UnstringFileEg.html
+++ b/examples/Strings/UnstringFileEg.html
@@ -59,10 +59,6 @@
 						<page-hero
 							title="String handling - Unpacking and size-validating comma separated records"
 						></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>UNSTRING File Example</span>
-						</nav>
 						<p>
 							An example showing the unpacking of comma-separated records and the size validation of the
 							unpacked fields.

--- a/examples/SubProg/DateValid/DateDriver.html
+++ b/examples/SubProg/DateValid/DateDriver.html
@@ -57,10 +57,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="Driver program for date validation sub-program"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../../index.html">Example programs</a> ›
-							<span>Date Driver Program</span>
-						</nav>
 						<p>
 							A driver program for the date validation sub-program. Accepts a date from the user, passes
 							it to the date validation sub-program and interprets and displays the result.

--- a/examples/SubProg/DateValid/ValiDate.html
+++ b/examples/SubProg/DateValid/ValiDate.html
@@ -57,10 +57,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="Date validation sub-program"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../../index.html">Example programs</a> ›
-							<span>Date Validation Sub-program</span>
-						</nav>
 						<p>
 							A date validation sub-program. Takes a date parameter in the form DDMMYYYY and returns a
 							code indicating whether the date was valid, and if not, why it was invalid.

--- a/examples/SubProg/DayDiff/DayDiffDriver.html
+++ b/examples/SubProg/DayDiff/DayDiffDriver.html
@@ -57,10 +57,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="Get difference between dates driver program"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../../index.html">Example programs</a> ›
-							<span>Day Difference Driver</span>
-						</nav>
 						<p>
 							A driver program that accepts two dates from the user and displays the difference in days
 							between them. Uses the Validate sub-program and also contains a number of contained

--- a/examples/SubProg/Multiply/DriverProg.html
+++ b/examples/SubProg/Multiply/DriverProg.html
@@ -57,10 +57,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="A driver for the MultiplyNums, Fickle and Steafast sub-programs"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../../index.html">Example programs</a> ›
-							<span>Sub-program Driver</span>
-						</nav>
 						<p>
 							Demonstrates the CALL verb by calling three external sub-programs that illustrate flow of
 							control, parameter passing, and state memory.

--- a/examples/SubProg/Multiply/Fickle.html
+++ b/examples/SubProg/Multiply/Fickle.html
@@ -57,10 +57,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="The Fickle sub-program demonstrates State Memory"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../../index.html">Example programs</a> ›
-							<span>Fickle Sub-program</span>
-						</nav>
 						<p>
 							A sub-program that demonstrates State Memory — each time it is called it remembers its state
 							from the previous call.

--- a/examples/SubProg/Multiply/MultiplyNums.html
+++ b/examples/SubProg/Multiply/MultiplyNums.html
@@ -57,10 +57,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="The MultiplyNums sub-program"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../../index.html">Example programs</a> ›
-							<span>MultiplyNums Sub-program</span>
-						</nav>
 						<p>
 							The MultiplyNums sub-program demonstrates flow of control from a driver program and the use
 							of numeric and string parameters with BY REFERENCE and BY CONTENT.

--- a/examples/SubProg/Multiply/Steadfast.html
+++ b/examples/SubProg/Multiply/Steadfast.html
@@ -57,10 +57,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="The Steadfast sub-program demonstrates the IS INITIAL phrase"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../../index.html">Example programs</a> ›
-							<span>Steadfast Sub-program</span>
-						</nav>
 						<p>
 							A sub-program identical to Fickle except that it uses the IS INITIAL phrase to avoid State
 							Memory — it always produces the same result for the same input.

--- a/examples/Tables/MonthTable.html
+++ b/examples/Tables/MonthTable.html
@@ -54,10 +54,6 @@
 				<div class="section-grid">
 					<div class="section-full">
 						<page-hero title="Tables - Counts number of students born in each month"></page-hero>
-						<nav aria-label="Breadcrumb">
-							<a href="../index.html">Example programs</a> ›
-							<span>Month Table</span>
-						</nav>
 						<p>
 							Counts the number of students born in each month using a pre-filled table of month names and
 							displays the result.

--- a/scripts/build-examples.js
+++ b/scripts/build-examples.js
@@ -358,16 +358,6 @@ function prefix(relFile) {
 }
 
 /**
- * Return the relative path from examples/<relFile> back to examples/index.html.
- * e.g. "Accept/ACCEPT.html"        -> "../index.html"
- *      "SubProg/Multiply/Foo.html" -> "../../index.html"
- */
-function defaultHtmlPath(relFile) {
-	const depth = relFile.split("/").length - 1;
-	return "../".repeat(depth) + "index.html";
-}
-
-/**
  * Build the <related-content> HTML for an example, sourced from cross-links.json.
  * Returns an empty string if the file is not in the cross-links map or has no
  * cross-references.
@@ -427,7 +417,6 @@ function relatedContentHtml(relFile) {
 
 function buildPage(entry) {
 	const pfx = prefix(entry.file);
-	const defPath = defaultHtmlPath(entry.file);
 	const canonical = BASE_URL + "examples/" + entry.file;
 	const metaDesc = escapeAttr(truncate(entry.desc));
 	const metaTitle = escapeAttr(entry.title);
@@ -487,10 +476,6 @@ ${runInCeScript}\t</head>
 \t\t\t\t<div class="section-grid">
 \t\t\t\t\t<div class="section-full">
 \t\t\t\t\t\t<page-hero title="${metaTitle}"></page-hero>
-\t\t\t\t\t\t<nav aria-label="Breadcrumb">
-\t\t\t\t\t\t\t<a href="${defPath}">Example programs</a> ›
-\t\t\t\t\t\t\t<span>${entry.crumb}</span>
-\t\t\t\t\t\t</nav>
 \t\t\t\t\t\t<p>${entry.desc}</p>
 \t\t\t\t\t\t\t<div class="code-toolbar">
 \t\t\t\t\t\t\t<a href="${entry.cbl}" download class="download-btn">Download ${entry.cbl}</a>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,690 +2,690 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/COBOLIntro.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/COBOLcommands.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Copy.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/DataDeclaration.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/EditedPics.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/IndexedFiles.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Inspect.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Intro2DirectAccess.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Iteration.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/RefMod.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/RelativeFiles.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/ReportWriter.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/ReportWriterSS.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/build-viewer.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/pdf-viewer.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Call.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro2.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro3.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro4.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro5.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro6.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Commands1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Commands2.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Condition1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Condition2.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Data1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Data2.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Perform1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Perform2.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Search2.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2a.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2b.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2c.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2d.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2e.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile3a.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables2.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables3.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables4.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables5.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables7.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables8.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Search.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Selection.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles2.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles3.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SortMerge.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/String.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Subprograms.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Tables1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Tables2.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Unstring.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Usage.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/glossary.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/index.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Accept/ACCEPT.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Accept/Multiplier.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Accept/Shortest.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Conditn/Conditions.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Conditn/IterIf.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Indexed/DirectReadIdx.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Indexed/Seq2Index.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Indexed/SeqReadIdx.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Merge/Merge.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/MileageCount.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform2.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform3.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform4.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Relative/ReadRel.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Relative/Seq2Rel.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteA.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteB.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteFull.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteSumm.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqIns/SEQINSERT.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREAD.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREADno88.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqRpt/SEQRPT.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqWrite/SEQWRITE.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Sort/InputSort.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Sort/MaleSort.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Strings/RefMod.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Strings/UnstringFileEg.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/DateDriver.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/ValiDate.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DayDiff/DayDiffDriver.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/DriverProg.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Fickle.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/MultiplyNums.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Steadfast.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Tables/MonthTable.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/index.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/COBOLExams/COBOLExams.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/CountDown.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FileConversion/Exm-FileConversion.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FileConversion/Prg-FileConversion.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-SFbyMail/Exm-SFbyMail.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-SFbyMail/Prg-SFbyMail.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-StudFeesRpt/Exm-StudPay.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-StudFeesRpt/Prg-StudPay.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/GettingStarted.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/MonthTable.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Proj-CSISEvalform/CSISEvalForm.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqInsert.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqRead.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqReadIf.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqUpdate.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqWrite.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SortIP.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/index.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/index.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/arithmetic.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/basics1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/basics2.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/call.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/cobintro.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/conditions.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/copy.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/cs4312topics.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/design.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/direct1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/dsr1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/genintro.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/index.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/indexed.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/inspect.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/perform.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/relative.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/reportwriterssweb.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/reportwriterweb.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/search.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/seqfile1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/seqfile2.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/seqfile3.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/sort.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/string.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/tables1.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/tables2.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/unstring.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/usage.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
- Remove the hardcoded `Example programs` breadcrumb block from the example page template.
- Regenerate all example HTML pages so they rely on the global breadcrumb widget only.
- Keep the example generator as the source of truth for future pages.

## Testing
- `npm run build:examples`
- `npm run validate`
- Browser-checked `examples/Accept/ACCEPT.html` and confirmed only one breadcrumb is rendered