### PR TITLE
ci: re-enable a11y check now that Chrome and partial-scan are fixed

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -35,8 +35,41 @@ jobs:
             - run: npm run check:assets
             - run: npm run check:img-dims
             - run: npm run links
-            # Accessibility check disabled — flaky failures
-            # - name: Accessibility check
+            - name: Accessibility check
+              run: |
+                  # On push to master there is no PR base; run the full scan.
+                  if [ -z "${{ github.base_ref }}" ]; then
+                    echo "Direct push — running full a11y scan"
+                    npm run a11y
+                    exit
+                  fi
+
+                  BASE="origin/${{ github.base_ref }}"
+
+                  # Full scan if any shared assets changed (they affect every page).
+                  if git diff --name-only "$BASE"...HEAD \
+                      | grep -qE '^(components/|course/Resources/)'; then
+                    echo "Shared assets changed — running full a11y scan"
+                    npm run a11y
+                    exit
+                  fi
+
+                  # Partial scan: only the HTML files touched in this PR.
+                  mapfile -t URLS < <(
+                    git diff --name-only "$BASE"...HEAD \
+                      | grep '\.html$' \
+                      | sed 's|^|http://localhost:8000/|'
+                  )
+
+                  if [ ${#URLS[@]} -eq 0 ]; then
+                    echo "No HTML files changed — skipping a11y"
+                    exit
+                  fi
+
+                  echo "Running a11y on ${#URLS[@]} changed file(s):"
+                  printf '  %s\n' "${URLS[@]}"
+                  PA11Y_PARTIAL=1 npx start-server-and-test 'npm run serve' http://localhost:8000 \
+                    "npx pa11y-ci --config .pa11yci.js ${URLS[*]}"
 
     typos:
         name: Spell check (typos)


### PR DESCRIPTION
## Summary

- Restores the `Accessibility check` step in `.github/workflows/checks.yml`, which was disabled in 5f55e563 due to two compounding bugs
- Chrome OOM fix is already in `.pa11yci.js` (`--disable-dev-shm-usage`, `--no-zygote`, etc.) — resolves #436
- Partial-scan fix is already in `.pa11yci.js` (omits the `urls` array when `PA11Y_PARTIAL=1` is set) — resolves #456
- The restored step sets `PA11Y_PARTIAL=1` on the partial-scan path so pa11y-ci uses only the CLI URL args instead of the full project list

## Test plan

- [ ] Verify the `Accessibility check` step appears and runs in CI on this PR
- [ ] Confirm the workflow prints `Running a11y on N changed file(s)` (not `Running Pa11y on ~175 URLs`) for a PR that touches only a few HTML files
- [ ] Confirm no `Target.closeTarget` / Chrome OOM errors in the run log

Fixes #456