### PR TITLE
style: modernize lectures index page navigation

### DIFF
--- a/lectures/index.html
+++ b/lectures/index.html
@@ -120,12 +120,16 @@
 						<li>Variables.</li>
 					</ul>
 					<div class="topic-nav">
-<a href="genintro.html" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+						<a href="genintro.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M4 3l9 5-9 5V3z" />
+							</svg>
 							View slides
 						</a>
 						<a href="genintro.pptx" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z" />
+							</svg>
 							Download .pptx
 						</a>
 					</div>
@@ -141,12 +145,16 @@
 						<li>Example COBOL programs.</li>
 					</ul>
 					<div class="topic-nav">
-<a href="cobintro.html" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+						<a href="cobintro.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M4 3l9 5-9 5V3z" />
+							</svg>
 							View slides
 						</a>
 						<a href="cobintro.pptx" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z" />
+							</svg>
 							Download .pptx
 						</a>
 					</div>
@@ -164,12 +172,16 @@
 						<li>Editing, compiling, linking and running COBOL programs</li>
 					</ul>
 					<div class="topic-nav">
-<a href="basics1.html" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+						<a href="basics1.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M4 3l9 5-9 5V3z" />
+							</svg>
 							View slides
 						</a>
 						<a href="basics1.pptx" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z" />
+							</svg>
 							Download .pptx
 						</a>
 					</div>
@@ -183,12 +195,16 @@
 						<li>DISPLAY and ACCEPT.</li>
 					</ul>
 					<div class="topic-nav">
-<a href="basics2.html" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+						<a href="basics2.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M4 3l9 5-9 5V3z" />
+							</svg>
 							View slides
 						</a>
 						<a href="basics2.pptx" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z" />
+							</svg>
 							Download .pptx
 						</a>
 					</div>
@@ -201,12 +217,16 @@
 						<li>OPEN, CLOSE, READ and WRITE verbs.</li>
 					</ul>
 					<div class="topic-nav">
-<a href="seqfile1.html" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+						<a href="seqfile1.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M4 3l9 5-9 5V3z" />
+							</svg>
 							View slides
 						</a>
 						<a href="seqfile1.pptx" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z" />
+							</svg>
 							Download .pptx
 						</a>
 					</div>
@@ -219,12 +239,16 @@
 						<li>Processing ordered files.</li>
 					</ul>
 					<div class="topic-nav">
-<a href="seqfile2.html" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+						<a href="seqfile2.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M4 3l9 5-9 5V3z" />
+							</svg>
 							View slides
 						</a>
 						<a href="seqfile2.pptx" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z" />
+							</svg>
 							Download .pptx
 						</a>
 					</div>
@@ -239,12 +263,16 @@
 						<li>Using the PERFORM...UNTIL in processing files.</li>
 					</ul>
 					<div class="topic-nav">
-<a href="perform.html" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+						<a href="perform.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M4 3l9 5-9 5V3z" />
+							</svg>
 							View slides
 						</a>
 						<a href="perform.pptx" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z" />
+							</svg>
 							Download .pptx
 						</a>
 					</div>
@@ -266,12 +294,16 @@
 						</li>
 					</ul>
 					<div class="topic-nav">
-<a href="arithmetic.html" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+						<a href="arithmetic.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M4 3l9 5-9 5V3z" />
+							</svg>
 							View slides
 						</a>
 						<a href="arithmetic.pptx" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z" />
+							</svg>
 							Download .pptx
 						</a>
 					</div>
@@ -289,12 +321,16 @@
 						<li>The SET verb.</li>
 					</ul>
 					<div class="topic-nav">
-<a href="conditions.html" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+						<a href="conditions.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M4 3l9 5-9 5V3z" />
+							</svg>
 							View slides
 						</a>
 						<a href="conditions.pptx" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z" />
+							</svg>
 							Download .pptx
 						</a>
 					</div>
@@ -310,12 +346,16 @@
 						<li>Guidelines for writing Cobol programs.</li>
 					</ul>
 					<div class="topic-nav">
-<a href="design.html" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+						<a href="design.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M4 3l9 5-9 5V3z" />
+							</svg>
 							View slides
 						</a>
 						<a href="design.pptx" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z" />
+							</svg>
 							Download .pptx
 						</a>
 					</div>
@@ -331,12 +371,16 @@
 						<li>Payroll Proof Totals program</li>
 					</ul>
 					<div class="topic-nav">
-<a href="dsr1.html" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+						<a href="dsr1.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M4 3l9 5-9 5V3z" />
+							</svg>
 							View slides
 						</a>
 						<a href="dsr1.pptx" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z" />
+							</svg>
 							Download .pptx
 						</a>
 					</div>
@@ -350,12 +394,16 @@
 						<li>The MERGE.</li>
 					</ul>
 					<div class="topic-nav">
-<a href="sort.html" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+						<a href="sort.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M4 3l9 5-9 5V3z" />
+							</svg>
 							View slides
 						</a>
 						<a href="sort.pptx" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z" />
+							</svg>
 							Download .pptx
 						</a>
 					</div>
@@ -367,12 +415,16 @@
 						<li>Processing tables using the PERFORM..VARYING.</li>
 					</ul>
 					<div class="topic-nav">
-<a href="tables1.html" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+						<a href="tables1.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M4 3l9 5-9 5V3z" />
+							</svg>
 							View slides
 						</a>
 						<a href="tables1.pptx" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z" />
+							</svg>
 							Download .pptx
 						</a>
 					</div>
@@ -387,12 +439,16 @@
 						<li>Defining variable length tables.</li>
 					</ul>
 					<div class="topic-nav">
-<a href="tables2.html" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+						<a href="tables2.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M4 3l9 5-9 5V3z" />
+							</svg>
 							View slides
 						</a>
 						<a href="tables2.pptx" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z" />
+							</svg>
 							Download .pptx
 						</a>
 					</div>
@@ -403,12 +459,16 @@
 						<li>The SEARCH ALL. verbs.</li>
 					</ul>
 					<div class="topic-nav">
-<a href="search.html" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+						<a href="search.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M4 3l9 5-9 5V3z" />
+							</svg>
 							View slides
 						</a>
 						<a href="search.pptx" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z" />
+							</svg>
 							Download .pptx
 						</a>
 					</div>
@@ -419,12 +479,16 @@
 						<li>Variable length records.</li>
 					</ul>
 					<div class="topic-nav">
-<a href="seqfile3.html" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+						<a href="seqfile3.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M4 3l9 5-9 5V3z" />
+							</svg>
 							View slides
 						</a>
 						<a href="seqfile3.pptx" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z" />
+							</svg>
 							Download .pptx
 						</a>
 					</div>
@@ -436,12 +500,16 @@
 						<li>Advantages and disadvantages of Sequential, Relative and Indexed files.</li>
 					</ul>
 					<div class="topic-nav">
-<a href="direct1.html" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+						<a href="direct1.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M4 3l9 5-9 5V3z" />
+							</svg>
 							View slides
 						</a>
 						<a href="direct1.pptx" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z" />
+							</svg>
 							Download .pptx
 						</a>
 					</div>
@@ -454,12 +522,16 @@
 						<li>Error handling using Declaratives.</li>
 					</ul>
 					<div class="topic-nav">
-<a href="relative.html" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+						<a href="relative.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M4 3l9 5-9 5V3z" />
+							</svg>
 							View slides
 						</a>
 						<a href="relative.pptx" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z" />
+							</svg>
 							Download .pptx
 						</a>
 					</div>
@@ -472,12 +544,16 @@
 						<li>OPEN, CLOSE, READ, WRITE, REWRITE, DELETE and START verbs.</li>
 					</ul>
 					<div class="topic-nav">
-<a href="indexed.html" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+						<a href="indexed.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M4 3l9 5-9 5V3z" />
+							</svg>
 							View slides
 						</a>
 						<a href="indexed.pptx" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z" />
+							</svg>
 							Download .pptx
 						</a>
 					</div>
@@ -495,12 +571,16 @@
 						<li>GLOBAL and EXTERNAL Data.</li>
 					</ul>
 					<div class="topic-nav">
-<a href="call.html" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+						<a href="call.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M4 3l9 5-9 5V3z" />
+							</svg>
 							View slides
 						</a>
 						<a href="call.pptx" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z" />
+							</svg>
 							Download .pptx
 						</a>
 					</div>
@@ -513,12 +593,16 @@
 						<li>The LEADING, FIRST, BEFORE, and AFTER phrases.</li>
 					</ul>
 					<div class="topic-nav">
-<a href="inspect.html" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+						<a href="inspect.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M4 3l9 5-9 5V3z" />
+							</svg>
 							View slides
 						</a>
 						<a href="inspect.pptx" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z" />
+							</svg>
 							Download .pptx
 						</a>
 					</div>
@@ -533,12 +617,16 @@
 						<li>The <code>ON OVERFLOW</code> and <code>NOT ON OVERFLOW</code> phrases.</li>
 					</ul>
 					<div class="topic-nav">
-<a href="string.html" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+						<a href="string.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M4 3l9 5-9 5V3z" />
+							</svg>
 							View slides
 						</a>
 						<a href="string.pptx" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z" />
+							</svg>
 							Download .pptx
 						</a>
 					</div>
@@ -551,12 +639,16 @@
 						<li>The <code>ALL</code> phrase and <code>ON OVERFLOW</code> clause.</li>
 					</ul>
 					<div class="topic-nav">
-<a href="unstring.html" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+						<a href="unstring.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M4 3l9 5-9 5V3z" />
+							</svg>
 							View slides
 						</a>
 						<a href="unstring.pptx" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z" />
+							</svg>
 							Download .pptx
 						</a>
 					</div>
@@ -569,12 +661,16 @@
 						<li>The <code>SYNCHRONIZED</code> clause and word-boundary alignment.</li>
 					</ul>
 					<div class="topic-nav">
-<a href="usage.html" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+						<a href="usage.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M4 3l9 5-9 5V3z" />
+							</svg>
 							View slides
 						</a>
 						<a href="usage.pptx" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z" />
+							</svg>
 							Download .pptx
 						</a>
 					</div>
@@ -595,8 +691,10 @@
 						<p>Please note the copyright restrictions at the end of the Report Writer tutorial.</p>
 					</blockquote>
 					<div class="topic-nav">
-<a href="reportwriterweb.html" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+						<a href="reportwriterweb.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M4 3l9 5-9 5V3z" />
+							</svg>
 							View slides
 						</a>
 					</div>
@@ -610,8 +708,10 @@
 						<p>Please note the copyright restrictions at the end of the Report Writer tutorial.</p>
 					</blockquote>
 					<div class="topic-nav">
-<a href="reportwriterssweb.html" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+						<a href="reportwriterssweb.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M4 3l9 5-9 5V3z" />
+							</svg>
 							View slides
 						</a>
 					</div>
@@ -622,12 +722,16 @@
 						<li>Why use COPY Libraries.</li>
 					</ul>
 					<div class="topic-nav">
-<a href="copy.html" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+						<a href="copy.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M4 3l9 5-9 5V3z" />
+							</svg>
 							View slides
 						</a>
 						<a href="copy.pptx" class="topic-nav__link">
-							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+								<path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z" />
+							</svg>
 							Download .pptx
 						</a>
 					</div>

--- a/lectures/index.html
+++ b/lectures/index.html
@@ -62,14 +62,35 @@
 				display: flex;
 				gap: 0.5rem;
 				align-items: center;
+				flex-wrap: wrap;
+				margin: 1rem 0 0;
 			}
 
-			.topic-nav a {
-				display: block;
+			.topic-nav__link {
+				display: inline-flex;
+				align-items: center;
+				gap: 0.4em;
+				padding: 0.3em 0.75em;
+				border: 1px solid var(--color-border-soft);
+				border-radius: 4px;
+				text-decoration: none;
+				font-size: 0.875em;
+				color: var(--color-link);
+				line-height: 1.4;
+			}
+
+			.topic-nav__link:hover {
+				background-color: var(--color-panel-bg);
+				text-decoration: none;
+			}
+
+			.topic-nav__link svg {
+				width: 1em;
+				height: 1em;
+				flex-shrink: 0;
 			}
 		</style>
 		<script src="../components/site-header.js" defer></script>
-		<script src="../components/related-content.js" defer></script>
 	</head>
 
 	<body>
@@ -86,35 +107,9 @@
 						<a href="../index.html">main COBOL page</a>.
 					</p>
 					<p>
-						The COBOL programming lectures are delivered using Microsoft PowerPoint slides. Each topic links
-						to a downloadable .pptx file alongside the in-browser HTML rendering.
+						The COBOL programming lectures are delivered using Microsoft PowerPoint slides. Each topic
+						includes links to view the slides in your browser and download the .pptx file.
 					</p>
-					<p>Each lecture topic in the module outline is followed by these three clickable buttons -</p>
-					<ul>
-						<a href="#Contents"
-							><img
-								height="52"
-								src="../pics/B-BackArrow.gif"
-								width="52"
-								alt="Back to Module Contents"
-								style="margin-left: 5px; margin-right: 5px" /></a
-						><img
-							height="52"
-							src="../pics/B-BrowserPPT2.gif"
-							width="52"
-							alt="View lecture in browser"
-							style="margin-left: 10px; margin-right: 10px"
-						/><img
-							height="52"
-							src="../pics/B-ZippedPPT2.gif"
-							width="52"
-							alt="Download PowerPoint file"
-							style="margin-left: 5px; margin-right: 5px"
-						/><br />
-						The first button returns you to the module contents. Try it now.<br />
-						The second runs the presentation in your browser.<br />
-						The third button downloads the .pptx file containing the presentation
-					</ul>
 					<hr />
 					<h2 id="Contents">Module Contents</h2>
 					<h3 id="General">General Introduction</h3>
@@ -125,15 +120,14 @@
 						<li>Variables.</li>
 					</ul>
 					<div class="topic-nav">
-						<a href="#Contents"
-							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
-						/></a>
-						<a href="genintro.html"
-							><img alt="Browser presentation" height="62" src="../pics/B-BrowserPPT2.gif" width="52"
-						/></a>
-						<a href="genintro.pptx"
-							><img alt="Download presentation" height="62" src="../pics/B-ZippedPPT2.gif" width="52"
-						/></a>
+<a href="genintro.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+							View slides
+						</a>
+						<a href="genintro.pptx" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							Download .pptx
+						</a>
 					</div>
 					<hr />
 					<h3 id="Introduction">Introduction to COBOL</h3>
@@ -147,15 +141,14 @@
 						<li>Example COBOL programs.</li>
 					</ul>
 					<div class="topic-nav">
-						<a href="#Contents"
-							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
-						/></a>
-						<a href="cobintro.html"
-							><img alt="Browser presentation" height="62" src="../pics/B-BrowserPPT2.gif" width="52"
-						/></a>
-						<a href="cobintro.pptx"
-							><img alt="Download presentation" height="62" src="../pics/B-ZippedPPT2.gif" width="52"
-						/></a>
+<a href="cobintro.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+							View slides
+						</a>
+						<a href="cobintro.pptx" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							Download .pptx
+						</a>
 					</div>
 					<hr />
 					<h3 id="Basics1">COBOL Basics 1</h3>
@@ -171,15 +164,14 @@
 						<li>Editing, compiling, linking and running COBOL programs</li>
 					</ul>
 					<div class="topic-nav">
-						<a href="#Contents"
-							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
-						/></a>
-						<a href="basics1.html"
-							><img alt="Browser presentation" height="62" src="../pics/B-BrowserPPT2.gif" width="52"
-						/></a>
-						<a href="basics1.pptx"
-							><img alt="Download presentation" height="62" src="../pics/B-ZippedPPT2.gif" width="52"
-						/></a>
+<a href="basics1.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+							View slides
+						</a>
+						<a href="basics1.pptx" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							Download .pptx
+						</a>
 					</div>
 					<hr />
 					<h3 id="Basics2">COBOL Basics 2</h3>
@@ -191,15 +183,14 @@
 						<li>DISPLAY and ACCEPT.</li>
 					</ul>
 					<div class="topic-nav">
-						<a href="#Contents"
-							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
-						/></a>
-						<a href="basics2.html"
-							><img alt="Browser presentation" height="62" src="../pics/B-BrowserPPT2.gif" width="52"
-						/></a>
-						<a href="basics2.pptx"
-							><img alt="Download presentation" height="62" src="../pics/B-ZippedPPT2.gif" width="52"
-						/></a>
+<a href="basics2.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+							View slides
+						</a>
+						<a href="basics2.pptx" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							Download .pptx
+						</a>
 					</div>
 					<hr />
 					<h3 id="IntroSeqFiles">Introduction to Sequential Files</h3>
@@ -210,15 +201,14 @@
 						<li>OPEN, CLOSE, READ and WRITE verbs.</li>
 					</ul>
 					<div class="topic-nav">
-						<a href="#Contents"
-							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
-						/></a>
-						<a href="seqfile1.html"
-							><img alt="Browser presentation" height="62" src="../pics/B-BrowserPPT2.gif" width="52"
-						/></a>
-						<a href="seqfile1.pptx"
-							><img alt="Download presentation" height="62" src="../pics/B-ZippedPPT2.gif" width="52"
-						/></a>
+<a href="seqfile1.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+							View slides
+						</a>
+						<a href="seqfile1.pptx" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							Download .pptx
+						</a>
 					</div>
 					<hr />
 					<h3 id="ProcessingSeqFiles">Processing Sequential Files</h3>
@@ -229,15 +219,14 @@
 						<li>Processing ordered files.</li>
 					</ul>
 					<div class="topic-nav">
-						<a href="#Contents"
-							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
-						/></a>
-						<a href="seqfile2.html"
-							><img alt="Browser presentation" height="62" src="../pics/B-BrowserPPT2.gif" width="52"
-						/></a>
-						<a href="seqfile2.pptx"
-							><img alt="Download presentation" height="62" src="../pics/B-ZippedPPT2.gif" width="52"
-						/></a>
+<a href="seqfile2.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+							View slides
+						</a>
+						<a href="seqfile2.pptx" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							Download .pptx
+						</a>
 					</div>
 					<hr />
 					<h3 id="PERFORM">Simple iteration with the PERFORM verb</h3>
@@ -250,15 +239,14 @@
 						<li>Using the PERFORM...UNTIL in processing files.</li>
 					</ul>
 					<div class="topic-nav">
-						<a href="#Contents"
-							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
-						/></a>
-						<a href="perform.html"
-							><img alt="Browser presentation" height="62" src="../pics/B-BrowserPPT2.gif" width="52"
-						/></a>
-						<a href="perform.pptx"
-							><img alt="Download presentation" height="62" src="../pics/B-ZippedPPT2.gif" width="52"
-						/></a>
+<a href="perform.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+							View slides
+						</a>
+						<a href="perform.pptx" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							Download .pptx
+						</a>
 					</div>
 					<hr />
 					<h3 id="Arithmetic">Arithmetic and Edited Pictures</h3>
@@ -278,15 +266,14 @@
 						</li>
 					</ul>
 					<div class="topic-nav">
-						<a href="#Contents"
-							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
-						/></a>
-						<a href="arithmetic.html"
-							><img alt="Browser presentation" height="62" src="../pics/B-BrowserPPT2.gif" width="52"
-						/></a>
-						<a href="arithmetic.pptx"
-							><img alt="Download presentation" height="62" src="../pics/B-ZippedPPT2.gif" width="52"
-						/></a>
+<a href="arithmetic.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+							View slides
+						</a>
+						<a href="arithmetic.pptx" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							Download .pptx
+						</a>
 					</div>
 					<hr />
 					<h3 id="Conditions">Conditions</h3>
@@ -302,15 +289,14 @@
 						<li>The SET verb.</li>
 					</ul>
 					<div class="topic-nav">
-						<a href="#Contents"
-							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
-						/></a>
-						<a href="conditions.html"
-							><img alt="Browser presentation" height="62" src="../pics/B-BrowserPPT2.gif" width="52"
-						/></a>
-						<a href="conditions.pptx"
-							><img alt="Download presentation" height="62" src="../pics/B-ZippedPPT2.gif" width="52"
-						/></a>
+<a href="conditions.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+							View slides
+						</a>
+						<a href="conditions.pptx" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							Download .pptx
+						</a>
 					</div>
 					<hr />
 					<h3 id="Designing">Designing Programs</h3>
@@ -324,15 +310,14 @@
 						<li>Guidelines for writing Cobol programs.</li>
 					</ul>
 					<div class="topic-nav">
-						<a href="#Contents"
-							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
-						/></a>
-						<a href="design.html"
-							><img alt="Browser presentation" height="62" src="../pics/B-BrowserPPT2.gif" width="52"
-						/></a>
-						<a href="design.pptx"
-							><img alt="Download presentation" height="62" src="../pics/B-ZippedPPT2.gif" width="52"
-						/></a>
+<a href="design.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+							View slides
+						</a>
+						<a href="design.pptx" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							Download .pptx
+						</a>
 					</div>
 					<hr />
 					<h3 id="DSR1">Introduction to Diagrammatic Stepwise Refinement</h3>
@@ -346,15 +331,14 @@
 						<li>Payroll Proof Totals program</li>
 					</ul>
 					<div class="topic-nav">
-						<a href="#Contents"
-							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
-						/></a>
-						<a href="dsr1.html"
-							><img alt="Browser presentation" height="62" src="../pics/B-BrowserPPT2.gif" width="52"
-						/></a>
-						<a href="dsr1.pptx"
-							><img alt="Download presentation" height="62" src="../pics/B-ZippedPPT2.gif" width="52"
-						/></a>
+<a href="dsr1.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+							View slides
+						</a>
+						<a href="dsr1.pptx" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							Download .pptx
+						</a>
 					</div>
 					<hr />
 					<h3 id="SORT">SORT and MERGE</h3>
@@ -366,15 +350,14 @@
 						<li>The MERGE.</li>
 					</ul>
 					<div class="topic-nav">
-						<a href="#Contents"
-							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
-						/></a>
-						<a href="sort.html"
-							><img alt="Browser presentation" height="62" src="../pics/B-BrowserPPT2.gif" width="52"
-						/></a>
-						<a href="sort.pptx"
-							><img alt="Download presentation" height="62" src="../pics/B-ZippedPPT2.gif" width="52"
-						/></a>
+<a href="sort.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+							View slides
+						</a>
+						<a href="sort.pptx" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							Download .pptx
+						</a>
 					</div>
 					<hr />
 					<h3 id="Tables">Tables and the PERFORM ... VARYING</h3>
@@ -384,15 +367,14 @@
 						<li>Processing tables using the PERFORM..VARYING.</li>
 					</ul>
 					<div class="topic-nav">
-						<a href="#Contents"
-							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
-						/></a>
-						<a href="tables1.html"
-							><img alt="Browser presentation" height="62" src="../pics/B-BrowserPPT2.gif" width="52"
-						/></a>
-						<a href="tables1.pptx"
-							><img alt="Download presentation" height="62" src="../pics/B-ZippedPPT2.gif" width="52"
-						/></a>
+<a href="tables1.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+							View slides
+						</a>
+						<a href="tables1.pptx" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							Download .pptx
+						</a>
 					</div>
 					<hr />
 					<h3 id="AdvancedTables">Advanced Tables</h3>
@@ -405,15 +387,14 @@
 						<li>Defining variable length tables.</li>
 					</ul>
 					<div class="topic-nav">
-						<a href="#Contents"
-							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
-						/></a>
-						<a href="tables2.html"
-							><img alt="Browser presentation" height="62" src="../pics/B-BrowserPPT2.gif" width="52"
-						/></a>
-						<a href="tables2.pptx"
-							><img alt="Download presentation" height="62" src="../pics/B-ZippedPPT2.gif" width="52"
-						/></a>
+<a href="tables2.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+							View slides
+						</a>
+						<a href="tables2.pptx" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							Download .pptx
+						</a>
 					</div>
 					<hr />
 					<h3 id="SearchingTAbles">Searching Tables</h3>
@@ -422,15 +403,14 @@
 						<li>The SEARCH ALL. verbs.</li>
 					</ul>
 					<div class="topic-nav">
-						<a href="#Contents"
-							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
-						/></a>
-						<a href="search.html"
-							><img alt="Browser presentation" height="62" src="../pics/B-BrowserPPT2.gif" width="52"
-						/></a>
-						<a href="search.pptx"
-							><img alt="Download presentation" height="62" src="../pics/B-ZippedPPT2.gif" width="52"
-						/></a>
+<a href="search.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+							View slides
+						</a>
+						<a href="search.pptx" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							Download .pptx
+						</a>
 					</div>
 					<hr />
 					<h3 id="AdvancedSeqFiles">Advanced Sequential Files</h3>
@@ -439,15 +419,14 @@
 						<li>Variable length records.</li>
 					</ul>
 					<div class="topic-nav">
-						<a href="#Contents"
-							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
-						/></a>
-						<a href="seqfile3.html"
-							><img alt="Browser presentation" height="62" src="../pics/B-BrowserPPT2.gif" width="52"
-						/></a>
-						<a href="seqfile3.pptx"
-							><img alt="Download presentation" height="62" src="../pics/B-ZippedPPT2.gif" width="52"
-						/></a>
+<a href="seqfile3.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+							View slides
+						</a>
+						<a href="seqfile3.pptx" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							Download .pptx
+						</a>
 					</div>
 					<hr />
 					<h3 id="IntroDirectAccessFiles">Introduction to Direct Access Files</h3>
@@ -457,15 +436,14 @@
 						<li>Advantages and disadvantages of Sequential, Relative and Indexed files.</li>
 					</ul>
 					<div class="topic-nav">
-						<a href="#Contents"
-							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
-						/></a>
-						<a href="direct1.html"
-							><img alt="Browser presentation" height="62" src="../pics/B-BrowserPPT2.gif" width="52"
-						/></a>
-						<a href="direct1.pptx"
-							><img alt="Download presentation" height="62" src="../pics/B-ZippedPPT2.gif" width="52"
-						/></a>
+<a href="direct1.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+							View slides
+						</a>
+						<a href="direct1.pptx" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							Download .pptx
+						</a>
 					</div>
 					<hr />
 					<h3 id="RelativeFiles">Relative Files</h3>
@@ -476,15 +454,14 @@
 						<li>Error handling using Declaratives.</li>
 					</ul>
 					<div class="topic-nav">
-						<a href="#Contents"
-							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
-						/></a>
-						<a href="relative.html"
-							><img alt="Browser presentation" height="62" src="../pics/B-BrowserPPT2.gif" width="52"
-						/></a>
-						<a href="relative.pptx"
-							><img alt="Download presentation" height="62" src="../pics/B-ZippedPPT2.gif" width="52"
-						/></a>
+<a href="relative.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+							View slides
+						</a>
+						<a href="relative.pptx" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							Download .pptx
+						</a>
 					</div>
 					<hr />
 					<h3 id="IndexedFiles">Indexed Files</h3>
@@ -495,15 +472,14 @@
 						<li>OPEN, CLOSE, READ, WRITE, REWRITE, DELETE and START verbs.</li>
 					</ul>
 					<div class="topic-nav">
-						<a href="#Contents"
-							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
-						/></a>
-						<a href="indexed.html"
-							><img alt="Browser presentation" height="62" src="../pics/B-BrowserPPT2.gif" width="52"
-						/></a>
-						<a href="indexed.pptx"
-							><img alt="Download presentation" height="62" src="../pics/B-ZippedPPT2.gif" width="52"
-						/></a>
+<a href="indexed.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+							View slides
+						</a>
+						<a href="indexed.pptx" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							Download .pptx
+						</a>
 					</div>
 					<hr />
 					<h3 id="Calling">Calling Subprograms</h3>
@@ -519,15 +495,14 @@
 						<li>GLOBAL and EXTERNAL Data.</li>
 					</ul>
 					<div class="topic-nav">
-						<a href="#Contents"
-							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
-						/></a>
-						<a href="call.html"
-							><img alt="Browser presentation" height="62" src="../pics/B-BrowserPPT2.gif" width="52"
-						/></a>
-						<a href="call.pptx"
-							><img alt="Download presentation" height="62" src="../pics/B-ZippedPPT2.gif" width="52"
-						/></a>
+<a href="call.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+							View slides
+						</a>
+						<a href="call.pptx" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							Download .pptx
+						</a>
 					</div>
 					<hr />
 					<h3 id="Inspect">The INSPECT</h3>
@@ -538,15 +513,14 @@
 						<li>The LEADING, FIRST, BEFORE, and AFTER phrases.</li>
 					</ul>
 					<div class="topic-nav">
-						<a href="#Contents"
-							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
-						/></a>
-						<a href="inspect.html"
-							><img alt="Browser presentation" height="62" src="../pics/B-BrowserPPT2.gif" width="52"
-						/></a>
-						<a href="inspect.pptx"
-							><img alt="Download presentation" height="62" src="../pics/B-ZippedPPT2.gif" width="52"
-						/></a>
+<a href="inspect.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+							View slides
+						</a>
+						<a href="inspect.pptx" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							Download .pptx
+						</a>
 					</div>
 					<hr />
 					<h3 id="String">The STRING</h3>
@@ -559,15 +533,14 @@
 						<li>The <code>ON OVERFLOW</code> and <code>NOT ON OVERFLOW</code> phrases.</li>
 					</ul>
 					<div class="topic-nav">
-						<a href="#Contents"
-							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
-						/></a>
-						<a href="string.html"
-							><img alt="Browser presentation" height="62" src="../pics/B-BrowserPPT2.gif" width="52"
-						/></a>
-						<a href="string.pptx"
-							><img alt="Download presentation" height="62" src="../pics/B-ZippedPPT2.gif" width="52"
-						/></a>
+<a href="string.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+							View slides
+						</a>
+						<a href="string.pptx" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							Download .pptx
+						</a>
 					</div>
 					<hr />
 					<h3 id="Unstring">The UNSTRING</h3>
@@ -578,15 +551,14 @@
 						<li>The <code>ALL</code> phrase and <code>ON OVERFLOW</code> clause.</li>
 					</ul>
 					<div class="topic-nav">
-						<a href="#Contents"
-							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
-						/></a>
-						<a href="unstring.html"
-							><img alt="Browser presentation" height="62" src="../pics/B-BrowserPPT2.gif" width="52"
-						/></a>
-						<a href="unstring.pptx"
-							><img alt="Download presentation" height="62" src="../pics/B-ZippedPPT2.gif" width="52"
-						/></a>
+<a href="unstring.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+							View slides
+						</a>
+						<a href="unstring.pptx" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							Download .pptx
+						</a>
 					</div>
 					<hr />
 					<h3 id="Usage">The USAGE clause</h3>
@@ -597,15 +569,14 @@
 						<li>The <code>SYNCHRONIZED</code> clause and word-boundary alignment.</li>
 					</ul>
 					<div class="topic-nav">
-						<a href="#Contents"
-							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
-						/></a>
-						<a href="usage.html"
-							><img alt="Browser presentation" height="62" src="../pics/B-BrowserPPT2.gif" width="52"
-						/></a>
-						<a href="usage.pptx"
-							><img alt="Download presentation" height="62" src="../pics/B-ZippedPPT2.gif" width="52"
-						/></a>
+<a href="usage.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+							View slides
+						</a>
+						<a href="usage.pptx" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							Download .pptx
+						</a>
 					</div>
 					<hr />
 					<h3 id="ReportWriter1">The COBOL Report Writer - A worked example</h3>
@@ -624,12 +595,10 @@
 						<p>Please note the copyright restrictions at the end of the Report Writer tutorial.</p>
 					</blockquote>
 					<div class="topic-nav">
-						<a href="#Contents"
-							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
-						/></a>
-						<a href="reportwriterweb.html"
-							><img alt="Browser presentation" height="62" src="../pics/B-BrowserPPT2.gif" width="52"
-						/></a>
+<a href="reportwriterweb.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+							View slides
+						</a>
 					</div>
 					<hr />
 					<h3 id="ReportWriter2">The COBOL Report Writer - Syntax and Semantics</h3>
@@ -641,12 +610,10 @@
 						<p>Please note the copyright restrictions at the end of the Report Writer tutorial.</p>
 					</blockquote>
 					<div class="topic-nav">
-						<a href="#Contents"
-							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
-						/></a>
-						<a href="reportwriterssweb.html"
-							><img alt="Browser presentation" height="62" src="../pics/B-BrowserPPT2.gif" width="52"
-						/></a>
+<a href="reportwriterssweb.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+							View slides
+						</a>
 					</div>
 					<hr />
 					<h3 id="Copy">The COPY</h3>
@@ -655,31 +622,15 @@
 						<li>Why use COPY Libraries.</li>
 					</ul>
 					<div class="topic-nav">
-						<a href="#Contents"
-							><img alt="Back to contents" height="62" src="../pics/B-BackArrow2.gif" width="52"
-						/></a>
-						<a href="copy.html"
-							><img alt="Browser presentation" height="62" src="../pics/B-BrowserPPT2.gif" width="52"
-						/></a>
-						<a href="copy.pptx"
-							><img alt="Download presentation" height="62" src="../pics/B-ZippedPPT2.gif" width="52"
-						/></a>
+<a href="copy.html" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M4 3l9 5-9 5V3z"/></svg>
+							View slides
+						</a>
+						<a href="copy.pptx" class="topic-nav__link">
+							<svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M8 11l-4.5-4.5H6V2h4v4.5h2.5L8 11zM2 13.5v1h12v-1H2z"/></svg>
+							Download .pptx
+						</a>
 					</div>
-					<hr />
-					<p>
-						The copyright for these presentations belongs to the author - Michael Coughlan. Permission is
-						given to use these presentations, in part or whole, in your own lectures but you may not use the
-						material in any published work without written permission from the author.
-					</p>
-					<p>
-						If you find any errors in these presentations or wish to make some comment concerning them
-						please email the author <a href="mailto:michael.coughlan@ul.ie">Michael Coughlan</a>.
-					</p>
-					<hr />
-					<related-content
-						exercises="../exercises/index.html|COBOL Exercises"
-						lectures="../course/index.html|COBOL Course"
-					></related-content>
 					<copyright-notice></copyright-notice>
 					<last-updated></last-updated>
 				</div>


### PR DESCRIPTION
## Summary

- Replaces all 27 sets of pixelated 1990s-era Netscape GIF icon buttons with modern chip-style text links (inline SVG icon + label) for **View slides** and **Download .pptx** actions
- Removes the intro section that explained how the old three-button icons worked
- Removes the non-functional **Back to contents** button from every topic (anchor scrolling adds no value on a linear page)
- Removes the `<related-content>` panel (the linked pages weren't meaningfully related to the lecture content here)
- Removes the two redundant copyright/contact paragraphs at the bottom that duplicate what `<copyright-notice>` already renders

## What a reviewer should know

No content was removed — only navigation chrome and duplicated boilerplate. All `href` targets (`.html` slide pages and `.pptx` downloads) are preserved exactly. HTML validates cleanly with `html-validate`.