### PR TITLE
feat: add Iteration-Calculator.cbl to build manifest

### DIFF
--- a/examples/Conditn/IterCalc.html
+++ b/examples/Conditn/IterCalc.html
@@ -20,27 +20,30 @@
 				}
 			})();
 		</script>
-		<title>Condition Names (level 88) example program</title>
-		<meta name="description" content="An example program demonstrating the use of Condition Names (level 88's)." />
-		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Conditn/Conditions.html" />
+		<title>Iteration Calculator with COMPUTE example program</title>
+		<meta
+			name="description"
+			content="Accepts two numbers and an operator from the user, then adds or multiplies them using the COMPUTE statement. Repeats three times with PERFORM TIMES. A"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/Conditn/IterCalc.html" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta
 			property="og:url"
-			content="https://bushidocodes.github.io/limerick-cobol/examples/Conditn/Conditions.html"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/Conditn/IterCalc.html"
 		/>
-		<meta property="og:title" content="Condition Names (level 88) example program" />
+		<meta property="og:title" content="Iteration Calculator with COMPUTE example program" />
 		<meta
 			property="og:description"
-			content="An example program demonstrating the use of Condition Names (level 88's)."
+			content="Accepts two numbers and an operator from the user, then adds or multiplies them using the COMPUTE statement. Repeats three times with PERFORM TIMES. A"
 		/>
 		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Condition Names (level 88) example program" />
+		<meta name="twitter:title" content="Iteration Calculator with COMPUTE example program" />
 		<meta
 			name="twitter:description"
-			content="An example program demonstrating the use of Condition Names (level 88's)."
+			content="Accepts two numbers and an operator from the user, then adds or multiplies them using the COMPUTE statement. Repeats three times with PERFORM TIMES. A"
 		/>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
@@ -64,46 +67,58 @@
 			<div class="page-wrapper">
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="Condition Names (level 88) example program"></page-hero>
-						<p>An example program demonstrating the use of Condition Names (level 88's).</p>
+						<page-hero title="Iteration Calculator with COMPUTE example program"></page-hero>
+						<p>
+							Accepts two numbers and an operator from the user, then adds or multiplies them using the
+							COMPUTE statement. Repeats three times with PERFORM TIMES. A companion to the Iteration with
+							IF example, showing COMPUTE as an alternative to the ADD and MULTIPLY verbs.
+						</p>
 						<div class="code-toolbar">
-							<a href="CONDITIONS.cbl" download class="download-btn">Download CONDITIONS.cbl</a>
+							<a href="Iteration-Calculator.cbl" download class="download-btn"
+								>Download Iteration-Calculator.cbl</a
+							>
 							<run-in-ce></run-in-ce>
 						</div>
 						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
 IDENTIFICATION DIVISION.
-PROGRAM-ID.  Conditions.
+PROGRAM-ID.  Iteration-Calculator.
 AUTHOR.  Michael Coughlan.
-*&gt; An example program demonstrating the use of 
-*&gt; condition names (level 88's).
-*&gt; The EVALUATE and PERFORM verbs are also used.
+*&gt; This program accepts two numbers and an operator from the user and
+*&gt; depending on the type of the operator either adds the numbers or
+*&gt; multiplys them together and displays the result.  It does this three times.
+*&gt; No error checking is done.
+
 
 DATA DIVISION.
 WORKING-STORAGE SECTION.
-01  Char               PIC X.
-    88 Vowel           VALUE "a", "e", "i", "o", "u".
-    88 Consonant       VALUE "b", "c", "d", "f", "g", "h"
-                             "j" THRU "n", "p" THRU "t", "v" THRU "z".
-    88 Digit           VALUE "0" THRU "9".
-    88 ValidCharacter  VALUE "a" THRU "z", "0" THRU "9".
+01  Num1           PIC 9  VALUE ZEROS.
+01  Num2           PIC 9  VALUE ZEROS.
+01  Result         PIC 99 VALUE ZEROS.
+01  Operator       PIC X  VALUE SPACE.
 
 PROCEDURE DIVISION.
-Begin.
-    DISPLAY "Enter lower case character or digit. No data ends.".
-    ACCEPT Char.
-    PERFORM UNTIL NOT ValidCharacter
-        EVALUATE TRUE
-           WHEN Vowel DISPLAY "The letter " Char " is a vowel."
-           WHEN Consonant DISPLAY "The letter " Char " is a consonant."
-           WHEN Digit DISPLAY Char " is a digit."
-           WHEN OTHER DISPLAY "problems found"
-        END-EVALUATE
-    END-PERFORM
+Calculator.
+    PERFORM 3 TIMES
+       DISPLAY "Enter First Number      : " WITH NO ADVANCING
+       ACCEPT Num1
+       DISPLAY "Enter Second Number     : " WITH NO ADVANCING
+       ACCEPT Num2
+       DISPLAY "Enter operator (+ or *) : " WITH NO ADVANCING
+       ACCEPT Operator
+       IF Operator = "+" THEN
+          COMPUTE Result = Num1 + Num2
+       END-IF
+       IF Operator = "*" THEN
+          COMPUTE Result = Num1 * Num2
+       END-IF
+       DISPLAY "Result is = ", Result
+    END-PERFORM.
     STOP RUN.
 </code></pre>
 						<related-content
-							lectures="../../course/Selection.html|Selection in COBOL"
-							examples="IterIf.html|Iteration with IF Example, IterCalc.html|Iteration Calculator (COMPUTE)"
+							lectures="../../course/Selection.html|Selection in COBOL, ../../course/Iteration.html|Iteration in COBOL"
+							examples="Conditions.html|Condition Names Example, IterIf.html|Iteration with IF Example, ../Perform/Perform1.html|PERFORM – Format 1, ../Perform/Perform2.html|PERFORM – Format 2"
+							exercises="../../exercises/CountDown.html|Calculator and Countdown"
 						></related-content>
 						<copyright-notice type="examples"></copyright-notice>
 						<last-updated></last-updated>

--- a/examples/Conditn/IterCalc.html
+++ b/examples/Conditn/IterCalc.html
@@ -85,7 +85,7 @@ PROGRAM-ID.  Iteration-Calculator.
 AUTHOR.  Michael Coughlan.
 *&gt; This program accepts two numbers and an operator from the user and
 *&gt; depending on the type of the operator either adds the numbers or
-*&gt; multiplys them together and displays the result.  It does this three times.
+*&gt; multiplies them together and displays the result.  It does this three times.
 *&gt; No error checking is done.
 
 

--- a/examples/Conditn/IterIf.html
+++ b/examples/Conditn/IterIf.html
@@ -106,7 +106,7 @@ Calculator.
 </code></pre>
 						<related-content
 							lectures="../../course/Selection.html|Selection in COBOL, ../../course/Iteration.html|Iteration in COBOL"
-							examples="Conditions.html|Condition Names Example, ../Perform/Perform1.html|PERFORM – Format 1, ../Perform/Perform2.html|PERFORM – Format 2, ../Perform/Perform3.html|PERFORM – Format 3"
+							examples="Conditions.html|Condition Names Example, IterCalc.html|Iteration Calculator (COMPUTE), ../Perform/Perform1.html|PERFORM – Format 1, ../Perform/Perform2.html|PERFORM – Format 2"
 							exercises="../../exercises/CountDown.html|Calculator and Countdown"
 						></related-content>
 						<copyright-notice type="examples"></copyright-notice>

--- a/examples/Conditn/Iteration-Calculator.cbl
+++ b/examples/Conditn/Iteration-Calculator.cbl
@@ -4,7 +4,7 @@ PROGRAM-ID.  Iteration-Calculator.
 AUTHOR.  Michael Coughlan.
 *> This program accepts two numbers and an operator from the user and
 *> depending on the type of the operator either adds the numbers or
-*> multiplys them together and displays the result.  It does this three times.
+*> multiplies them together and displays the result.  It does this three times.
 *> No error checking is done.
 
 

--- a/scripts/build-examples.js
+++ b/scripts/build-examples.js
@@ -74,6 +74,14 @@ const MANIFEST = [
 		runInCe: true,
 	},
 	{
+		file: "Conditn/IterCalc.html",
+		cbl: "Iteration-Calculator.cbl",
+		title: "Iteration Calculator with COMPUTE example program",
+		crumb: "Iteration Calculator",
+		desc: "Accepts two numbers and an operator from the user, then adds or multiplies them using the COMPUTE statement. Repeats three times with PERFORM TIMES. A companion to the Iteration with IF example, showing COMPUTE as an alternative to the ADD and MULTIPLY verbs.",
+		runInCe: true,
+	},
+	{
 		file: "Conditn/IterIf.html",
 		cbl: "Iteration-If.cbl",
 		title: "Iteration with IF example program",

--- a/scripts/cross-links.json
+++ b/scripts/cross-links.json
@@ -35,7 +35,8 @@
 			"lectures": [["course/Selection.html", "Selection in COBOL"]],
 			"examples": [
 				["examples/Conditn/Conditions.html", "Condition Names Example"],
-				["examples/Conditn/IterIf.html", "Iteration with IF Example"]
+				["examples/Conditn/IterIf.html", "Iteration with IF Example"],
+				["examples/Conditn/IterCalc.html", "Iteration Calculator (COMPUTE)"]
 			]
 		},
 		"iteration": {
@@ -47,7 +48,8 @@
 				["examples/Perform/Perform3.html", "PERFORM – Format 3"],
 				["examples/Perform/Perform4.html", "PERFORM – Format 4"],
 				["examples/Perform/MileageCount.html", "Mileage Counter"],
-				["examples/Conditn/IterIf.html", "Iteration with IF"]
+				["examples/Conditn/IterIf.html", "Iteration with IF"],
+				["examples/Conditn/IterCalc.html", "Iteration Calculator (COMPUTE)"]
 			],
 			"exercises": [["exercises/CountDown.html", "Calculator and Countdown"]]
 		},
@@ -160,6 +162,7 @@
 		"examples/Accept/Multiplier.html": ["basic-commands", "data-declaration"],
 		"examples/Accept/Shortest.html": ["intro"],
 		"examples/Conditn/Conditions.html": ["selection"],
+		"examples/Conditn/IterCalc.html": ["selection", "iteration"],
 		"examples/Conditn/IterIf.html": ["selection", "iteration"],
 		"examples/Indexed/DirectReadIdx.html": ["indexed-files"],
 		"examples/Indexed/Seq2Index.html": ["indexed-files"],

--- a/search-index.json
+++ b/search-index.json
@@ -186,6 +186,12 @@
 		"s": "examples"
 	},
 	{
+		"p": "examples/Conditn/IterCalc.html",
+		"t": "Iteration Calculator with COMPUTE example program",
+		"d": "Accepts two numbers and an operator from the user, then adds or multiplies them using the COMPUTE statement. Repeats three times with PERFORM TIMES. A",
+		"s": "examples"
+	},
+	{
 		"p": "examples/Conditn/IterIf.html",
 		"t": "Iteration with IF example program",
 		"d": "An example program that implements a primitive calculator. The calculator only does additions and multiplications.",

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -245,6 +245,10 @@
     <lastmod>2026-05-16</lastmod>
   </url>
   <url>
+    <loc>https://bushidocodes.github.io/limerick-cobol/examples/Conditn/IterCalc.html</loc>
+    <lastmod>2026-05-16</lastmod>
+  </url>
+  <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Conditn/IterIf.html</loc>
     <lastmod>2026-05-16</lastmod>
   </url>


### PR DESCRIPTION
## Summary

- `examples/Conditn/Iteration-Calculator.cbl` was an orphan on disk with no manifest entry in `scripts/build-examples.js`.
- The file is a distinct, valid example — it uses the `COMPUTE` statement for arithmetic while the sibling `Iteration-If.cbl` uses the traditional `ADD`/`MULTIPLY` verbs, making it a useful pedagogical counterpart.
- Added a manifest entry generating `examples/Conditn/IterCalc.html` with `runInCe: true`.
- Registered the new page in `scripts/cross-links.json` under the `selection` and `iteration` families (mirroring `IterIf.html`).
- Rebuilt `sitemap.xml` (170 URLs) and `search-index.json` (140 entries) to include the new page.

## Test plan

- [x] `npm run build:examples` — 38 pages written, 0 failed
- [x] `npm run validate` — passes with no errors
- [x] `npm run build:sitemap` and `npm run build:search-index` — rebuilt cleanly
- [x] Browser preview of `examples/Conditn/IterCalc.html` — title, description, breadcrumb, COBOL source, download link, and "Run on Compiler Explorer" all render correctly

Fixes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)