### PR TITLE
fix: correct three copy-paste program specification hrefs

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -633,7 +633,7 @@
 										Exam paper model answer. A program is required which will produce a file, sorted
 										on ascending email domain, from the unsorted GraduateInfo file.<br />
 										Read the
-										<a href="../exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html"
+										<a href="../exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html"
 											>program specification</a
 										>
 										first. The required data files may be downloaded from there.
@@ -1564,7 +1564,7 @@
 									major vessels (Vessels of tonnage 3,500 or greater and all submarines) in each of
 									oceans and major seas of the world.<br />
 									Read the
-									<a href="../exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html"
+									<a href="../exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html"
 										>program specification</a
 									>
 									first. The required data files may be downloaded from there.

--- a/exercises/index.html
+++ b/exercises/index.html
@@ -267,7 +267,7 @@
 						</dd>
 						<dt>
 							<span class="ball-green" aria-hidden="true"></span
-							><a href="Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html">ACME Stock Reorder</a>
+							><a href="Exm-AcmeStockReorder/Exm-AcmeStockReorder.html">ACME Stock Reorder</a>
 						</dt>
 						<dd>
 							<p>


### PR DESCRIPTION
## Summary

- `exercises/index.html` ACME Stock Reorder row: href was pointing at `Exm-BookshopLectReqRpt` instead of `Exm-AcmeStockReorder`
- `examples/index.html` CSISEmailDomain row: href was pointing at `Exm-AromaSalesRpt` instead of `Exm-CSISEmailDomain`
- `examples/index.html` USSRship row: href was pointing at `Exm-FlyByNightTravel` instead of `Exm-USSRshipRpt`

All three were copy-paste bugs where the surrounding row was updated but the `href` was never changed. Because every target file exists, `npm run links` did not catch them.

Fixes #561

## Test plan

- [ ] `npm run validate` passes (no HTML errors)
- [ ] Spot-check: CSISEmailDomain and USSRship "program specification" links in `examples/index.html` land on their matching exam pages
- [ ] Spot-check: ACME Stock Reorder "program specification" link in `exercises/index.html` lands on the correct exam page

🤖 Generated with [Claude Code](https://claude.com/claude-code)