### PR TITLE
feat: add exercises-nav to all 9 simple exercise pages

### DIFF
--- a/components/exercise-progress.js
+++ b/components/exercise-progress.js
@@ -3,6 +3,16 @@
 // Paths are relative to the exercises/ root (subdir/file.html).
 
 window.COBOL_EXERCISES = Object.freeze([
+	// --- Simple Programming Exercises ---
+	{ file: "GettingStarted.html", title: "Getting Started" },
+	{ file: "CountDown.html", title: "The Calculator and Countdown" },
+	{ file: "SeqRead.html", title: "Reading Sequential Files" },
+	{ file: "SeqReadIf.html", title: "Counting Records in a Sequential File" },
+	{ file: "SeqWrite.html", title: "Writing Records to a Sequential File" },
+	{ file: "SeqInsert.html", title: "Inserting Records in a Sequential File" },
+	{ file: "SeqUpdate.html", title: "Updating a Sequential File" },
+	{ file: "SortIP.html", title: "Sorting a Sequential File" },
+	{ file: "MonthTable.html", title: "Using Tables" },
 	// --- Programming Exam Specifications ---
 	{ file: "Exm-StudFeesRpt/Exm-StudPay.html", title: "Student Fees Report" },
 	{ file: "Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html", title: "Aromamora Summary Sales" },

--- a/components/exercises-nav.js
+++ b/components/exercises-nav.js
@@ -11,10 +11,16 @@ class ExercisesNav extends HTMLElement {
 		const EXERCISES = window.COBOL_EXERCISES;
 		if (!EXERCISES) return;
 
-		// Match against the last two path segments (subdir/file.html) since each
-		// exercise lives in its own subdirectory under exercises/.
+		// Build currentFile as a path relative to the exercises/ directory so it
+		// matches entries in COBOL_EXERCISES regardless of nesting depth.
+		// Simple exercises live directly in exercises/ (depth 0, e.g. "CountDown.html");
+		// exam/project pages live one level deeper (depth 1, e.g. "Exm-Foo/Exm-Foo.html").
 		const segments = window.location.pathname.split("/").filter(Boolean);
-		const currentFile = segments.slice(-2).join("/");
+		const exercisesIdx = segments.lastIndexOf("exercises");
+		const relSegments = exercisesIdx >= 0 ? segments.slice(exercisesIdx + 1) : segments.slice(-2);
+		const currentFile = relSegments.join("/");
+		const depth = relSegments.length - 1;
+		const prefix = depth > 0 ? "../".repeat(depth) : "";
 
 		const index = EXERCISES.findIndex((e) => e.file === currentFile);
 		if (index === -1) return;
@@ -23,11 +29,11 @@ class ExercisesNav extends HTMLElement {
 		const next = index < EXERCISES.length - 1 ? EXERCISES[index + 1] : null;
 
 		const prevHTML = prev
-			? `<a class="lesson-nav-prev" href="../${prev.file}">← Previous: ${prev.title}</a>`
+			? `<a class="lesson-nav-prev" href="${prefix}${prev.file}">← Previous: ${prev.title}</a>`
 			: `<span></span>`;
 		const positionHTML = `<span class="lesson-nav-position">Exercise ${index + 1} of ${EXERCISES.length}</span>`;
 		const nextHTML = next
-			? `<a class="lesson-nav-next" href="../${next.file}">Next: ${next.title} →</a>`
+			? `<a class="lesson-nav-next" href="${prefix}${next.file}">Next: ${next.title} →</a>`
 			: `<span></span>`;
 
 		this.innerHTML = `<nav class="lesson-nav" aria-label="Exercise navigation">${prevHTML}${positionHTML}${nextHTML}</nav>`;

--- a/exercises/CountDown.html
+++ b/exercises/CountDown.html
@@ -45,6 +45,8 @@
 		<script src="../components/site-header.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
 		<script src="../components/edit-on-github.js" defer></script>
+		<script src="../components/exercise-progress.js" defer></script>
+		<script src="../components/exercises-nav.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -184,6 +186,7 @@ Your name is Mike Ryan</samp></pre>
 							examples="../examples/Perform/Perform1.html|PERFORM – Format 1, ../examples/Perform/Perform2.html|PERFORM – Format 2, ../examples/Perform/Perform3.html|PERFORM – Format 3, ../examples/Perform/Perform4.html|PERFORM – Format 4"
 						></related-content>
 						<hr />
+						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
 						<edit-on-github></edit-on-github>

--- a/exercises/GettingStarted.html
+++ b/exercises/GettingStarted.html
@@ -54,6 +54,8 @@
 		<script src="../components/site-header.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
 		<script src="../components/edit-on-github.js" defer></script>
+		<script src="../components/exercise-progress.js" defer></script>
+		<script src="../components/exercises-nav.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -273,6 +275,7 @@
 							examples="../examples/Accept/ACCEPT.html|ACCEPT and DISPLAY Example, ../examples/Accept/Shortest.html|Shortest COBOL Program, ../examples/Accept/Multiplier.html|ACCEPT, DISPLAY and MULTIPLY Example"
 						></related-content>
 						<hr />
+						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
 						<edit-on-github></edit-on-github>

--- a/exercises/MonthTable.html
+++ b/exercises/MonthTable.html
@@ -54,6 +54,8 @@
 		<script src="../components/site-header.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
 		<script src="../components/edit-on-github.js" defer></script>
+		<script src="../components/exercise-progress.js" defer></script>
+		<script src="../components/exercises-nav.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -213,6 +215,7 @@ December          5</samp></pre>
 							examples="../examples/Tables/MonthTable.html|Month Table"
 						></related-content>
 						<hr />
+						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
 						<edit-on-github></edit-on-github>

--- a/exercises/SeqInsert.html
+++ b/exercises/SeqInsert.html
@@ -54,6 +54,8 @@
 		<script src="../components/site-header.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
 		<script src="../components/edit-on-github.js" defer></script>
+		<script src="../components/exercise-progress.js" defer></script>
+		<script src="../components/exercises-nav.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -264,6 +266,7 @@
 							exercises="SeqWrite.html|Writing Records, SeqRead.html|Reading Sequential Files, SeqReadIf.html|Counting Records, SeqUpdate.html|Updating Sequential Files"
 						></related-content>
 						<hr />
+						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
 						<edit-on-github></edit-on-github>

--- a/exercises/SeqRead.html
+++ b/exercises/SeqRead.html
@@ -54,6 +54,8 @@
 		<script src="../components/site-header.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
 		<script src="../components/edit-on-github.js" defer></script>
+		<script src="../components/exercise-progress.js" defer></script>
+		<script src="../components/exercises-nav.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -233,6 +235,7 @@ etc.</samp></pre>
 							exercises="SeqWrite.html|Writing Records, SeqReadIf.html|Counting Records, SeqInsert.html|Inserting Records, SeqUpdate.html|Updating Sequential Files"
 						></related-content>
 						<hr />
+						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
 						<edit-on-github></edit-on-github>

--- a/exercises/SeqReadIf.html
+++ b/exercises/SeqReadIf.html
@@ -54,6 +54,8 @@
 		<script src="../components/site-header.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
 		<script src="../components/edit-on-github.js" defer></script>
+		<script src="../components/exercise-progress.js" defer></script>
+		<script src="../components/exercises-nav.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -184,6 +186,7 @@ Number of Females = 15</samp></pre>
 							exercises="SeqWrite.html|Writing Records, SeqRead.html|Reading Sequential Files, SeqInsert.html|Inserting Records, SeqUpdate.html|Updating Sequential Files"
 						></related-content>
 						<hr />
+						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
 						<edit-on-github></edit-on-github>

--- a/exercises/SeqUpdate.html
+++ b/exercises/SeqUpdate.html
@@ -54,6 +54,8 @@
 		<script src="../components/site-header.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
 		<script src="../components/edit-on-github.js" defer></script>
+		<script src="../components/exercise-progress.js" defer></script>
+		<script src="../components/exercises-nav.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -285,6 +287,7 @@
 							exercises="SeqWrite.html|Writing Records, SeqRead.html|Reading Sequential Files, SeqReadIf.html|Counting Records, SeqInsert.html|Inserting Records"
 						></related-content>
 						<hr />
+						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
 						<edit-on-github></edit-on-github>

--- a/exercises/SeqWrite.html
+++ b/exercises/SeqWrite.html
@@ -54,6 +54,8 @@
 		<script src="../components/site-header.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
 		<script src="../components/edit-on-github.js" defer></script>
+		<script src="../components/exercise-progress.js" defer></script>
+		<script src="../components/exercises-nav.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -184,6 +186,7 @@ nnnnnnnSSSSSSSSiiG
 							exercises="SeqRead.html|Reading Sequential Files, SeqReadIf.html|Counting Records, SeqInsert.html|Inserting Records, SeqUpdate.html|Updating Sequential Files"
 						></related-content>
 						<hr />
+						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
 						<edit-on-github></edit-on-github>

--- a/exercises/SortIP.html
+++ b/exercises/SortIP.html
@@ -54,6 +54,8 @@
 		<script src="../components/site-header.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
 		<script src="../components/edit-on-github.js" defer></script>
+		<script src="../components/exercise-progress.js" defer></script>
+		<script src="../components/exercises-nav.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -255,6 +257,7 @@
 							examples="../examples/Sort/InputSort.html|SORT with Input Procedure, ../examples/Sort/MaleSort.html|SORT with Output Procedure, ../examples/Merge/Merge.html|Merging Files"
 						></related-content>
 						<hr />
+						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
 						<edit-on-github></edit-on-github>


### PR DESCRIPTION
## Summary

- Prepends the 9 simple lab exercises (GettingStarted → MonthTable) to `COBOL_EXERCISES` in `exercise-progress.js`, expanding the sequence from 20 to 29 entries
- Adds `exercise-progress.js`, `exercises-nav.js`, and `<exercises-nav>` to each of the 9 simple exercise pages so they show prev/next navigation
- Fixes a bug in `exercises-nav.js` where pages at the `exercises/` root (depth 0) were not matching their entry in `COBOL_EXERCISES` — the old `segments.slice(-2).join("/")` produced `"exercises/CountDown.html"` instead of `"CountDown.html"`; the fix finds the `exercises` segment and builds the relative path from there, computing the href prefix from depth

## Test plan

- [x] `grep -L 'exercise-progress.js' exercises/CountDown.html exercises/GettingStarted.html exercises/MonthTable.html exercises/SeqInsert.html exercises/SeqRead.html exercises/SeqReadIf.html exercises/SeqUpdate.html exercises/SeqWrite.html exercises/SortIP.html` returns empty
- [x] `npm run validate` passes with no errors
- [x] `exercises/CountDown.html` shows "Exercise 2 of 29 — Next: Reading Sequential Files"
- [x] `exercises/Exm-StudFeesRpt/Exm-StudPay.html` shows "Exercise 10 of 29" with correct prev/next

Fixes #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)