### PR TITLE
fix: editorial corrections across 26 course and exercise pages

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -221,7 +221,7 @@
 							but none has yet displaced COBOL. Two recent challengers though, Java and Visual Basic, are
 							proving to be serious contenders.
 						</p>
-						<p>COBOL's dominance in underlined by the reports from the Gartner group.</p>
+						<p>COBOL's dominance is underlined by the reports from the Gartner group.</p>
 						<blockquote>
 							<p>
 								In 1997 they estimated that there were about 300 billion lines of computer code in use
@@ -402,7 +402,7 @@
 							The COBOL standard does not belong to any particular vendor. The vendor independent ANSI
 							COBOL committee legislates formal, non-vendor-specific syntax and semantic language
 							standards. COBOL has been ported to virtually every hardware platform - from every favour of
-							Windows, to every falser of Unix, to AS/400, VSE, OS/2, DOS, VMS, Unisys, DG, VM, and MVS.
+							Windows, to every flavour of Unix, to AS/400, VSE, OS/2, DOS, VMS, Unisys, DG, VM, and MVS.
 						</p>
 						<h4>COBOL is Maintainable</h4>
 						<p>
@@ -442,7 +442,7 @@
 						</p>
 						<p>
 							Most of this material is available on the web but as the web is dynamic and links are all
-							too easily broken I won't give the URL's here. You will have to search for them.
+							too easily broken, some of the links below may be broken. You may have to search for them.
 						</p>
 						<h3 class="center-block">Resources</h3>
 						<p>
@@ -503,7 +503,7 @@
 							COBOLReport.com
 						</p>
 						<p>
-							Reimann, Artur -COBOL, Language of Choice - Then and Now (January, 2001) - COBOLReport.com
+							Reimann, Artur - COBOL, Language of Choice - Then and Now (January, 2001) - COBOLReport.com
 						</p>
 						<p>
 							Sayles, Jonathan - COBOL and the Enterprise Business Application Programming Legacy -
@@ -532,7 +532,7 @@
 					</div>
 					<div class="section-content">
 						<p>
-							In this section a gentle introduction to programing in general, and to programming in COBOL
+							In this section a gentle introduction to programming in general, and to programming in COBOL
 							in particular, is provided. This is done by writing some simple COBOL programs that use the
 							three main programming constructs - Sequence, Iteration and Selection.
 						</p>
@@ -571,7 +571,7 @@
 					</div>
 					<div class="section-content">
 						<p>
-							We want to write a program which will accept two numbers from the users keyboard, multiply
+							We want to write a program which will accept two numbers from the user's keyboard, multiply
 							them together and display the result on the computer screen.
 						</p>
 						<p>Any program consists of three main things;</p>
@@ -673,7 +673,7 @@
 						<p>
 							Because this program is short, simple and easy to understand, you may think that programming
 							mistakes like these could never happen. But don't be deceived - when writing a larger
-							program it is all to easy to make the mistake of trying to use, or output, the contents of a
+							program it is all too easy to make the mistake of trying to use, or output, the contents of a
 							data item before you have assigned it a value.
 						</p>
 						<hr class="thin-rule" />
@@ -1158,7 +1158,7 @@ AUTHOR. Michael Coughlan.</code></pre>
 						</p>
 						<p>
 							The purpose of the <code class="language-cobol">ENVIRONMENT DIVISION</code> is to isolate in
-							one place all aspects of the program that are dependant upon a specific computer, device or
+							one place all aspects of the program that are dependent upon a specific computer, device or
 							encoding sequence.
 						</p>
 						<p>

--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -673,8 +673,8 @@
 						<p>
 							Because this program is short, simple and easy to understand, you may think that programming
 							mistakes like these could never happen. But don't be deceived - when writing a larger
-							program it is all too easy to make the mistake of trying to use, or output, the contents of a
-							data item before you have assigned it a value.
+							program it is all too easy to make the mistake of trying to use, or output, the contents of
+							a data item before you have assigned it a value.
 						</p>
 						<hr class="thin-rule" />
 					</div>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -330,8 +330,8 @@ DISPLAY PrinterSetupCodes UPON PrinterPort1.
 							The problem with <code class="language-cobol">ACCEPT ..FROM DATE</code> and
 							<code class="language-cobol">ACCEPT..FROM DAY</code> is that since they hold only the year
 							in only two digits, they are subject to the millennium bug. To resolve this problem, these
-							two formats now take additional (optional) formatting instructions to allow the
-							programmer to specify that the date is to be supplied with a 4 digit year.
+							two formats now take additional (optional) formatting instructions to allow the programmer
+							to specify that the date is to be supplied with a 4 digit year.
 						</p>
 						<p>The syntax for these new formatting instructions is:</p>
 						<ul>
@@ -1101,8 +1101,8 @@ The time is 14:41
 							</tr>
 						</table>
 						<p>
-							Note that unlike some other programming languages, COBOL provides the ** expression symbol to
-							represent raising to a power.
+							Note that unlike some other programming languages, COBOL provides the ** expression symbol
+							to represent raising to a power.
 						</p>
 						<hr width="50%" />
 					</div>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -208,7 +208,7 @@
 							<p>
 								The symbols used in the syntax diagram identifiers have the following significance:-<br />
 								<b>$</b> signifies a string item,<br />
-								<b>#</b> is numeric item,<br />
+								<b>#</b> is a numeric item,<br />
 								<b>i</b> indicates that the item can be a variable identifier<br />
 								<b>l</b> indicates that the item can be a literal.
 							</p>
@@ -330,7 +330,7 @@ DISPLAY PrinterSetupCodes UPON PrinterPort1.
 							The problem with <code class="language-cobol">ACCEPT ..FROM DATE</code> and
 							<code class="language-cobol">ACCEPT..FROM DAY</code> is that since they hold only the year
 							in only two digits, they are subject to the millennium bug. To resolve this problem, these
-							two formats of now take additional (optional) formatting instructions to allow the
+							two formats now take additional (optional) formatting instructions to allow the
 							programmer to specify that the date is to be supplied with a 4 digit year.
 						</p>
 						<p>The syntax for these new formatting instructions is:</p>
@@ -448,7 +448,7 @@ The time is 14:41
 					</div>
 					<div class="section-content">
 						<p>
-							In "strongly typed" languages like Modula-2, Pascal or ADA the assignment operation is
+							In "strongly typed" languages like Modula-2, Pascal or Ada the assignment operation is
 							simple because assignment is only allowed between data items with compatible types. The
 							simplicity of assignment in these languages, is achieved at the "cost" of having a large
 							number of data types.
@@ -537,7 +537,7 @@ The time is 14:41
 					<div class="section-content">
 						<p id="com1">
 							Examine the examples in the animation below in combination with the MOVE rules above. Make
-							sure you understand the why the moves produce the results shown.
+							sure you understand why the moves produce the results shown.
 						</p>
 						<p class="center-block">
 							<a href="Resources/ppz/TC-Commands1.html"
@@ -1101,7 +1101,7 @@ The time is 14:41
 							</tr>
 						</table>
 						<p>
-							Note that unlike some other programming languages COBOL provides the ** expression symbol to
+							Note that unlike some other programming languages, COBOL provides the ** expression symbol to
 							represent raising to a power.
 						</p>
 						<hr width="50%" />

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -223,13 +223,13 @@
 						</p>
 						<p>
 							When a <code class="language-cobol">COPY</code> statement is used in a COBOL program the
-							source code text is copied into the program from a copy file or from a copy library
-							before the program is compiled.
+							source code text is copied into the program from a copy file or from a copy library before
+							the program is compiled.
 						</p>
 						<p>A copy file, is a file containing a segment of COBOL code.</p>
 						<p>
-							A copy library, is a collection of code segments each of which can be referenced using a name.
-							Each program that wants to use items described in the copy library uses the
+							A copy library, is a collection of code segments each of which can be referenced using a
+							name. Each program that wants to use items described in the copy library uses the
 							<code class="language-cobol">COPY</code> verb to include the descriptions it requires.
 						</p>
 						<p>

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -148,7 +148,7 @@
 						</p>
 						<p>
 							It introduces the syntax of the <code class="language-cobol">COPY</code> verb and discusses
-							how the <code class="language-cobol">COPY</code> verb, and in particular they
+							how the <code class="language-cobol">COPY</code> verb, and in particular how
 							<code class="language-cobol">COPY..REPLACING</code>, works.
 						</p>
 						<p>
@@ -223,12 +223,12 @@
 						</p>
 						<p>
 							When a <code class="language-cobol">COPY</code> statement is used in a COBOL program the
-							source code text is copied into the program from from a copy file or from a copy library
+							source code text is copied into the program from a copy file or from a copy library
 							before the program is compiled.
 						</p>
 						<p>A copy file, is a file containing a segment of COBOL code.</p>
 						<p>
-							A copy library, is a collection code segment each of which can be referenced using a name.
+							A copy library, is a collection of code segments each of which can be referenced using a name.
 							Each program that wants to use items described in the copy library uses the
 							<code class="language-cobol">COPY</code> verb to include the descriptions it requires.
 						</p>
@@ -321,7 +321,7 @@
 							The matching procedure in the
 							<code class="language-cobol">REPLACING</code> phrase operates on text words.
 						</p>
-						<p>A text word is defined as ;</p>
+						<p>A text word is defined as:</p>
 						<div>
 							<ul>
 								<li>

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -214,8 +214,8 @@
 							Some languages like Modula-2,Pascal or Ada are described as being
 							<i>strongly typed</i>. In these languages there are a large number of different data types
 							and the distinction between them is rigorously enforced by the compiler. For instance, the
-							compiler will reject a statement that attempts to assign a character value to an integer data
-							item.
+							compiler will reject a statement that attempts to assign a character value to an integer
+							data item.
 						</p>
 						<p>In COBOL, there are really only three data types -</p>
 						<ul>

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -145,7 +145,7 @@
 								Be able to create a record structure by assigning the appropriate level numbers to its
 								data-items.
 							</li>
-							<li>Understand the difference between group and an elementary data-items.</li>
+							<li>Understand the difference between a group and an elementary data-item.</li>
 							<li>Be able to assign an initial value to a variable.</li>
 						</ol>
 						<hr width="50%" />
@@ -214,7 +214,7 @@
 							Some languages like Modula-2,Pascal or Ada are described as being
 							<i>strongly typed</i>. In these languages there are a large number of different data types
 							and the distinction between them is rigorously enforced by the compiler. For instance, the
-							compiler will reject a statement that attempts to assign character value to an integer data
+							compiler will reject a statement that attempts to assign a character value to an integer data
 							item.
 						</p>
 						<p>In COBOL, there are really only three data types -</p>
@@ -299,7 +299,7 @@
 					</div>
 					<div class="section-content">
 						<p>
-							Unlike most other programming languages COBOL does not provide a mechanism for creating
+							Unlike most other programming languages, COBOL does not provide a mechanism for creating
 							user-defined constants but it does provide a set of special constants called Figurative
 							Constants.
 						</p>
@@ -566,7 +566,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 							data-items. Group items are defined using only a level-number and an identifying name; no
 							picture clause is required or allowed.
 						</p>
-						<p>Which begs the question - what is a group item and what is an elementary item?</p>
+						<p>Which raises the question - what is a group item and what is an elementary item?</p>
 					</div>
 					<div class="section-sidebar">
 						<h3>Elementary items</h3>
@@ -618,8 +618,8 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 					<div class="section-content">
 						<p>
 							Sometimes when we are manipulating data it is convenient to treat a collection of elementary
-							items as a single group. For instance, we may want to group the data-items YearofBirth,
-							MonthofBirth, DayOfBirth under the group name - DateOfBirth. If we are recording information
+							items as a single group. For instance, we may want to group the data-items YearOfBirth,
+							MonthOfBirth, DayOfBirth under the group name - DateOfBirth. If we are recording information
 							about students we may want to subdivide StudentName into FirstName, MiddleInitial and
 							Surname. And we may want to use both these group items and the elementary items StudentId
 							and CourseCode in a student record description.

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -275,7 +275,7 @@
 						<h3>Editing symbols</h3>
 					</div>
 					<div class="section-content">
-						<p>COBOL permits two basic types of editing picture:&gt;</p>
+						<p>COBOL permits two basic types of editing picture:</p>
 						<table
 							style="margin: 0 auto"
 							bgcolor="#E1FFE1"

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -134,7 +134,7 @@
 							</div>
 							<div class="section-content">
 								<p>
-									The aim of this unit is to provide you with a solid understanding of; the
+									The aim of this unit is to provide you with a solid understanding of the
 									organization of Indexed files, the declarations required for them and the Procedure
 									Division verbs used to process them.
 								</p>
@@ -153,7 +153,7 @@
 									</li>
 									<li>Understand how the primary key and alternate key indexes are organized.</li>
 									<li>
-										Be able to used the use the
+										Be able to use the
 										<code class="language-cobol">START</code>,
 										<code class="language-cobol">OPEN</code>,
 										<code class="language-cobol">CLOSE</code>,
@@ -342,7 +342,7 @@ Enter Video Code (5 digits) -&gt; 44444
 VIDEO STATUS :- 23</code></pre>
 								<hr />
 								<p>
-									You can use the Indexed file that is created when you run the first sexample program
+									You can use the Indexed file that is created when you run the first example program
 									with this third Indexed example program.
 								</p>
 								<p>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -381,7 +381,7 @@ INSPECT SourceLine TALLYING ECount
 							alt="INSPECT REPLACING syntax diagram"
 						/>
 					</p>
-					<p>This format of the INSPECT is used to count characters in a string.</p>
+					<p>This format of the INSPECT is used to replace characters in a string.</p>
 					<hr />
 				</div>
 				<div class="section-grid">

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -685,9 +685,7 @@ END-IF</code></pre>
 											</div>
 										</td>
 										<td width="364" style="vertical-align: top">
-											<p>
-												Sequential files may be stored on serial media such as magnetic tape.
-											</p>
+											<p>Sequential files may be stored on serial media such as magnetic tape.</p>
 											<p>These media are cheap, removable and voluminous.</p>
 										</td>
 									</tr>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -156,7 +156,7 @@
 									</li>
 									<li>
 										Be able to choose the appropriate file organization for a particular set of
-										circumstances .
+										circumstances.
 									</li>
 								</ol>
 							</div>
@@ -230,7 +230,7 @@
 									While Sequential files have a number of advantages over other types of file
 									organization (and these are discussed fully in the
 									<a href="#comp">final section</a>) the fact that a new file must be created when we
-									delete, update or insert a records causes problems.
+									delete, update or insert records causes problems.
 								</p>
 								<p>
 									These problems are addressed by direct access files. Direct access files allow us to
@@ -347,7 +347,7 @@
 							<div class="section-content">
 								<p>
 									As we have already noted, the problem with Sequential files is that access to the
-									records is serial. To reach a particular record, all the proceeding records must be
+									records is serial. To reach a particular record, all the preceding records must be
 									read.
 								</p>
 								<p>
@@ -686,7 +686,7 @@ END-IF</code></pre>
 										</td>
 										<td width="364" style="vertical-align: top">
 											<p>
-												Sequential files may be stored on serial media such as magnetica tape.
+												Sequential files may be stored on serial media such as magnetic tape.
 											</p>
 											<p>These media are cheap, removable and voluminous.</p>
 										</td>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -282,19 +282,19 @@
 							</p>
 							<h4>Closed subroutines.</h4>
 							<p>
-								A closed subroutine is a named block of code that can only be executed by invoking it
-								by name. Usually a closed subroutine can declare its own local data which cannot be
+								A closed subroutine is a named block of code that can only be executed by invoking it by
+								name. Usually a closed subroutine can declare its own local data which cannot be
 								accessed outside the subroutine. In a closed subroutine, data is usually passed between
-								the main program and the subroutine by means of parameters passed to the subroutine
-								when it is invoked.
+								the main program and the subroutine by means of parameters passed to the subroutine when
+								it is invoked.
 							</p>
 							<p>In C and Modula-2, Procedures and Functions implement closed subroutines.</p>
 							<h4>COBOL subroutines.</h4>
 							<p>
 								COBOL supports both open and closed subroutines. Open subroutines are implemented using
 								the first format of the <code class="language-cobol">PERFORM</code> verb. Closed
-								subroutines are implemented using the <code class="language-cobol">CALL</code> verb
-								and contained or external subprograms.
+								subroutines are implemented using the <code class="language-cobol">CALL</code> verb and
+								contained or external subprograms.
 							</p>
 						</div>
 						<div>
@@ -332,9 +332,9 @@
 								Unless it is otherwise instructed, a computer running a COBOL program processes the
 								statements of the program in sequence, starting at the top of the program and working
 								its way down until the <code class="language-cobol">STOP RUN</code> is reached. The
-								<code class="language-cobol">PERFORM</code> verb is one way of altering the
-								sequential flow of control in a COBOL program. The
-								<code class="language-cobol">PERFORM</code> verb can be used for two major purposes;
+								<code class="language-cobol">PERFORM</code> verb is one way of altering the sequential
+								flow of control in a COBOL program. The <code class="language-cobol">PERFORM</code> verb
+								can be used for two major purposes;
 							</p>
 						</div>
 						<ol>
@@ -392,9 +392,9 @@
 							<p>1stProc and EndProc are the names of paragraphs or sections.</p>
 							<p>
 								When the <code class="language-cobol">PERFORM..THRU</code> is used, the paragraphs or
-								sections from 1stProc to EndProc are treated as a single block of code. COBOL programmers
-								typically use this format of the <code class="language-cobol">PERFORM</code> to divide a
-								program into open subroutines.
+								sections from 1stProc to EndProc are treated as a single block of code. COBOL
+								programmers typically use this format of the
+								<code class="language-cobol">PERFORM</code> to divide a program into open subroutines.
 							</p>
 							<p>
 								These subroutines are not as robust as the user-defined Procedures or Functions found in
@@ -402,8 +402,8 @@
 								contained or external subprograms.
 							</p>
 							<p>
-								Open subroutines are useful because they allow a programmer to code a subroutine
-								without the formality or overhead involved in coding a Procedure or Function.
+								Open subroutines are useful because they allow a programmer to code a subroutine without
+								the formality or overhead involved in coding a Procedure or Function.
 							</p>
 						</div>
 						<div>
@@ -898,8 +898,8 @@ Back in Begin. About to stop</pre>
 						</p>
 						<p>
 							The <code class="language-cobol">WITH TEST AFTER</code> phrase causes the
-							<code class="language-cobol">PERFORM</code> to act like a <i>do/repeat</i> loop and the condition
-							is tested after the loop body is entered.
+							<code class="language-cobol">PERFORM</code> to act like a <i>do/repeat</i> loop and the
+							condition is tested after the loop body is entered.
 						</p>
 						<p>
 							The <code class="language-cobol">WITH TEST BEFORE</code> phrase is the default and so is
@@ -1155,8 +1155,8 @@ END-PERFORM</code></pre>
 					</div>
 					<div class="section-content">
 						<p>
-							The example program simulates the mileage counter mentioned above. Examine this program
-							and then attempt to answer the Self Assessment Questions which follow.
+							The example program simulates the mileage counter mentioned above. Examine this program and
+							then attempt to answer the Self Assessment Questions which follow.
 						</p>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
@@ -1232,10 +1232,10 @@ CountMileage.
 										<p>
 											Consider what happens just after UnitsCnt displays the value 9 in the loop
 											body. As control exits the loop the counter is incremented making it =10. If
-											UnitsCnt had been defined as PIC 9, there would not be enough room for
-											the 2 digits in 10 and the most significant digit would be truncated,
-											leaving the 0. When UnitsCnt was tested by the condition it would be found
-											to contain a 0 and the program would continue to loop interminably.
+											UnitsCnt had been defined as PIC 9, there would not be enough room for the 2
+											digits in 10 and the most significant digit would be truncated, leaving the
+											0. When UnitsCnt was tested by the condition it would be found to contain a
+											0 and the program would continue to loop interminably.
 										</p>
 									</details>
 								</div>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -271,29 +271,29 @@
 							</p>
 							<h4>Open subroutines.</h4>
 							<p>
-								An open subroutine., is a named block of code that control can fall into, or through. An
-								open subroutine., usually has access to all the data-items declared in the main program
+								An open subroutine is a named block of code that control can fall into, or through. An
+								open subroutine usually has access to all the data-items declared in the main program
 								and it can't declare any data-items of its own.
 							</p>
 							<p>
-								Although an open subroutine. is normally executed by invoking it by name, it is also
+								Although an open subroutine is normally executed by invoking it by name, it is also
 								possible, unless the programmer is careful, to fall into it from the main program. In
 								BASIC, the GOSUB command allows programmers to implement open subroutines.
 							</p>
 							<h4>Closed subroutines.</h4>
 							<p>
-								A closed subroutine., is a named block of code that can only be executed by invoking it
-								by name. Usually a closed subroutine. can declare its own local data which cannot be
-								accessed outside the subroutine. In a closed subroutine., data is usually passed between
-								the main program and the subroutine. By means of parameters passed to the subroutine.
+								A closed subroutine is a named block of code that can only be executed by invoking it
+								by name. Usually a closed subroutine can declare its own local data which cannot be
+								accessed outside the subroutine. In a closed subroutine, data is usually passed between
+								the main program and the subroutine by means of parameters passed to the subroutine
 								when it is invoked.
 							</p>
 							<p>In C and Modula-2, Procedures and Functions implement closed subroutines.</p>
 							<h4>COBOL subroutines.</h4>
 							<p>
-								COBOL supports both open and closed subroutines. Open subroutines, are implemented using
+								COBOL supports both open and closed subroutines. Open subroutines are implemented using
 								the first format of the <code class="language-cobol">PERFORM</code> verb. Closed
-								subroutines., are implemented using the <code class="language-cobol">CALL</code> verb
+								subroutines are implemented using the <code class="language-cobol">CALL</code> verb
 								and contained or external subprograms.
 							</p>
 						</div>
@@ -332,7 +332,7 @@
 								Unless it is otherwise instructed, a computer running a COBOL program processes the
 								statements of the program in sequence, starting at the top of the program and working
 								its way down until the <code class="language-cobol">STOP RUN</code> is reached. The
-								<code class="language-cobol">PERFORM</code> verb is is one way of altering the
+								<code class="language-cobol">PERFORM</code> verb is one way of altering the
 								sequential flow of control in a COBOL program. The
 								<code class="language-cobol">PERFORM</code> verb can be used for two major purposes;
 							</p>
@@ -358,13 +358,13 @@
 								<img height="62" src="Resources/pics/i-BugAlert.svg" width="56" alt="" />
 							</p>
 							<p>
-								>The <code class="language-cobol">PERFORM..THRU</code> should be used sparingly and then
+								The <code class="language-cobol">PERFORM..THRU</code> should be used sparingly and then
 								only to <code class="language-cobol">PERFORM</code> a paragraph and its immediately
 								succeeding paragraph.
 							</p>
 							<p>
 								The problem with using the <code class="language-cobol">PERFORM..THRU</code> to execute
-								an number of paragraphs as one unit is that, in the maintenance phase of your program's
+								a number of paragraphs as one unit is that, in the maintenance phase of your program's
 								life, another programmer may insert a paragraph in the middle of your
 								<code class="language-cobol">PERFORM..THRU</code>
 								block. Suddenly your block won't work correctly because now its executing an additional,
@@ -392,7 +392,7 @@
 							<p>1stProc and EndProc are the names of paragraphs or sections.</p>
 							<p>
 								When the <code class="language-cobol">PERFORM..THRU</code> is used, the paragraphs or
-								sections from 1stProc to EndProc are treated a single block of code. COBOL programmers
+								sections from 1stProc to EndProc are treated as a single block of code. COBOL programmers
 								typically use this format of the <code class="language-cobol">PERFORM</code> to divide a
 								program into open subroutines.
 							</p>
@@ -402,7 +402,7 @@
 								contained or external subprograms.
 							</p>
 							<p>
-								Open subroutines. are useful because they allow a programmer to code a subroutine.
+								Open subroutines are useful because they allow a programmer to code a subroutine
 								without the formality or overhead involved in coding a Procedure or Function.
 							</p>
 						</div>
@@ -757,7 +757,7 @@ SumSalesExit.
 							This format of the PERFORM executes a block of code RepeatCount number of times before
 							returning control to the statement following the PERFORM.
 						</p>
-						<p>Like the remaining formats of the PERFORM, this format allow two types of execution.</p>
+						<p>Like the remaining formats of the PERFORM, this format allows two types of execution.</p>
 						<ul>
 							<li>Out-of-line execution of a block of code</li>
 							<li>In-line execution of a block of code.</li>
@@ -898,7 +898,7 @@ Back in Begin. About to stop</pre>
 						</p>
 						<p>
 							The <code class="language-cobol">WITH TEST AFTER</code> phrase causes the
-							<code class="language-cobol">PERFORM</code> to act <i>do/repeat</i> loop and the condition
+							<code class="language-cobol">PERFORM</code> to act like a <i>do/repeat</i> loop and the condition
 							is tested after the loop body is entered.
 						</p>
 						<p>
@@ -1081,7 +1081,7 @@ END-PERFORM</code></pre>
 							counter is the least significant.
 						</p>
 						<p>
-							The least significant counter must go though all its values and reach its terminating
+							The least significant counter must go through all its values and reach its terminating
 							condition before the next most significant counter can be incremented.
 						</p>
 						<p>The item after the FROM, is the starting value of the counter.</p>
@@ -1108,7 +1108,7 @@ END-PERFORM</code></pre>
 					<div class="section-content">
 						<p>
 							The example animation below demonstrates how a simple PERFORM..VARYING, using only one
-							counter, work. Pay particular attention to when the counter is incremented. In the example
+							counter, works. Pay particular attention to when the counter is incremented. In the example
 							note that the condition
 							<i>Idx1 = 3</i> results in only two passes through the loop body.
 						</p>
@@ -1133,7 +1133,7 @@ END-PERFORM</code></pre>
 							before the Idx1 counter is incremented. An easy way to think about this is to think of it as
 							a mileage counter. In a mileage counter, the units counter must go through all its values
 							0-9 before the tens counter is incremented, and the tens counter must go through all its
-							values before the hundreds counter is increment.
+							values before the hundreds counter is incremented.
 						</p>
 						<p>
 							Note that the first counter mentioned in the PERFORM is the most significant and the next is
@@ -1155,8 +1155,8 @@ END-PERFORM</code></pre>
 					</div>
 					<div class="section-content">
 						<p>
-							In the example program simulates the mileage counter mentioned above. Examine this program
-							an then attempt to answer the Self Assessment Question which follow.
+							The example program simulates the mileage counter mentioned above. Examine this program
+							and then attempt to answer the Self Assessment Questions which follow.
 						</p>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
@@ -1232,7 +1232,7 @@ CountMileage.
 										<p>
 											Consider what happens just after UnitsCnt displays the value 9 in the loop
 											body. As control exits the loop the counter is incremented making it =10. If
-											UnitsCnt had been been defined as PIC 9, there would not be enough room for
+											UnitsCnt had been defined as PIC 9, there would not be enough room for
 											the 2 digits in 10 and the most significant digit would be truncated,
 											leaving the 0. When UnitsCnt was tested by the condition it would be found
 											to contain a 0 and the program would continue to loop interminably.

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -131,9 +131,9 @@
 					</div>
 					<div class="section-content">
 						<p>
-							The aim of this unit is to provide you with a solid understanding of string
-							manipulation using Reference Modification. It will also introduce you to Intrinsic Functions
-							and will show how strings may be manipulated using the String Intrinsic Functions.
+							The aim of this unit is to provide you with a solid understanding of string manipulation
+							using Reference Modification. It will also introduce you to Intrinsic Functions and will
+							show how strings may be manipulated using the String Intrinsic Functions.
 						</p>
 						<hr />
 					</div>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -27,7 +27,7 @@
 				"@context": "https://schema.org",
 				"@type": "LearningResource",
 				"name": "Reference modification and Intrinsic Functions",
-				"description": "The aim of this unit is to provide to provide you with a solid understanding of string manipulation using Reference Modification. It will also introduce",
+				"description": "The aim of this unit is to provide you with a solid understanding of string manipulation using Reference Modification. It will also introduce",
 				"url": "https://bushidocodes.github.io/limerick-cobol/course/RefMod.html",
 				"position": 23,
 				"isPartOf": {
@@ -51,7 +51,7 @@
 		<title>Reference Modification and Intrinsic Functions</title>
 		<meta
 			name="description"
-			content="The aim of this unit is to provide to provide you with a solid understanding of string manipulation using Reference Modification. It will also introduce"
+			content="The aim of this unit is to provide you with a solid understanding of string manipulation using Reference Modification. It will also introduce"
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/RefMod.html" />
 		<link rel="prev" href="https://bushidocodes.github.io/limerick-cobol/course/Unstring.html" />
@@ -62,7 +62,7 @@
 		<meta property="og:title" content="Reference Modification and Intrinsic Functions" />
 		<meta
 			property="og:description"
-			content="The aim of this unit is to provide to provide you with a solid understanding of string manipulation using Reference Modification. It will also introduce"
+			content="The aim of this unit is to provide you with a solid understanding of string manipulation using Reference Modification. It will also introduce"
 		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
@@ -70,7 +70,7 @@
 		<meta name="twitter:title" content="Reference Modification and Intrinsic Functions" />
 		<meta
 			name="twitter:description"
-			content="The aim of this unit is to provide to provide you with a solid understanding of string manipulation using Reference Modification. It will also introduce"
+			content="The aim of this unit is to provide you with a solid understanding of string manipulation using Reference Modification. It will also introduce"
 		/>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />
@@ -131,7 +131,7 @@
 					</div>
 					<div class="section-content">
 						<p>
-							The aim of this unit is to provide to provide you with a solid understanding of string
+							The aim of this unit is to provide you with a solid understanding of string
 							manipulation using Reference Modification. It will also introduce you to Intrinsic Functions
 							and will show how strings may be manipulated using the String Intrinsic Functions.
 						</p>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -626,8 +626,8 @@ Enter supplier key (2 digits)-&gt; 05
 							<li>Then the DELETE must be executed.</li>
 						</ol>
 						<p>
-							The record with the Relative Record number equal to the current value of the key area will be
-							deleted.
+							The record with the Relative Record number equal to the current value of the key area will
+							be deleted.
 						</p>
 						<h4>Notes</h4>
 						<p>To use the DELETE, the file must have been opened for I-O.</p>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -154,7 +154,7 @@
 							</li>
 							<li>Understand the difference between a file's access mode and its organization.</li>
 							<li>
-								Be able to used the use the START, OPEN, CLOSE, READ, WRITE, REWRITE and
+								Be able to use the START, OPEN, CLOSE, READ, WRITE, REWRITE and
 								<code class="language-cobol">DELETE</code>
 								Procedure Division verbs required to process Relative files.
 							</li>
@@ -583,7 +583,7 @@ Enter supplier key (2 digits)-&gt; 05
 						<ol>
 							<li>
 								The record we wish to update is read directly into the record buffer (place the key
-								value in the key are and execute the READ).
+								value in the key area and execute the READ).
 							</li>
 							<li>The required changes are made to the record in the buffer.</li>
 							<li>The record in the buffer is rewritten to the file.</li>
@@ -626,7 +626,7 @@ Enter supplier key (2 digits)-&gt; 05
 							<li>Then the DELETE must be executed.</li>
 						</ol>
 						<p>
-							The record with the Relative Record number equal to the current value of the key are will be
+							The record with the Relative Record number equal to the current value of the key area will be
 							deleted.
 						</p>
 						<h4>Notes</h4>

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -387,7 +387,7 @@ PrintSalaryReport.
 							merely to move values to their corresponding items in the print line. A line count has to be
 							kept to control when the report prints on a new page and a page count is often required.
 						</p>
-						<p>The Report Writer makes all of this easy by;</p>
+						<p>The Report Writer makes all of this easy by:</p>
 						<ul>
 							<li>
 								Allowing simple vertical and horizontal placement of printed items using the
@@ -715,7 +715,7 @@ RD  SalesReport
 						</p>
 						<p>
 							Calculating the commission requires more than just simple addition so the Report Writer
-							cannot handle it automatically. To calculate the commission are
+							cannot handle it automatically. To calculate the commission,
 							<code class="language-cobol">DECLARATIVES</code> are required. The
 							<code class="language-cobol">USE BEFORE REPORTING</code> Salespsn-Line phrase in the
 							<code class="language-cobol">DECLARATIVES</code> allows these items to be calculated when

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -1090,7 +1090,7 @@ Programmer - Michael Coughlan               Page :  1</code></pre>
 					<div class="section-content">
 						<p>
 							Declaratives are used to extend the functionality of the Report Writer when its standard
-							operations are insufficient of create the desired report. Declaratives extend the
+							operations are insufficient to create the desired report. Declaratives extend the
 							functionality of the Report Writer by performing tasks or calculations that the Report
 							Writer can not do automatically or by selectively stopping the report group from being
 							printed (using the

--- a/course/Search.html
+++ b/course/Search.html
@@ -881,10 +881,10 @@ END-SEARCH</code></pre>
 						<p>
 							The <code class="language-cobol">SEARCH ALL</code> is used when a binary search is required.
 							For this reason, the <code class="language-cobol">SEARCH ALL</code> will only work on an
-							ordered table. The table must be ordered on some key field. The key field may be the
-							element itself or, where the element is a group item, a field within the element. The key
-							field must be identified by using the <code class="language-cobol">KEY IS</code> phrase in
-							the table declaration.
+							ordered table. The table must be ordered on some key field. The key field may be the element
+							itself or, where the element is a group item, a field within the element. The key field must
+							be identified by using the <code class="language-cobol">KEY IS</code> phrase in the table
+							declaration.
 						</p>
 						<hr class="thin-rule" />
 					</div>

--- a/course/Search.html
+++ b/course/Search.html
@@ -881,7 +881,7 @@ END-SEARCH</code></pre>
 						<p>
 							The <code class="language-cobol">SEARCH ALL</code> is used when a binary search is required.
 							For this reason, the <code class="language-cobol">SEARCH ALL</code> will only work on an
-							ordered table. The table must be ordered on some some key field. The key field may be the
+							ordered table. The table must be ordered on some key field. The key field may be the
 							element itself or, where the element is a group item, a field within the element. The key
 							field must be identified by using the <code class="language-cobol">KEY IS</code> phrase in
 							the table declaration.

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -1033,8 +1033,8 @@ END-IF
 					<div class="section-content">
 						<p>
 							The SET verb is used for a number of unrelated functions in COBOL, so instead of dealing
-							with it as a single topic, we will deal with each format as we examine the construct to which it
-							is most closely related.
+							with it as a single topic, we will deal with each format as we examine the construct to
+							which it is most closely related.
 						</p>
 						<p>
 							In this section, we show how the <code class="language-cobol">SET</code> verb may be used to

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -395,7 +395,7 @@ Statement6.</code></pre>
 							contained numeric data.
 						</p>
 						<p>
-							The UserDefinedClassName is name that a programmer can assign to a set of characters. The
+							The UserDefinedClassName is a name that a programmer can assign to a set of characters. The
 							programmer must use the <code class="language-cobol">CLASS</code> clause of the
 							<code class="language-cobol">SPECIAL-NAMES</code> paragraph, of the
 							<code class="language-cobol">CONFIGURATION SECTION</code>, in the
@@ -414,7 +414,7 @@ Statement6.</code></pre>
 						</p>
 						<p>An alphabetic test may not be used with any data items described as numeric (PIC 9).</p>
 						<p>
-							An data-item conforms to the UserDefinedClassName if its contents consist entirely of the
+							A data-item conforms to the UserDefinedClassName if its contents consist entirely of the
 							characters listed in the definition of the UserDefinedClassName.
 						</p>
 						<p><strong>Example</strong></p>
@@ -439,7 +439,7 @@ END-IF</code></pre>
 						</p>
 						<p>
 							The Sign Condition determines whether or not the value of an arithmetic expression is less
-							than, greater than, or equal to zero. Sign Conditions are shorter way of writing certain
+							than, greater than, or equal to zero. Sign Conditions are a shorter way of writing certain
 							Relational Conditions.
 						</p>
 					</div>
@@ -1033,7 +1033,7 @@ END-IF
 					<div class="section-content">
 						<p>
 							The SET verb is used for a number of unrelated functions in COBOL, so instead of dealing
-							with it as a single topic, we will deal each format as we examine the construct to which it
+							with it as a single topic, we will deal with each format as we examine the construct to which it
 							is most closely related.
 						</p>
 						<p>
@@ -1049,7 +1049,7 @@ END-IF
 					<div class="section-content">
 						<p>SET {ConditionName} ... TO TRUE</p>
 						<p>
-							A Condition Name set to true when one of the condition values mentioned in its
+							A Condition Name is set to true when one of the condition values mentioned in its
 							<code class="language-cobol">VALUE</code> clause is moved into its associated data-item. But
 							you can also set a Condition Name to true using the
 							<code class="language-cobol">SET</code> verb.
@@ -1201,7 +1201,7 @@ Begin.
 							are called <i>objects</i>.
 						</p>
 						<p>
-							The number of subject be equal to the number of objects and the type of each
+							The number of subjects must be equal to the number of objects and the type of each
 							<i>subject</i> must be compatible with the type of its corresponding <i>object</i>.
 						</p>
 						<p>
@@ -1287,12 +1287,12 @@ END-EVALUATE
 						<p>
 							The <strong>subjects</strong> are <code class="language-cobol">TRUE</code> and Position. So
 							the first <strong>object</strong> after the <code class="language-cobol">WHEN</code> clause
-							must specify a condition to be compatible. with its <strong>subject</strong>, and the second
+							must specify a condition to be compatible with its <strong>subject</strong>, and the second
 							must specify a value or range of values. So the first
 							<code class="language-cobol">WHEN</code> clause reads as -
 							<i
 								>When the L-Arrow Condition Name is true and the data-item Position has a value in the
-								range 2-10 then we add 1 to the Position</i
+								range 2-10 then we subtract 1 from the Position</i
 							>.
 						</p>
 						<p>
@@ -1482,7 +1482,7 @@ END-EVALUATE
 							accurate reflection of the decision table or has the programmer introduced an error?
 						</p>
 						<p>
-							This code will also cause maintenance problems. What's going to happen if Jupiter decide
+							This code will also cause maintenance problems. What's going to happen if Jupiter decides to
 							change the second 23% discount to 20%. Big rewrite of the C code. One change to the COBOL
 							code.
 						</p>

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -149,7 +149,7 @@
 						<p>In a Serial File, the records are organized and accessed serially.</p>
 						<p>
 							In a Direct Access File, the records are organized in a manner that allows direct access to
-							a particular record without having the read any of the preceding records.
+							a particular record without having to read any of the preceding records.
 						</p>
 						<p>In this tutorial, you will discover how COBOL may be used to process serial files.</p>
 						<hr width="50%" />
@@ -162,7 +162,7 @@
 						<ol>
 							<li>Understand concepts and terminology like file, record, field and record buffer.</li>
 							<li>Be able to write the file and record declarations for a Sequential File.</li>
-							<li>Understand how <code class="language-cobol">READ</code> verbs works</li>
+							<li>Understand how <code class="language-cobol">READ</code> verb works</li>
 							<li>
 								Be able to use the <code class="language-cobol">READ</code>,
 								<code class="language-cobol">WRITE</code>, <code class="language-cobol">OPEN</code> and
@@ -198,14 +198,14 @@
 						<h3>Files, Records, Fields</h3>
 					</div>
 					<div class="section-content">
-						<p>In record-based files;</p>
+						<p>In record-based files:</p>
 						<ul>
 							<li>
 								We use the term <i>file</i>, to describe a collection of one or more occurrences
 								(instances) of a record type (template).
 							</li>
 							<li>
-								We use the term r<i>ecord,</i> to describe a collection of fields which record
+								We use the term <i>record,</i> to describe a collection of fields which record
 								information about an object.
 							</li>
 							<li>
@@ -411,7 +411,7 @@
 							<code class="language-cobol">FD</code> and an internal name that the programmer assigns to
 							the file.
 						</p>
-						<p>So the full file description for the students file might be;.</p>
+						<p>So the full file description for the students file might be:</p>
 						<pre class="language-cobol"><code class="language-cobol">DATA DIVISION.
 FILE SECTION.
 FD StudentFile.
@@ -439,7 +439,7 @@ FD StudentFile.
 						<p>
 							Although the name of the students file on disk is <i>Students.dat</i> we are going to refer
 							to it in our program as StudentFile. How can we connect the name we are going to use
-							internally with the actual name of the program on disk?
+							internally with the actual name of the file on disk?
 						</p>
 						<p>
 							The internal file name used in a file's <code class="language-cobol">FD</code> entry is

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -131,7 +131,7 @@
 						<p>
 							The records in a Sequential file are organized serially, one after another, but the records
 							in the file may be ordered or unordered. The serial organization of the file and whether the
-							file is ordered or unordered has a significant baring on how we process the records in the
+							file is ordered or unordered has a significant bearing on how we process the records in the
 							file and what kind of processing we can do.
 						</p>
 						<p>

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -202,7 +202,7 @@
 							that the file will contain records of different types (i.e. records with different
 							structures) and this may give rise to records of different lengths. A deletion record only
 							needs the key field StudentId (7 characters), while an insertion requires the whole record
-							(30 characters, and an update may be somewhere between these two depending on which fields,
+							(30 characters), and an update may be somewhere between these two depending on which fields,
 							and how many of them, are being updated.
 						</p>
 						<hr width="50%" />
@@ -333,7 +333,7 @@ FD TransFile.
 						</p>
 						<p>
 							To allow us to distinguish between record types, a special data-item, which identifies the
-							transaction type, is usually inserted into each transaction, . This data-item is usually
+							transaction type, is usually inserted into each transaction. This data-item is usually
 							called the transaction type-code. It is usually the first data-item in the transaction
 							record and is usually one character in size, but it can be placed anywhere in the record, be
 							of any size, and be any type of character.
@@ -356,7 +356,7 @@ FD TransFile.
 							In the program fragment below, the revised record descriptions are shown. These record
 							descriptions now include a one character field, which stores the type-code inserted into
 							each transaction record to indicate the transaction type. Obviously the transaction file
-							(TRANS.dat) must must also be altered so that its actual records contain the type-code.
+							(TRANS.dat) must also be altered so that its actual records contain the type-code.
 						</p>
 						<pre class="language-cobol"><code class="language-cobol">ENVIRONMENT DIVISION.
 INPUT-OUTPUT SECTION.
@@ -586,7 +586,7 @@ FD TransFile.
 						<hr width="50%" />
 					</div>
 					<div class="section-sidebar">
-						<h3>Problems multiple print records.</h3>
+						<h3>Problems with multiple print records.</h3>
 					</div>
 					<div class="section-content">
 						<p>
@@ -894,7 +894,7 @@ FD Stringfile
 						<h3>Example program</h3>
 					</div>
 					<div class="section-content">
-						<p>The example program below introduces and number of new techniques and concepts;</p>
+						<p>The example program below introduces a number of new techniques and concepts;</p>
 						<ul>
 							<li>
 								The filenames we have used so far have been defined at compile-time. In this example we

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -221,7 +221,7 @@
 					</div>
 					<div class="section-content">
 						<p>
-							Sometimes, processing that is is difficult or impossible to do if the file is unordered, is
+							Sometimes, processing that is difficult or impossible to do if the file is unordered, is
 							easy if the file is ordered. In these situations, an obvious part of the solution is to sort
 							the file. This is an approach to problem solving sometimes called, "beneficial wishful
 							thinking". We start by thinking
@@ -1461,7 +1461,7 @@ PrintReportBody.
 						<p>
 							It is often useful to combine two or more files into a single large file. If the files are
 							unordered, this is easy to accomplish because we can simply append the records in one file
-							to the end of the other. But if the files are unordered, the task is somewhat more
+							to the end of the other. But if the files are ordered, the task is somewhat more
 							complicated, especially if there are more than two files, because we must preserve the
 							ordering in the combined file.
 						</p>

--- a/course/String.html
+++ b/course/String.html
@@ -127,10 +127,7 @@
 						<h3>Aims</h3>
 					</div>
 					<div class="section-content">
-						<p>
-							The aim of this unit is to provide you with a solid understanding of the STRING
-							verb.
-						</p>
+						<p>The aim of this unit is to provide you with a solid understanding of the STRING verb.</p>
 						<hr />
 					</div>
 					<div class="section-sidebar">

--- a/course/String.html
+++ b/course/String.html
@@ -27,7 +27,7 @@
 				"@context": "https://schema.org",
 				"@type": "LearningResource",
 				"name": "String",
-				"description": "The aim of this unit is to provide to provide you with a solid understanding of the STRING verb.",
+				"description": "The aim of this unit is to provide you with a solid understanding of the STRING verb.",
 				"url": "https://bushidocodes.github.io/limerick-cobol/course/String.html",
 				"position": 21,
 				"isPartOf": {
@@ -51,7 +51,7 @@
 		<title>STRING</title>
 		<meta
 			name="description"
-			content="The aim of this unit is to provide to provide you with a solid understanding of the STRING verb."
+			content="The aim of this unit is to provide you with a solid understanding of the STRING verb."
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/String.html" />
 		<link rel="prev" href="https://bushidocodes.github.io/limerick-cobol/course/Inspect.html" />
@@ -62,7 +62,7 @@
 		<meta property="og:title" content="STRING" />
 		<meta
 			property="og:description"
-			content="The aim of this unit is to provide to provide you with a solid understanding of the STRING verb."
+			content="The aim of this unit is to provide you with a solid understanding of the STRING verb."
 		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
@@ -70,7 +70,7 @@
 		<meta name="twitter:title" content="STRING" />
 		<meta
 			name="twitter:description"
-			content="The aim of this unit is to provide to provide you with a solid understanding of the STRING verb."
+			content="The aim of this unit is to provide you with a solid understanding of the STRING verb."
 		/>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />
@@ -128,7 +128,7 @@
 					</div>
 					<div class="section-content">
 						<p>
-							The aim of this unit is to provide to provide you with a solid understanding of the STRING
+							The aim of this unit is to provide you with a solid understanding of the STRING
 							verb.
 						</p>
 						<hr />

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -704,9 +704,7 @@ CALL "Fickle" USING BY CONTENT IncValue.</code></pre>
 						</h3>
 					</div>
 					<div class="section-content">
-						<p>
-							COBOL subprograms are identical to standard COBOL programs with the following exceptions:
-						</p>
+						<p>COBOL subprograms are identical to standard COBOL programs with the following exceptions:</p>
 						<ol>
 							<li>
 								The <code class="language-cobol">PROGRAM-ID</code> may take the
@@ -883,9 +881,9 @@ END-PROGRAM ContainerProgram.</code></pre>
 							/>
 						</p>
 						<p>
-							Unfortunately, this arrangement is not allowed in COBOL because, although subprograms may
-							be nested, a contained subprogram can only be called by the immediate containing program or
-							by a subprogram at the same level. So in the diagram above, the main program would not be
+							Unfortunately, this arrangement is not allowed in COBOL because, although subprograms may be
+							nested, a contained subprogram can only be called by the immediate containing program or by
+							a subprogram at the same level. So in the diagram above, the main program would not be
 							allowed direct access to the contained subprograms.
 						</p>
 						<p>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -705,7 +705,7 @@ CALL "Fickle" USING BY CONTENT IncValue.</code></pre>
 					</div>
 					<div class="section-content">
 						<p>
-							COBOL subprograms. are identical to standard COBOL programs with the following exceptions:
+							COBOL subprograms are identical to standard COBOL programs with the following exceptions:
 						</p>
 						<ol>
 							<li>
@@ -735,7 +735,7 @@ CALL "Fickle" USING BY CONTENT IncValue.</code></pre>
 								it is encountered in a subprogram) instead of just the subprogram
 							</li>
 							<li>
-								Contained subprograms. must end with the
+								Contained subprograms must end with the
 								<code class="language-cobol">END PROGRAM</code> statement. The END PROGRAM statement
 								delimits the scope of a contained subprogram
 							</li>
@@ -759,7 +759,7 @@ CALL "Fickle" USING BY CONTENT IncValue.</code></pre>
 							executable run-unit) or they can be contained within the text of a containing program.
 						</p>
 						<p>
-							Contained subprograms. are very similar to the procedures (or user defined functions) found
+							Contained subprograms are very similar to the procedures (or user defined functions) found
 							in other languages except that they are invoked with the
 							<code class="language-cobol">CALL</code> verb and are better protected against accidental
 							data corruption.
@@ -883,7 +883,7 @@ END-PROGRAM ContainerProgram.</code></pre>
 							/>
 						</p>
 						<p>
-							Unfortunately, this arrangement is not allowed in COBOL because, although subprograms. may
+							Unfortunately, this arrangement is not allowed in COBOL because, although subprograms may
 							be nested, a contained subprogram can only be called by the immediate containing program or
 							by a subprogram at the same level. So in the diagram above, the main program would not be
 							allowed direct access to the contained subprograms.
@@ -1206,7 +1206,7 @@ Value - 0</code></pre>
 					<div class="section-content">
 						<p>
 							Anyone who considers creating a system that consists of subprograms and contained
-							subprograms should not embark on such an undertaking without an sound understanding how such
+							subprograms should not embark on such an undertaking without a sound understanding how such
 							a system is designed and what makes a good subprogram and what does not.
 						</p>
 						<p>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -151,7 +151,7 @@
 							</li>
 							<li>
 								Understand how a numeric field in a record can be used as an index or subscript for a
-								table..
+								table.
 							</li>
 							<li>Understand how the subscript of one table can be used an index into another.</li>
 						</ol>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -1421,8 +1421,8 @@ DisplayCountyTaxes.
 						<p>
 							The 1985 COBOL standard introduced a number of changes to tables. Among these changes was a
 							method that allowed pre-filled tables to be created without using the
-							<code class="language-cobol">REDEFINES</code> clause. But this new method only works as
-							long as the number of values is small. For large amounts of data the
+							<code class="language-cobol">REDEFINES</code> clause. But this new method only works as long
+							as the number of values is small. For large amounts of data the
 							<code class="language-cobol">REDEFINES</code> clause is still required.
 						</p>
 						<p>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -317,7 +317,7 @@
 					</div>
 					<div class="section-content">
 						<p>
-							This section of the tutorial introduces simple version of the
+							This section of the tutorial introduces a simple version of the
 							<code class="language-cobol">OCCURS</code> clause but keep in mind that the
 							<code class="language-cobol">OCCURS</code> clause contains a number of other entries;
 							including entries for declaring variable length tables and for satisfying the special
@@ -1421,7 +1421,7 @@ DisplayCountyTaxes.
 						<p>
 							The 1985 COBOL standard introduced a number of changes to tables. Among these changes was a
 							method that allowed pre-filled tables to be created without using the
-							<code class="language-cobol">REDEFINES</code> clause. But this new method only works as as
+							<code class="language-cobol">REDEFINES</code> clause. But this new method only works as
 							long as the number of values is small. For large amounts of data the
 							<code class="language-cobol">REDEFINES</code> clause is still required.
 						</p>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -27,7 +27,7 @@
 				"@context": "https://schema.org",
 				"@type": "LearningResource",
 				"name": "Unstring",
-				"description": "The aim of this unit is to provide to provide you with a solid understanding of the UNSTRING verb.",
+				"description": "The aim of this unit is to provide you with a solid understanding of the UNSTRING verb.",
 				"url": "https://bushidocodes.github.io/limerick-cobol/course/unstring.html",
 				"position": 22,
 				"isPartOf": {
@@ -51,7 +51,7 @@
 		<title>UNSTRING</title>
 		<meta
 			name="description"
-			content="The aim of this unit is to provide to provide you with a solid understanding of the UNSTRING verb."
+			content="The aim of this unit is to provide you with a solid understanding of the UNSTRING verb."
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/unstring.html" />
 		<link rel="prev" href="https://bushidocodes.github.io/limerick-cobol/course/String.html" />
@@ -62,7 +62,7 @@
 		<meta property="og:title" content="UNSTRING" />
 		<meta
 			property="og:description"
-			content="The aim of this unit is to provide to provide you with a solid understanding of the UNSTRING verb."
+			content="The aim of this unit is to provide you with a solid understanding of the UNSTRING verb."
 		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
@@ -70,7 +70,7 @@
 		<meta name="twitter:title" content="UNSTRING" />
 		<meta
 			name="twitter:description"
-			content="The aim of this unit is to provide to provide you with a solid understanding of the UNSTRING verb."
+			content="The aim of this unit is to provide you with a solid understanding of the UNSTRING verb."
 		/>
 		<link href="Resources/css/course.css" rel="stylesheet" />
 		<link href="Resources/css/course-components.css" rel="stylesheet" />
@@ -260,7 +260,7 @@ END-UNSTRING.</code></pre>
 					<div class="section-content">
 						<p>
 							When the DELIMITED BY clause is used data movement from the source string to the current
-							destination string ends when either ;
+							destination string ends when either:
 						</p>
 						<ul>
 							<li>a delimiter is encountered in the source string</li>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -291,7 +291,7 @@ Begin.
 							>.
 						</p>
 						<p>
-							When these these binary numbers are added together the result is
+							When these binary numbers are added together the result is
 							<b>
 								<span class="cobol-highlight">01100101</span>
 							</b>

--- a/exercises/GettingStarted.html
+++ b/exercises/GettingStarted.html
@@ -78,7 +78,7 @@
 							compiling and running the program.
 						</p>
 						<p>
-							The development environment we are using for this course is Microfocus NetExpress.
+							The development environment we are using for this course is Micro Focus NetExpress.
 							NetExpress is an Integrated Development Environment (IDE) supporting an Object Oriented
 							version of COBOL. The OO-COBOL supported by NetExpress is a preview of the coming standard.
 						</p>
@@ -147,7 +147,7 @@
 						<h2>Starting to run the program</h2>
 						<p>
 							For the time being we will run our COBOL programs from within the NetExpress Animator. Later
-							in the course we will create stand alone programs (.EXE's).
+							in the course we will create standalone programs (.EXEs).
 						</p>
 						<p>
 							Position the cursor over program statement "ACCEPT Num1.". Click the right mouse button.
@@ -155,7 +155,7 @@
 						</p>
 						<p>
 							Now select "<b><i>Start Animating</i></b
-							>" from within the <b><i>Animate</i></b> menu option and chose <b><i>OK</i></b> from the
+							>" from within the <b><i>Animate</i></b> menu option and choose <b><i>OK</i></b> from the
 							dialogue box which appears.
 						</p>
 						<p>

--- a/search-index.json
+++ b/search-index.json
@@ -68,7 +68,7 @@
 	{
 		"p": "course/RefMod.html",
 		"t": "Reference Modification and Intrinsic Functions",
-		"d": "The aim of this unit is to provide to provide you with a solid understanding of string manipulation using Reference Modification. It will also introduce",
+		"d": "The aim of this unit is to provide you with a solid understanding of string manipulation using Reference Modification. It will also introduce",
 		"s": "course"
 	},
 	{
@@ -128,7 +128,7 @@
 	{
 		"p": "course/String.html",
 		"t": "STRING",
-		"d": "The aim of this unit is to provide to provide you with a solid understanding of the STRING verb.",
+		"d": "The aim of this unit is to provide you with a solid understanding of the STRING verb.",
 		"s": "course"
 	},
 	{
@@ -152,7 +152,7 @@
 	{
 		"p": "course/Unstring.html",
 		"t": "UNSTRING",
-		"d": "The aim of this unit is to provide to provide you with a solid understanding of the UNSTRING verb.",
+		"d": "The aim of this unit is to provide you with a solid understanding of the UNSTRING verb.",
 		"s": "course"
 	},
 	{


### PR DESCRIPTION
## Summary

Systematic editorial pass over all course pages and exercises, fixing typos, duplicate words, missing articles/prepositions, subject-verb disagreement, stray punctuation, misspellings, and a handful of factual errors.

**First commit — 7 files:**
- `course/COBOLIntro.html` — 8 fixes (typos, missing articles, wrong words, updated broken-links disclaimer)
- `course/DataDeclaration.html` — 5 fixes (missing articles, missing comma, wrong article, capitalisation, "begs the question" → "raises the question")
- `course/COBOLcommands.html` — 5 fixes (spurious word, duplicate "the", missing article, missing comma, "ADA" → "Ada")
- `exercises/GettingStarted.html` — 4 fixes ("Microfocus" → "Micro Focus", "chose" → "choose", "stand alone" → "standalone", ".EXE's" → ".EXEs")
- `course/Selection.html` — 9 fixes (missing articles, missing prepositions, missing verb, wrong plural, stray period, factual error in EVALUATE example explanation)
- `course/Iteration.html` — 12 fixes including a pervasive pattern of spurious periods after "subroutine" in prose, plus duplicate words, misspellings, subject–verb agreement errors, and a stray `>` character

**Second commit — 20 files:**
- `course/SequentialFiles1.html` — 6 fixes ("having the read" → "to read"; "READ verbs works" → "verb works"; 2× semicolons → colons before lists; stray `r` outside `<i>record</i>`; "program on disk" → "file on disk")
- `course/SequentialFiles2.html` — 1 fix ("baring" → "bearing")
- `course/SequentialFiles3.html` — 5 fixes (missing `)` in "(30 characters,"; stray ", ." → "."; "must must" → "must"; heading missing "with"; "and number" → "a number")
- `course/Tables1.html` — 1 fix ("table.." → "table.")
- `course/Tables2.html` — 2 fixes (missing "a" before "simple version"; "as as long" → "as long")
- `course/Search.html` — 1 fix ("some some key field" → "some key field")
- `course/Subprograms.html` — 5 fixes (four stray periods after "subprograms." in prose; "an sound" → "a sound")
- `course/Copy.html` — 4 fixes ("they COPY..REPLACING" → "how"; "from from" → "from"; "collection code segment" → "of code segments"; "defined as ;" → "as:")
- `course/Inspect.html` — 1 factual fix (REPLACING diagram caption said "count characters" but should say "replace characters")
- `course/SortMerge.html` — 2 fixes ("is is difficult" → "is difficult"; factual: merge requires *ordered* files, not "unordered")
- `course/Unstring.html` — 3 fixes ("provide to provide" in JSON-LD and meta description; semicolon → colon after "ends when either")
- `course/IndexedFiles.html` — 3 fixes ("understanding of;" → "understanding of"; "Be able to used the use the" → "use the"; "sexample" → "example")
- `course/Intro2DirectAccess.html` — 4 fixes ("circumstances ." → "."; "insert a records" → "insert records"; "proceeding" → "preceding"; "magnetica" → "magnetic")
- `course/RelativeFiles.html` — 2 fixes ("Be able to used the use the" → "use the"; "key are" → "key area" ×2)
- `course/ReportWriter.html` — 2 fixes ("easy by;" → "by:"; "commission are DECLARATIVES" → "commission, DECLARATIVES")
- `course/ReportWriterSS.html` — 1 fix ("insufficient of create" → "insufficient to create")
- `course/EditedPics.html` — 1 fix (stray `&gt;` after list-intro colon)
- `course/Usage.html` — 1 fix ("these these" → "these")
- `course/RefMod.html` — 3 fixes ("provide to provide" in JSON-LD, meta, and prose ×3)
- `course/String.html` — 3 fixes ("provide to provide" in JSON-LD, meta, and prose ×3)

## Test plan

- [x] `npm run validate` passes (HTML validation)
- [ ] Spot-check affected pages in the preview server