### PR TITLE
chore: add .gitattributes pinning LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Normalize text files to LF in the repo, regardless of platform.
+# Without this, Windows clones with core.autocrlf=true store CRLF in the
+# working tree, which makes `git status` flag every text file as modified
+# and floods every `git add` with "LF will be replaced by CRLF" warnings.
+* text=auto eol=lf


### PR DESCRIPTION
## Summary

Adds a one-line `.gitattributes` (`* text=auto eol=lf`) so the working tree matches the repo on all platforms.

## Why

Working on this repo from Windows is noisy without it:
- `git status` flags hundreds of unchanged text files as modified (working-tree CRLF vs index LF).
- Every `git add` prints a stack of "LF will be replaced by CRLF the next time Git touches it" warnings.
- `gh pr create` warns about "305 uncommitted changes" when only six files actually changed.

These false positives make it hard to verify *what actually changed* before a commit or PR, and the warning floods drown out real errors.

## Migration

Existing checkouts that already have CRLF in their working tree can run a one-time `git add --renormalize .` to clear stale line endings. Fresh clones will be clean.

## Test plan

- [x] On a Windows checkout with `core.autocrlf=true`, `git status` is clean immediately after a fresh clone with this file present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)