### PR TITLE
fix: replace slugified titles with human names on lecture and animation viewer pages

### DIFF
--- a/course/Resources/ppz/TC-Call.html
+++ b/course/Resources/ppz/TC-Call.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-Call - COBOL Course Animation</title>
+		<title>COBOL CALL Statement — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Call." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Call.html" />
 		<!-- Open Graph -->
@@ -13,12 +13,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Call.html"
 		/>
-		<meta property="og:title" content="TC-Call - COBOL Course Animation" />
+		<meta property="og:title" content="COBOL CALL Statement — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-Call." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-Call - COBOL Course Animation" />
+		<meta name="twitter:title" content="COBOL CALL Statement — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-Call." />
 		<script>
 			(function () {

--- a/course/Resources/ppz/TC-CobIntro1.html
+++ b/course/Resources/ppz/TC-CobIntro1.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-CobIntro1 - COBOL Course Animation</title>
+		<title>Introduction to COBOL, Part 1 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-CobIntro1." />
 		<link
 			rel="canonical"
@@ -16,12 +16,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro1.html"
 		/>
-		<meta property="og:title" content="TC-CobIntro1 - COBOL Course Animation" />
+		<meta property="og:title" content="Introduction to COBOL, Part 1 — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-CobIntro1." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-CobIntro1 - COBOL Course Animation" />
+		<meta name="twitter:title" content="Introduction to COBOL, Part 1 — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-CobIntro1." />
 		<script>
 			(function () {

--- a/course/Resources/ppz/TC-CobIntro2.html
+++ b/course/Resources/ppz/TC-CobIntro2.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-CobIntro2 - COBOL Course Animation</title>
+		<title>Introduction to COBOL, Part 2 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-CobIntro2." />
 		<link
 			rel="canonical"
@@ -16,12 +16,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro2.html"
 		/>
-		<meta property="og:title" content="TC-CobIntro2 - COBOL Course Animation" />
+		<meta property="og:title" content="Introduction to COBOL, Part 2 — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-CobIntro2." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-CobIntro2 - COBOL Course Animation" />
+		<meta name="twitter:title" content="Introduction to COBOL, Part 2 — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-CobIntro2." />
 		<script>
 			(function () {

--- a/course/Resources/ppz/TC-CobIntro3.html
+++ b/course/Resources/ppz/TC-CobIntro3.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-CobIntro3 - COBOL Course Animation</title>
+		<title>Introduction to COBOL, Part 3 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-CobIntro3." />
 		<link
 			rel="canonical"
@@ -16,12 +16,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro3.html"
 		/>
-		<meta property="og:title" content="TC-CobIntro3 - COBOL Course Animation" />
+		<meta property="og:title" content="Introduction to COBOL, Part 3 — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-CobIntro3." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-CobIntro3 - COBOL Course Animation" />
+		<meta name="twitter:title" content="Introduction to COBOL, Part 3 — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-CobIntro3." />
 		<script>
 			(function () {

--- a/course/Resources/ppz/TC-CobIntro4.html
+++ b/course/Resources/ppz/TC-CobIntro4.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-CobIntro4 - COBOL Course Animation</title>
+		<title>Introduction to COBOL, Part 4 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-CobIntro4." />
 		<link
 			rel="canonical"
@@ -16,12 +16,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro4.html"
 		/>
-		<meta property="og:title" content="TC-CobIntro4 - COBOL Course Animation" />
+		<meta property="og:title" content="Introduction to COBOL, Part 4 — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-CobIntro4." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-CobIntro4 - COBOL Course Animation" />
+		<meta name="twitter:title" content="Introduction to COBOL, Part 4 — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-CobIntro4." />
 		<script>
 			(function () {

--- a/course/Resources/ppz/TC-CobIntro5.html
+++ b/course/Resources/ppz/TC-CobIntro5.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-CobIntro5 - COBOL Course Animation</title>
+		<title>Introduction to COBOL, Part 5 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-CobIntro5." />
 		<link
 			rel="canonical"
@@ -16,12 +16,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro5.html"
 		/>
-		<meta property="og:title" content="TC-CobIntro5 - COBOL Course Animation" />
+		<meta property="og:title" content="Introduction to COBOL, Part 5 — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-CobIntro5." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-CobIntro5 - COBOL Course Animation" />
+		<meta name="twitter:title" content="Introduction to COBOL, Part 5 — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-CobIntro5." />
 		<script>
 			(function () {

--- a/course/Resources/ppz/TC-CobIntro6.html
+++ b/course/Resources/ppz/TC-CobIntro6.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-CobIntro6 - COBOL Course Animation</title>
+		<title>Introduction to COBOL, Part 6 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-CobIntro6." />
 		<link
 			rel="canonical"
@@ -16,12 +16,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro6.html"
 		/>
-		<meta property="og:title" content="TC-CobIntro6 - COBOL Course Animation" />
+		<meta property="og:title" content="Introduction to COBOL, Part 6 — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-CobIntro6." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-CobIntro6 - COBOL Course Animation" />
+		<meta name="twitter:title" content="Introduction to COBOL, Part 6 — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-CobIntro6." />
 		<script>
 			(function () {

--- a/course/Resources/ppz/TC-Commands1.html
+++ b/course/Resources/ppz/TC-Commands1.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-Commands1 - COBOL Course Animation</title>
+		<title>COBOL Commands, Part 1 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Commands1." />
 		<link
 			rel="canonical"
@@ -16,12 +16,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Commands1.html"
 		/>
-		<meta property="og:title" content="TC-Commands1 - COBOL Course Animation" />
+		<meta property="og:title" content="COBOL Commands, Part 1 — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-Commands1." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-Commands1 - COBOL Course Animation" />
+		<meta name="twitter:title" content="COBOL Commands, Part 1 — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-Commands1." />
 		<script>
 			(function () {

--- a/course/Resources/ppz/TC-Commands2.html
+++ b/course/Resources/ppz/TC-Commands2.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-Commands2 - COBOL Course Animation</title>
+		<title>COBOL Commands, Part 2 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Commands2." />
 		<link
 			rel="canonical"
@@ -16,12 +16,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Commands2.html"
 		/>
-		<meta property="og:title" content="TC-Commands2 - COBOL Course Animation" />
+		<meta property="og:title" content="COBOL Commands, Part 2 — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-Commands2." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-Commands2 - COBOL Course Animation" />
+		<meta name="twitter:title" content="COBOL Commands, Part 2 — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-Commands2." />
 		<script>
 			(function () {

--- a/course/Resources/ppz/TC-Condition1.html
+++ b/course/Resources/ppz/TC-Condition1.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-Condition1 - COBOL Course Animation</title>
+		<title>COBOL Conditions, Part 1 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Condition1." />
 		<link
 			rel="canonical"
@@ -16,12 +16,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Condition1.html"
 		/>
-		<meta property="og:title" content="TC-Condition1 - COBOL Course Animation" />
+		<meta property="og:title" content="COBOL Conditions, Part 1 — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-Condition1." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-Condition1 - COBOL Course Animation" />
+		<meta name="twitter:title" content="COBOL Conditions, Part 1 — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-Condition1." />
 		<script>
 			(function () {

--- a/course/Resources/ppz/TC-Condition2.html
+++ b/course/Resources/ppz/TC-Condition2.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-Condition2 - COBOL Course Animation</title>
+		<title>COBOL Conditions, Part 2 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Condition2." />
 		<link
 			rel="canonical"
@@ -16,12 +16,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Condition2.html"
 		/>
-		<meta property="og:title" content="TC-Condition2 - COBOL Course Animation" />
+		<meta property="og:title" content="COBOL Conditions, Part 2 — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-Condition2." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-Condition2 - COBOL Course Animation" />
+		<meta name="twitter:title" content="COBOL Conditions, Part 2 — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-Condition2." />
 		<script>
 			(function () {

--- a/course/Resources/ppz/TC-Data1.html
+++ b/course/Resources/ppz/TC-Data1.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-Data1 - COBOL Course Animation</title>
+		<title>COBOL Data Division, Part 1 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Data1." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Data1.html" />
 		<!-- Open Graph -->
@@ -13,12 +13,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Data1.html"
 		/>
-		<meta property="og:title" content="TC-Data1 - COBOL Course Animation" />
+		<meta property="og:title" content="COBOL Data Division, Part 1 — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-Data1." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-Data1 - COBOL Course Animation" />
+		<meta name="twitter:title" content="COBOL Data Division, Part 1 — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-Data1." />
 		<script>
 			(function () {

--- a/course/Resources/ppz/TC-Data2.html
+++ b/course/Resources/ppz/TC-Data2.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-Data2 - COBOL Course Animation</title>
+		<title>COBOL Data Division, Part 2 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Data2." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Data2.html" />
 		<!-- Open Graph -->
@@ -13,12 +13,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Data2.html"
 		/>
-		<meta property="og:title" content="TC-Data2 - COBOL Course Animation" />
+		<meta property="og:title" content="COBOL Data Division, Part 2 — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-Data2." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-Data2 - COBOL Course Animation" />
+		<meta name="twitter:title" content="COBOL Data Division, Part 2 — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-Data2." />
 		<script>
 			(function () {

--- a/course/Resources/ppz/TC-Perform1.html
+++ b/course/Resources/ppz/TC-Perform1.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-Perform1 - COBOL Course Animation</title>
+		<title>COBOL PERFORM Statement, Part 1 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Perform1." />
 		<link
 			rel="canonical"
@@ -16,12 +16,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Perform1.html"
 		/>
-		<meta property="og:title" content="TC-Perform1 - COBOL Course Animation" />
+		<meta property="og:title" content="COBOL PERFORM Statement, Part 1 — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-Perform1." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-Perform1 - COBOL Course Animation" />
+		<meta name="twitter:title" content="COBOL PERFORM Statement, Part 1 — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-Perform1." />
 		<script>
 			(function () {

--- a/course/Resources/ppz/TC-Perform2.html
+++ b/course/Resources/ppz/TC-Perform2.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-Perform2 - COBOL Course Animation</title>
+		<title>COBOL PERFORM Statement, Part 2 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Perform2." />
 		<link
 			rel="canonical"
@@ -16,12 +16,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Perform2.html"
 		/>
-		<meta property="og:title" content="TC-Perform2 - COBOL Course Animation" />
+		<meta property="og:title" content="COBOL PERFORM Statement, Part 2 — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-Perform2." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-Perform2 - COBOL Course Animation" />
+		<meta name="twitter:title" content="COBOL PERFORM Statement, Part 2 — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-Perform2." />
 		<script>
 			(function () {

--- a/course/Resources/ppz/TC-Search2.html
+++ b/course/Resources/ppz/TC-Search2.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-Search2 - COBOL Course Animation</title>
+		<title>COBOL SEARCH Statement, Part 2 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Search2." />
 		<link
 			rel="canonical"
@@ -16,12 +16,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Search2.html"
 		/>
-		<meta property="og:title" content="TC-Search2 - COBOL Course Animation" />
+		<meta property="og:title" content="COBOL SEARCH Statement, Part 2 — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-Search2." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-Search2 - COBOL Course Animation" />
+		<meta name="twitter:title" content="COBOL SEARCH Statement, Part 2 — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-Search2." />
 		<script>
 			(function () {

--- a/course/Resources/ppz/TC-SeqFile1.html
+++ b/course/Resources/ppz/TC-SeqFile1.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-SeqFile1 - COBOL Course Animation</title>
+		<title>Sequential Files in COBOL, Part 1 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-SeqFile1." />
 		<link
 			rel="canonical"
@@ -16,12 +16,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile1.html"
 		/>
-		<meta property="og:title" content="TC-SeqFile1 - COBOL Course Animation" />
+		<meta property="og:title" content="Sequential Files in COBOL, Part 1 — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-SeqFile1." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-SeqFile1 - COBOL Course Animation" />
+		<meta name="twitter:title" content="Sequential Files in COBOL, Part 1 — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-SeqFile1." />
 		<script>
 			(function () {

--- a/course/Resources/ppz/TC-SeqFile2a.html
+++ b/course/Resources/ppz/TC-SeqFile2a.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-SeqFile2a - COBOL Course Animation</title>
+		<title>Sequential Files in COBOL, Part 2a — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-SeqFile2a." />
 		<link
 			rel="canonical"
@@ -16,12 +16,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2a.html"
 		/>
-		<meta property="og:title" content="TC-SeqFile2a - COBOL Course Animation" />
+		<meta property="og:title" content="Sequential Files in COBOL, Part 2a — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-SeqFile2a." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-SeqFile2a - COBOL Course Animation" />
+		<meta name="twitter:title" content="Sequential Files in COBOL, Part 2a — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-SeqFile2a." />
 		<script>
 			(function () {

--- a/course/Resources/ppz/TC-SeqFile2b.html
+++ b/course/Resources/ppz/TC-SeqFile2b.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-SeqFile2b - COBOL Course Animation</title>
+		<title>Sequential Files in COBOL, Part 2b — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-SeqFile2b." />
 		<link
 			rel="canonical"
@@ -16,12 +16,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2b.html"
 		/>
-		<meta property="og:title" content="TC-SeqFile2b - COBOL Course Animation" />
+		<meta property="og:title" content="Sequential Files in COBOL, Part 2b — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-SeqFile2b." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-SeqFile2b - COBOL Course Animation" />
+		<meta name="twitter:title" content="Sequential Files in COBOL, Part 2b — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-SeqFile2b." />
 		<script>
 			(function () {

--- a/course/Resources/ppz/TC-SeqFile2c.html
+++ b/course/Resources/ppz/TC-SeqFile2c.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-SeqFile2c - COBOL Course Animation</title>
+		<title>Sequential Files in COBOL, Part 2c — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-SeqFile2c." />
 		<link
 			rel="canonical"
@@ -16,12 +16,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2c.html"
 		/>
-		<meta property="og:title" content="TC-SeqFile2c - COBOL Course Animation" />
+		<meta property="og:title" content="Sequential Files in COBOL, Part 2c — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-SeqFile2c." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-SeqFile2c - COBOL Course Animation" />
+		<meta name="twitter:title" content="Sequential Files in COBOL, Part 2c — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-SeqFile2c." />
 		<script>
 			(function () {

--- a/course/Resources/ppz/TC-SeqFile2d.html
+++ b/course/Resources/ppz/TC-SeqFile2d.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-SeqFile2d - COBOL Course Animation</title>
+		<title>Sequential Files in COBOL, Part 2d — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-SeqFile2d." />
 		<link
 			rel="canonical"
@@ -16,12 +16,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2d.html"
 		/>
-		<meta property="og:title" content="TC-SeqFile2d - COBOL Course Animation" />
+		<meta property="og:title" content="Sequential Files in COBOL, Part 2d — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-SeqFile2d." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-SeqFile2d - COBOL Course Animation" />
+		<meta name="twitter:title" content="Sequential Files in COBOL, Part 2d — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-SeqFile2d." />
 		<script>
 			(function () {

--- a/course/Resources/ppz/TC-SeqFile2e.html
+++ b/course/Resources/ppz/TC-SeqFile2e.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-SeqFile2e - COBOL Course Animation</title>
+		<title>Sequential Files in COBOL, Part 2e — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-SeqFile2e." />
 		<link
 			rel="canonical"
@@ -16,12 +16,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2e.html"
 		/>
-		<meta property="og:title" content="TC-SeqFile2e - COBOL Course Animation" />
+		<meta property="og:title" content="Sequential Files in COBOL, Part 2e — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-SeqFile2e." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-SeqFile2e - COBOL Course Animation" />
+		<meta name="twitter:title" content="Sequential Files in COBOL, Part 2e — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-SeqFile2e." />
 		<script>
 			(function () {

--- a/course/Resources/ppz/TC-SeqFile3a.html
+++ b/course/Resources/ppz/TC-SeqFile3a.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-SeqFile3a - COBOL Course Animation</title>
+		<title>Sequential Files in COBOL, Part 3a — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-SeqFile3a." />
 		<link
 			rel="canonical"
@@ -16,12 +16,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile3a.html"
 		/>
-		<meta property="og:title" content="TC-SeqFile3a - COBOL Course Animation" />
+		<meta property="og:title" content="Sequential Files in COBOL, Part 3a — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-SeqFile3a." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-SeqFile3a - COBOL Course Animation" />
+		<meta name="twitter:title" content="Sequential Files in COBOL, Part 3a — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-SeqFile3a." />
 		<script>
 			(function () {

--- a/course/Resources/ppz/TC-Tables1.html
+++ b/course/Resources/ppz/TC-Tables1.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-Tables1 - COBOL Course Animation</title>
+		<title>COBOL Tables, Part 1 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Tables1." />
 		<link
 			rel="canonical"
@@ -16,12 +16,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables1.html"
 		/>
-		<meta property="og:title" content="TC-Tables1 - COBOL Course Animation" />
+		<meta property="og:title" content="COBOL Tables, Part 1 — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-Tables1." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-Tables1 - COBOL Course Animation" />
+		<meta name="twitter:title" content="COBOL Tables, Part 1 — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-Tables1." />
 		<script>
 			(function () {

--- a/course/Resources/ppz/TC-Tables2.html
+++ b/course/Resources/ppz/TC-Tables2.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-Tables2 - COBOL Course Animation</title>
+		<title>COBOL Tables, Part 2 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Tables2." />
 		<link
 			rel="canonical"
@@ -16,12 +16,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables2.html"
 		/>
-		<meta property="og:title" content="TC-Tables2 - COBOL Course Animation" />
+		<meta property="og:title" content="COBOL Tables, Part 2 — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-Tables2." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-Tables2 - COBOL Course Animation" />
+		<meta name="twitter:title" content="COBOL Tables, Part 2 — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-Tables2." />
 		<script>
 			(function () {

--- a/course/Resources/ppz/TC-Tables3.html
+++ b/course/Resources/ppz/TC-Tables3.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-Tables3 - COBOL Course Animation</title>
+		<title>COBOL Tables, Part 3 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Tables3." />
 		<link
 			rel="canonical"
@@ -16,12 +16,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables3.html"
 		/>
-		<meta property="og:title" content="TC-Tables3 - COBOL Course Animation" />
+		<meta property="og:title" content="COBOL Tables, Part 3 — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-Tables3." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-Tables3 - COBOL Course Animation" />
+		<meta name="twitter:title" content="COBOL Tables, Part 3 — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-Tables3." />
 		<script>
 			(function () {

--- a/course/Resources/ppz/TC-Tables4.html
+++ b/course/Resources/ppz/TC-Tables4.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-Tables4 - COBOL Course Animation</title>
+		<title>COBOL Tables, Part 4 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Tables4." />
 		<link
 			rel="canonical"
@@ -16,12 +16,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables4.html"
 		/>
-		<meta property="og:title" content="TC-Tables4 - COBOL Course Animation" />
+		<meta property="og:title" content="COBOL Tables, Part 4 — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-Tables4." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-Tables4 - COBOL Course Animation" />
+		<meta name="twitter:title" content="COBOL Tables, Part 4 — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-Tables4." />
 		<script>
 			(function () {

--- a/course/Resources/ppz/TC-Tables5.html
+++ b/course/Resources/ppz/TC-Tables5.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-Tables5 - COBOL Course Animation</title>
+		<title>COBOL Tables, Part 5 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Tables5." />
 		<link
 			rel="canonical"
@@ -16,12 +16,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables5.html"
 		/>
-		<meta property="og:title" content="TC-Tables5 - COBOL Course Animation" />
+		<meta property="og:title" content="COBOL Tables, Part 5 — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-Tables5." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-Tables5 - COBOL Course Animation" />
+		<meta name="twitter:title" content="COBOL Tables, Part 5 — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-Tables5." />
 		<script>
 			(function () {

--- a/course/Resources/ppz/TC-Tables7.html
+++ b/course/Resources/ppz/TC-Tables7.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-Tables7 - COBOL Course Animation</title>
+		<title>COBOL Tables, Part 7 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Tables7." />
 		<link
 			rel="canonical"
@@ -16,12 +16,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables7.html"
 		/>
-		<meta property="og:title" content="TC-Tables7 - COBOL Course Animation" />
+		<meta property="og:title" content="COBOL Tables, Part 7 — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-Tables7." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-Tables7 - COBOL Course Animation" />
+		<meta name="twitter:title" content="COBOL Tables, Part 7 — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-Tables7." />
 		<script>
 			(function () {

--- a/course/Resources/ppz/TC-Tables8.html
+++ b/course/Resources/ppz/TC-Tables8.html
@@ -4,7 +4,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
-		<title>TC-Tables8 - COBOL Course Animation</title>
+		<title>COBOL Tables, Part 8 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Tables8." />
 		<link
 			rel="canonical"
@@ -16,12 +16,12 @@
 			property="og:url"
 			content="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables8.html"
 		/>
-		<meta property="og:title" content="TC-Tables8 - COBOL Course Animation" />
+		<meta property="og:title" content="COBOL Tables, Part 8 — COBOL Course Animation" />
 		<meta property="og:description" content="COBOL programming lesson on TC-Tables8." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/course.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="TC-Tables8 - COBOL Course Animation" />
+		<meta name="twitter:title" content="COBOL Tables, Part 8 — COBOL Course Animation" />
 		<meta name="twitter:description" content="COBOL programming lesson on TC-Tables8." />
 		<script>
 			(function () {

--- a/lectures/arithmetic.html
+++ b/lectures/arithmetic.html
@@ -20,18 +20,18 @@
 				}
 			})();
 		</script>
-		<title>Arithmetic - COBOL Lecture</title>
+		<title>Arithmetic and Edited Pictures — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Arithmetic." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/arithmetic.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/arithmetic.html" />
-		<meta property="og:title" content="Arithmetic - COBOL Lecture" />
+		<meta property="og:title" content="Arithmetic and Edited Pictures — COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering Arithmetic." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Arithmetic - COBOL Lecture" />
+		<meta name="twitter:title" content="Arithmetic and Edited Pictures — COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering Arithmetic." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/basics1.html
+++ b/lectures/basics1.html
@@ -20,18 +20,18 @@
 				}
 			})();
 		</script>
-		<title>Basics1 - COBOL Lecture</title>
+		<title>COBOL Basics 1 — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Basics1." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/basics1.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/basics1.html" />
-		<meta property="og:title" content="Basics1 - COBOL Lecture" />
+		<meta property="og:title" content="COBOL Basics 1 — COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering Basics1." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Basics1 - COBOL Lecture" />
+		<meta name="twitter:title" content="COBOL Basics 1 — COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering Basics1." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/basics2.html
+++ b/lectures/basics2.html
@@ -20,18 +20,18 @@
 				}
 			})();
 		</script>
-		<title>Basics2 - COBOL Lecture</title>
+		<title>COBOL Basics 2 — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering basics2." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/basics2.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/basics2.html" />
-		<meta property="og:title" content="Basics2 - COBOL Lecture" />
+		<meta property="og:title" content="COBOL Basics 2 — COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering basics2." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Basics2 - COBOL Lecture" />
+		<meta name="twitter:title" content="COBOL Basics 2 — COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering basics2." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/call.html
+++ b/lectures/call.html
@@ -20,18 +20,18 @@
 				}
 			})();
 		</script>
-		<title>Call - COBOL Lecture</title>
+		<title>Calling Subprograms — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering call." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/call.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/call.html" />
-		<meta property="og:title" content="Call - COBOL Lecture" />
+		<meta property="og:title" content="Calling Subprograms — COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering call." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Call - COBOL Lecture" />
+		<meta name="twitter:title" content="Calling Subprograms — COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering call." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/cobintro.html
+++ b/lectures/cobintro.html
@@ -20,18 +20,18 @@
 				}
 			})();
 		</script>
-		<title>Cobintro - COBOL Lecture</title>
+		<title>Introduction to COBOL — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering cobintro." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/cobintro.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/cobintro.html" />
-		<meta property="og:title" content="Cobintro - COBOL Lecture" />
+		<meta property="og:title" content="Introduction to COBOL — COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering cobintro." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Cobintro - COBOL Lecture" />
+		<meta name="twitter:title" content="Introduction to COBOL — COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering cobintro." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/conditions.html
+++ b/lectures/conditions.html
@@ -20,18 +20,18 @@
 				}
 			})();
 		</script>
-		<title>Conditions - COBOL Lecture</title>
+		<title>Conditions — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Conditions." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/conditions.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/conditions.html" />
-		<meta property="og:title" content="Conditions - COBOL Lecture" />
+		<meta property="og:title" content="Conditions — COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering Conditions." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Conditions - COBOL Lecture" />
+		<meta name="twitter:title" content="Conditions — COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering Conditions." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/copy.html
+++ b/lectures/copy.html
@@ -20,18 +20,18 @@
 				}
 			})();
 		</script>
-		<title>COPY - COBOL Lecture</title>
+		<title>The COPY — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering COPY." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/copy.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/copy.html" />
-		<meta property="og:title" content="COPY - COBOL Lecture" />
+		<meta property="og:title" content="The COPY — COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering COPY." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="COPY - COBOL Lecture" />
+		<meta name="twitter:title" content="The COPY — COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering COPY." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/design.html
+++ b/lectures/design.html
@@ -20,18 +20,18 @@
 				}
 			})();
 		</script>
-		<title>Design - COBOL Lecture</title>
+		<title>Designing Programs — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering design." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/design.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/design.html" />
-		<meta property="og:title" content="Design - COBOL Lecture" />
+		<meta property="og:title" content="Designing Programs — COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering design." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Design - COBOL Lecture" />
+		<meta name="twitter:title" content="Designing Programs — COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering design." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/direct1.html
+++ b/lectures/direct1.html
@@ -20,18 +20,18 @@
 				}
 			})();
 		</script>
-		<title>Direct1 - COBOL Lecture</title>
+		<title>Introduction to Direct Access Files — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering direct1." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/direct1.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/direct1.html" />
-		<meta property="og:title" content="Direct1 - COBOL Lecture" />
+		<meta property="og:title" content="Introduction to Direct Access Files — COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering direct1." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Direct1 - COBOL Lecture" />
+		<meta name="twitter:title" content="Introduction to Direct Access Files — COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering direct1." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/dsr1.html
+++ b/lectures/dsr1.html
@@ -20,18 +20,18 @@
 				}
 			})();
 		</script>
-		<title>Dsr1 - COBOL Lecture</title>
+		<title>Introduction to Diagrammatic Stepwise Refinement — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering dsr1." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/dsr1.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/dsr1.html" />
-		<meta property="og:title" content="Dsr1 - COBOL Lecture" />
+		<meta property="og:title" content="Introduction to Diagrammatic Stepwise Refinement — COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering dsr1." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Dsr1 - COBOL Lecture" />
+		<meta name="twitter:title" content="Introduction to Diagrammatic Stepwise Refinement — COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering dsr1." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/genintro.html
+++ b/lectures/genintro.html
@@ -20,18 +20,18 @@
 				}
 			})();
 		</script>
-		<title>GenIntro - COBOL Lecture</title>
+		<title>General Introduction — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering GenIntro." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/genintro.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/genintro.html" />
-		<meta property="og:title" content="GenIntro - COBOL Lecture" />
+		<meta property="og:title" content="General Introduction — COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering GenIntro." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="GenIntro - COBOL Lecture" />
+		<meta name="twitter:title" content="General Introduction — COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering GenIntro." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/indexed.html
+++ b/lectures/indexed.html
@@ -20,18 +20,18 @@
 				}
 			})();
 		</script>
-		<title>Indexed - COBOL Lecture</title>
+		<title>Indexed Files — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Indexed." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/indexed.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/indexed.html" />
-		<meta property="og:title" content="Indexed - COBOL Lecture" />
+		<meta property="og:title" content="Indexed Files — COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering Indexed." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Indexed - COBOL Lecture" />
+		<meta name="twitter:title" content="Indexed Files — COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering Indexed." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/inspect.html
+++ b/lectures/inspect.html
@@ -20,18 +20,18 @@
 				}
 			})();
 		</script>
-		<title>Inspect - COBOL Lecture</title>
+		<title>The INSPECT — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Inspect." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/inspect.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/inspect.html" />
-		<meta property="og:title" content="Inspect - COBOL Lecture" />
+		<meta property="og:title" content="The INSPECT — COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering Inspect." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Inspect - COBOL Lecture" />
+		<meta name="twitter:title" content="The INSPECT — COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering Inspect." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/perform.html
+++ b/lectures/perform.html
@@ -20,18 +20,18 @@
 				}
 			})();
 		</script>
-		<title>Perform - COBOL Lecture</title>
+		<title>Simple Iteration with the PERFORM Verb — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering perform." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/perform.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/perform.html" />
-		<meta property="og:title" content="Perform - COBOL Lecture" />
+		<meta property="og:title" content="Simple Iteration with the PERFORM Verb — COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering perform." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Perform - COBOL Lecture" />
+		<meta name="twitter:title" content="Simple Iteration with the PERFORM Verb — COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering perform." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/relative.html
+++ b/lectures/relative.html
@@ -20,18 +20,18 @@
 				}
 			})();
 		</script>
-		<title>Relative - COBOL Lecture</title>
+		<title>Relative Files — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Relative." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/relative.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/relative.html" />
-		<meta property="og:title" content="Relative - COBOL Lecture" />
+		<meta property="og:title" content="Relative Files — COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering Relative." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Relative - COBOL Lecture" />
+		<meta name="twitter:title" content="Relative Files — COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering Relative." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/search.html
+++ b/lectures/search.html
@@ -20,18 +20,18 @@
 				}
 			})();
 		</script>
-		<title>Search - COBOL Lecture</title>
+		<title>Searching Tables — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Search." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/search.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/search.html" />
-		<meta property="og:title" content="Search - COBOL Lecture" />
+		<meta property="og:title" content="Searching Tables — COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering Search." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Search - COBOL Lecture" />
+		<meta name="twitter:title" content="Searching Tables — COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering Search." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/seqfile1.html
+++ b/lectures/seqfile1.html
@@ -20,18 +20,18 @@
 				}
 			})();
 		</script>
-		<title>SeqFile1 - COBOL Lecture</title>
+		<title>Introduction to Sequential Files — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering SeqFile1." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/seqfile1.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/seqfile1.html" />
-		<meta property="og:title" content="SeqFile1 - COBOL Lecture" />
+		<meta property="og:title" content="Introduction to Sequential Files — COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering SeqFile1." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="SeqFile1 - COBOL Lecture" />
+		<meta name="twitter:title" content="Introduction to Sequential Files — COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering SeqFile1." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/seqfile2.html
+++ b/lectures/seqfile2.html
@@ -20,18 +20,18 @@
 				}
 			})();
 		</script>
-		<title>SeqFile2 - COBOL Lecture</title>
+		<title>Processing Sequential Files — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering SeqFile2." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/seqfile2.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/seqfile2.html" />
-		<meta property="og:title" content="SeqFile2 - COBOL Lecture" />
+		<meta property="og:title" content="Processing Sequential Files — COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering SeqFile2." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="SeqFile2 - COBOL Lecture" />
+		<meta name="twitter:title" content="Processing Sequential Files — COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering SeqFile2." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/seqfile3.html
+++ b/lectures/seqfile3.html
@@ -20,18 +20,18 @@
 				}
 			})();
 		</script>
-		<title>SeqFile3 - COBOL Lecture</title>
+		<title>Advanced Sequential Files — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering SeqFile3." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/seqfile3.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/seqfile3.html" />
-		<meta property="og:title" content="SeqFile3 - COBOL Lecture" />
+		<meta property="og:title" content="Advanced Sequential Files — COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering SeqFile3." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="SeqFile3 - COBOL Lecture" />
+		<meta name="twitter:title" content="Advanced Sequential Files — COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering SeqFile3." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/sort.html
+++ b/lectures/sort.html
@@ -20,18 +20,18 @@
 				}
 			})();
 		</script>
-		<title>SORT - COBOL Lecture</title>
+		<title>SORT and MERGE — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering SORT." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/sort.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/sort.html" />
-		<meta property="og:title" content="SORT - COBOL Lecture" />
+		<meta property="og:title" content="SORT and MERGE — COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering SORT." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="SORT - COBOL Lecture" />
+		<meta name="twitter:title" content="SORT and MERGE — COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering SORT." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/string.html
+++ b/lectures/string.html
@@ -20,18 +20,18 @@
 				}
 			})();
 		</script>
-		<title>String - COBOL Lecture</title>
+		<title>The STRING — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering String." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/string.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/string.html" />
-		<meta property="og:title" content="String - COBOL Lecture" />
+		<meta property="og:title" content="The STRING — COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering String." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="String - COBOL Lecture" />
+		<meta name="twitter:title" content="The STRING — COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering String." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/tables1.html
+++ b/lectures/tables1.html
@@ -20,18 +20,18 @@
 				}
 			})();
 		</script>
-		<title>Tables1 - COBOL Lecture</title>
+		<title>Tables and the PERFORM ... VARYING — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Tables1." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/tables1.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/tables1.html" />
-		<meta property="og:title" content="Tables1 - COBOL Lecture" />
+		<meta property="og:title" content="Tables and the PERFORM ... VARYING — COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering Tables1." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Tables1 - COBOL Lecture" />
+		<meta name="twitter:title" content="Tables and the PERFORM ... VARYING — COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering Tables1." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/tables2.html
+++ b/lectures/tables2.html
@@ -20,18 +20,18 @@
 				}
 			})();
 		</script>
-		<title>Tables2 - COBOL Lecture</title>
+		<title>Advanced Tables — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Tables2." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/tables2.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/tables2.html" />
-		<meta property="og:title" content="Tables2 - COBOL Lecture" />
+		<meta property="og:title" content="Advanced Tables — COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering Tables2." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Tables2 - COBOL Lecture" />
+		<meta name="twitter:title" content="Advanced Tables — COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering Tables2." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/unstring.html
+++ b/lectures/unstring.html
@@ -20,18 +20,18 @@
 				}
 			})();
 		</script>
-		<title>Unstring - COBOL Lecture</title>
+		<title>The UNSTRING — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Unstring." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/unstring.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/unstring.html" />
-		<meta property="og:title" content="Unstring - COBOL Lecture" />
+		<meta property="og:title" content="The UNSTRING — COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering Unstring." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Unstring - COBOL Lecture" />
+		<meta name="twitter:title" content="The UNSTRING — COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering Unstring." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/lectures/usage.html
+++ b/lectures/usage.html
@@ -20,18 +20,18 @@
 				}
 			})();
 		</script>
-		<title>Usage - COBOL Lecture</title>
+		<title>The USAGE Clause — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Usage." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/usage.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/lectures/usage.html" />
-		<meta property="og:title" content="Usage - COBOL Lecture" />
+		<meta property="og:title" content="The USAGE Clause — COBOL Lecture" />
 		<meta property="og:description" content="COBOL lecture slides covering Usage." />
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/lectures.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Usage - COBOL Lecture" />
+		<meta name="twitter:title" content="The USAGE Clause — COBOL Lecture" />
 		<meta name="twitter:description" content="COBOL lecture slides covering Usage." />
 		<link href="../course/Resources/css/course.css" rel="stylesheet" />
 		<link href="../course/Resources/css/course-components.css" rel="stylesheet" />

--- a/search-index.json
+++ b/search-index.json
@@ -661,43 +661,43 @@
 	},
 	{
 		"p": "lectures/arithmetic.html",
-		"t": "Arithmetic - COBOL Lecture",
+		"t": "Arithmetic and Edited Pictures — COBOL Lecture",
 		"d": "COBOL lecture slides covering Arithmetic.",
 		"s": "lectures"
 	},
 	{
 		"p": "lectures/basics1.html",
-		"t": "Basics1 - COBOL Lecture",
+		"t": "COBOL Basics 1 — COBOL Lecture",
 		"d": "COBOL lecture slides covering Basics1.",
 		"s": "lectures"
 	},
 	{
 		"p": "lectures/basics2.html",
-		"t": "Basics2 - COBOL Lecture",
+		"t": "COBOL Basics 2 — COBOL Lecture",
 		"d": "COBOL lecture slides covering basics2.",
 		"s": "lectures"
 	},
 	{
 		"p": "lectures/call.html",
-		"t": "Call - COBOL Lecture",
+		"t": "Calling Subprograms — COBOL Lecture",
 		"d": "COBOL lecture slides covering call.",
 		"s": "lectures"
 	},
 	{
 		"p": "lectures/cobintro.html",
-		"t": "Cobintro - COBOL Lecture",
+		"t": "Introduction to COBOL — COBOL Lecture",
 		"d": "COBOL lecture slides covering cobintro.",
 		"s": "lectures"
 	},
 	{
 		"p": "lectures/conditions.html",
-		"t": "Conditions - COBOL Lecture",
+		"t": "Conditions — COBOL Lecture",
 		"d": "COBOL lecture slides covering Conditions.",
 		"s": "lectures"
 	},
 	{
 		"p": "lectures/copy.html",
-		"t": "COPY - COBOL Lecture",
+		"t": "The COPY — COBOL Lecture",
 		"d": "COBOL lecture slides covering COPY.",
 		"s": "lectures"
 	},
@@ -709,25 +709,25 @@
 	},
 	{
 		"p": "lectures/design.html",
-		"t": "Design - COBOL Lecture",
+		"t": "Designing Programs — COBOL Lecture",
 		"d": "COBOL lecture slides covering design.",
 		"s": "lectures"
 	},
 	{
 		"p": "lectures/direct1.html",
-		"t": "Direct1 - COBOL Lecture",
+		"t": "Introduction to Direct Access Files — COBOL Lecture",
 		"d": "COBOL lecture slides covering direct1.",
 		"s": "lectures"
 	},
 	{
 		"p": "lectures/dsr1.html",
-		"t": "Dsr1 - COBOL Lecture",
+		"t": "Introduction to Diagrammatic Stepwise Refinement — COBOL Lecture",
 		"d": "COBOL lecture slides covering dsr1.",
 		"s": "lectures"
 	},
 	{
 		"p": "lectures/genintro.html",
-		"t": "GenIntro - COBOL Lecture",
+		"t": "General Introduction — COBOL Lecture",
 		"d": "COBOL lecture slides covering GenIntro.",
 		"s": "lectures"
 	},
@@ -739,25 +739,25 @@
 	},
 	{
 		"p": "lectures/indexed.html",
-		"t": "Indexed - COBOL Lecture",
+		"t": "Indexed Files — COBOL Lecture",
 		"d": "COBOL lecture slides covering Indexed.",
 		"s": "lectures"
 	},
 	{
 		"p": "lectures/inspect.html",
-		"t": "Inspect - COBOL Lecture",
+		"t": "The INSPECT — COBOL Lecture",
 		"d": "COBOL lecture slides covering Inspect.",
 		"s": "lectures"
 	},
 	{
 		"p": "lectures/perform.html",
-		"t": "Perform - COBOL Lecture",
+		"t": "Simple Iteration with the PERFORM Verb — COBOL Lecture",
 		"d": "COBOL lecture slides covering perform.",
 		"s": "lectures"
 	},
 	{
 		"p": "lectures/relative.html",
-		"t": "Relative - COBOL Lecture",
+		"t": "Relative Files — COBOL Lecture",
 		"d": "COBOL lecture slides covering Relative.",
 		"s": "lectures"
 	},
@@ -775,61 +775,61 @@
 	},
 	{
 		"p": "lectures/search.html",
-		"t": "Search - COBOL Lecture",
+		"t": "Searching Tables — COBOL Lecture",
 		"d": "COBOL lecture slides covering Search.",
 		"s": "lectures"
 	},
 	{
 		"p": "lectures/seqfile1.html",
-		"t": "SeqFile1 - COBOL Lecture",
+		"t": "Introduction to Sequential Files — COBOL Lecture",
 		"d": "COBOL lecture slides covering SeqFile1.",
 		"s": "lectures"
 	},
 	{
 		"p": "lectures/seqfile2.html",
-		"t": "SeqFile2 - COBOL Lecture",
+		"t": "Processing Sequential Files — COBOL Lecture",
 		"d": "COBOL lecture slides covering SeqFile2.",
 		"s": "lectures"
 	},
 	{
 		"p": "lectures/seqfile3.html",
-		"t": "SeqFile3 - COBOL Lecture",
+		"t": "Advanced Sequential Files — COBOL Lecture",
 		"d": "COBOL lecture slides covering SeqFile3.",
 		"s": "lectures"
 	},
 	{
 		"p": "lectures/sort.html",
-		"t": "SORT - COBOL Lecture",
+		"t": "SORT and MERGE — COBOL Lecture",
 		"d": "COBOL lecture slides covering SORT.",
 		"s": "lectures"
 	},
 	{
 		"p": "lectures/string.html",
-		"t": "String - COBOL Lecture",
+		"t": "The STRING — COBOL Lecture",
 		"d": "COBOL lecture slides covering String.",
 		"s": "lectures"
 	},
 	{
 		"p": "lectures/tables1.html",
-		"t": "Tables1 - COBOL Lecture",
+		"t": "Tables and the PERFORM ... VARYING — COBOL Lecture",
 		"d": "COBOL lecture slides covering Tables1.",
 		"s": "lectures"
 	},
 	{
 		"p": "lectures/tables2.html",
-		"t": "Tables2 - COBOL Lecture",
+		"t": "Advanced Tables — COBOL Lecture",
 		"d": "COBOL lecture slides covering Tables2.",
 		"s": "lectures"
 	},
 	{
 		"p": "lectures/unstring.html",
-		"t": "Unstring - COBOL Lecture",
+		"t": "The UNSTRING — COBOL Lecture",
 		"d": "COBOL lecture slides covering Unstring.",
 		"s": "lectures"
 	},
 	{
 		"p": "lectures/usage.html",
-		"t": "Usage - COBOL Lecture",
+		"t": "The USAGE Clause — COBOL Lecture",
 		"d": "COBOL lecture slides covering Usage.",
 		"s": "lectures"
 	}


### PR DESCRIPTION
## Summary

- Replaces slugified `<title>`, `og:title`, and `twitter:title` values ("Basics1 - COBOL Lecture", "TC-Tables5 - COBOL Course Animation", etc.) with human-readable names on all 25 lecture viewer pages and 30 animation viewer shells
- Lecture names sourced from the `<h3 id="…">` entries in `lectures/index.html`; animation names derived from the `<iframe title>` attribute and TC-* prefix convention
- Three files intentionally left untouched: `cs4312topics.html` (meta-refresh stub), `reportwriterweb.html` and `reportwriterssweb.html` (already had proper titles)

## Test plan

- [x] Verification grep returns no hits: `grep -nP '<title>\w+\d* - COBOL (Lecture|Course Animation)</title>' lectures/*.html course/Resources/ppz/*.html`
- [x] `npm run validate` passes

Fixes #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)