### PR TITLE
feat: add check-example-orphans script (#383)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,11 @@
 		"check:reading-time": "node scripts/add-reading-time.js && prettier --write \"course/**/*.html\" && git diff --exit-code \"course/**/*.html\"",
 		"build:prev-next-links": "node scripts/add-prev-next-links.js && prettier --write \"course/**/*.html\"",
 		"check:prev-next-links": "node scripts/add-prev-next-links.js && prettier --write \"course/**/*.html\" && git diff --exit-code \"course/**/*.html\"",
+		"check:example-orphans": "node scripts/check-example-orphans.js",
 		"check:assets": "node scripts/check-assets.js",
 		"format:check": "prettier --check .",
 		"format:write": "prettier --write .",
-		"check": "npm run check:examples && npm run check:search-index && npm run validate && npm run check:assets && npm run check:img-dims && npm run links && npm run a11y"
+		"check": "npm run check:examples && npm run check:example-orphans && npm run check:search-index && npm run validate && npm run check:assets && npm run check:img-dims && npm run links && npm run a11y"
 	},
 	"devDependencies": {
 		"@resvg/resvg-js": "^2.6.2",

--- a/scripts/build-examples.js
+++ b/scripts/build-examples.js
@@ -580,23 +580,27 @@ ${relatedEl}\t\t\t\t\t\t<copyright-notice type="examples"></copyright-notice>
 // Main
 // ---------------------------------------------------------------------------
 
-console.log("Building example HTML pages from .cbl sources…\n");
+module.exports = { MANIFEST, EXAMPLES_DIR };
 
-let ok = 0;
-let fail = 0;
+if (require.main === module) {
+	console.log("Building example HTML pages from .cbl sources…\n");
 
-for (const entry of MANIFEST) {
-	const absPath = path.join(EXAMPLES_DIR, entry.file);
-	try {
-		const html = buildPage(entry);
-		fs.writeFileSync(absPath, html, "utf8");
-		console.log(`  OK  ${entry.file}`);
-		ok++;
-	} catch (err) {
-		console.error(`  ERR ${entry.file}: ${err.message}`);
-		fail++;
+	let ok = 0;
+	let fail = 0;
+
+	for (const entry of MANIFEST) {
+		const absPath = path.join(EXAMPLES_DIR, entry.file);
+		try {
+			const html = buildPage(entry);
+			fs.writeFileSync(absPath, html, "utf8");
+			console.log(`  OK  ${entry.file}`);
+			ok++;
+		} catch (err) {
+			console.error(`  ERR ${entry.file}: ${err.message}`);
+			fail++;
+		}
 	}
-}
 
-console.log(`\nDone. ${ok} written, ${fail} failed.`);
-if (fail > 0) process.exit(1);
+	console.log(`\nDone. ${ok} written, ${fail} failed.`);
+	if (fail > 0) process.exit(1);
+}

--- a/scripts/check-example-orphans.js
+++ b/scripts/check-example-orphans.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+/**
+ * check-example-orphans.js
+ *
+ * Fails CI if any .cbl file exists under examples/ without a matching entry
+ * in the MANIFEST defined in build-examples.js.
+ *
+ * Usage:  npm run check:example-orphans
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const { MANIFEST, EXAMPLES_DIR } = require("./build-examples.js");
+
+// Build the set of manifest-referenced .cbl paths (relative to EXAMPLES_DIR,
+// forward slashes) so we can compare against on-disk files.
+const manifestPaths = new Set(
+	MANIFEST.map((entry) => {
+		const dir = path.dirname(entry.file).replace(/\\/g, "/");
+		return `${dir}/${entry.cbl}`;
+	}),
+);
+
+// Walk examples/ and collect every .cbl file.
+function walkCbl(dir, results = []) {
+	for (const name of fs.readdirSync(dir)) {
+		const full = path.join(dir, name);
+		if (fs.statSync(full).isDirectory()) {
+			walkCbl(full, results);
+		} else if (name.endsWith(".cbl")) {
+			results.push(path.relative(EXAMPLES_DIR, full).replace(/\\/g, "/"));
+		}
+	}
+	return results;
+}
+
+const onDisk = walkCbl(EXAMPLES_DIR);
+const orphans = onDisk.filter((p) => !manifestPaths.has(p));
+
+if (orphans.length === 0) {
+	console.log(`check-example-orphans: all ${onDisk.length} .cbl files are registered in the MANIFEST. OK`);
+	process.exit(0);
+} else {
+	console.error(`check-example-orphans: ${orphans.length} orphaned .cbl file(s) found (not in MANIFEST):\n`);
+	for (const p of orphans) {
+		console.error(`  examples/${p}`);
+	}
+	console.error("\nAdd each file to the MANIFEST in scripts/build-examples.js or remove it.");
+	process.exit(1);
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/check-example-orphans.js`: walks `examples/` recursively, compares every `.cbl` file against the `MANIFEST` in `build-examples.js`, and exits 1 if any are unregistered.
- Refactors `build-examples.js` to `module.exports = { MANIFEST, EXAMPLES_DIR }` and guards the build loop with `if (require.main === module)` so the checker can import the manifest without triggering a rebuild.
- Registers `npm run check:example-orphans` and wires it into `npm run check`.

## Test plan

- [ ] `npm run check:example-orphans` passes (all 41 `.cbl` files registered)
- [ ] `npm run build:examples` still works correctly (build loop runs when executed directly)
- [ ] Manually add a stray `.cbl` file under `examples/` and confirm the script exits 1 with a clear error message

Fixes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)