### PR TITLE
chore: auto-assign issues on view and enforce Fixes #NNN in PR bodies

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,21 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "shell": "powershell",
+            "if": "Bash(gh issue view *)",
+            "async": true,
+            "statusMessage": "Claiming issue...",
+            "command": "$j = $input | Out-String | ConvertFrom-Json; $cmd = $j.tool_input.command; if ($cmd -match 'gh issue view (\\d+)') { gh issue edit $matches[1] --add-assignee bushidocodes --repo bushidocodes/limerick-cobol 2>$null }"
+          }
+        ]
+      }
     ]
   },
   "permissions": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ Several generated files must be kept in sync with the source HTML. Run the relev
 
 ## Pull requests
 
-- Reference the issue being fixed with `Fixes #NNN` in the commit message body so GitHub closes it on merge.
+- Reference the issue being fixed with `Fixes #NNN` in **both** the commit message body and the PR body. GitHub only auto-closes issues when the exact keyword form (`Fixes #NNN`, `Closes #NNN`, etc.) appears — plain references like `(issue #NNN)` do not trigger auto-close.
 - Open PRs with `gh pr create` from the worktree branch.
 
 ## CSS architecture


### PR DESCRIPTION
## Summary

- **Auto-assign hook** — adds a `PreToolUse` hook to `.claude/settings.json` that fires whenever an agent runs `gh issue view NNN`. The hook asynchronously runs `gh issue edit NNN --add-assignee bushidocodes`, claiming the issue so concurrent agents know it's taken.
- **CLAUDE.md PR rule tightened** — the pull-request guidance now explicitly requires `Fixes #NNN` in **both** the commit body and the PR body. Issue #526 was left open after PR #552 merged because the PR body used `(issue #526)` instead of `Fixes #526`, which GitHub does not recognise as a close trigger.

## How the hook works

The hook uses `shell: powershell` (jq is not available on this Windows host), the `if: Bash(gh issue view *)` pre-filter so it only fires on issue-view commands, and `async: true` so it does not block the agent. Pattern: `gh issue view (\d+)` → `gh issue edit <N> --add-assignee bushidocodes`.

## Test plan

- [ ] Open a new session, run `gh issue view <any open issue>` — confirm the issue is assigned to bushidocodes afterward
- [ ] Verify `npm run validate` still passes (no HTML touched)
- [ ] Confirm `.claude/settings.json` parses as valid JSON

🤖 Generated with [Claude Code](https://claude.ai/claude-code)