### PR TITLE
fix: glossary table dark-mode borders + SessionStart staleness hook + visual-bug workflow

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,19 @@
 {
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "git fetch origin master --quiet 2>/dev/null; count=$(git rev-list --count HEAD..origin/master 2>/dev/null); if [ -n \"$count\" ] && [ \"$count\" -gt 0 ]; then printf '{\"systemMessage\":\"Branch is %s commit(s) behind origin/master. Run: git rebase origin/master\",\"hookSpecificOutput\":{\"hookEventName\":\"SessionStart\",\"additionalContext\":\"Branch is %s commit(s) behind origin/master. CLAUDE.md requires rebasing before making changes.\"}}' \"$count\" \"$count\"; fi",
+            "shell": "bash",
+            "timeout": 30,
+            "statusMessage": "Checking branch freshness..."
+          }
+        ]
+      }
+    ]
+  },
   "permissions": {
     "allow": [
       "WebFetch(domain:bushidocodes.github.io)",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,17 @@ The launch.json server name is `limerick-cobol` (serves the repo root via `http-
 
 Use `preview_inspect` with explicit `styles` to verify computed dimensions and colours — it is more reliable than screenshots for style assertions.
 
+## Visual bug investigation
+
+When an issue describes a visual or CSS symptom (colour, contrast, dark-mode rendering, layout), **screenshot before reading files**:
+
+1. `preview_start("limerick-cobol")` — note the assigned port
+2. Screenshot in light mode
+3. Toggle dark mode, screenshot again
+4. Decide: is the symptom reproduced, already fixed, or ambiguous?
+
+Only move to static analysis (reading CSS/HTML) if the screenshots are inconclusive. The browser is ground truth; a two-screenshot check replaces several rounds of colour-arithmetic and selector tracing.
+
 ## Formatting
 
 ```bash

--- a/course/glossary.html
+++ b/course/glossary.html
@@ -248,6 +248,20 @@
 					background-color: transparent;
 				}
 			}
+
+			@media (prefers-color-scheme: dark) {
+				:root:not([data-theme="light"]) table.glossary-table,
+				:root:not([data-theme="light"]) table.glossary-table th,
+				:root:not([data-theme="light"]) table.glossary-table td {
+					border-color: #888;
+				}
+			}
+
+			:root[data-theme="dark"] table.glossary-table,
+			:root[data-theme="dark"] table.glossary-table th,
+			:root[data-theme="dark"] table.glossary-table td {
+				border-color: #888;
+			}
 		</style>
 		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>


### PR DESCRIPTION
## Summary

- **Fixes #531** — Glossary table cell borders were using `currentColor` in dark mode, which resolved to different values for header cells (`#ffb3b3`, from `--color-panel-text`) and body cells (`#e6e6e6`, from `--color-text`), making borders inconsistent and context-dependent. Pins `border-color` to `#888` in dark mode across the outer table, `th`, and `td`, giving ≥ 3:1 contrast against every cell background (`#3a3520` headers, `#2d2d2d` even rows, `#1a1a1a` odd rows). Light mode is unchanged.
- **Adds a `SessionStart` hook** to `.claude/settings.json` that fetches `origin/master` and emits a warning (UI `systemMessage` + model `additionalContext`) when the branch is behind, so the CLAUDE.md rebase requirement is never silently skipped.
- **Adds a "Visual bug investigation" section** to `CLAUDE.md` directing Claude to screenshot in light and dark mode before doing static CSS/HTML analysis, avoiding wasted rounds of colour-arithmetic when the browser is the faster ground truth.

## Test plan

- [ ] Load `course/glossary.html` at 1280 px in light mode — all cell borders visible and consistent across columns
- [ ] Load `course/glossary.html` at 1280 px in dark mode — all cell borders visible (`#888` against darkest bg `#1a1a1a` = 4.8:1) and uniform across header and body rows
- [ ] `npm run validate` passes (no HTML errors)
- [ ] Start a new Claude Code session on a stale branch — confirm the "Branch is N commit(s) behind" banner appears
- [ ] Start a new Claude Code session on a current branch — confirm no banner appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)