### PR TITLE
feat: add SeqUpd/SeqUpdate.html example page

### DIFF
--- a/examples/SeqIns/SEQINSERT.html
+++ b/examples/SeqIns/SEQINSERT.html
@@ -181,7 +181,7 @@ BEGIN.
 </code></pre>
 						<related-content
 							lectures="../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3"
-							examples="../SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../SeqRead/SEQREAD.html|Reading a Sequential File, ../SeqRead/SEQREADno88.html|Reading a Sequential File (no 88), ../SeqRpt/SEQRPT.html|Sequential Student Number Report"
+							examples="../SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../SeqRead/SEQREAD.html|Reading a Sequential File, ../SeqRead/SEQREADno88.html|Reading a Sequential File (no 88), ../SeqUpd/SeqUpdate.html|Updating a Sequential File"
 							exercises="../../exercises/SeqWrite.html|Writing Records, ../../exercises/SeqRead.html|Reading Sequential Files, ../../exercises/SeqReadIf.html|Counting Records, ../../exercises/SeqInsert.html|Inserting Records"
 						></related-content>
 						<copyright-notice type="examples"></copyright-notice>

--- a/examples/SeqRead/SEQREAD.html
+++ b/examples/SeqRead/SEQREAD.html
@@ -127,7 +127,7 @@ Begin.
 </code></pre>
 						<related-content
 							lectures="../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3"
-							examples="../SeqWrite/SEQWRITE.html|Writing to a Sequential File, SEQREADno88.html|Reading a Sequential File (no 88), ../SeqIns/SEQINSERT.html|Inserting Records in a Sequential File, ../SeqRpt/SEQRPT.html|Sequential Student Number Report"
+							examples="../SeqWrite/SEQWRITE.html|Writing to a Sequential File, SEQREADno88.html|Reading a Sequential File (no 88), ../SeqIns/SEQINSERT.html|Inserting Records in a Sequential File, ../SeqUpd/SeqUpdate.html|Updating a Sequential File"
 							exercises="../../exercises/SeqWrite.html|Writing Records, ../../exercises/SeqRead.html|Reading Sequential Files, ../../exercises/SeqReadIf.html|Counting Records, ../../exercises/SeqInsert.html|Inserting Records"
 						></related-content>
 						<copyright-notice type="examples"></copyright-notice>

--- a/examples/SeqRead/SEQREADno88.html
+++ b/examples/SeqRead/SEQREADno88.html
@@ -131,7 +131,7 @@ Begin.
 </code></pre>
 						<related-content
 							lectures="../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3"
-							examples="../SeqWrite/SEQWRITE.html|Writing to a Sequential File, SEQREAD.html|Reading a Sequential File, ../SeqIns/SEQINSERT.html|Inserting Records in a Sequential File, ../SeqRpt/SEQRPT.html|Sequential Student Number Report"
+							examples="../SeqWrite/SEQWRITE.html|Writing to a Sequential File, SEQREAD.html|Reading a Sequential File, ../SeqIns/SEQINSERT.html|Inserting Records in a Sequential File, ../SeqUpd/SeqUpdate.html|Updating a Sequential File"
 							exercises="../../exercises/SeqWrite.html|Writing Records, ../../exercises/SeqRead.html|Reading Sequential Files, ../../exercises/SeqReadIf.html|Counting Records, ../../exercises/SeqInsert.html|Inserting Records"
 						></related-content>
 						<copyright-notice type="examples"></copyright-notice>

--- a/examples/SeqUpd/SeqUpdate.html
+++ b/examples/SeqUpd/SeqUpdate.html
@@ -1,0 +1,203 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<script>
+			(function () {
+				var t = localStorage.getItem("lc-theme");
+				if (t === "dark" || t === "light") {
+					document.documentElement.setAttribute("data-theme", t);
+					var color = t === "dark" ? "#1a1a1a" : "#ffffff";
+					var meta = document.querySelector('meta[name="theme-color"]:not([media])');
+					if (!meta) {
+						meta = document.createElement("meta");
+						meta.name = "theme-color";
+						document.head.appendChild(meta);
+					}
+					meta.content = color;
+				}
+			})();
+		</script>
+		<title>Updating a Sequential File</title>
+		<meta
+			name="description"
+			content="Updates the Students.dat master file using course-transfer transactions from Transfer.dat to produce a new Students.New file. Demonstrates the sequential"
+		/>
+		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/examples/SeqUpd/SeqUpdate.html" />
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta
+			property="og:url"
+			content="https://bushidocodes.github.io/limerick-cobol/examples/SeqUpd/SeqUpdate.html"
+		/>
+		<meta property="og:title" content="Updating a Sequential File" />
+		<meta
+			property="og:description"
+			content="Updates the Students.dat master file using course-transfer transactions from Transfer.dat to produce a new Students.New file. Demonstrates the sequential"
+		/>
+		<meta property="og:image" content="https://bushidocodes.github.io/limerick-cobol/pics/og/examples.png" />
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary_large_image" />
+		<meta name="twitter:title" content="Updating a Sequential File" />
+		<meta
+			name="twitter:description"
+			content="Updates the Students.dat master file using course-transfer transactions from Transfer.dat to produce a new Students.New file. Demonstrates the sequential"
+		/>
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+		<link href="../../course/Resources/css/course.css" rel="stylesheet" />
+		<link href="../../course/Resources/css/course-components.css" rel="stylesheet" />
+		<link href="../../course/Resources/vendor/prism/themes/prism.min.css" rel="stylesheet" />
+		<script src="../../course/Resources/vendor/prism/prism.min.js" defer></script>
+		<script src="../../course/Resources/vendor/prism/components/prism-cobol.min.js" defer></script>
+		<script src="../../components/theme-toggle.js" defer></script>
+		<script src="../../components/page-hero.js" defer></script>
+		<script src="../../components/related-content.js" defer></script>
+		<script src="../../components/copy-button.js" defer></script>
+		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/copyright-notice.js" defer></script>
+		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
+	</head>
+	<body>
+		<a class="skip-link" href="#main-content">Skip to main content</a>
+		<main id="main-content">
+			<div class="page-wrapper">
+				<div class="section-grid">
+					<div class="section-full">
+						<page-hero title="Updating a Sequential File"></page-hero>
+						<p>
+							Updates the Students.dat master file using course-transfer transactions from Transfer.dat to
+							produce a new Students.New file. Demonstrates the sequential file matching algorithm and
+							detects two error conditions: unmatched transaction records and mismatched course codes.
+						</p>
+						<div class="code-toolbar">
+							<a href="SeqUpdate.cbl" download class="download-btn">Download SeqUpdate.cbl</a>
+						</div>
+						<pre class="language-cobol"><code class="language-cobol">       &gt;&gt;SOURCE FORMAT IS FREE
+IDENTIFICATION DIVISION.
+PROGRAM-ID. SeqUpdate.
+AUTHOR. Michael Coughlan.
+*&gt; This program updates the Students.dat file using the
+*&gt; course-transfer transactions in Transfer.dat to create
+*&gt; a new file - Students.New - which contains the updated
+*&gt; records.
+*&gt;
+*&gt; Both the master file and the transaction file are
+*&gt; sequential files held in ascending StudentId order, and
+*&gt; there is at most one transaction per student.
+*&gt;
+*&gt; The program detects two error conditions:
+*&gt;    1) A transaction StudentId with no matching record in
+*&gt;       the student file.
+*&gt;    2) A transaction whose OldCourseCode does not match the
+*&gt;       CourseCode currently held in the student record.
+
+ENVIRONMENT DIVISION.
+INPUT-OUTPUT SECTION.
+FILE-CONTROL.
+    SELECT StudentFile ASSIGN TO "STUDENTS.dat"
+        ORGANIZATION IS LINE SEQUENTIAL.
+
+    SELECT TransferFile ASSIGN TO "Transfer.dat"
+        ORGANIZATION IS LINE SEQUENTIAL.
+
+    SELECT NewStudentFile ASSIGN TO "Students.New"
+        ORGANIZATION IS LINE SEQUENTIAL.
+
+
+DATA DIVISION.
+FILE SECTION.
+FD StudentFile.
+01 StudentDetails.
+   88 EndOfStudentFile     VALUE HIGH-VALUES.
+   02 StudentId            PIC 9(7).
+   02 StudentName.
+      03 Surname           PIC X(8).
+      03 Initials          PIC XX.
+   02 DateOfBirth.
+      03 YOBirth           PIC 9(4).
+      03 MOBirth           PIC 9(2).
+      03 DOBirth           PIC 9(2).
+   02 CourseCode           PIC X(4).
+   02 Gender               PIC X.
+
+FD TransferFile.
+01 TransferDetails.
+   88 EndOfTransferFile    VALUE HIGH-VALUES.
+   02 TransStudentId       PIC 9(7).
+   02 OldCourseCode        PIC X(4).
+   02 NewCourseCode        PIC X(4).
+
+FD NewStudentFile.
+01 NewStudentDetails       PIC X(30).
+
+
+PROCEDURE DIVISION.
+Begin.
+    OPEN INPUT  StudentFile
+                TransferFile
+         OUTPUT NewStudentFile
+
+    READ StudentFile
+       AT END SET EndOfStudentFile TO TRUE
+    END-READ
+
+    READ TransferFile
+       AT END SET EndOfTransferFile TO TRUE
+    END-READ
+
+    PERFORM UNTIL EndOfStudentFile AND EndOfTransferFile
+       EVALUATE TRUE
+          WHEN TransStudentId &lt; StudentId
+             DISPLAY "Error - Transaction " TransStudentId
+                     " has no matching student record"
+             READ TransferFile
+                AT END SET EndOfTransferFile TO TRUE
+             END-READ
+
+          WHEN TransStudentId = StudentId
+             IF OldCourseCode = CourseCode
+                MOVE NewCourseCode TO CourseCode
+             ELSE
+                DISPLAY "Error - Transaction " TransStudentId
+                        " OldCourseCode " OldCourseCode
+                        " does not match student CourseCode "
+                        CourseCode
+             END-IF
+             WRITE NewStudentDetails FROM StudentDetails
+             READ StudentFile
+                AT END SET EndOfStudentFile TO TRUE
+             END-READ
+             READ TransferFile
+                AT END SET EndOfTransferFile TO TRUE
+             END-READ
+
+          WHEN TransStudentId &gt; StudentId
+             WRITE NewStudentDetails FROM StudentDetails
+             READ StudentFile
+                AT END SET EndOfStudentFile TO TRUE
+             END-READ
+       END-EVALUATE
+    END-PERFORM
+
+    CLOSE StudentFile
+          TransferFile
+          NewStudentFile
+    STOP RUN.
+</code></pre>
+						<related-content
+							lectures="../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3"
+							examples="../SeqWrite/SEQWRITE.html|Writing to a Sequential File, ../SeqRead/SEQREAD.html|Reading a Sequential File, ../SeqRead/SEQREADno88.html|Reading a Sequential File (no 88), ../SeqIns/SEQINSERT.html|Inserting Records in a Sequential File"
+							exercises="../../exercises/SeqWrite.html|Writing Records, ../../exercises/SeqRead.html|Reading Sequential Files, ../../exercises/SeqReadIf.html|Counting Records, ../../exercises/SeqInsert.html|Inserting Records"
+						></related-content>
+						<copyright-notice type="examples"></copyright-notice>
+						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
+					</div>
+				</div>
+			</div>
+		</main>
+	</body>
+</html>

--- a/examples/SeqWrite/SEQWRITE.html
+++ b/examples/SeqWrite/SEQWRITE.html
@@ -125,7 +125,7 @@ GetStudentDetails.
 </code></pre>
 						<related-content
 							lectures="../../course/SequentialFiles1.html|Sequential Files 1, ../../course/SequentialFiles2.html|Sequential Files 2, ../../course/SequentialFiles3.html|Sequential Files 3"
-							examples="../SeqRead/SEQREAD.html|Reading a Sequential File, ../SeqRead/SEQREADno88.html|Reading a Sequential File (no 88), ../SeqIns/SEQINSERT.html|Inserting Records in a Sequential File, ../SeqRpt/SEQRPT.html|Sequential Student Number Report"
+							examples="../SeqRead/SEQREAD.html|Reading a Sequential File, ../SeqRead/SEQREADno88.html|Reading a Sequential File (no 88), ../SeqIns/SEQINSERT.html|Inserting Records in a Sequential File, ../SeqUpd/SeqUpdate.html|Updating a Sequential File"
 							exercises="../../exercises/SeqWrite.html|Writing Records, ../../exercises/SeqRead.html|Reading Sequential Files, ../../exercises/SeqReadIf.html|Counting Records, ../../exercises/SeqInsert.html|Inserting Records"
 						></related-content>
 						<copyright-notice type="examples"></copyright-notice>

--- a/examples/index.html
+++ b/examples/index.html
@@ -517,6 +517,34 @@
 									</div>
 								</td>
 							</tr>
+							<tr>
+								<td>
+									<div style="text-align: center">SeqUpdate.cbl</div>
+								</td>
+								<td>
+									Updates the Students.dat master file using course-transfer transactions from
+									Transfer.dat to produce a new Students.New file. Demonstrates the sequential file
+									matching algorithm and error detection for unmatched or mismatched transaction
+									records.<br />
+									To test this program you will need to download Student Masterfile -
+									<a href="SeqUpd/STUDENTS.dat">Students.dat</a> and the Transaction file
+									<a href="SeqUpd/Transfer.dat">Transfer.dat</a>.
+								</td>
+								<td>
+									<div style="text-align: center">
+										Sequential Files, Condition Names (level 88's),
+										<code class="language-cobol">READ</code>,
+										<code class="language-cobol">WRITE</code>,
+										<code class="language-cobol">EVALUATE</code>
+									</div>
+								</td>
+								<td>
+									<div style="text-align: center">
+										<a href="SeqUpd/SeqUpdate.cbl">Download</a><br />
+										<a href="SeqUpd/SeqUpdate.html">View</a>
+									</div>
+								</td>
+							</tr>
 						</tbody>
 					</table>
 					<table class="data-table">

--- a/scripts/build-examples.js
+++ b/scripts/build-examples.js
@@ -250,6 +250,14 @@ const MANIFEST = [
 		crumb: "Student Numbers Report",
 		desc: "Reads records from the student file, counts the total number of student records and the number of records for females and males, and prints the results in a short report.",
 	},
+	// ── SeqUpd ──────────────────────────────────────────────────────────────
+	{
+		file: "SeqUpd/SeqUpdate.html",
+		cbl: "SeqUpdate.cbl",
+		title: "Updating a Sequential File",
+		crumb: "Sequential Update",
+		desc: "Updates the Students.dat master file using course-transfer transactions from Transfer.dat to produce a new Students.New file. Demonstrates the sequential file matching algorithm and detects two error conditions: unmatched transaction records and mismatched course codes.",
+	},
 	// ── SeqWrite ────────────────────────────────────────────────────────────
 	{
 		file: "SeqWrite/SEQWRITE.html",

--- a/scripts/cross-links.json
+++ b/scripts/cross-links.json
@@ -65,6 +65,7 @@
 				["examples/SeqRead/SEQREAD.html", "Reading a Sequential File"],
 				["examples/SeqRead/SEQREADno88.html", "Reading a Sequential File (no 88)"],
 				["examples/SeqIns/SEQINSERT.html", "Inserting Records in a Sequential File"],
+				["examples/SeqUpd/SeqUpdate.html", "Updating a Sequential File"],
 				["examples/SeqRpt/SEQRPT.html", "Sequential Student Number Report"]
 			],
 			"exercises": [
@@ -184,6 +185,7 @@
 		"examples/SeqRead/SEQREAD.html": ["sequential-files"],
 		"examples/SeqRead/SEQREADno88.html": ["sequential-files"],
 		"examples/SeqRpt/SEQRPT.html": ["sequential-files"],
+		"examples/SeqUpd/SeqUpdate.html": ["sequential-files"],
 		"examples/SeqWrite/SEQWRITE.html": ["sequential-files"],
 		"examples/Sort/InputSort.html": ["sort-merge"],
 		"examples/Sort/MaleSort.html": ["sort-merge"],

--- a/search-index.json
+++ b/search-index.json
@@ -324,6 +324,12 @@
 		"s": "examples"
 	},
 	{
+		"p": "examples/SeqUpd/SeqUpdate.html",
+		"t": "Updating a Sequential File",
+		"d": "Updates the Students.dat master file using course-transfer transactions from Transfer.dat to produce a new Students.New file. Demonstrates the sequential",
+		"s": "examples"
+	},
+	{
 		"p": "examples/SeqWrite/SEQWRITE.html",
 		"t": "Writing to a Sequential File",
 		"d": "Example program demonstrating how to create a sequential file from data input by the user.",

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -333,6 +333,10 @@
     <lastmod>2026-05-16</lastmod>
   </url>
   <url>
+    <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqUpd/SeqUpdate.html</loc>
+    <lastmod>2026-05-16</lastmod>
+  </url>
+  <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqWrite/SEQWRITE.html</loc>
     <lastmod>2026-05-16</lastmod>
   </url>


### PR DESCRIPTION
## Summary

- Adds a manifest entry in `scripts/build-examples.js` for `examples/SeqUpd/SeqUpdate.cbl` so an HTML page is generated at `examples/SeqUpd/SeqUpdate.html`
- Registers the new page in `scripts/cross-links.json` under the `sequential-files` family so it gets a Related section linking to the Sequential Files 1/2/3 lessons and sibling examples
- Adds a row for `SeqUpdate.cbl` in the Sequential Files table in `examples/index.html`
- Regenerates sitemap, search index, and all example HTML pages (cross-link rebuild caused SeqUpd to appear in sibling pages' Related panels)

## Test plan

- [ ] `examples/SeqUpd/SeqUpdate.html` renders with syntax-highlighted source and a Related panel showing all three Sequential Files lectures
- [ ] `examples/index.html` Sequential Files table includes a `SeqUpdate.cbl` row with Download and View links
- [ ] HTML validation passes (`npm run validate`)
- [ ] No dead links (`npm run links`)

Fixes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)