### PR TITLE
fix: normalise examples/index.html title to Title Case

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -22,7 +22,7 @@
 		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
-		<title>COBOL example programs</title>
+		<title>COBOL Example Programs</title>
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />
 		<meta name="resource-type" content="document" />
@@ -43,7 +43,7 @@
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/examples/index.html" />
-		<meta property="og:title" content="COBOL example programs" />
+		<meta property="og:title" content="COBOL Example Programs" />
 		<meta
 			property="og:description"
 			content="These pages contain a large number of example COBOL programs. The example COBOL programs may be downloaded or viewed in your browser. Test data for the example COBOL programs is also provided."
@@ -51,7 +51,7 @@
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="COBOL example programs" />
+		<meta name="twitter:title" content="COBOL Example Programs" />
 		<meta
 			name="twitter:description"
 			content="These pages contain a large number of example COBOL programs. The example COBOL programs may be downloaded or viewed in your browser. Test data for the example COBOL programs is also provided."

--- a/search-index.json
+++ b/search-index.json
@@ -193,7 +193,7 @@
 	},
 	{
 		"p": "examples/index.html",
-		"t": "COBOL example programs",
+		"t": "COBOL Example Programs",
 		"d": "These pages contain a large number of example COBOL programs. The example COBOL programs may be downloaded or viewed in your browser. Test data for the example COBOL programs is also provided.",
 		"s": "examples"
 	},


### PR DESCRIPTION
## Summary

- `examples/index.html` used sentence case (`COBOL example programs`) for its `<title>`, `og:title`, and `twitter:title` while the other three section entry points (`course/`, `exercises/`, `lectures/`) all use Title Case.
- Updated all three tags to `COBOL Example Programs` to match the established convention.

## Verification

```sh
grep '<title>' index.html course/index.html exercises/index.html examples/index.html lectures/index.html
npm run validate
```

Both pass cleanly.

Fixes #570