### PR TITLE
feat: add collapsible sample-data viewer to example pages with .dat fixtures

### DIFF
--- a/course/Resources/css/course-components.css
+++ b/course/Resources/css/course-components.css
@@ -2250,3 +2250,34 @@ course-sidebar {
 	border-color: #555;
 	color: #e0e0e0;
 }
+
+/* Sample data viewer (examples/*.html) */
+
+.sample-data {
+	border: 1px solid var(--color-border-soft);
+	border-radius: 3px;
+	background-color: var(--color-code-bg);
+	margin: 1rem 0;
+}
+
+.sample-data summary {
+	cursor: pointer;
+	padding: 3px 6px;
+	list-style: none;
+}
+
+.sample-data summary::before {
+	content: "▶ ";
+	font-size: 0.7em;
+}
+
+details[open].sample-data summary::before {
+	content: "▼ ";
+}
+
+.sample-data > pre {
+	padding: 4px 8px;
+	margin: 0;
+	overflow-x: auto;
+	white-space: pre;
+}

--- a/examples/Indexed/DirectReadIdx.html
+++ b/examples/Indexed/DirectReadIdx.html
@@ -74,6 +74,16 @@
 							Does a direct read on the Indexed file. Allows the user to choose which of the keys to use
 							for the direct read.
 						</p>
+						<details class="sample-data">
+							<summary>Sample data: SEQVIDEO.dat (first 5 of 29 records)</summary>
+							<pre>
+00121FLIGHT OF THE CONDOR, THE               03
+00333PREDATOR                                02
+00444LIVING EARTH, THE                       03
+01001COMMANDO                                02
+01100ROBOCOP                                 01</pre
+							>
+						</details>
 						<div class="code-toolbar">
 							<a href="DirectReadIdx.cbl" download class="download-btn">Download DirectReadIdx.cbl</a>
 						</div>

--- a/examples/Indexed/Seq2Index.html
+++ b/examples/Indexed/Seq2Index.html
@@ -59,6 +59,16 @@
 					<div class="section-full">
 						<page-hero title="Creating an Indexed file from a sequential file"></page-hero>
 						<p>Creates a direct access Indexed file from a Sequential file.</p>
+						<details class="sample-data">
+							<summary>Sample data: SEQVIDEO.dat (first 5 of 29 records)</summary>
+							<pre>
+00121FLIGHT OF THE CONDOR, THE               03
+00333PREDATOR                                02
+00444LIVING EARTH, THE                       03
+01001COMMANDO                                02
+01100ROBOCOP                                 01</pre
+							>
+						</details>
 						<div class="code-toolbar">
 							<a href="Seq2Index.cbl" download class="download-btn">Download Seq2Index.cbl</a>
 						</div>

--- a/examples/Indexed/SeqReadIdx.html
+++ b/examples/Indexed/SeqReadIdx.html
@@ -71,6 +71,16 @@
 							Reads the Indexed file sequentially on whichever key is chosen by the user. Displays all the
 							records in the file.
 						</p>
+						<details class="sample-data">
+							<summary>Sample data: SEQVIDEO.dat (first 5 of 29 records)</summary>
+							<pre>
+00121FLIGHT OF THE CONDOR, THE               03
+00333PREDATOR                                02
+00444LIVING EARTH, THE                       03
+01001COMMANDO                                02
+01100ROBOCOP                                 01</pre
+							>
+						</details>
 						<div class="code-toolbar">
 							<a href="SeqReadIdx.cbl" download class="download-btn">Download SeqReadIdx.cbl</a>
 						</div>

--- a/examples/Relative/ReadRel.html
+++ b/examples/Relative/ReadRel.html
@@ -71,6 +71,16 @@
 							Reads the Relative file and displays the records. Allows the user to choose to read
 							sequentially through all the records or to use a key to read a single record directly.
 						</p>
+						<details class="sample-data">
+							<summary>Sample data: SEQSUPP.dat (first 5 of 11 records)</summary>
+							<pre>
+01VESTRON VIDEOS      OVER THE SEA, SOMEWHERE IN LONDON
+02EMI STUDIOS         HOLLYWOOD, CALIFORNIA, USA 
+03BBC WILDLIFE        BUSH HOUSE, LONDON, ENGLAND
+04CBS STUDIOS         HOLLYWOOD, CALIFORNIA, USA
+05YACHTING MONTHLY    TREE HOUSE, LONDON, ENGLAND </pre
+							>
+						</details>
 						<div class="code-toolbar">
 							<a href="ReadRelative.cbl" download class="download-btn">Download ReadRelative.cbl</a>
 						</div>

--- a/examples/Relative/Seq2Rel.html
+++ b/examples/Relative/Seq2Rel.html
@@ -59,6 +59,16 @@
 					<div class="section-full">
 						<page-hero title="Sequential to Relative File example program"></page-hero>
 						<p>Creates a direct access Relative file from a Sequential File.</p>
+						<details class="sample-data">
+							<summary>Sample data: SEQSUPP.dat (first 5 of 11 records)</summary>
+							<pre>
+01VESTRON VIDEOS      OVER THE SEA, SOMEWHERE IN LONDON
+02EMI STUDIOS         HOLLYWOOD, CALIFORNIA, USA 
+03BBC WILDLIFE        BUSH HOUSE, LONDON, ENGLAND
+04CBS STUDIOS         HOLLYWOOD, CALIFORNIA, USA
+05YACHTING MONTHLY    TREE HOUSE, LONDON, ENGLAND </pre
+							>
+						</details>
 						<div class="code-toolbar">
 							<a href="Seq2Rel.cbl" download class="download-btn">Download Seq2Rel.cbl</a>
 						</div>

--- a/examples/SeqIns/SEQINSERT.html
+++ b/examples/SeqIns/SEQINSERT.html
@@ -71,6 +71,26 @@
 							Demonstrates how to insert records into a sequential file from a file of transaction
 							records. A new file is created which contains the inserted records.
 						</p>
+						<details class="sample-data">
+							<summary>Sample data: STUDENTS.dat (first 5 of 32 records)</summary>
+							<pre>
+8712351SMITH   MS19671012LM51F
+8712352POWER   TG19681219LM51M
+8712353SWEENEY ST19690905LM52M
+8712354WALSH   SM19700313LM60M
+8712355WILLIAMSTJ19650128LM51M</pre
+							>
+						</details>
+						<details class="sample-data">
+							<summary>Sample data: TRANSINS.dat (5 records)</summary>
+							<pre>
+8700234Insert1 ok19531223LM60M
+8805733Insert2 ok19631009LM51F
+8912345Insert3 ok19570723LM53F
+9012354Rec Exists19520418LM60F
+9123453Insert4 ok19591230LM53F</pre
+							>
+						</details>
 						<div class="code-toolbar">
 							<a href="InsertRecords.cbl" download class="download-btn">Download InsertRecords.cbl</a>
 						</div>

--- a/examples/SeqRead/SEQREAD.html
+++ b/examples/SeqRead/SEQREAD.html
@@ -68,6 +68,16 @@
 							An example program that reads a sequential file and displays the records. Uses the Condition
 							Name (level 88) "EndOfFile" to signal when the end of the file has been reached.
 						</p>
+						<details class="sample-data">
+							<summary>Sample data: STUDENTS.dat (first 5 of 32 records)</summary>
+							<pre>
+8712351SMITH   MS19671012LM51F
+8712352POWER   TG19681219LM51M
+8712353SWEENEY ST19690905LM52M
+8712354WALSH   SM19700313LM60M
+8712355WILLIAMSTJ19650128LM51M</pre
+							>
+						</details>
 						<div class="code-toolbar">
 							<a href="Seqread.cbl" download class="download-btn">Download Seqread.cbl</a>
 						</div>

--- a/examples/SeqRead/SEQREADno88.html
+++ b/examples/SeqRead/SEQREADno88.html
@@ -71,6 +71,16 @@
 							An example program that reads a sequential file and displays the records. This version does
 							not use level 88's to signal when the end of the file has been reached.
 						</p>
+						<details class="sample-data">
+							<summary>Sample data: STUDENTS.dat (first 5 of 32 records)</summary>
+							<pre>
+8712351SMITH   MS19671012LM51F
+8712352POWER   TG19681219LM51M
+8712353SWEENEY ST19690905LM52M
+8712354WALSH   SM19700313LM60M
+8712355WILLIAMSTJ19650128LM51M</pre
+							>
+						</details>
 						<div class="code-toolbar">
 							<a href="SeqreadNo88.cbl" download class="download-btn">Download SeqreadNo88.cbl</a>
 						</div>

--- a/examples/Strings/UnstringFileEg.html
+++ b/examples/Strings/UnstringFileEg.html
@@ -76,6 +76,16 @@
 							An example showing the unpacking of comma-separated records and the size validation of the
 							unpacked fields.
 						</p>
+						<details class="sample-data">
+							<summary>Sample data: VarLen.dat (first 5 of 12 records)</summary>
+							<pre>
+1,This, one, is quite long
+3,12345678,1234567,ok for size,12 
+3,123456789,1234567,Date size wrong,23
+3,12345678,123456789,video code size wrong,43
+3,12345678,1234567,this video title is much to long for its good,45</pre
+							>
+						</details>
 						<div class="code-toolbar">
 							<a href="UnstringFileEg.cbl" download class="download-btn">Download UnstringFileEg.cbl</a>
 						</div>

--- a/scripts/build-examples.js
+++ b/scripts/build-examples.js
@@ -88,6 +88,7 @@ const MANIFEST = [
 		title: "Reading an Indexed file directly by key",
 		crumb: "Direct Read on Indexed File",
 		desc: "Does a direct read on the Indexed file. Allows the user to choose which of the keys to use for the direct read.",
+		fixtures: ["SEQVIDEO.dat"],
 	},
 	{
 		file: "Indexed/Seq2Index.html",
@@ -95,6 +96,7 @@ const MANIFEST = [
 		title: "Creating an Indexed file from a sequential file",
 		crumb: "Sequential to Indexed",
 		desc: "Creates a direct access Indexed file from a Sequential file.",
+		fixtures: ["SEQVIDEO.dat"],
 	},
 	{
 		file: "Indexed/SeqReadIdx.html",
@@ -102,6 +104,7 @@ const MANIFEST = [
 		title: "Reading an Indexed file sequentially on any of its keys",
 		crumb: "Sequential Read of Indexed File",
 		desc: "Reads the Indexed file sequentially on whichever key is chosen by the user. Displays all the records in the file.",
+		fixtures: ["SEQVIDEO.dat"],
 	},
 	// ── Merge ───────────────────────────────────────────────────────────────
 	{
@@ -159,6 +162,7 @@ const MANIFEST = [
 		title: "Read Relative File example program",
 		crumb: "Read Relative File",
 		desc: "Reads the Relative file and displays the records. Allows the user to choose to read sequentially through all the records or to use a key to read a single record directly.",
+		fixtures: ["SEQSUPP.dat"],
 	},
 	{
 		file: "Relative/Seq2Rel.html",
@@ -166,6 +170,7 @@ const MANIFEST = [
 		title: "Sequential to Relative File example program",
 		crumb: "Sequential to Relative",
 		desc: "Creates a direct access Relative file from a Sequential File.",
+		fixtures: ["SEQSUPP.dat"],
 	},
 	// ── ReportWriter ────────────────────────────────────────────────────────
 	{
@@ -203,6 +208,7 @@ const MANIFEST = [
 		title: "Inserting records in a Sequential File",
 		crumb: "Insert Records",
 		desc: "Demonstrates how to insert records into a sequential file from a file of transaction records. A new file is created which contains the inserted records.",
+		fixtures: ["STUDENTS.dat", "TRANSINS.dat"],
 	},
 	// ── SeqRead ─────────────────────────────────────────────────────────────
 	{
@@ -211,6 +217,7 @@ const MANIFEST = [
 		title: "Reading a Sequential File",
 		crumb: "Sequential Read",
 		desc: 'An example program that reads a sequential file and displays the records. Uses the Condition Name (level 88) "EndOfFile" to signal when the end of the file has been reached.',
+		fixtures: ["STUDENTS.dat"],
 	},
 	{
 		file: "SeqRead/SEQREADno88.html",
@@ -218,6 +225,7 @@ const MANIFEST = [
 		title: "Reading a Sequential File",
 		crumb: "Sequential Read (without level 88s)",
 		desc: "An example program that reads a sequential file and displays the records. This version does not use level 88's to signal when the end of the file has been reached.",
+		fixtures: ["STUDENTS.dat"],
 	},
 	// ── SeqRpt ──────────────────────────────────────────────────────────────
 	{
@@ -265,6 +273,7 @@ const MANIFEST = [
 		title: "String handling - Unpacking and size-validating comma separated records",
 		crumb: "UNSTRING File Example",
 		desc: "An example showing the unpacking of comma-separated records and the size validation of the unpacked fields.",
+		fixtures: ["VarLen.dat"],
 	},
 	// ── SubProg/DateValid (depth 3) ──────────────────────────────────────────
 	{
@@ -345,6 +354,37 @@ function truncate(text, max = 155) {
 	if (text.length <= max) return text;
 	const cut = text.lastIndexOf(" ", max);
 	return (cut > 80 ? text.slice(0, cut) : text.slice(0, max)).trimEnd();
+}
+
+const MAX_FIXTURE_ROWS = 5;
+
+/**
+ * Build collapsible <details> blocks for each fixture file listed in entry.fixtures.
+ * Missing files are silently skipped so entries can be declared defensively.
+ */
+function sampleDataHtml(entry) {
+	if (!entry.fixtures || !entry.fixtures.length) return "";
+	const dir = path.join(EXAMPLES_DIR, path.dirname(entry.file));
+	let html = "";
+	for (const dat of entry.fixtures) {
+		const datPath = path.join(dir, dat);
+		if (!fs.existsSync(datPath)) continue;
+		const raw = fs.readFileSync(datPath, "utf8").replace(/\r\n/g, "\n");
+		const allLines = raw.split("\n").filter((l) => l.length > 0);
+		const shown = allLines.slice(0, MAX_FIXTURE_ROWS);
+		const total = allLines.length;
+		const suffix =
+			total > MAX_FIXTURE_ROWS
+				? ` (first ${MAX_FIXTURE_ROWS} of ${total} records)`
+				: ` (${total} records)`;
+		const escaped = escapeHtml(shown.join("\n"));
+		html +=
+			`\t\t\t\t\t\t<details class="sample-data">\n` +
+			`\t\t\t\t\t\t\t<summary>Sample data: ${dat}${suffix}</summary>\n` +
+			`\t\t\t\t\t\t\t<pre>${escaped}</pre>\n` +
+			`\t\t\t\t\t\t</details>\n`;
+	}
+	return html;
 }
 
 /**
@@ -428,6 +468,7 @@ function buildPage(entry) {
 	const escapedSource = escapeHtml(cblSource);
 
 	const relatedEl = relatedContentHtml(entry.file);
+	const sampleDataEl = sampleDataHtml(entry);
 
 	const runInCeScript = entry.runInCe ? `\t\t<script src="${pfx}components/run-in-ce.js" defer></script>\n` : "";
 	const runInCeToolbarEl = entry.runInCe ? `\t\t\t\t\t\t\t<run-in-ce></run-in-ce>\n` : "";
@@ -490,7 +531,7 @@ ${runInCeScript}\t</head>
 \t\t\t\t\t<div class="section-full">
 \t\t\t\t\t\t<page-hero title="${metaTitle}"></page-hero>
 \t\t\t\t\t\t<p>${entry.desc}</p>
-\t\t\t\t\t\t\t<div class="code-toolbar">
+${sampleDataEl}\t\t\t\t\t\t\t<div class="code-toolbar">
 \t\t\t\t\t\t\t<a href="${entry.cbl}" download class="download-btn">Download ${entry.cbl}</a>
 ${runInCeToolbarEl}\t\t\t\t\t\t</div>
 \t\t\t\t\t\t<pre class="language-cobol"><code class="language-cobol">${escapedSource}

--- a/scripts/build-examples.js
+++ b/scripts/build-examples.js
@@ -374,9 +374,7 @@ function sampleDataHtml(entry) {
 		const shown = allLines.slice(0, MAX_FIXTURE_ROWS);
 		const total = allLines.length;
 		const suffix =
-			total > MAX_FIXTURE_ROWS
-				? ` (first ${MAX_FIXTURE_ROWS} of ${total} records)`
-				: ` (${total} records)`;
+			total > MAX_FIXTURE_ROWS ? ` (first ${MAX_FIXTURE_ROWS} of ${total} records)` : ` (${total} records)`;
 		const escaped = escapeHtml(shown.join("\n"));
 		html +=
 			`\t\t\t\t\t\t<details class="sample-data">\n` +


### PR DESCRIPTION
## Summary

- Adds a `<details class="sample-data">` disclosure widget between the description and the COBOL source block on each example page that ships a `.dat` fixture file
- Shows the first 5 records (collapsed by default) so learners can preview the input without downloading
- Generator lives in `scripts/build-examples.js` as `sampleDataHtml()`; missing fixture files are silently skipped, so manifest entries can be declared defensively
- CSS uses existing design tokens (`--color-code-bg`, `--color-border-soft`) so dark mode adapts automatically

**Pages updated:** SeqRead × 2 (`STUDENTS.dat`), SeqIns (`STUDENTS.dat` + `TRANSINS.dat`), Indexed × 3 (`SEQVIDEO.dat`), Relative × 2 (`SEQSUPP.dat`), Strings/UnstringFileEg (`VarLen.dat`)

## Test plan

- [x] `npm run build:examples` — 37 pages written, 0 failed
- [x] `npm run validate` — no errors
- [x] Light-mode preview: closed widget shows `▶ Sample data: STUDENTS.dat (first 5 of 32 records)`, expanded shows 5 fixed-width records in a monospace block
- [x] Dark-mode preview: `var(--color-code-bg)` / `var(--color-border-soft)` tokens adapt without extra overrides

Fixes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)