### PR TITLE
fix: add bullet lists to four stub lecture index entries

### DIFF
--- a/lectures/index.html
+++ b/lectures/index.html
@@ -551,7 +551,10 @@
 					<hr />
 					<h3 id="String">The STRING</h3>
 					<ul>
-						<li><code>STRING ... DELIMITED BY</code> — concatenating multiple strings into one destination string.</li>
+						<li>
+							<code>STRING ... DELIMITED BY</code> — concatenating multiple strings into one destination
+							string.
+						</li>
 						<li>The <code>WITH POINTER</code> phrase.</li>
 						<li>The <code>ON OVERFLOW</code> and <code>NOT ON OVERFLOW</code> phrases.</li>
 					</ul>

--- a/lectures/index.html
+++ b/lectures/index.html
@@ -531,6 +531,12 @@
 					</div>
 					<hr />
 					<h3 id="Inspect">The INSPECT</h3>
+					<ul>
+						<li><code>INSPECT ... TALLYING</code> — counting character occurrences in a string.</li>
+						<li><code>INSPECT ... REPLACING</code> — replacing characters in a string.</li>
+						<li><code>INSPECT ... CONVERTING</code> — character-by-character substitution.</li>
+						<li>The LEADING, FIRST, BEFORE, and AFTER phrases.</li>
+					</ul>
 					<div class="topic-nav">
 						<a href="#Contents"
 							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
@@ -544,6 +550,11 @@
 					</div>
 					<hr />
 					<h3 id="String">The STRING</h3>
+					<ul>
+						<li><code>STRING ... DELIMITED BY</code> — concatenating multiple strings into one destination string.</li>
+						<li>The <code>WITH POINTER</code> phrase.</li>
+						<li>The <code>ON OVERFLOW</code> and <code>NOT ON OVERFLOW</code> phrases.</li>
+					</ul>
 					<div class="topic-nav">
 						<a href="#Contents"
 							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
@@ -557,6 +568,12 @@
 					</div>
 					<hr />
 					<h3 id="Unstring">The UNSTRING</h3>
+					<ul>
+						<li><code>UNSTRING ... DELIMITED BY</code> — splitting a source string on a delimiter.</li>
+						<li>The <code>DELIMITER IN</code> and <code>COUNT IN</code> phrases.</li>
+						<li>The <code>WITH POINTER</code> and <code>TALLYING IN</code> phrases.</li>
+						<li>The <code>ALL</code> phrase and <code>ON OVERFLOW</code> clause.</li>
+					</ul>
 					<div class="topic-nav">
 						<a href="#Contents"
 							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
@@ -570,6 +587,12 @@
 					</div>
 					<hr />
 					<h3 id="Usage">The USAGE clause</h3>
+					<ul>
+						<li><code>USAGE IS DISPLAY</code> — default character-format storage.</li>
+						<li><code>USAGE IS COMP</code> — binary two's complement storage.</li>
+						<li><code>USAGE IS PACKED-DECIMAL</code> — binary-coded-decimal (BCD) storage.</li>
+						<li>The <code>SYNCHRONIZED</code> clause and word-boundary alignment.</li>
+					</ul>
 					<div class="topic-nav">
 						<a href="#Contents"
 							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"


### PR DESCRIPTION
## Summary

- Populated `<ul>` bullet lists for the four stub entries in `lectures/index.html` (Inspect, String, Unstring, Usage) that had headings and nav but no topic-preview content
- Content sourced from the matching `.pptx` slide decks via markitdown extraction
- HTML validates clean; verification check confirms no remaining `<h3>` directly followed by `<div class="topic-nav">`

## Test plan

- [ ] Visual check: each of the four sections now shows bullet points in the lectures index
- [ ] `npm run validate` passes
- [ ] Run the issue's node one-liner — no stubs print (ReportWriter uses `<blockquote>` intentionally, pre-existing)

Fixes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)