### PR TITLE
fix: move <related-content> to page footer on all exercise pages

### DIFF
--- a/exercises/CountDown.html
+++ b/exercises/CountDown.html
@@ -52,10 +52,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="The Calculator and Countdown exercises"></page-hero>
-					<related-content
-						lectures="../course/Iteration.html|Iteration in COBOL"
-						examples="../examples/Perform/Perform1.html|PERFORM – Format 1, ../examples/Perform/Perform2.html|PERFORM – Format 2, ../examples/Perform/Perform3.html|PERFORM – Format 3, ../examples/Perform/Perform4.html|PERFORM – Format 4"
-					></related-content>
 					<p class="center-block">
 						<code class="language-cobol">ACCEPT</code>, <code class="language-cobol">DISPLAY</code>,
 						<code class="language-cobol">PERFORM..TIMES</code>, <code class="language-cobol">COMPUTE</code>,
@@ -182,10 +178,17 @@ Your name is Mike Ryan</samp></pre>
 						</p>
 					</section>
 
-					<copyright-notice type="exercises"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="index.html">&larr; Back to COBOL Exercises</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../course/Iteration.html|Iteration in COBOL"
+							examples="../examples/Perform/Perform1.html|PERFORM – Format 1, ../examples/Perform/Perform2.html|PERFORM – Format 2, ../examples/Perform/Perform3.html|PERFORM – Format 3, ../examples/Perform/Perform4.html|PERFORM – Format 4"
+						></related-content>
+						<hr />
+						<copyright-notice type="exercises"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="index.html">&larr; Back to COBOL Exercises</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html
+++ b/exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html
@@ -69,10 +69,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="The ACME Stock Reorder System"></page-hero>
-					<related-content
-						lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/RelativeFiles.html|Relative Files, ../../course/Subprograms.html|Subprograms"
-						examples="Prg-AcmeStockReorder.html|ACME Stock Reorder – Sample Solution, ../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly"
-					></related-content>
 					<hr />
 
 					<dl class="exam-meta">
@@ -557,11 +553,18 @@
 						</p>
 					</section>
 
-					<exercises-nav></exercises-nav>
-					<copyright-notice type="exercises"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/RelativeFiles.html|Relative Files, ../../course/Subprograms.html|Subprograms"
+							examples="Prg-AcmeStockReorder.html|ACME Stock Reorder – Sample Solution, ../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly"
+						></related-content>
+						<hr />
+						<exercises-nav></exercises-nav>
+						<copyright-notice type="exercises"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html
+++ b/exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html
@@ -71,10 +71,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="ACME Stock Reorder"></page-hero>
-					<related-content
-						lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/RelativeFiles.html|Relative Files, ../../course/Subprograms.html|Subprograms"
-						examples="Exm-AcmeStockReorder.html|ACME Stock Reorder – Exam Paper, ../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly"
-					></related-content>
 					<hr />
 					<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
@@ -277,10 +273,17 @@ EXTRACT-ADDRESS-ITEMS.
    DISPLAY "COUNTY = "  COUNTY-WC.
    DISPLAY "COUNTRY = " COUNTRY-WC.
  </code></pre>
-					<copyright-notice type="examples"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="Exm-AcmeStockReorder.html">&larr; Back to specification</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/RelativeFiles.html|Relative Files, ../../course/Subprograms.html|Subprograms"
+							examples="Exm-AcmeStockReorder.html|ACME Stock Reorder – Exam Paper, ../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly"
+						></related-content>
+						<hr />
+						<copyright-notice type="examples"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="Exm-AcmeStockReorder.html">&larr; Back to specification</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html
+++ b/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html
@@ -69,10 +69,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Aromamora Oil Stock File Maintenance and Report"></page-hero>
-					<related-content
-						lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/RelativeFiles.html|Relative Files, ../../course/ReportWriter.html|Report Writer"
-						examples="Prg-AromaOilFileMainRpt.html|Aroma Oil File Maintenance – Sample Solution, ../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly"
-					></related-content>
 					<hr />
 
 					<dl class="exam-meta">
@@ -372,11 +368,18 @@
 						</p>
 					</section>
 
-					<exercises-nav></exercises-nav>
-					<copyright-notice type="exercises"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/RelativeFiles.html|Relative Files, ../../course/ReportWriter.html|Report Writer"
+							examples="Prg-AromaOilFileMainRpt.html|Aroma Oil File Maintenance – Sample Solution, ../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly"
+						></related-content>
+						<hr />
+						<exercises-nav></exercises-nav>
+						<copyright-notice type="exercises"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html
+++ b/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html
@@ -77,10 +77,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Aromamora Oil Stock Maintenance and Report"></page-hero>
-					<related-content
-						lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/RelativeFiles.html|Relative Files, ../../course/ReportWriter.html|Report Writer"
-						examples="Exm-AromaOilFileMainRpt.html|Aroma Oil File Maintenance – Exam Paper, ../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly"
-					></related-content>
 					<hr />
 					<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
@@ -262,10 +258,17 @@ Print-Stock-Report.
       AT END SET End-Of-ODF TO TRUE
    END-READ.
  </code></pre>
-					<copyright-notice type="examples"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="Exm-AromaOilFileMainRpt.html">&larr; Back to specification</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/RelativeFiles.html|Relative Files, ../../course/ReportWriter.html|Report Writer"
+							examples="Exm-AromaOilFileMainRpt.html|Aroma Oil File Maintenance – Exam Paper, ../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly"
+						></related-content>
+						<hr />
+						<copyright-notice type="examples"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="Exm-AromaOilFileMainRpt.html">&larr; Back to specification</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html
+++ b/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html
@@ -267,7 +267,9 @@ Print-Stock-Report.
 						<copyright-notice type="examples"></copyright-notice>
 						<last-updated></last-updated>
 						<edit-on-github></edit-on-github>
-						<p class="center-block"><a href="Exm-AromaOilFileMainRpt.html">&larr; Back to specification</a></p>
+						<p class="center-block">
+							<a href="Exm-AromaOilFileMainRpt.html">&larr; Back to specification</a>
+						</p>
 					</div>
 				</div>
 			</div>

--- a/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html
+++ b/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html
@@ -69,11 +69,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Aromamora Summary Sales Report"></page-hero>
-					<related-content
-						lectures="../../course/SortMerge.html|SORT and MERGE, ../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3"
-						examples="Prg-AromaSalesSummaryRpt.html|Aroma Summary Sales – Sample Solution, ../../examples/Sort/InputSort.html|SORT with Input Procedure, ../../examples/Sort/MaleSort.html|SORT with Output Procedure, ../../examples/Merge/Merge.html|Merging Files"
-						exercises="../SortIP.html|Sorting a Sequential File, ../SeqWrite.html|Writing Records, ../SeqRead.html|Reading Sequential Files, ../SeqReadIf.html|Counting Records"
-					></related-content>
 					<hr />
 
 					<dl class="exam-meta">
@@ -238,11 +233,19 @@
 						</p>
 					</section>
 
-					<exercises-nav></exercises-nav>
-					<copyright-notice type="exercises"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/SortMerge.html|SORT and MERGE, ../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3"
+							examples="Prg-AromaSalesSummaryRpt.html|Aroma Summary Sales – Sample Solution, ../../examples/Sort/InputSort.html|SORT with Input Procedure, ../../examples/Sort/MaleSort.html|SORT with Output Procedure, ../../examples/Merge/Merge.html|Merging Files"
+							exercises="../SortIP.html|Sorting a Sequential File, ../SeqWrite.html|Writing Records, ../SeqRead.html|Reading Sequential Files, ../SeqReadIf.html|Counting Records"
+						></related-content>
+						<hr />
+						<exercises-nav></exercises-nav>
+						<copyright-notice type="exercises"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html
+++ b/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html
@@ -280,7 +280,9 @@ Print-Customer-Lines.
 						<copyright-notice type="examples"></copyright-notice>
 						<last-updated></last-updated>
 						<edit-on-github></edit-on-github>
-						<p class="center-block"><a href="Exm-AromaSalesSummaryRpt.html">&larr; Back to specification</a></p>
+						<p class="center-block">
+							<a href="Exm-AromaSalesSummaryRpt.html">&larr; Back to specification</a>
+						</p>
 					</div>
 				</div>
 			</div>

--- a/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html
+++ b/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html
@@ -71,11 +71,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Aromamora Summary Sales Report"></page-hero>
-					<related-content
-						lectures="../../course/SortMerge.html|SORT and MERGE, ../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3"
-						examples="Exm-AromaSalesSummaryRpt.html|Aroma Summary Sales – Exam Paper, ../../examples/Sort/InputSort.html|SORT with Input Procedure, ../../examples/Sort/MaleSort.html|SORT with Output Procedure, ../../examples/Merge/Merge.html|Merging Files"
-						exercises="../SortIP.html|Sorting a Sequential File, ../SeqWrite.html|Writing Records, ../SeqRead.html|Reading Sequential Files, ../SeqReadIf.html|Counting Records"
-					></related-content>
 					<hr />
 					<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
@@ -275,10 +270,18 @@ Print-Customer-Lines.
 
     WRITE Print-Line FROM Cust-Sales-Line AFTER ADVANCING 2 LINES.
  </code></pre>
-					<copyright-notice type="examples"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="Exm-AromaSalesSummaryRpt.html">&larr; Back to specification</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/SortMerge.html|SORT and MERGE, ../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3"
+							examples="Exm-AromaSalesSummaryRpt.html|Aroma Summary Sales – Exam Paper, ../../examples/Sort/InputSort.html|SORT with Input Procedure, ../../examples/Sort/MaleSort.html|SORT with Output Procedure, ../../examples/Merge/Merge.html|Merging Files"
+							exercises="../SortIP.html|Sorting a Sequential File, ../SeqWrite.html|Writing Records, ../SeqRead.html|Reading Sequential Files, ../SeqReadIf.html|Counting Records"
+						></related-content>
+						<hr />
+						<copyright-notice type="examples"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="Exm-AromaSalesSummaryRpt.html">&larr; Back to specification</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html
+++ b/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html
@@ -69,11 +69,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Folio Society Best Sellers List Report"></page-hero>
-					<related-content
-						lectures="../../course/SortMerge.html|SORT and MERGE, ../../course/Tables1.html|Tables 1, ../../course/Tables2.html|Tables 2, ../../course/Search.html|SEARCH and SEARCH ALL"
-						examples="Prg-FolioBestSellersRpt.html|Folio Best Sellers Report – Sample Solution, ../../examples/Sort/InputSort.html|SORT with Input Procedure, ../../examples/Sort/MaleSort.html|SORT with Output Procedure, ../../examples/Merge/Merge.html|Merging Files"
-						exercises="../SortIP.html|Sorting a Sequential File, ../MonthTable.html|Using Tables Exercise"
-					></related-content>
 					<hr />
 
 					<dl class="exam-meta">
@@ -241,11 +236,19 @@
 						</div>
 					</section>
 
-					<exercises-nav></exercises-nav>
-					<copyright-notice type="exercises"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/SortMerge.html|SORT and MERGE, ../../course/Tables1.html|Tables 1, ../../course/Tables2.html|Tables 2, ../../course/Search.html|SEARCH and SEARCH ALL"
+							examples="Prg-FolioBestSellersRpt.html|Folio Best Sellers Report – Sample Solution, ../../examples/Sort/InputSort.html|SORT with Input Procedure, ../../examples/Sort/MaleSort.html|SORT with Output Procedure, ../../examples/Merge/Merge.html|Merging Files"
+							exercises="../SortIP.html|Sorting a Sequential File, ../MonthTable.html|Using Tables Exercise"
+						></related-content>
+						<hr />
+						<exercises-nav></exercises-nav>
+						<copyright-notice type="exercises"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html
+++ b/exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html
@@ -77,11 +77,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Folio Society Best Sellers List Report"></page-hero>
-					<related-content
-						lectures="../../course/SortMerge.html|SORT and MERGE, ../../course/Tables1.html|Tables 1, ../../course/Tables2.html|Tables 2, ../../course/Search.html|SEARCH and SEARCH ALL"
-						examples="Exm-FolioBestSellersRpt.html|Folio Best Sellers Report – Exam Paper, ../../examples/Sort/InputSort.html|SORT with Input Procedure, ../../examples/Sort/MaleSort.html|SORT with Output Procedure, ../../examples/Merge/Merge.html|Merging Files"
-						exercises="../SortIP.html|Sorting a Sequential File, ../MonthTable.html|Using Tables Exercise"
-					></related-content>
 					<hr />
 					<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
@@ -258,10 +253,18 @@ CheckBookRank.
     END-IF.
 
 </code></pre>
-					<copyright-notice type="examples"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="Exm-FolioBestSellersRpt.html">&larr; Back to specification</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/SortMerge.html|SORT and MERGE, ../../course/Tables1.html|Tables 1, ../../course/Tables2.html|Tables 2, ../../course/Search.html|SEARCH and SEARCH ALL"
+							examples="Exm-FolioBestSellersRpt.html|Folio Best Sellers Report – Exam Paper, ../../examples/Sort/InputSort.html|SORT with Input Procedure, ../../examples/Sort/MaleSort.html|SORT with Output Procedure, ../../examples/Merge/Merge.html|Merging Files"
+							exercises="../SortIP.html|Sorting a Sequential File, ../MonthTable.html|Using Tables Exercise"
+						></related-content>
+						<hr />
+						<copyright-notice type="examples"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="Exm-FolioBestSellersRpt.html">&larr; Back to specification</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html
+++ b/exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html
@@ -263,7 +263,9 @@ CheckBookRank.
 						<copyright-notice type="examples"></copyright-notice>
 						<last-updated></last-updated>
 						<edit-on-github></edit-on-github>
-						<p class="center-block"><a href="Exm-FolioBestSellersRpt.html">&larr; Back to specification</a></p>
+						<p class="center-block">
+							<a href="Exm-FolioBestSellersRpt.html">&larr; Back to specification</a>
+						</p>
 					</div>
 				</div>
 			</div>

--- a/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html
+++ b/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html
@@ -69,10 +69,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Campus Bookshop Purchase Requirements Report"></page-hero>
-					<related-content
-						lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/ReportWriter.html|Report Writer, ../../course/ReportWriterSS.html|Report Writer – Syntax and Semantics"
-						examples="Prg-BookshopLectReqRpt.html|Bookshop Lecturer Requirements – Sample Solution, ../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly"
-					></related-content>
 					<hr />
 
 					<dl class="exam-meta">
@@ -324,11 +320,18 @@
 						</p>
 					</section>
 
-					<exercises-nav></exercises-nav>
-					<copyright-notice type="exercises"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/ReportWriter.html|Report Writer, ../../course/ReportWriterSS.html|Report Writer – Syntax and Semantics"
+							examples="Prg-BookshopLectReqRpt.html|Bookshop Lecturer Requirements – Sample Solution, ../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly"
+						></related-content>
+						<hr />
+						<exercises-nav></exercises-nav>
+						<copyright-notice type="exercises"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html
+++ b/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html
@@ -293,7 +293,9 @@ Process-Publisher.
 						<copyright-notice type="examples"></copyright-notice>
 						<last-updated></last-updated>
 						<edit-on-github></edit-on-github>
-						<p class="center-block"><a href="Exm-BookshopLectReqRpt.html">&larr; Back to specification</a></p>
+						<p class="center-block">
+							<a href="Exm-BookshopLectReqRpt.html">&larr; Back to specification</a>
+						</p>
 					</div>
 				</div>
 			</div>

--- a/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html
+++ b/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html
@@ -77,10 +77,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Campus Bookshop Purchase Requirements Report"></page-hero>
-					<related-content
-						lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/ReportWriter.html|Report Writer, ../../course/ReportWriterSS.html|Report Writer – Syntax and Semantics"
-						examples="Exm-BookshopLectReqRpt.html|Bookshop Lecturer Requirements – Exam Paper, ../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly"
-					></related-content>
 					<hr />
 					<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
@@ -288,10 +284,17 @@ Process-Publisher.
         END-READ.
         DISPLAY "book rec " Book-Rec.
  </code></pre>
-					<copyright-notice type="examples"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="Exm-BookshopLectReqRpt.html">&larr; Back to specification</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/ReportWriter.html|Report Writer, ../../course/ReportWriterSS.html|Report Writer – Syntax and Semantics"
+							examples="Exm-BookshopLectReqRpt.html|Bookshop Lecturer Requirements – Exam Paper, ../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly"
+						></related-content>
+						<hr />
+						<copyright-notice type="examples"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="Exm-BookshopLectReqRpt.html">&larr; Back to specification</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html
+++ b/exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html
@@ -69,11 +69,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="CSIS Web Site Email Domain File"></page-hero>
-					<related-content
-						lectures="../../course/SortMerge.html|SORT and MERGE, ../../course/Tables1.html|Tables 1, ../../course/Tables2.html|Tables 2, ../../course/Search.html|SEARCH and SEARCH ALL"
-						examples="Prg-CSISEmailDomain.html|CSIS Email Domain – Sample Solution, ../../examples/Sort/InputSort.html|SORT with Input Procedure, ../../examples/Sort/MaleSort.html|SORT with Output Procedure, ../../examples/Merge/Merge.html|Merging Files"
-						exercises="../SortIP.html|Sorting a Sequential File, ../MonthTable.html|Using Tables Exercise"
-					></related-content>
 					<hr />
 
 					<dl class="exam-meta">
@@ -367,11 +362,19 @@
 						</div>
 					</section>
 
-					<exercises-nav></exercises-nav>
-					<copyright-notice type="exercises"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/SortMerge.html|SORT and MERGE, ../../course/Tables1.html|Tables 1, ../../course/Tables2.html|Tables 2, ../../course/Search.html|SEARCH and SEARCH ALL"
+							examples="Prg-CSISEmailDomain.html|CSIS Email Domain – Sample Solution, ../../examples/Sort/InputSort.html|SORT with Input Procedure, ../../examples/Sort/MaleSort.html|SORT with Output Procedure, ../../examples/Merge/Merge.html|Merging Files"
+							exercises="../SortIP.html|Sorting a Sequential File, ../MonthTable.html|Using Tables Exercise"
+						></related-content>
+						<hr />
+						<exercises-nav></exercises-nav>
+						<copyright-notice type="exercises"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html
+++ b/exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html
@@ -71,11 +71,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="CSIS Web Site Email Domain File"></page-hero>
-					<related-content
-						lectures="../../course/SortMerge.html|SORT and MERGE, ../../course/Tables1.html|Tables 1, ../../course/Tables2.html|Tables 2, ../../course/Search.html|SEARCH and SEARCH ALL"
-						examples="Exm-CSISEmailDomain.html|CSIS Email Domain – Exam Paper, ../../examples/Sort/InputSort.html|SORT with Input Procedure, ../../examples/Sort/MaleSort.html|SORT with Output Procedure, ../../examples/Merge/Merge.html|Merging Files"
-						exercises="../SortIP.html|Sorting a Sequential File, ../MonthTable.html|Using Tables Exercise"
-					></related-content>
 					<hr />
 					<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
@@ -220,10 +215,18 @@ LoadCountryTable.
     END-PERFORM.
     CLOSE CountryFile.
 </code></pre>
-					<copyright-notice type="examples"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="Exm-CSISEmailDomain.html">&larr; Back to specification</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/SortMerge.html|SORT and MERGE, ../../course/Tables1.html|Tables 1, ../../course/Tables2.html|Tables 2, ../../course/Search.html|SEARCH and SEARCH ALL"
+							examples="Exm-CSISEmailDomain.html|CSIS Email Domain – Exam Paper, ../../examples/Sort/InputSort.html|SORT with Input Procedure, ../../examples/Sort/MaleSort.html|SORT with Output Procedure, ../../examples/Merge/Merge.html|Merging Files"
+							exercises="../SortIP.html|Sorting a Sequential File, ../MonthTable.html|Using Tables Exercise"
+						></related-content>
+						<hr />
+						<copyright-notice type="examples"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="Exm-CSISEmailDomain.html">&larr; Back to specification</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html
+++ b/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html
@@ -69,11 +69,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="NetNews Due Subscriptions Report"></page-hero>
-					<related-content
-						lectures="../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3, ../../course/SortMerge.html|SORT and MERGE"
-						examples="Prg-DueSubsRpt.html|Due Subscriptions Report – Sample Solution, ../../examples/SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../../examples/SeqRead/SEQREAD.html|Reading a Sequential File, ../../examples/SeqRead/SEQREADno88.html|Reading a Sequential File (no 88)"
-						exercises="../SeqWrite.html|Writing Records, ../SeqRead.html|Reading Sequential Files, ../SeqReadIf.html|Counting Records, ../SeqInsert.html|Inserting Records"
-					></related-content>
 					<hr />
 
 					<dl class="exam-meta">
@@ -337,11 +332,19 @@
 						</p>
 					</section>
 
-					<exercises-nav></exercises-nav>
-					<copyright-notice type="exercises"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3, ../../course/SortMerge.html|SORT and MERGE"
+							examples="Prg-DueSubsRpt.html|Due Subscriptions Report – Sample Solution, ../../examples/SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../../examples/SeqRead/SEQREAD.html|Reading a Sequential File, ../../examples/SeqRead/SEQREADno88.html|Reading a Sequential File (no 88)"
+							exercises="../SeqWrite.html|Writing Records, ../SeqRead.html|Reading Sequential Files, ../SeqReadIf.html|Counting Records, ../SeqInsert.html|Inserting Records"
+						></related-content>
+						<hr />
+						<exercises-nav></exercises-nav>
+						<copyright-notice type="exercises"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html
+++ b/exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html
@@ -71,11 +71,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="NetNews Due Subscriptions Report"></page-hero>
-					<related-content
-						lectures="../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3, ../../course/SortMerge.html|SORT and MERGE"
-						examples="Exm-DueSubsRpt.html|Due Subscriptions Report – Exam Paper, ../../examples/SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../../examples/SeqRead/SEQREAD.html|Reading a Sequential File, ../../examples/SeqRead/SEQREADno88.html|Reading a Sequential File (no 88)"
-						exercises="../SeqWrite.html|Writing Records, ../SeqRead.html|Reading Sequential Files, ../SeqReadIf.html|Counting Records, ../SeqInsert.html|Inserting Records"
-					></related-content>
 					<hr />
 					<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
@@ -377,10 +372,18 @@ PrintFinalTotals.
     WRITE PrintLine FROM AmExTotalLine   AFTER ADVANCING 1 LINE
     WRITE PrintLine FROM ChequeTotalLine AFTER ADVANCING 1 LINE.
  </code></pre>
-					<copyright-notice type="examples"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="Exm-DueSubsRpt.html">&larr; Back to specification</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3, ../../course/SortMerge.html|SORT and MERGE"
+							examples="Exm-DueSubsRpt.html|Due Subscriptions Report – Exam Paper, ../../examples/SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../../examples/SeqRead/SEQREAD.html|Reading a Sequential File, ../../examples/SeqRead/SEQREADno88.html|Reading a Sequential File (no 88)"
+							exercises="../SeqWrite.html|Writing Records, ../SeqRead.html|Reading Sequential Files, ../SeqReadIf.html|Counting Records, ../SeqInsert.html|Inserting Records"
+						></related-content>
+						<hr />
+						<copyright-notice type="examples"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="Exm-DueSubsRpt.html">&larr; Back to specification</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Exm-FileConversion/Exm-FileConversion.html
+++ b/exercises/Exm-FileConversion/Exm-FileConversion.html
@@ -69,11 +69,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="File Conversion Program"></page-hero>
-					<related-content
-						lectures="../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3, ../../course/SortMerge.html|SORT and MERGE"
-						examples="Prg-FileConversion.html|File Conversion – Sample Solution, ../../examples/SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../../examples/SeqRead/SEQREAD.html|Reading a Sequential File, ../../examples/SeqRead/SEQREADno88.html|Reading a Sequential File (no 88)"
-						exercises="../SeqWrite.html|Writing Records, ../SeqRead.html|Reading Sequential Files, ../SeqReadIf.html|Counting Records, ../SeqInsert.html|Inserting Records"
-					></related-content>
 					<hr />
 
 					<dl class="exam-meta">
@@ -358,11 +353,19 @@ Ryan Michael Terence          34 Winchester Drive Dubline 7 Co. Dublin    090123
 						</div>
 					</section>
 
-					<exercises-nav></exercises-nav>
-					<copyright-notice type="exercises"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3, ../../course/SortMerge.html|SORT and MERGE"
+							examples="Prg-FileConversion.html|File Conversion – Sample Solution, ../../examples/SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../../examples/SeqRead/SEQREAD.html|Reading a Sequential File, ../../examples/SeqRead/SEQREADno88.html|Reading a Sequential File (no 88)"
+							exercises="../SeqWrite.html|Writing Records, ../SeqRead.html|Reading Sequential Files, ../SeqReadIf.html|Counting Records, ../SeqInsert.html|Inserting Records"
+						></related-content>
+						<hr />
+						<exercises-nav></exercises-nav>
+						<copyright-notice type="exercises"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Exm-FileConversion/Prg-FileConversion.html
+++ b/exercises/Exm-FileConversion/Prg-FileConversion.html
@@ -71,11 +71,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="File Conversion Program"></page-hero>
-					<related-content
-						lectures="../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3, ../../course/SortMerge.html|SORT and MERGE"
-						examples="Exm-FileConversion.html|File Conversion – Exam Paper, ../../examples/SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../../examples/SeqRead/SEQREAD.html|Reading a Sequential File, ../../examples/SeqRead/SEQREADno88.html|Reading a Sequential File (no 88)"
-						exercises="../SeqWrite.html|Writing Records, ../SeqRead.html|Reading Sequential Files, ../SeqReadIf.html|Counting Records, ../SeqInsert.html|Inserting Records"
-					></related-content>
 					<hr />
 					<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
@@ -253,10 +248,18 @@ RESTRUCTURE-NAME.
             WITH POINTER STR-PTR
     END-PERFORM.
  </code></pre>
-					<copyright-notice type="examples"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="Exm-FileConversion.html">&larr; Back to specification</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3, ../../course/SortMerge.html|SORT and MERGE"
+							examples="Exm-FileConversion.html|File Conversion – Exam Paper, ../../examples/SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../../examples/SeqRead/SEQREAD.html|Reading a Sequential File, ../../examples/SeqRead/SEQREADno88.html|Reading a Sequential File (no 88)"
+							exercises="../SeqWrite.html|Writing Records, ../SeqRead.html|Reading Sequential Files, ../SeqReadIf.html|Counting Records, ../SeqInsert.html|Inserting Records"
+						></related-content>
+						<hr />
+						<copyright-notice type="examples"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="Exm-FileConversion.html">&larr; Back to specification</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html
+++ b/exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html
@@ -69,11 +69,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Fly By Night Travel Agency Sorted Summary File"></page-hero>
-					<related-content
-						lectures="../../course/SortMerge.html|SORT and MERGE, ../../course/Tables1.html|Tables 1, ../../course/Tables2.html|Tables 2, ../../course/Search.html|SEARCH and SEARCH ALL"
-						examples="Prg-FlyByNight.html|FlyByNight Travel – Sample Solution, ../../examples/Sort/InputSort.html|SORT with Input Procedure, ../../examples/Sort/MaleSort.html|SORT with Output Procedure, ../../examples/Merge/Merge.html|Merging Files"
-						exercises="../SortIP.html|Sorting a Sequential File, ../MonthTable.html|Using Tables Exercise"
-					></related-content>
 					<hr />
 
 					<dl class="exam-meta">
@@ -269,11 +264,19 @@
 						</blockquote>
 					</section>
 
-					<exercises-nav></exercises-nav>
-					<copyright-notice type="exercises"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/SortMerge.html|SORT and MERGE, ../../course/Tables1.html|Tables 1, ../../course/Tables2.html|Tables 2, ../../course/Search.html|SEARCH and SEARCH ALL"
+							examples="Prg-FlyByNight.html|FlyByNight Travel – Sample Solution, ../../examples/Sort/InputSort.html|SORT with Input Procedure, ../../examples/Sort/MaleSort.html|SORT with Output Procedure, ../../examples/Merge/Merge.html|Merging Files"
+							exercises="../SortIP.html|Sorting a Sequential File, ../MonthTable.html|Using Tables Exercise"
+						></related-content>
+						<hr />
+						<exercises-nav></exercises-nav>
+						<copyright-notice type="exercises"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html
+++ b/exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html
@@ -71,11 +71,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Travel Agency Sorted Summary File"></page-hero>
-					<related-content
-						lectures="../../course/SortMerge.html|SORT and MERGE, ../../course/Tables1.html|Tables 1, ../../course/Tables2.html|Tables 2, ../../course/Search.html|SEARCH and SEARCH ALL"
-						examples="Exm-FlyByNight.html|FlyByNight Travel – Exam Paper, ../../examples/Sort/InputSort.html|SORT with Input Procedure, ../../examples/Sort/MaleSort.html|SORT with Output Procedure, ../../examples/Merge/Merge.html|Merging Files"
-						exercises="../SortIP.html|Sorting a Sequential File, ../MonthTable.html|Using Tables Exercise"
-					></related-content>
 					<hr />
 					<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
@@ -240,10 +235,18 @@ BEGIN.
         SET NOT-END-OF-FILE TO TRUE.
         CLOSE BOOKING-FILE.
  </code></pre>
-					<copyright-notice type="examples"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="Exm-FlyByNight.html">&larr; Back to specification</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/SortMerge.html|SORT and MERGE, ../../course/Tables1.html|Tables 1, ../../course/Tables2.html|Tables 2, ../../course/Search.html|SEARCH and SEARCH ALL"
+							examples="Exm-FlyByNight.html|FlyByNight Travel – Exam Paper, ../../examples/Sort/InputSort.html|SORT with Input Procedure, ../../examples/Sort/MaleSort.html|SORT with Output Procedure, ../../examples/Merge/Merge.html|Merging Files"
+							exercises="../SortIP.html|Sorting a Sequential File, ../MonthTable.html|Using Tables Exercise"
+						></related-content>
+						<hr />
+						<copyright-notice type="examples"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="Exm-FlyByNight.html">&larr; Back to specification</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html
+++ b/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html
@@ -69,10 +69,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Pascal Memorial Library Royalty Payments Report Program"></page-hero>
-					<related-content
-						lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/ReportWriter.html|Report Writer, ../../course/ReportWriterSS.html|Report Writer – Syntax and Semantics"
-						examples="Prg-LibRoyaltyRpt.html|Library Royalty Report – Sample Solution, ../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly"
-					></related-content>
 					<hr />
 
 					<dl class="exam-meta">
@@ -356,11 +352,18 @@
 						</div>
 					</section>
 
-					<exercises-nav></exercises-nav>
-					<copyright-notice type="exercises"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/ReportWriter.html|Report Writer, ../../course/ReportWriterSS.html|Report Writer – Syntax and Semantics"
+							examples="Prg-LibRoyaltyRpt.html|Library Royalty Report – Sample Solution, ../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly"
+						></related-content>
+						<hr />
+						<exercises-nav></exercises-nav>
+						<copyright-notice type="exercises"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html
+++ b/exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html
@@ -71,10 +71,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Library Royalty Payment Report"></page-hero>
-					<related-content
-						lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/ReportWriter.html|Report Writer, ../../course/ReportWriterSS.html|Report Writer – Syntax and Semantics"
-						examples="Exm-LibRoyaltyRpt.html|Library Royalty Report – Exam Paper, ../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly"
-					></related-content>
 					<hr />
 					<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
@@ -291,10 +287,17 @@ PROCEDURE DIVISION.
         DISPLAY "REWRITE 50-PROCESS-ONE-BOOK " BOOK-ERROR-STATUS
     END-REWRITE.
 </code></pre>
-					<copyright-notice type="examples"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="Exm-LibRoyaltyRpt.html">&larr; Back to specification</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/ReportWriter.html|Report Writer, ../../course/ReportWriterSS.html|Report Writer – Syntax and Semantics"
+							examples="Exm-LibRoyaltyRpt.html|Library Royalty Report – Exam Paper, ../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly"
+						></related-content>
+						<hr />
+						<copyright-notice type="examples"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="Exm-LibRoyaltyRpt.html">&larr; Back to specification</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Exm-SFbyMail/Exm-SFbyMail.html
+++ b/exercises/Exm-SFbyMail/Exm-SFbyMail.html
@@ -69,11 +69,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Science Fiction by Mail Order Processing Program"></page-hero>
-					<related-content
-						lectures="../../course/Subprograms.html|Subprograms, ../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3"
-						examples="Prg-SFbyMail.html|SF by Mail – Sample Solution, ../../examples/SubProg/Multiply/DriverProg.html|Subprogram Driver, ../../examples/SubProg/Multiply/MultiplyNums.html|MultiplyNums Subprogram, ../../examples/SubProg/Multiply/Fickle.html|Fickle Subprogram (State Memory)"
-						exercises="../SeqWrite.html|Writing Records, ../SeqRead.html|Reading Sequential Files, ../SeqReadIf.html|Counting Records, ../SeqInsert.html|Inserting Records"
-					></related-content>
 					<hr />
 
 					<dl class="exam-meta">
@@ -423,11 +418,19 @@
 						</blockquote>
 					</section>
 
-					<exercises-nav></exercises-nav>
-					<copyright-notice type="exercises"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/Subprograms.html|Subprograms, ../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3"
+							examples="Prg-SFbyMail.html|SF by Mail – Sample Solution, ../../examples/SubProg/Multiply/DriverProg.html|Subprogram Driver, ../../examples/SubProg/Multiply/MultiplyNums.html|MultiplyNums Subprogram, ../../examples/SubProg/Multiply/Fickle.html|Fickle Subprogram (State Memory)"
+							exercises="../SeqWrite.html|Writing Records, ../SeqRead.html|Reading Sequential Files, ../SeqReadIf.html|Counting Records, ../SeqInsert.html|Inserting Records"
+						></related-content>
+						<hr />
+						<exercises-nav></exercises-nav>
+						<copyright-notice type="exercises"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Exm-SFbyMail/Prg-SFbyMail.html
+++ b/exercises/Exm-SFbyMail/Prg-SFbyMail.html
@@ -71,11 +71,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Science Fiction by Mail Order Processing"></page-hero>
-					<related-content
-						lectures="../../course/Subprograms.html|Subprograms, ../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3"
-						examples="Exm-SFbyMail.html|SF by Mail – Exam Paper, ../../examples/SubProg/Multiply/DriverProg.html|Subprogram Driver, ../../examples/SubProg/Multiply/MultiplyNums.html|MultiplyNums Subprogram, ../../examples/SubProg/Multiply/Fickle.html|Fickle Subprogram (State Memory)"
-						exercises="../SeqWrite.html|Writing Records, ../SeqRead.html|Reading Sequential Files, ../SeqReadIf.html|Counting Records, ../SeqInsert.html|Inserting Records"
-					></related-content>
 					<hr />
 					<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
@@ -205,10 +200,18 @@ GetCopyPostage.
                             BY REFERENCE Copy-Postage.
 
  </code></pre>
-					<copyright-notice type="examples"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="Exm-SFbyMail.html">&larr; Back to specification</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/Subprograms.html|Subprograms, ../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3"
+							examples="Exm-SFbyMail.html|SF by Mail – Exam Paper, ../../examples/SubProg/Multiply/DriverProg.html|Subprogram Driver, ../../examples/SubProg/Multiply/MultiplyNums.html|MultiplyNums Subprogram, ../../examples/SubProg/Multiply/Fickle.html|Fickle Subprogram (State Memory)"
+							exercises="../SeqWrite.html|Writing Records, ../SeqRead.html|Reading Sequential Files, ../SeqReadIf.html|Counting Records, ../SeqInsert.html|Inserting Records"
+						></related-content>
+						<hr />
+						<copyright-notice type="examples"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="Exm-SFbyMail.html">&larr; Back to specification</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Exm-StudFeesRpt/Exm-StudPay.html
+++ b/exercises/Exm-StudFeesRpt/Exm-StudPay.html
@@ -69,10 +69,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Student Fee Payment Update and Report"></page-hero>
-					<related-content
-						lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/ReportWriter.html|Report Writer, ../../course/ReportWriterSS.html|Report Writer – Syntax and Semantics"
-						examples="Prg-StudPay.html|Student Fees Report – Sample Solution, ../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly"
-					></related-content>
 					<hr />
 
 					<dl class="exam-meta">
@@ -254,11 +250,18 @@
 						</p>
 					</section>
 
-					<exercises-nav></exercises-nav>
-					<copyright-notice type="exercises"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/ReportWriter.html|Report Writer, ../../course/ReportWriterSS.html|Report Writer – Syntax and Semantics"
+							examples="Prg-StudPay.html|Student Fees Report – Sample Solution, ../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly"
+						></related-content>
+						<hr />
+						<exercises-nav></exercises-nav>
+						<copyright-notice type="exercises"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Exm-StudFeesRpt/Prg-StudPay.html
+++ b/exercises/Exm-StudFeesRpt/Prg-StudPay.html
@@ -71,10 +71,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Student Fee Payment Update and Report"></page-hero>
-					<related-content
-						lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/ReportWriter.html|Report Writer, ../../course/ReportWriterSS.html|Report Writer – Syntax and Semantics"
-						examples="Exm-StudPay.html|Student Fees Report – Exam Paper, ../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly"
-					></related-content>
 					<hr />
 					<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
@@ -219,10 +215,17 @@ Print-Outstanding-Fees-Rpt.
          AT END SET End-Of-SMF TO TRUE
     END-READ.
  </code></pre>
-					<copyright-notice type="examples"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="Exm-StudPay.html">&larr; Back to specification</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/ReportWriter.html|Report Writer, ../../course/ReportWriterSS.html|Report Writer – Syntax and Semantics"
+							examples="Exm-StudPay.html|Student Fees Report – Exam Paper, ../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly"
+						></related-content>
+						<hr />
+						<copyright-notice type="examples"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="Exm-StudPay.html">&larr; Back to specification</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html
+++ b/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html
@@ -69,11 +69,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Top Video Suppliers Report"></page-hero>
-					<related-content
-						lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/RelativeFiles.html|Relative Files, ../../course/Tables1.html|Tables 1"
-						examples="Prg-TopSupplierRpt.html|Top Supplier Report – Sample Solution, ../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly"
-						exercises="../MonthTable.html|Using Tables Exercise"
-					></related-content>
 					<hr />
 
 					<dl class="exam-meta">
@@ -298,11 +293,19 @@
 						</p>
 					</section>
 
-					<exercises-nav></exercises-nav>
-					<copyright-notice type="exercises"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/RelativeFiles.html|Relative Files, ../../course/Tables1.html|Tables 1"
+							examples="Prg-TopSupplierRpt.html|Top Supplier Report – Sample Solution, ../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly"
+							exercises="../MonthTable.html|Using Tables Exercise"
+						></related-content>
+						<hr />
+						<exercises-nav></exercises-nav>
+						<copyright-notice type="exercises"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html
+++ b/exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html
@@ -71,11 +71,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Top Video Supplier Report"></page-hero>
-					<related-content
-						lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/RelativeFiles.html|Relative Files, ../../course/Tables1.html|Tables 1"
-						examples="Exm-TopSupplierRpt.html|Top Supplier Report – Exam Paper, ../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly"
-						exercises="../MonthTable.html|Using Tables Exercise"
-					></related-content>
 					<hr />
 					<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
@@ -344,10 +339,18 @@ SUM-TITLE-EARNINGS.
         AT END SET VDF-FILE-END TO TRUE
     END-READ.
  </code></pre>
-					<copyright-notice type="examples"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="Exm-TopSupplierRpt.html">&larr; Back to specification</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/RelativeFiles.html|Relative Files, ../../course/Tables1.html|Tables 1"
+							examples="Exm-TopSupplierRpt.html|Top Supplier Report – Exam Paper, ../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly"
+							exercises="../MonthTable.html|Using Tables Exercise"
+						></related-content>
+						<hr />
+						<copyright-notice type="examples"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="Exm-TopSupplierRpt.html">&larr; Back to specification</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html
+++ b/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html
@@ -69,11 +69,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="USSR Naval Vessel Inventory Report"></page-hero>
-					<related-content
-						lectures="../../course/SortMerge.html|SORT and MERGE, ../../course/Tables1.html|Tables 1, ../../course/Tables2.html|Tables 2, ../../course/Search.html|SEARCH and SEARCH ALL"
-						examples="Prg-USSRshipRpt.html|USSR Ship Report – Sample Solution, ../../examples/Sort/InputSort.html|SORT with Input Procedure, ../../examples/Sort/MaleSort.html|SORT with Output Procedure, ../../examples/Merge/Merge.html|Merging Files"
-						exercises="../SortIP.html|Sorting a Sequential File, ../MonthTable.html|Using Tables Exercise, ../SeqWrite.html|Writing Records, ../SeqRead.html|Reading Sequential Files"
-					></related-content>
 					<hr />
 
 					<dl class="exam-meta">
@@ -457,11 +452,19 @@
 						</p>
 					</section>
 
-					<exercises-nav></exercises-nav>
-					<copyright-notice type="exercises"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/SortMerge.html|SORT and MERGE, ../../course/Tables1.html|Tables 1, ../../course/Tables2.html|Tables 2, ../../course/Search.html|SEARCH and SEARCH ALL"
+							examples="Prg-USSRshipRpt.html|USSR Ship Report – Sample Solution, ../../examples/Sort/InputSort.html|SORT with Input Procedure, ../../examples/Sort/MaleSort.html|SORT with Output Procedure, ../../examples/Merge/Merge.html|Merging Files"
+							exercises="../SortIP.html|Sorting a Sequential File, ../MonthTable.html|Using Tables Exercise, ../SeqWrite.html|Writing Records, ../SeqRead.html|Reading Sequential Files"
+						></related-content>
+						<hr />
+						<exercises-nav></exercises-nav>
+						<copyright-notice type="exercises"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html
+++ b/exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html
@@ -71,11 +71,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="USSR Naval Vessel Inventory Report"></page-hero>
-					<related-content
-						lectures="../../course/SortMerge.html|SORT and MERGE, ../../course/Tables1.html|Tables 1, ../../course/Tables2.html|Tables 2, ../../course/Search.html|SEARCH and SEARCH ALL"
-						examples="Exm-USSRshipRpt.html|USSR Ship Report – Exam Paper, ../../examples/Sort/InputSort.html|SORT with Input Procedure, ../../examples/Sort/MaleSort.html|SORT with Output Procedure, ../../examples/Merge/Merge.html|Merging Files"
-						exercises="../SortIP.html|Sorting a Sequential File, ../MonthTable.html|Using Tables Exercise, ../SeqWrite.html|Writing Records, ../SeqRead.html|Reading Sequential Files"
-					></related-content>
 					<hr />
 					<pre class="language-cobol"><code class="language-cobol">
        &gt;&gt;SOURCE FORMAT IS FREE
@@ -310,10 +305,18 @@ SELECT-MAJOR-SHIPS SECTION.
 30-EXIT-SELECT-MAJOR-SHIPS.
         EXIT.
  </code></pre>
-					<copyright-notice type="examples"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="Exm-USSRshipRpt.html">&larr; Back to specification</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/SortMerge.html|SORT and MERGE, ../../course/Tables1.html|Tables 1, ../../course/Tables2.html|Tables 2, ../../course/Search.html|SEARCH and SEARCH ALL"
+							examples="Exm-USSRshipRpt.html|USSR Ship Report – Exam Paper, ../../examples/Sort/InputSort.html|SORT with Input Procedure, ../../examples/Sort/MaleSort.html|SORT with Output Procedure, ../../examples/Merge/Merge.html|Merging Files"
+							exercises="../SortIP.html|Sorting a Sequential File, ../MonthTable.html|Using Tables Exercise, ../SeqWrite.html|Writing Records, ../SeqRead.html|Reading Sequential Files"
+						></related-content>
+						<hr />
+						<copyright-notice type="examples"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="Exm-USSRshipRpt.html">&larr; Back to specification</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/GettingStarted.html
+++ b/exercises/GettingStarted.html
@@ -61,10 +61,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Getting Started with the NetExpress Environment"></page-hero>
-					<related-content
-						lectures="../course/COBOLIntro.html|Introduction to COBOL, ../course/COBOLcommands.html|Basic COBOL Commands"
-						examples="../examples/Accept/ACCEPT.html|ACCEPT and DISPLAY Example, ../examples/Accept/Shortest.html|Shortest COBOL Program, ../examples/Accept/Multiplier.html|ACCEPT, DISPLAY and MULTIPLY Example"
-					></related-content>
 					<p class="center-block">
 						<code class="language-cobol">ACCEPT</code>, <code class="language-cobol">DISPLAY</code>,
 						<code class="language-cobol">MULTIPLY</code>, <code class="language-cobol">COMPUTE</code>
@@ -271,10 +267,17 @@
 						</p>
 					</section>
 
-					<copyright-notice type="exercises"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="index.html">&larr; Back to COBOL Exercises</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../course/COBOLIntro.html|Introduction to COBOL, ../course/COBOLcommands.html|Basic COBOL Commands"
+							examples="../examples/Accept/ACCEPT.html|ACCEPT and DISPLAY Example, ../examples/Accept/Shortest.html|Shortest COBOL Program, ../examples/Accept/Multiplier.html|ACCEPT, DISPLAY and MULTIPLY Example"
+						></related-content>
+						<hr />
+						<copyright-notice type="exercises"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="index.html">&larr; Back to COBOL Exercises</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/MonthTable.html
+++ b/exercises/MonthTable.html
@@ -61,10 +61,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Using Tables"></page-hero>
-					<related-content
-						lectures="../course/Tables1.html|Tables 1, ../course/Tables2.html|Tables 2, ../course/Search.html|SEARCH and SEARCH ALL"
-						examples="../examples/Tables/MonthTable.html|Month Table"
-					></related-content>
 					<p class="center-block"><code class="language-cobol">READ</code>, pre-defined Tables, Tables.</p>
 					<hr />
 
@@ -211,10 +207,17 @@ December          5</samp></pre>
 						</p>
 					</section>
 
-					<copyright-notice type="exercises"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="index.html">&larr; Back to COBOL Exercises</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../course/Tables1.html|Tables 1, ../course/Tables2.html|Tables 2, ../course/Search.html|SEARCH and SEARCH ALL"
+							examples="../examples/Tables/MonthTable.html|Month Table"
+						></related-content>
+						<hr />
+						<copyright-notice type="exercises"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="index.html">&larr; Back to COBOL Exercises</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html
+++ b/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html
@@ -69,10 +69,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Aromamora Outstanding Invoices Report"></page-hero>
-					<related-content
-						lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/ReportWriter.html|Report Writer, ../../course/ReportWriterSS.html|Report Writer – Syntax and Semantics"
-						examples="../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly, ../../examples/ReportWriter/RepWriteFull.html|Full Report Writer"
-					></related-content>
 					<hr />
 
 					<dl class="exam-meta">
@@ -273,11 +269,18 @@
 						</p>
 					</section>
 
-					<exercises-nav></exercises-nav>
-					<copyright-notice type="project"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/ReportWriter.html|Report Writer, ../../course/ReportWriterSS.html|Report Writer – Syntax and Semantics"
+							examples="../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly, ../../examples/ReportWriter/RepWriteFull.html|Full Report Writer"
+						></related-content>
+						<hr />
+						<exercises-nav></exercises-nav>
+						<copyright-notice type="project"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html
+++ b/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html
@@ -69,11 +69,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Aromamora Essential Oils Sales Report"></page-hero>
-					<related-content
-						lectures="../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3, ../../course/SortMerge.html|SORT and MERGE"
-						examples="../../examples/SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../../examples/SeqRead/SEQREAD.html|Reading a Sequential File, ../../examples/SeqRead/SEQREADno88.html|Reading a Sequential File (no 88), ../../examples/SeqIns/SEQINSERT.html|Inserting Records in a Sequential File"
-						exercises="../SeqWrite.html|Writing Records, ../SeqRead.html|Reading Sequential Files, ../SeqReadIf.html|Counting Records, ../SeqInsert.html|Inserting Records"
-					></related-content>
 					<hr />
 
 					<dl class="exam-meta">
@@ -308,11 +303,19 @@
 						</p>
 					</section>
 
-					<exercises-nav></exercises-nav>
-					<copyright-notice type="project"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3, ../../course/SortMerge.html|SORT and MERGE"
+							examples="../../examples/SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../../examples/SeqRead/SEQREAD.html|Reading a Sequential File, ../../examples/SeqRead/SEQREADno88.html|Reading a Sequential File (no 88), ../../examples/SeqIns/SEQINSERT.html|Inserting Records in a Sequential File"
+							exercises="../SeqWrite.html|Writing Records, ../SeqRead.html|Reading Sequential Files, ../SeqReadIf.html|Counting Records, ../SeqInsert.html|Inserting Records"
+						></related-content>
+						<hr />
+						<exercises-nav></exercises-nav>
+						<copyright-notice type="project"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html
+++ b/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html
@@ -69,11 +69,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="UL CAO points calculator and Report"></page-hero>
-					<related-content
-						lectures="../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3, ../../course/Tables1.html|Tables 1"
-						examples="../../examples/SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../../examples/SeqRead/SEQREAD.html|Reading a Sequential File, ../../examples/SeqRead/SEQREADno88.html|Reading a Sequential File (no 88), ../../examples/SeqIns/SEQINSERT.html|Inserting Records in a Sequential File"
-						exercises="../SeqWrite.html|Writing Records, ../SeqRead.html|Reading Sequential Files, ../SeqReadIf.html|Counting Records, ../SeqInsert.html|Inserting Records"
-					></related-content>
 					<hr />
 
 					<dl class="exam-meta">
@@ -630,11 +625,19 @@
 						</div>
 					</section>
 
-					<exercises-nav></exercises-nav>
-					<copyright-notice type="project"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3, ../../course/Tables1.html|Tables 1"
+							examples="../../examples/SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../../examples/SeqRead/SEQREAD.html|Reading a Sequential File, ../../examples/SeqRead/SEQREADno88.html|Reading a Sequential File (no 88), ../../examples/SeqIns/SEQINSERT.html|Inserting Records in a Sequential File"
+							exercises="../SeqWrite.html|Writing Records, ../SeqRead.html|Reading Sequential Files, ../SeqReadIf.html|Counting Records, ../SeqInsert.html|Inserting Records"
+						></related-content>
+						<hr />
+						<exercises-nav></exercises-nav>
+						<copyright-notice type="project"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html
+++ b/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html
@@ -69,11 +69,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Munster Surnames Frequency Report"></page-hero>
-					<related-content
-						lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/Tables1.html|Tables 1, ../../course/Tables2.html|Tables 2"
-						examples="../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly, ../../examples/Tables/MonthTable.html|Month Table"
-						exercises="../MonthTable.html|Using Tables Exercise"
-					></related-content>
 					<hr />
 
 					<dl class="exam-meta">
@@ -181,11 +176,19 @@
 						</p>
 					</section>
 
-					<exercises-nav></exercises-nav>
-					<copyright-notice type="project"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/Tables1.html|Tables 1, ../../course/Tables2.html|Tables 2"
+							examples="../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly, ../../examples/Tables/MonthTable.html|Month Table"
+							exercises="../MonthTable.html|Using Tables Exercise"
+						></related-content>
+						<hr />
+						<exercises-nav></exercises-nav>
+						<copyright-notice type="project"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html
+++ b/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html
@@ -102,11 +102,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Newtronics Plc. File Maintenance Program"></page-hero>
-					<related-content
-						lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2"
-						examples="../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly, ../../examples/SeqWrite/SEQWRITE.html|Writing to a Sequential File"
-						exercises="../SeqWrite.html|Writing Records, ../SeqRead.html|Reading Sequential Files, ../SeqReadIf.html|Counting Records, ../SeqInsert.html|Inserting Records"
-					></related-content>
 					<hr />
 
 					<dl class="exam-meta">
@@ -668,11 +663,19 @@ Check Digit       =            4</pre
 						</p>
 					</section>
 
-					<exercises-nav></exercises-nav>
-					<copyright-notice type="project"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/IndexedFiles.html|Indexed Files, ../../course/Intro2DirectAccess.html|Introduction to Direct Access, ../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2"
+							examples="../../examples/Indexed/Seq2Index.html|Sequential to Indexed File, ../../examples/Indexed/SeqReadIdx.html|Reading an Indexed File Sequentially, ../../examples/Indexed/DirectReadIdx.html|Reading an Indexed File Directly, ../../examples/SeqWrite/SEQWRITE.html|Writing to a Sequential File"
+							exercises="../SeqWrite.html|Writing Records, ../SeqRead.html|Reading Sequential Files, ../SeqReadIf.html|Counting Records, ../SeqInsert.html|Inserting Records"
+						></related-content>
+						<hr />
+						<exercises-nav></exercises-nav>
+						<copyright-notice type="project"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/Proj-CSISEvalform/CSISEvalForm.html
+++ b/exercises/Proj-CSISEvalform/CSISEvalForm.html
@@ -69,11 +69,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="CSIS WebSite Evaluation Form Report"></page-hero>
-					<related-content
-						lectures="../../course/Tables1.html|Tables 1, ../../course/Tables2.html|Tables 2, ../../course/Search.html|SEARCH and SEARCH ALL, ../../course/SortMerge.html|SORT and MERGE"
-						examples="../../examples/Tables/MonthTable.html|Month Table, ../../examples/Sort/InputSort.html|SORT with Input Procedure, ../../examples/Sort/MaleSort.html|SORT with Output Procedure, ../../examples/Merge/Merge.html|Merging Files"
-						exercises="../MonthTable.html|Using Tables Exercise, ../SortIP.html|Sorting a Sequential File"
-					></related-content>
 					<hr />
 
 					<dl class="exam-meta">
@@ -298,11 +293,19 @@
 <b>Overall Evaluation  - XXXXXXXXX</b></pre>
 					</section>
 
-					<exercises-nav></exercises-nav>
-					<copyright-notice type="project"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../../course/Tables1.html|Tables 1, ../../course/Tables2.html|Tables 2, ../../course/Search.html|SEARCH and SEARCH ALL, ../../course/SortMerge.html|SORT and MERGE"
+							examples="../../examples/Tables/MonthTable.html|Month Table, ../../examples/Sort/InputSort.html|SORT with Input Procedure, ../../examples/Sort/MaleSort.html|SORT with Output Procedure, ../../examples/Merge/Merge.html|Merging Files"
+							exercises="../MonthTable.html|Using Tables Exercise, ../SortIP.html|Sorting a Sequential File"
+						></related-content>
+						<hr />
+						<exercises-nav></exercises-nav>
+						<copyright-notice type="project"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/SeqInsert.html
+++ b/exercises/SeqInsert.html
@@ -61,11 +61,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Inserting records in a Sequential File"></page-hero>
-					<related-content
-						lectures="../course/SequentialFiles1.html|Sequential Files 1, ../course/SequentialFiles2.html|Sequential Files 2, ../course/SequentialFiles3.html|Sequential Files 3"
-						examples="../examples/SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../examples/SeqRead/SEQREAD.html|Reading a Sequential File, ../examples/SeqRead/SEQREADno88.html|Reading a Sequential File (no 88), ../examples/SeqIns/SEQINSERT.html|Inserting Records in a Sequential File"
-						exercises="SeqWrite.html|Writing Records, SeqRead.html|Reading Sequential Files, SeqReadIf.html|Counting Records, SeqUpdate.html|Updating Sequential Files"
-					></related-content>
 					<p class="center-block">
 						<code class="language-cobol">READ</code>, <code class="language-cobol">WRITE</code>,
 						<code class="language-cobol">PERFORM..UNTIL</code>, <code class="language-cobol">IF</code>,
@@ -262,10 +257,18 @@
 						</ol>
 					</section>
 
-					<copyright-notice type="exercises"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="index.html">&larr; Back to COBOL Exercises</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../course/SequentialFiles1.html|Sequential Files 1, ../course/SequentialFiles2.html|Sequential Files 2, ../course/SequentialFiles3.html|Sequential Files 3"
+							examples="../examples/SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../examples/SeqRead/SEQREAD.html|Reading a Sequential File, ../examples/SeqRead/SEQREADno88.html|Reading a Sequential File (no 88), ../examples/SeqIns/SEQINSERT.html|Inserting Records in a Sequential File"
+							exercises="SeqWrite.html|Writing Records, SeqRead.html|Reading Sequential Files, SeqReadIf.html|Counting Records, SeqUpdate.html|Updating Sequential Files"
+						></related-content>
+						<hr />
+						<copyright-notice type="exercises"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="index.html">&larr; Back to COBOL Exercises</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/SeqRead.html
+++ b/exercises/SeqRead.html
@@ -61,11 +61,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Reading Sequential Files"></page-hero>
-					<related-content
-						lectures="../course/SequentialFiles1.html|Sequential Files 1, ../course/SequentialFiles2.html|Sequential Files 2, ../course/SequentialFiles3.html|Sequential Files 3"
-						examples="../examples/SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../examples/SeqRead/SEQREAD.html|Reading a Sequential File, ../examples/SeqRead/SEQREADno88.html|Reading a Sequential File (no 88), ../examples/SeqIns/SEQINSERT.html|Inserting Records in a Sequential File"
-						exercises="SeqWrite.html|Writing Records, SeqReadIf.html|Counting Records, SeqInsert.html|Inserting Records, SeqUpdate.html|Updating Sequential Files"
-					></related-content>
 					<p class="center-block">
 						<code class="language-cobol">READ</code>, <code class="language-cobol">PERFORM .. UNTIL</code>,
 						<code class="language-cobol">DISPLAY</code>
@@ -231,10 +226,18 @@ etc.</samp></pre>
 						</figure>
 					</section>
 
-					<copyright-notice type="exercises"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="index.html">&larr; Back to COBOL Exercises</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../course/SequentialFiles1.html|Sequential Files 1, ../course/SequentialFiles2.html|Sequential Files 2, ../course/SequentialFiles3.html|Sequential Files 3"
+							examples="../examples/SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../examples/SeqRead/SEQREAD.html|Reading a Sequential File, ../examples/SeqRead/SEQREADno88.html|Reading a Sequential File (no 88), ../examples/SeqIns/SEQINSERT.html|Inserting Records in a Sequential File"
+							exercises="SeqWrite.html|Writing Records, SeqReadIf.html|Counting Records, SeqInsert.html|Inserting Records, SeqUpdate.html|Updating Sequential Files"
+						></related-content>
+						<hr />
+						<copyright-notice type="exercises"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="index.html">&larr; Back to COBOL Exercises</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/SeqReadIf.html
+++ b/exercises/SeqReadIf.html
@@ -61,11 +61,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Counting records in a sequential file"></page-hero>
-					<related-content
-						lectures="../course/SequentialFiles1.html|Sequential Files 1, ../course/SequentialFiles2.html|Sequential Files 2, ../course/SequentialFiles3.html|Sequential Files 3"
-						examples="../examples/SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../examples/SeqRead/SEQREAD.html|Reading a Sequential File, ../examples/SeqRead/SEQREADno88.html|Reading a Sequential File (no 88), ../examples/SeqIns/SEQINSERT.html|Inserting Records in a Sequential File"
-						exercises="SeqWrite.html|Writing Records, SeqRead.html|Reading Sequential Files, SeqInsert.html|Inserting Records, SeqUpdate.html|Updating Sequential Files"
-					></related-content>
 					<p class="center-block">
 						<code class="language-cobol">READ</code>, <code class="language-cobol">PERFORM</code> ..
 						<code class="language-cobol">UNTIL</code>, <code class="language-cobol">IF</code>,
@@ -182,10 +177,18 @@ Number of Females = 15</samp></pre>
 						</figure>
 					</section>
 
-					<copyright-notice type="exercises"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="index.html">&larr; Back to COBOL Exercises</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../course/SequentialFiles1.html|Sequential Files 1, ../course/SequentialFiles2.html|Sequential Files 2, ../course/SequentialFiles3.html|Sequential Files 3"
+							examples="../examples/SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../examples/SeqRead/SEQREAD.html|Reading a Sequential File, ../examples/SeqRead/SEQREADno88.html|Reading a Sequential File (no 88), ../examples/SeqIns/SEQINSERT.html|Inserting Records in a Sequential File"
+							exercises="SeqWrite.html|Writing Records, SeqRead.html|Reading Sequential Files, SeqInsert.html|Inserting Records, SeqUpdate.html|Updating Sequential Files"
+						></related-content>
+						<hr />
+						<copyright-notice type="exercises"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="index.html">&larr; Back to COBOL Exercises</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/SeqUpdate.html
+++ b/exercises/SeqUpdate.html
@@ -61,11 +61,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Updating a Sequential File"></page-hero>
-					<related-content
-						lectures="../course/SequentialFiles1.html|Sequential Files 1, ../course/SequentialFiles2.html|Sequential Files 2, ../course/SequentialFiles3.html|Sequential Files 3"
-						examples="../examples/SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../examples/SeqRead/SEQREAD.html|Reading a Sequential File, ../examples/SeqRead/SEQREADno88.html|Reading a Sequential File (no 88), ../examples/SeqIns/SEQINSERT.html|Inserting Records in a Sequential File"
-						exercises="SeqWrite.html|Writing Records, SeqRead.html|Reading Sequential Files, SeqReadIf.html|Counting Records, SeqInsert.html|Inserting Records"
-					></related-content>
 					<p class="center-block">
 						<code class="language-cobol">READ</code>, <code class="language-cobol">WRITE</code>,
 						<code class="language-cobol">PERFORM..UNTIL</code>,
@@ -283,10 +278,18 @@
 						</p>
 					</section>
 
-					<copyright-notice type="exercises"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="index.html">&larr; Back to COBOL Exercises</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../course/SequentialFiles1.html|Sequential Files 1, ../course/SequentialFiles2.html|Sequential Files 2, ../course/SequentialFiles3.html|Sequential Files 3"
+							examples="../examples/SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../examples/SeqRead/SEQREAD.html|Reading a Sequential File, ../examples/SeqRead/SEQREADno88.html|Reading a Sequential File (no 88), ../examples/SeqIns/SEQINSERT.html|Inserting Records in a Sequential File"
+							exercises="SeqWrite.html|Writing Records, SeqRead.html|Reading Sequential Files, SeqReadIf.html|Counting Records, SeqInsert.html|Inserting Records"
+						></related-content>
+						<hr />
+						<copyright-notice type="exercises"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="index.html">&larr; Back to COBOL Exercises</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/SeqWrite.html
+++ b/exercises/SeqWrite.html
@@ -61,11 +61,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Writing records to a Sequential File"></page-hero>
-					<related-content
-						lectures="../course/SequentialFiles1.html|Sequential Files 1, ../course/SequentialFiles2.html|Sequential Files 2, ../course/SequentialFiles3.html|Sequential Files 3"
-						examples="../examples/SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../examples/SeqRead/SEQREAD.html|Reading a Sequential File, ../examples/SeqRead/SEQREADno88.html|Reading a Sequential File (no 88), ../examples/SeqIns/SEQINSERT.html|Inserting Records in a Sequential File"
-						exercises="SeqRead.html|Reading Sequential Files, SeqReadIf.html|Counting Records, SeqInsert.html|Inserting Records, SeqUpdate.html|Updating Sequential Files"
-					></related-content>
 					<p class="center-block">
 						<code class="language-cobol">ACCEPT</code>, <code class="language-cobol">DISPLAY</code>,
 						<code class="language-cobol">WRITE</code>, <code class="language-cobol">PERFORM..UNTIL</code>
@@ -182,10 +177,18 @@ nnnnnnnSSSSSSSSiiG
 						</p>
 					</section>
 
-					<copyright-notice type="exercises"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="index.html">&larr; Back to COBOL Exercises</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../course/SequentialFiles1.html|Sequential Files 1, ../course/SequentialFiles2.html|Sequential Files 2, ../course/SequentialFiles3.html|Sequential Files 3"
+							examples="../examples/SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../examples/SeqRead/SEQREAD.html|Reading a Sequential File, ../examples/SeqRead/SEQREADno88.html|Reading a Sequential File (no 88), ../examples/SeqIns/SEQINSERT.html|Inserting Records in a Sequential File"
+							exercises="SeqRead.html|Reading Sequential Files, SeqReadIf.html|Counting Records, SeqInsert.html|Inserting Records, SeqUpdate.html|Updating Sequential Files"
+						></related-content>
+						<hr />
+						<copyright-notice type="exercises"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="index.html">&larr; Back to COBOL Exercises</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/exercises/SortIP.html
+++ b/exercises/SortIP.html
@@ -61,10 +61,6 @@
 			<div class="page-wrapper">
 				<div class="page-content">
 					<page-hero title="Sorting a Sequential File"></page-hero>
-					<related-content
-						lectures="../course/SortMerge.html|SORT and MERGE"
-						examples="../examples/Sort/InputSort.html|SORT with Input Procedure, ../examples/Sort/MaleSort.html|SORT with Output Procedure, ../examples/Merge/Merge.html|Merging Files"
-					></related-content>
 					<p class="center-block">
 						<code class="language-cobol">READ</code>, <code class="language-cobol">RELEASE</code>,
 						<code class="language-cobol">SORT</code>, Input Procedure
@@ -253,10 +249,17 @@
 						</p>
 					</section>
 
-					<copyright-notice type="exercises"></copyright-notice>
-					<last-updated></last-updated>
-					<edit-on-github></edit-on-github>
-					<p class="center-block"><a href="index.html">&larr; Back to COBOL Exercises</a></p>
+					<div class="page-footer">
+						<related-content
+							lectures="../course/SortMerge.html|SORT and MERGE"
+							examples="../examples/Sort/InputSort.html|SORT with Input Procedure, ../examples/Sort/MaleSort.html|SORT with Output Procedure, ../examples/Merge/Merge.html|Merging Files"
+						></related-content>
+						<hr />
+						<copyright-notice type="exercises"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+						<p class="center-block"><a href="index.html">&larr; Back to COBOL Exercises</a></p>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/scripts/fix-related-content-placement.js
+++ b/scripts/fix-related-content-placement.js
@@ -3,70 +3,68 @@
 // <div class="page-footer"> at the bottom of the page, matching the course-tutorial
 // footer pattern. Fixes https://github.com/bushidocodes/limerick-cobol/issues/567.
 
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
 const FILES = [
 	// simple exercises (depth 1, no exercises-nav)
-	'exercises/CountDown.html',
-	'exercises/GettingStarted.html',
-	'exercises/MonthTable.html',
-	'exercises/SeqInsert.html',
-	'exercises/SeqRead.html',
-	'exercises/SeqReadIf.html',
-	'exercises/SeqUpdate.html',
-	'exercises/SeqWrite.html',
-	'exercises/SortIP.html',
+	"exercises/CountDown.html",
+	"exercises/GettingStarted.html",
+	"exercises/MonthTable.html",
+	"exercises/SeqInsert.html",
+	"exercises/SeqRead.html",
+	"exercises/SeqReadIf.html",
+	"exercises/SeqUpdate.html",
+	"exercises/SeqWrite.html",
+	"exercises/SortIP.html",
 	// exam spec pages (depth 2, with exercises-nav)
-	'exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html',
-	'exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html',
-	'exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html',
-	'exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html',
-	'exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html',
-	'exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html',
-	'exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html',
-	'exercises/Exm-FileConversion/Exm-FileConversion.html',
-	'exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html',
-	'exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html',
-	'exercises/Exm-SFbyMail/Exm-SFbyMail.html',
-	'exercises/Exm-StudFeesRpt/Exm-StudPay.html',
-	'exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html',
-	'exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html',
+	"exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html",
+	"exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html",
+	"exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html",
+	"exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html",
+	"exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html",
+	"exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html",
+	"exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html",
+	"exercises/Exm-FileConversion/Exm-FileConversion.html",
+	"exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html",
+	"exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html",
+	"exercises/Exm-SFbyMail/Exm-SFbyMail.html",
+	"exercises/Exm-StudFeesRpt/Exm-StudPay.html",
+	"exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html",
+	"exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html",
 	// exam program pages (depth 2, no exercises-nav)
-	'exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html',
-	'exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html',
-	'exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html',
-	'exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html',
-	'exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html',
-	'exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html',
-	'exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html',
-	'exercises/Exm-FileConversion/Prg-FileConversion.html',
-	'exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html',
-	'exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html',
-	'exercises/Exm-SFbyMail/Prg-SFbyMail.html',
-	'exercises/Exm-StudFeesRpt/Prg-StudPay.html',
-	'exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html',
-	'exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html',
+	"exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html",
+	"exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html",
+	"exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html",
+	"exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html",
+	"exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html",
+	"exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html",
+	"exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html",
+	"exercises/Exm-FileConversion/Prg-FileConversion.html",
+	"exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html",
+	"exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html",
+	"exercises/Exm-SFbyMail/Prg-SFbyMail.html",
+	"exercises/Exm-StudFeesRpt/Prg-StudPay.html",
+	"exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html",
+	"exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html",
 	// project pages (depth 2, with exercises-nav)
-	'exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html',
-	'exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html',
-	'exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html',
-	'exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html',
-	'exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html',
-	'exercises/Proj-CSISEvalform/CSISEvalForm.html',
+	"exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html",
+	"exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html",
+	"exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html",
+	"exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html",
+	"exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html",
+	"exercises/Proj-CSISEvalform/CSISEvalForm.html",
 ];
 
-const T5 = '\t\t\t\t\t'; // 5 tabs — children of .page-content
-const T6 = '\t\t\t\t\t\t'; // 6 tabs — children of .page-footer
+const T5 = "\t\t\t\t\t"; // 5 tabs — children of .page-content
+const T6 = "\t\t\t\t\t\t"; // 6 tabs — children of .page-footer
 
 function transformFile(filePath) {
-	const raw = fs.readFileSync(filePath, 'utf8');
+	const raw = fs.readFileSync(filePath, "utf8");
 
 	// ── Step 1: capture the <related-content> block ─────────────────────────
 	// Matches: T5<related-content\n  (one or more T6 attribute lines)\n  T5></related-content>\n
-	const rcRe = new RegExp(
-		`(${T5}<related-content\n(?:${T6}[^\n]+\n)+${T5}><\\/related-content>)\n`,
-	);
+	const rcRe = new RegExp(`(${T5}<related-content\n(?:${T6}[^\n]+\n)+${T5}><\\/related-content>)\n`);
 	const rcMatch = raw.match(rcRe);
 	if (!rcMatch) {
 		console.error(`  SKIP (no related-content block found): ${filePath}`);
@@ -75,12 +73,12 @@ function transformFile(filePath) {
 	const rcBlock = rcMatch[1]; // block without trailing newline
 	// Re-indent: each line gains one leading tab
 	const rcBlockIndented = rcBlock
-		.split('\n')
-		.map((l) => '\t' + l)
-		.join('\n');
+		.split("\n")
+		.map((l) => "\t" + l)
+		.join("\n");
 
 	// ── Step 2: remove the block from after <page-hero> ─────────────────────
-	let content = raw.replace(rcBlock + '\n', '');
+	let content = raw.replace(rcBlock + "\n", "");
 
 	// ── Step 3: wrap footer elements in <div class="page-footer"> ───────────
 	// Footer sequence (optional exercises-nav, then copyright-notice through
@@ -106,10 +104,10 @@ function transformFile(filePath) {
 
 	// Re-indent footer elements to T6
 	const newFooterLines = oldFooterLines
-		.split('\n')
+		.split("\n")
 		.filter((l) => l.length > 0)
-		.map((l) => '\t' + l)
-		.join('\n');
+		.map((l) => "\t" + l)
+		.join("\n");
 
 	const newFooter =
 		`${T5}<div class="page-footer">\n` +
@@ -121,17 +119,17 @@ function transformFile(filePath) {
 
 	content = content.replace(footerRe, newFooter);
 
-	fs.writeFileSync(filePath, content, 'utf8');
+	fs.writeFileSync(filePath, content, "utf8");
 	return true;
 }
 
 let ok = 0;
 let skip = 0;
 for (const f of FILES) {
-	const fullPath = path.join(__dirname, '..', f);
+	const fullPath = path.join(__dirname, "..", f);
 	process.stdout.write(`Processing ${f} … `);
 	if (transformFile(fullPath)) {
-		console.log('OK');
+		console.log("OK");
 		ok++;
 	} else {
 		skip++;

--- a/scripts/fix-related-content-placement.js
+++ b/scripts/fix-related-content-placement.js
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+// One-time script: move <related-content> from after <page-hero> to inside a
+// <div class="page-footer"> at the bottom of the page, matching the course-tutorial
+// footer pattern. Fixes https://github.com/bushidocodes/limerick-cobol/issues/567.
+
+const fs = require('fs');
+const path = require('path');
+
+const FILES = [
+	// simple exercises (depth 1, no exercises-nav)
+	'exercises/CountDown.html',
+	'exercises/GettingStarted.html',
+	'exercises/MonthTable.html',
+	'exercises/SeqInsert.html',
+	'exercises/SeqRead.html',
+	'exercises/SeqReadIf.html',
+	'exercises/SeqUpdate.html',
+	'exercises/SeqWrite.html',
+	'exercises/SortIP.html',
+	// exam spec pages (depth 2, with exercises-nav)
+	'exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html',
+	'exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html',
+	'exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html',
+	'exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html',
+	'exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html',
+	'exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html',
+	'exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html',
+	'exercises/Exm-FileConversion/Exm-FileConversion.html',
+	'exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html',
+	'exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html',
+	'exercises/Exm-SFbyMail/Exm-SFbyMail.html',
+	'exercises/Exm-StudFeesRpt/Exm-StudPay.html',
+	'exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html',
+	'exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html',
+	// exam program pages (depth 2, no exercises-nav)
+	'exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html',
+	'exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html',
+	'exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html',
+	'exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html',
+	'exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html',
+	'exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html',
+	'exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html',
+	'exercises/Exm-FileConversion/Prg-FileConversion.html',
+	'exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html',
+	'exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html',
+	'exercises/Exm-SFbyMail/Prg-SFbyMail.html',
+	'exercises/Exm-StudFeesRpt/Prg-StudPay.html',
+	'exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html',
+	'exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html',
+	// project pages (depth 2, with exercises-nav)
+	'exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html',
+	'exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html',
+	'exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html',
+	'exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html',
+	'exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html',
+	'exercises/Proj-CSISEvalform/CSISEvalForm.html',
+];
+
+const T5 = '\t\t\t\t\t'; // 5 tabs — children of .page-content
+const T6 = '\t\t\t\t\t\t'; // 6 tabs — children of .page-footer
+
+function transformFile(filePath) {
+	const raw = fs.readFileSync(filePath, 'utf8');
+
+	// ── Step 1: capture the <related-content> block ─────────────────────────
+	// Matches: T5<related-content\n  (one or more T6 attribute lines)\n  T5></related-content>\n
+	const rcRe = new RegExp(
+		`(${T5}<related-content\n(?:${T6}[^\n]+\n)+${T5}><\\/related-content>)\n`,
+	);
+	const rcMatch = raw.match(rcRe);
+	if (!rcMatch) {
+		console.error(`  SKIP (no related-content block found): ${filePath}`);
+		return false;
+	}
+	const rcBlock = rcMatch[1]; // block without trailing newline
+	// Re-indent: each line gains one leading tab
+	const rcBlockIndented = rcBlock
+		.split('\n')
+		.map((l) => '\t' + l)
+		.join('\n');
+
+	// ── Step 2: remove the block from after <page-hero> ─────────────────────
+	let content = raw.replace(rcBlock + '\n', '');
+
+	// ── Step 3: wrap footer elements in <div class="page-footer"> ───────────
+	// Footer sequence (optional exercises-nav, then copyright-notice through
+	// the back-link paragraph), then the closing T4</div> for .page-content.
+	const footerRe = new RegExp(
+		`(` +
+			`(?:${T5}<exercises-nav><\\/exercises-nav>\n)?` +
+			`${T5}<copyright-notice[^\n]+\n` +
+			`${T5}<last-updated><\\/last-updated>\n` +
+			`${T5}<edit-on-github><\\/edit-on-github>\n` +
+			`${T5}<p class="center-block">[^\n]+\n` +
+			`)` +
+			`(\t{4}<\\/div>)`, // closing tag for .page-content
+	);
+	const footerMatch = content.match(footerRe);
+	if (!footerMatch) {
+		console.error(`  SKIP (no footer sequence found): ${filePath}`);
+		return false;
+	}
+
+	const oldFooterLines = footerMatch[1]; // footer elements, still at T5
+	const closingDiv = footerMatch[2]; // \t\t\t\t</div>
+
+	// Re-indent footer elements to T6
+	const newFooterLines = oldFooterLines
+		.split('\n')
+		.filter((l) => l.length > 0)
+		.map((l) => '\t' + l)
+		.join('\n');
+
+	const newFooter =
+		`${T5}<div class="page-footer">\n` +
+		`${rcBlockIndented}\n` +
+		`${T6}<hr />\n` +
+		`${newFooterLines}\n` +
+		`${T5}</div>\n` +
+		closingDiv;
+
+	content = content.replace(footerRe, newFooter);
+
+	fs.writeFileSync(filePath, content, 'utf8');
+	return true;
+}
+
+let ok = 0;
+let skip = 0;
+for (const f of FILES) {
+	const fullPath = path.join(__dirname, '..', f);
+	process.stdout.write(`Processing ${f} … `);
+	if (transformFile(fullPath)) {
+		console.log('OK');
+		ok++;
+	} else {
+		skip++;
+	}
+}
+console.log(`\nDone: ${ok} transformed, ${skip} skipped.`);


### PR DESCRIPTION
## Summary

- `<related-content>` was appearing at the top of exercise pages (immediately after `<page-hero>`), pushing the spec body below the fold and competing visually with `<page-hero>` and `<exam-meta>`
- Moves it into a `<div class="page-footer">` at the bottom on all affected surfaces: 9 simple exercises, 14 exam spec pages, 14 exam program pages, and 6 project pages (43 files total)
- Matches the existing course-tutorial footer convention (`related-content` → `hr` → nav/copyright)

## Test plan

- [ ] HTML validation passes (`npm run validate`)
- [ ] Spot-check simple exercise: `exercises/CountDown.html` — related-content panel appears at bottom; spec text visible without scrolling
- [ ] Spot-check exam page: `exercises/Exm-StudFeesRpt/Exm-StudPay.html` — `exam-meta` and spec appear directly after `page-hero`; related-content is at bottom
- [ ] Spot-check project page: `exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html` — same as exam page

Fixes #567

🤖 Generated with [Claude Code](https://claude.com/claude-code)