### PR TITLE
fix: replace broken ftp:// MonthTable.cbl download link with relative path

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -1521,7 +1521,7 @@
 								<td>
 									<div style="text-align: center">
 										<p>
-											<a href="ftp://www.csis.ul.ie/cobol/exercises/MonthTable.cbl">Download</a
+											<a href="Tables/MonthTable.cbl">Download</a
 											><br />
 											<a href="Tables/MonthTable.html">View</a>
 										</p>

--- a/examples/index.html
+++ b/examples/index.html
@@ -1521,8 +1521,7 @@
 								<td>
 									<div style="text-align: center">
 										<p>
-											<a href="Tables/MonthTable.cbl">Download</a
-											><br />
+											<a href="Tables/MonthTable.cbl">Download</a><br />
 											<a href="Tables/MonthTable.html">View</a>
 										</p>
 									</div>


### PR DESCRIPTION
## Summary

- The MonthTable.cbl Download link in `examples/index.html` pointed at an `ftp://` URL that modern browsers no longer follow
- Replaced with the in-repo relative path `Tables/MonthTable.cbl`, matching every other download link on the page
- `Tables/MonthTable.cbl` already exists in the repo — no file copy needed

## Test plan

- [ ] `grep -n 'ftp://' examples/index.html` returns no hits
- [ ] `ls examples/Tables/MonthTable.cbl` exists
- [ ] `npm run validate` passes
- [ ] Open `examples/index.html`, scroll to COBOL Tables section, click Download for MonthTable.cbl — file downloads

Fixes #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)