### PR TITLE
fix: constrain wide-viewport layout, lower page-toc breakpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,8 @@ Runs `html-validate` against all HTML pages. Run after any HTML edits.
 
 The launch.json server name is `limerick-cobol` (serves the repo root via `http-server`). Start it with `preview_start("limerick-cobol")` — port is auto-assigned. Use the preview tools to verify layout, breadcrumb, and hero-title changes before committing.
 
+Use `preview_inspect` with explicit `styles` to verify computed dimensions and colours — it is more reliable than screenshots for style assertions.
+
 ## Formatting
 
 ```bash
@@ -52,8 +54,24 @@ Prettier runs automatically in CI on every PR merge. Run it locally after editin
 - Reference the issue being fixed with `Fixes #NNN` in the commit message body so GitHub closes it on merge.
 - Open PRs with `gh pr create` from the worktree branch.
 
+## CSS architecture
+
+Two stylesheets are loaded on every page:
+
+- `course/Resources/css/course.css` — design tokens (CSS custom properties), base element and reset styles, dark-mode overrides, print styles. Touch this when changing colours or tokens.
+- `course/Resources/css/course-components.css` — all component classes (`.site-header`, `.page-wrapper`, `.page-toc`, `.edit-on-github`, etc.) and breakpoint layout rules. New visual rules go here.
+
+## Component scripts
+
+`components/` holds JS web components auto-injected on every page:
+
+- `site-header.js` — sticky header (logo, primary nav, search input)
+- `breadcrumbs.js` — secondary sticky bar with breadcrumb trail and theme toggle
+- `course-sidebar.js` — left-rail course outline, visible at ≥1100 px
+- `page-toc.js` — right-rail in-page TOC; standalone at ≥1100 px, three-column with course-sidebar at ≥1280 px
+
 ## Key conventions
 
 - `<page-hero title="…">` is the source of truth for page titles. Keep `<title>`, `og:title`, and `twitter:title` in sync with it.
 - The viewport meta tag must be the **first** element inside `<head>` to prevent FOUC from layout reflow.
-- Exercises live in `exercises/`, lectures in `course/`, code examples in `examples/`.
+- Tutorials live in `course/`, exercises in `exercises/`, lectures in `lectures/`, code examples in `examples/`.

--- a/course/Resources/css/course-components.css
+++ b/course/Resources/css/course-components.css
@@ -113,6 +113,7 @@
 .site-header .site-search {
 	margin-top: 0;
 	width: 100%;
+	max-width: 360px;
 }
 
 .site-header .site-search__label {
@@ -2075,7 +2076,7 @@ course-sidebar {
    re-show the inline lesson-toc / ul.toc so the reader can still jump
    between page sections. The existing :has(page-toc) rule hides those by
    default; this override (more specific via the extra :has clause) wins. */
-@media (min-width: 1100px) and (max-width: 1399px) {
+@media (min-width: 1100px) and (max-width: 1279px) {
 	.page-wrapper:has(course-sidebar):has(page-toc) > page-toc {
 		display: none;
 	}
@@ -2093,7 +2094,7 @@ course-sidebar {
 
 /* Wide-desktop three-column layout: course-sidebar left, content middle,
    page-toc right. Mirrors MDN's CSS reference pages. */
-@media (min-width: 1400px) {
+@media (min-width: 1280px) {
 	.page-wrapper:has(course-sidebar):has(page-toc) {
 		grid-template-columns: 220px minmax(0, 715px) 200px;
 		max-width: 1199px;

--- a/index.html
+++ b/index.html
@@ -63,8 +63,12 @@
 			content="COBOL programming site with a full COBOL course as well as lectures, tutorials, programming exercises, and over 50 example COBOL programs."
 		/>
 		<style type="text/css">
-			#page-header {
-				width: 97%;
+			/* Constrain all homepage content to a single centered column */
+			#main-content {
+				max-width: 605px;
+				margin-inline: auto;
+				padding: 0 0.5em;
+				box-sizing: border-box;
 			}
 
 			#page-description {
@@ -79,11 +83,6 @@
 			}
 
 			@media (max-width: 600px) {
-				#page-header {
-					grid-template-columns: 40px 1fr;
-					width: 100%;
-				}
-
 				#page-description {
 					width: 100%;
 				}


### PR DESCRIPTION
Fixes #534

## Summary

- **Site header search** — cap `.site-header .site-search` at `max-width: 360px` so the input stops stretching to viewport edge at 1600px+
- **Homepage content column** — add `max-width: 605px; margin-inline: auto` to `#main-content` on `index.html`, centering the h1, description, link list, and "Help improve this page" banner in a consistent column instead of bleeding to full viewport width; remove stale `#page-header { width: 97% }` rule
- **page-toc breakpoint** — lower three-column breakpoint from 1400px → 1280px so users on 1280–1440px laptops see the right-rail TOC alongside the course sidebar (previously `0×0` at those widths)
- **CLAUDE.md** — merge CSS architecture, component scripts, and preview_inspect tip with master's new Preview server / Formatting / Pull requests sections; fix incorrect directory listing (`lectures in course/` → `lectures in lectures/`)

## Test plan

- [ ] At 1920px: homepage content stays in a ~605px centered column; header search stays ≤360px wide
- [ ] At 1280px: course tutorial page with both sidebars shows three-column layout (course-sidebar + content + page-toc)
- [ ] At 1100–1279px: course-sidebar shows, page-toc hidden, lesson-toc visible inline at top of page
- [ ] At 375px (mobile): homepage looks unchanged; course pages unchanged
- [ ] `npm run validate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)