### PR TITLE
fix: misc small content fixes (#572)

### DIFF
--- a/course/Resources/css/course-components.css
+++ b/course/Resources/css/course-components.css
@@ -844,6 +844,20 @@ details[open].saq-reveal summary::before {
 	flex: 0 0 207px;
 }
 
+.legend-grid {
+	display: grid;
+	grid-template-columns: auto 1fr;
+	gap: 0.25rem 0.5rem;
+	align-items: center;
+	margin: 0;
+	padding: 0;
+}
+
+.legend-grid dt,
+.legend-grid dd {
+	margin: 0;
+}
+
 .course-hr {
 	width: 605px;
 	max-width: 100%;

--- a/course/index.html
+++ b/course/index.html
@@ -123,34 +123,14 @@
 						>
 					</p>
 					<div class="course-header-legend">
-						<!-- Legend table: real tabular data (icon → meaning), kept as <table> -->
-						<table width="100%" height="100" cellpadding="2" cellspacing="0">
-							<tr>
-								<td colspan="2" height="29">
-									<div class="center-block">
-										<img src="Resources/pics/aai-Legend.gif" alt="Legend" width="65" height="62" />
-									</div>
-								</td>
-							</tr>
-							<tr>
-								<td width="14%" height="15">
-									<span class="icon-tut" style="margin: 1px 2px" aria-hidden="true">T</span>
-								</td>
-								<td width="86%" height="15">COBOL tutorial</td>
-							</tr>
-							<tr>
-								<td width="14%">
-									<span class="icon-exercise" style="margin: 1px 2px" aria-hidden="true">E</span>
-								</td>
-								<td width="86%">COBOL programming exercise</td>
-							</tr>
-							<tr>
-								<td width="14%" height="8">
-									<span class="icon-ref" style="margin: 0 2px" aria-hidden="true">R</span>
-								</td>
-								<td width="86%" height="8">COBOL reference</td>
-							</tr>
-						</table>
+						<dl class="legend-grid">
+							<dt><span class="icon-tut" aria-label="COBOL tutorial">T</span></dt>
+							<dd>COBOL tutorial</dd>
+							<dt><span class="icon-exercise" aria-label="COBOL programming exercise">E</span></dt>
+							<dd>COBOL programming exercise</dd>
+							<dt><span class="icon-ref" aria-label="COBOL reference">R</span></dt>
+							<dd>COBOL reference</dd>
+						</dl>
 					</div>
 					<hr />
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -136,9 +136,7 @@
 					<table class="data-table" bordercolordark="#000000" bordercolorlight="#FFFFFF" width="725">
 						<tr bgcolor="#990000" style="vertical-align: top">
 							<td colspan="4">
-								<h2 style="text-align: center" id="SimplePrograms">
-									<b> Beginners programs </b>
-								</h2>
+								<h2 style="text-align: center" id="SimplePrograms">Beginners programs</h2>
 							</td>
 						</tr>
 						<tr style="vertical-align: top">
@@ -226,9 +224,7 @@
 					<table class="data-table" bordercolordark="#999999" bordercolorlight="#FFFFFF" width="725">
 						<tr bgcolor="#990000" style="vertical-align: top">
 							<td colspan="4">
-								<h2 style="text-align: center" id="Selection">
-									<b> Selection and Iteration</b>
-								</h2>
+								<h2 style="text-align: center" id="Selection">Selection and Iteration</h2>
 							</td>
 						</tr>
 						<tr style="vertical-align: top">
@@ -400,9 +396,7 @@
 					<table class="data-table" bordercolorlight="#FFFFFF" width="725">
 						<tr bgcolor="#990000" style="vertical-align: top">
 							<td colspan="4">
-								<h2 style="text-align: center" id="SequentialFiles">
-									<b> Sequential Files </b>
-								</h2>
+								<h2 style="text-align: center" id="SequentialFiles">Sequential Files</h2>
 							</td>
 						</tr>
 						<tr style="vertical-align: top">
@@ -544,9 +538,7 @@
 					<table class="data-table" bordercolorlight="#FFFFFF" width="725">
 						<tr bgcolor="#990000" style="vertical-align: top">
 							<td colspan="4">
-								<h2 style="text-align: center" id="Sort">
-									<b> Sorting and Merging </b>
-								</h2>
+								<h2 style="text-align: center" id="Sort">Sorting and Merging</h2>
 							</td>
 						</tr>
 						<tr style="vertical-align: top">
@@ -732,9 +724,7 @@
 					<table class="data-table" bordercolorlight="#FFFFFF" width="725">
 						<tr bgcolor="#990000" style="vertical-align: top">
 							<td colspan="4">
-								<h2 style="text-align: center" id="Direct">
-									<b> Direct Access Files </b>
-								</h2>
+								<h2 style="text-align: center" id="Direct">Direct Access Files</h2>
 							</td>
 						</tr>
 						<tr style="vertical-align: top">
@@ -1039,9 +1029,7 @@
 					<table class="data-table" bordercolorlight="#FFFFFF" width="725">
 						<tr bgcolor="#990000" style="vertical-align: top">
 							<td colspan="4">
-								<h2 style="text-align: center" id="Call">
-									<b> CALLing sub-programs </b>
-								</h2>
+								<h2 style="text-align: center" id="Call">CALLing sub-programs</h2>
 							</td>
 						</tr>
 						<tr style="vertical-align: top">
@@ -1301,9 +1289,7 @@
 					<table class="data-table" bordercolorlight="#FFFFFF" width="725">
 						<tr bgcolor="#990000" style="vertical-align: top">
 							<td colspan="4">
-								<h2 style="text-align: center" id="Strings">
-									<b> String handling </b>
-								</h2>
+								<h2 style="text-align: center" id="Strings">String handling</h2>
 							</td>
 						</tr>
 						<tr style="vertical-align: top">
@@ -1405,9 +1391,7 @@
 					<table class="data-table" bordercolorlight="#FFFFFF" width="725">
 						<tr bgcolor="#990000" style="vertical-align: top">
 							<td colspan="4">
-								<h2 style="text-align: center" id="Reports">
-									<b> The COBOL Report Writer </b>
-								</h2>
+								<h2 style="text-align: center" id="Reports">The COBOL Report Writer</h2>
 							</td>
 						</tr>
 						<tr style="vertical-align: top">
@@ -1525,9 +1509,7 @@
 					<table class="data-table" bordercolorlight="#FFFFFF" width="725">
 						<tr bgcolor="#990000" style="vertical-align: top">
 							<td colspan="4">
-								<h2 style="text-align: center" id="Tables">
-									<b> COBOL Tables </b>
-								</h2>
+								<h2 style="text-align: center" id="Tables">COBOL Tables</h2>
 							</td>
 						</tr>
 						<tr style="vertical-align: top">

--- a/exercises/Exm-StudFeesRpt/Exm-StudPay.html
+++ b/exercises/Exm-StudFeesRpt/Exm-StudPay.html
@@ -22,7 +22,7 @@
 		</script>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
-		<title>Student Fee Payment - Update and Report (Exam Question)</title>
+		<title>Student Fee Payment Update and Report</title>
 		<meta
 			name="description"
 			content="At the beginning of each term Student Services creates a report showing those students whose fees are still outstanding. Until now this report was created"
@@ -37,7 +37,7 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/exercises/Exm-StudFeesRpt/Exm-StudPay.html"
 		/>
-		<meta property="og:title" content="Student Fee Payment - Update and Report (Exam Question)" />
+		<meta property="og:title" content="Student Fee Payment Update and Report" />
 		<meta
 			property="og:description"
 			content="At the beginning of each term Student Services creates a report showing those students whose fees are still outstanding. Until now this report was created"
@@ -45,7 +45,7 @@
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/exercises.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Student Fee Payment - Update and Report (Exam Question)" />
+		<meta name="twitter:title" content="Student Fee Payment Update and Report" />
 		<meta
 			name="twitter:description"
 			content="At the beginning of each term Student Services creates a report showing those students whose fees are still outstanding. Until now this report was created"

--- a/exercises/index.html
+++ b/exercises/index.html
@@ -219,7 +219,7 @@
 						</dt>
 						<dd>
 							<p>
-								A program is required which will read the tourist bookings master filee to produce a
+								A program is required which will read the tourist bookings master file to produce a
 								summary file sequenced upon ascending Destination-Name.<br />
 								(Pre-Filled Tables, Sequential Files, <code class="language-cobol">SORT</code> with
 								Input Procedure, <code class="language-cobol">SEARCH</code>,

--- a/lectures/index.html
+++ b/lectures/index.html
@@ -650,7 +650,7 @@
 						please email the author <a href="mailto:michael.coughlan@ul.ie">Michael Coughlan</a>.
 					</p>
 					<hr />
-<related-content
+					<related-content
 						exercises="../exercises/index.html|COBOL Exercises"
 						lectures="../course/index.html|COBOL Course"
 					></related-content>

--- a/lectures/index.html
+++ b/lectures/index.html
@@ -650,19 +650,7 @@
 						please email the author <a href="mailto:michael.coughlan@ul.ie">Michael Coughlan</a>.
 					</p>
 					<hr />
-					<div style="display: flex; gap: 1.5rem; align-items: flex-start; text-align: center">
-						<div>
-							<a href="../index.html"
-								><img
-									alt="Back to other COBOL resources"
-									height="52"
-									src="../pics/B-BackArrow.gif"
-									width="52" /></a
-							><br />
-							To COBOL resources
-						</div>
-					</div>
-					<related-content
+<related-content
 						exercises="../exercises/index.html|COBOL Exercises"
 						lectures="../course/index.html|COBOL Course"
 					></related-content>

--- a/search-index.json
+++ b/search-index.json
@@ -535,7 +535,7 @@
 	},
 	{
 		"p": "exercises/Exm-StudFeesRpt/Exm-StudPay.html",
-		"t": "Student Fee Payment - Update and Report (Exam Question)",
+		"t": "Student Fee Payment Update and Report",
 		"d": "At the beginning of each term Student Services creates a report showing those students whose fees are still outstanding. Until now this report was created",
 		"s": "exercises"
 	},


### PR DESCRIPTION
## Summary

- **Typo fix**: `exercises/index.html` — `master filee` → `master file`
- **Redundant `<b>` in `<h2>`**: `examples/index.html` — stripped `<b>` wrappers from all 9 section headers (leading/trailing whitespace and spurious bold removed)
- **Title mismatch**: `exercises/Exm-StudFeesRpt/Exm-StudPay.html` — aligned `<title>`, `og:title`, and `twitter:title` with the `<page-hero>` source of truth ("Student Fee Payment Update and Report")
- **Redundant back-link**: `lectures/index.html` — removed the 52×52 GIF back-link footer that duplicated the breadcrumb
- **Legacy icon legend table**: `course/index.html` — replaced `<table width height cellpadding cellspacing>` with `<dl class="legend-grid">`; added `.legend-grid` CSS grid rule to `course-components.css`

## Test plan

- [x] `grep -n 'filee' exercises/index.html` — empty
- [x] `grep -nP '<h2[^>]*>\s*<b' examples/index.html` — empty
- [x] `grep -n 'B-BackArrow.gif' lectures/index.html` — only the icon-legend explanation at line 97, not the footer
- [x] `grep -nP '<table[^>]+(width|cellpadding|cellspacing)' course/index.html` — empty
- [x] `npm run validate` — passes
- [x] Browser spot-check: `course/index.html` legend renders as `<dl>` with 3 dt/dd pairs; `lectures/index.html` back-link footer is absent

Fixes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)