### PR TITLE
fix: align og:title and twitter:title casing with browser title on lecture pages

### DIFF
--- a/lectures/basics2.html
+++ b/lectures/basics2.html
@@ -26,12 +26,12 @@
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/basics2.html" />
-		<meta property="og:title" content="basics2 - COBOL Lecture" />
+		<meta property="og:title" content="Basics2 - COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering basics2." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="basics2 - COBOL Lecture" />
+		<meta name="twitter:title" content="Basics2 - COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering basics2." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/call.html
+++ b/lectures/call.html
@@ -26,12 +26,12 @@
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/call.html" />
-		<meta property="og:title" content="call - COBOL Lecture" />
+		<meta property="og:title" content="Call - COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering call." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="call - COBOL Lecture" />
+		<meta name="twitter:title" content="Call - COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering call." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/cobintro.html
+++ b/lectures/cobintro.html
@@ -26,12 +26,12 @@
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/cobintro.html" />
-		<meta property="og:title" content="cobintro - COBOL Lecture" />
+		<meta property="og:title" content="Cobintro - COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering cobintro." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="cobintro - COBOL Lecture" />
+		<meta name="twitter:title" content="Cobintro - COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering cobintro." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/design.html
+++ b/lectures/design.html
@@ -26,12 +26,12 @@
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/design.html" />
-		<meta property="og:title" content="design - COBOL Lecture" />
+		<meta property="og:title" content="Design - COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering design." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="design - COBOL Lecture" />
+		<meta name="twitter:title" content="Design - COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering design." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/direct1.html
+++ b/lectures/direct1.html
@@ -26,12 +26,12 @@
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/direct1.html" />
-		<meta property="og:title" content="direct1 - COBOL Lecture" />
+		<meta property="og:title" content="Direct1 - COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering direct1." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="direct1 - COBOL Lecture" />
+		<meta name="twitter:title" content="Direct1 - COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering direct1." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/dsr1.html
+++ b/lectures/dsr1.html
@@ -26,12 +26,12 @@
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/dsr1.html" />
-		<meta property="og:title" content="dsr1 - COBOL Lecture" />
+		<meta property="og:title" content="Dsr1 - COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering dsr1." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="dsr1 - COBOL Lecture" />
+		<meta name="twitter:title" content="Dsr1 - COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering dsr1." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/perform.html
+++ b/lectures/perform.html
@@ -26,12 +26,12 @@
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/perform.html" />
-		<meta property="og:title" content="perform - COBOL Lecture" />
+		<meta property="og:title" content="Perform - COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering perform." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="perform - COBOL Lecture" />
+		<meta name="twitter:title" content="Perform - COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering perform." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />


### PR DESCRIPTION
## Summary

- Fixes `og:title` and `twitter:title` on 7 lecture pages where the social metadata still used lowercase text after #540 capitalized the visible `<title>`
- Affected pages: `basics2.html`, `call.html`, `cobintro.html`, `design.html`, `direct1.html`, `dsr1.html`, `perform.html`

Closes #545

## Test plan

- [ ] Verify `<title>`, `og:title`, and `twitter:title` match on each of the 7 affected pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)