### PR TITLE
feat: add hamburger menu and fix narrow-viewport layout issues

### DIFF
--- a/components/site-header.js
+++ b/components/site-header.js
@@ -30,6 +30,8 @@
 		{ label: "Lectures", dir: "lectures", entry: "lectures/index.html" },
 	];
 
+	const MOBILE_NAV_ID = "site-nav-mobile";
+
 	function ensureScript(filename) {
 		if (document.querySelector(`script[src*="components/${filename}"]`)) return;
 		const s = document.createElement("script");
@@ -46,14 +48,17 @@
 	ensureScript("breadcrumbs.js");
 	ensureScript("course-sidebar.js");
 
-	function buildNavHTML() {
+	function buildNavItems() {
 		const path = location.pathname;
-		const items = NAV_SECTIONS.map((s) => {
+		return NAV_SECTIONS.map((s) => {
 			const isActive = new RegExp("/" + s.dir + "/").test(path);
 			const attrs = isActive ? ' data-active aria-current="page"' : "";
 			return `<li><a href="${baseUrl}${s.entry}"${attrs}>${s.label}</a></li>`;
 		}).join("");
-		return `<nav class="site-nav" aria-label="Primary"><ul>${items}</ul></nav>`;
+	}
+
+	function buildNavHTML() {
+		return `<nav class="site-nav" aria-label="Primary"><ul>${buildNavItems()}</ul></nav>`;
 	}
 
 	function inject() {
@@ -63,13 +68,61 @@
 		header.innerHTML =
 			`<a class="site-header__logo" href="${homeUrl}">` +
 			`<img src="${faviconUrl}" alt="COBOL Tutorial" width="32" height="28">` +
-			`</a>${buildNavHTML()}<site-search></site-search>`;
+			`</a>${buildNavHTML()}<site-search></site-search>` +
+			`<button class="site-header__hamburger" type="button" ` +
+			`aria-expanded="false" aria-controls="${MOBILE_NAV_ID}" ` +
+			`aria-label="Open navigation">` +
+			`<span aria-hidden="true">&#9776;</span>` +
+			`</button>` +
+			`<nav id="${MOBILE_NAV_ID}" class="site-nav-mobile" aria-label="Primary" hidden>` +
+			`<ul>${buildNavItems()}</ul>` +
+			`</nav>`;
+
 		const skipLink = document.body.querySelector("a.skip-link");
 		if (skipLink) {
 			skipLink.insertAdjacentElement("afterend", header);
 		} else {
 			document.body.prepend(header);
 		}
+
+		const btn = header.querySelector(".site-header__hamburger");
+		const mobileNav = header.querySelector(`#${MOBILE_NAV_ID}`);
+
+		function openMenu() {
+			mobileNav.removeAttribute("hidden");
+			btn.setAttribute("aria-expanded", "true");
+			btn.setAttribute("aria-label", "Close navigation");
+			const first = mobileNav.querySelector("a");
+			if (first) first.focus();
+		}
+
+		function closeMenu(returnFocus) {
+			mobileNav.setAttribute("hidden", "");
+			btn.setAttribute("aria-expanded", "false");
+			btn.setAttribute("aria-label", "Open navigation");
+			if (returnFocus) btn.focus();
+		}
+
+		btn.addEventListener("click", () => {
+			if (btn.getAttribute("aria-expanded") === "true") {
+				closeMenu(true);
+			} else {
+				openMenu();
+			}
+		});
+
+		mobileNav.addEventListener("keydown", (e) => {
+			if (e.key === "Escape") {
+				closeMenu(true);
+			}
+		});
+
+		document.addEventListener("click", (e) => {
+			if (btn.getAttribute("aria-expanded") === "true" && !header.contains(e.target)) {
+				closeMenu(false);
+			}
+		});
+
 		measureStickyHeights(header);
 	}
 

--- a/components/site-search.js
+++ b/components/site-search.js
@@ -43,6 +43,10 @@ class SiteSearch extends HTMLElement {
 	#pointer = -1;
 	#listboxId = "";
 
+	static #SHORT_MQL = window.matchMedia("(max-width: 360px)");
+	static #FULL_PLACEHOLDER = "Search lessons, exercises, examples… (Ctrl+K)";
+	static #SHORT_PLACEHOLDER = "Search…";
+
 	connectedCallback() {
 		const uid = ++instanceCounter;
 		this.#listboxId = `site-search-results-${uid}`;
@@ -54,7 +58,6 @@ class SiteSearch extends HTMLElement {
 					id="${inputId}"
 					class="site-search__input"
 					type="search"
-					placeholder="Search lessons, exercises, examples… (Ctrl+K)"
 					autocomplete="off"
 					autocapitalize="off"
 					spellcheck="false"
@@ -75,6 +78,14 @@ class SiteSearch extends HTMLElement {
 		this.#input = this.querySelector(".site-search__input");
 		this.#results = this.querySelector(".site-search__results");
 		this.#status = this.querySelector(".site-search__status");
+
+		const updatePlaceholder = () => {
+			this.#input.placeholder = SiteSearch.#SHORT_MQL.matches
+				? SiteSearch.#SHORT_PLACEHOLDER
+				: SiteSearch.#FULL_PLACEHOLDER;
+		};
+		updatePlaceholder();
+		SiteSearch.#SHORT_MQL.addEventListener("change", updatePlaceholder);
 
 		this.#input.addEventListener("focus", () => this.#ensureLoaded());
 		this.#input.addEventListener("input", () => this.#render());

--- a/course/Resources/css/course-components.css
+++ b/course/Resources/css/course-components.css
@@ -96,9 +96,14 @@
 	border-bottom-color: #ff9966;
 }
 
+/* Hidden on desktop; the @media (max-width: 720px) block below shows it. */
+.site-header__hamburger {
+	display: none;
+}
+
 @media (max-width: 720px) {
 	.site-header {
-		grid-template-columns: auto 1fr;
+		grid-template-columns: auto 1fr auto;
 	}
 
 	.site-header .site-nav {
@@ -107,6 +112,64 @@
 
 	.site-header site-search {
 		grid-column: 2;
+		min-width: 0;
+	}
+
+	.site-header__hamburger {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		grid-column: 3;
+		grid-row: 1;
+		padding: 0.3em 0.5em;
+		background: none;
+		border: 1px solid var(--color-border-mute);
+		border-radius: 3px;
+		cursor: pointer;
+		font-size: 1.25em;
+		line-height: 1;
+		color: var(--color-text);
+	}
+
+	.site-header__hamburger:hover {
+		background-color: var(--color-border-mute);
+	}
+
+	.site-header__hamburger:focus-visible {
+		outline: 2px solid var(--color-emphasis);
+		outline-offset: 1px;
+	}
+
+	/* Mobile nav dropdown — full-width row below logo/search/hamburger */
+	.site-nav-mobile {
+		grid-column: 1 / -1;
+		border-top: 1px solid var(--color-border-mute);
+		padding: 0.25em 0;
+	}
+
+	.site-nav-mobile ul {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	.site-nav-mobile a {
+		display: block;
+		padding: 0.5em 0.75em;
+		font-family: Arial, Helvetica, sans-serif;
+		font-size: 0.95em;
+		text-decoration: none;
+		color: var(--color-text);
+	}
+
+	.site-nav-mobile a:hover {
+		background-color: var(--color-border-mute);
+	}
+
+	.site-nav-mobile a[data-active] {
+		font-weight: bold;
+		border-left: 3px solid var(--color-header-bg);
+		padding-left: calc(0.75em - 3px);
 	}
 }
 
@@ -114,6 +177,11 @@
 	margin-top: 0;
 	width: 100%;
 	max-width: 360px;
+	min-width: 0;
+}
+
+.site-header .site-search__input {
+	min-width: 0;
 }
 
 .site-header .site-search__label {
@@ -1845,6 +1913,27 @@ page-breadcrumbs {
 	margin-top: 0;
 }
 
+/* At narrow viewports, stack the breadcrumb trail and theme toggle vertically
+   so a long breadcrumb chain (e.g. Home › Course › Topic › Page) that wraps
+   to a second line doesn't cause the toggle to overlap the wrapped text. */
+@media (max-width: 480px) {
+	.breadcrumb-bar-inner {
+		flex-wrap: wrap;
+		align-items: flex-start;
+		gap: 0.25em 0.5em;
+	}
+
+	.breadcrumb-bar-inner > nav.page-breadcrumbs,
+	.breadcrumb-bar-inner > .breadcrumb-bar-spacer {
+		flex: 1 1 100%;
+	}
+
+	.breadcrumb-bar-inner > theme-toggle,
+	.breadcrumb-bar-inner > .theme-toggle {
+		margin-left: auto;
+	}
+}
+
 nav.page-breadcrumbs {
 	font-size: 0.85em;
 	color: var(--color-text-muted);
@@ -2146,4 +2235,41 @@ course-sidebar {
 	background: #1a1a1a;
 	border-color: #555;
 	color: #e0e0e0;
+}
+
+/* ============================================================================
+   Homepage layout (index.html).
+   Scoped via :has(#page-description) so the max-width constraint only
+   applies to the one page that contains this element — other pages'
+   #main-content stays unconstrained.
+   ============================================================================ */
+main:has(#page-description) {
+	max-width: 605px;
+	margin-inline: auto;
+	padding: 0 0.5em;
+	box-sizing: border-box;
+}
+
+#page-description {
+	width: 80%;
+	margin: 0 auto;
+	font-size: smaller;
+	box-sizing: border-box;
+}
+
+/* Blue ball marker on homepage TOC — overrides the green from course.css */
+ul.toc ::marker {
+	color: #0066cc;
+}
+
+@media (max-width: 600px) {
+	#page-description {
+		width: 100%;
+	}
+
+	ul.toc {
+		margin-left: 12px;
+		margin-right: 12px;
+		padding-left: 1.5em;
+	}
 }

--- a/index.html
+++ b/index.html
@@ -62,39 +62,7 @@
 			name="twitter:description"
 			content="COBOL programming site with a full COBOL course as well as lectures, tutorials, programming exercises, and over 50 example COBOL programs."
 		/>
-		<style type="text/css">
-			/* Constrain all homepage content to a single centered column */
-			#main-content {
-				max-width: 605px;
-				margin-inline: auto;
-				padding: 0 0.5em;
-				box-sizing: border-box;
-			}
-
-			#page-description {
-				width: 80%;
-				margin: 0 auto;
-				font-size: smaller;
-			}
-
-			/* Blue ball marker — overrides the green from course.css */
-			ul.toc ::marker {
-				color: #0066cc;
-			}
-
-			@media (max-width: 600px) {
-				#page-description {
-					width: 100%;
-				}
-
-				ul.toc {
-					margin-left: 12px;
-					margin-right: 12px;
-					padding-left: 1.5em;
-				}
-			}
-		</style>
-		<script src="./components/site-header.js" defer></script>
+<script src="./components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
 			name="twitter:description"
 			content="COBOL programming site with a full COBOL course as well as lectures, tutorials, programming exercises, and over 50 example COBOL programs."
 		/>
-<script src="./components/site-header.js" defer></script>
+		<script src="./components/site-header.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>


### PR DESCRIPTION
## Summary

- **Hamburger menu**: site-header now shows a ☰ button below 720px that opens/closes a full-width dropdown with all four nav links (Course, Exercises, Examples, Lectures). Keyboard-navigable: Escape closes the menu and returns focus to the button; click-outside closes it; `aria-expanded` and `aria-label` track state.
- **Breadcrumb / theme-toggle overlap fix**: at ≤480px the breadcrumb bar switches to `flex-wrap` so a long breadcrumb chain that wraps to a second line no longer causes the theme-toggle to overlap the text — the toggle drops to its own row below.
- **Search input clipping**: added `min-width: 0` to the `site-search` element and its `<input>` inside the header so the field can shrink below its placeholder text's intrinsic width at 320px.
- **Short search placeholder**: `site-search.js` swaps the placeholder to `"Search…"` at ≤360px via a `matchMedia` listener.
- **Homepage inline style cleanup**: stripped the `<style>` block from `index.html` and moved all homepage layout rules to `course-components.css`, scoped via `main:has(#page-description)` so they only apply to the homepage.

## Test plan

- [ ] 320px: no horizontal scrollbar; search input shrinks and shows "Search…" placeholder
- [ ] 390px: hamburger visible; theme toggle doesn't overlap breadcrumbs on deep pages
- [ ] 600px: hamburger visible; tapping it opens/closes mobile nav
- [ ] 768px+: hamburger hidden, desktop nav (Course/Exercises/Examples/Lectures) visible
- [ ] Escape closes mobile nav and returns focus to hamburger button
- [ ] Click outside header closes mobile nav
- [ ] `npm run validate` passes

Fixes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)