### PR TITLE
fix: restructure home page nav — remove Report Writer duplicate and group destinations

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,32 +80,36 @@
 					</p>
 					<hr />
 					<nav aria-label="COBOL resources">
+						<h2>On this site</h2>
 						<ul class="toc">
-							<li>
-								<a href="course/index.html">COBOL programming course (comprehensive COBOL tutorials)</a>
-							</li>
-							<li>
-								<a href="lectures/index.html#ReportWriter1"
-									>Report Writer Tutorials (part of the COBOL course)</a
-								>
-							</li>
+							<li><a href="course/index.html">COBOL programming course</a></li>
 							<li><a href="exercises/index.html">COBOL programming exercises</a></li>
 							<li><a href="examples/index.html">Example COBOL programs</a></li>
-							<li><a href="lectures/">COBOL lecture notes</a></li>
-							<li><a href="course/glossary.html">COBOL glossary (keyword and concept reference)</a></li>
+							<li><a href="lectures/index.html">COBOL lecture notes</a></li>
+							<li><a href="course/glossary.html">COBOL glossary</a></li>
+						</ul>
+
+						<h2>Related sites</h2>
+						<ul class="toc">
 							<li><a href="https://www.infogoal.com/cbd/index.htm">The COBOL Centre</a></li>
+							<li><a href="https://bushidocodes.github.io/klein-cobol-faq/">COBOL FAQ</a></li>
+						</ul>
+
+						<h2>Archived references</h2>
+						<ul class="toc">
 							<li>
 								<a href="https://web.archive.org/web/20130424202748/http://www.cobug.com/"
 									>The COBUG portal site for COBOL users</a
 								>
+								(Wayback Machine, 2013)
 							</li>
 							<li>
 								<a
 									href="https://web.archive.org/web/20100201014654/http://www-949.ibm.com/software/rational/cafe/community/cobol/"
 									>IBM's COBOL Cafe</a
 								>
+								(Wayback Machine, 2010)
 							</li>
-							<li><a href="https://bushidocodes.github.io/klein-cobol-faq/">COBOL FAQ</a></li>
 						</ul>
 					</nav>
 					<copyright-notice></copyright-notice>


### PR DESCRIPTION
## Summary

- Drops the "Report Writer Tutorials (part of the COBOL course)" entry whose link text contradicted its `href` (`lectures/index.html#ReportWriter1` vs `course/`) — Option A from the issue
- Splits the flat 10-item `<ul>` into three labelled groups: **On this site**, **Related sites**, and **Archived references**
- Wayback Machine links are retained but annotated with "(Wayback Machine, YYYY)" to clarify they are snapshots

## Test plan

- [x] `npm run validate` — passes
- [x] `npx linkinator http://localhost:8000 --config linkinator.config.json` — 585 links, all 200
- [x] Preview panel shows updated home page with three sections

Fixes #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)