### PR TITLE
fix: prevent duplicate Help Improve banner on example pages

### DIFF
--- a/components/copyright-notice.js
+++ b/components/copyright-notice.js
@@ -18,7 +18,11 @@ const COMPONENTS_DIR = (() => {
 function ensureEditOnGithubLoaded() {
 	if (customElements.get("edit-on-github")) return;
 	if (!COMPONENTS_DIR) return;
-	if (document.querySelector('script[data-component="edit-on-github"]')) return;
+	// Match both dynamically-added (data-component) and manually-included
+	// <script src="…/edit-on-github.js"> tags to avoid loading the script twice
+	// when a page hand-includes it (which re-runs the top-level `const`
+	// declarations and throws "REPO_EDIT_URL has already been declared").
+	if (document.querySelector('script[data-component="edit-on-github"], script[src$="/edit-on-github.js"]')) return;
 	const s = document.createElement("script");
 	s.src = COMPONENTS_DIR + "edit-on-github.js";
 	s.defer = true;
@@ -35,7 +39,10 @@ class CopyrightNotice extends HTMLElement {
 			${this._getContent(type)}
 		`;
 		// Insert after <last-updated> sibling when present so the footer order is:
-		// copyright → last updated → help improve this page.
+		// copyright → last updated → help improve this page. Skip if the page
+		// already includes its own <edit-on-github> — otherwise example pages
+		// (which hand-include both) get the banner rendered twice.
+		if (document.querySelector("edit-on-github")) return;
 		const anchor = this.nextElementSibling?.tagName === "LAST-UPDATED" ? this.nextElementSibling : this;
 		anchor.insertAdjacentElement("afterend", document.createElement("edit-on-github"));
 	}


### PR DESCRIPTION
## Summary

42 example pages (e.g. `examples/Accept/Shortest.html`) render the "Help improve this page" footer twice and throw `Identifier 'REPO_EDIT_URL' has already been declared` in the console.

Root cause: those pages already include `<script src=".../edit-on-github.js">` and `<edit-on-github></edit-on-github>` in their source HTML. `copyright-notice.js` then unconditionally injects a *second* `<edit-on-github>` sibling and queues a *second* script tag (its existence check only matched the dynamically-added script, identified by `data-component`).

This change makes the injection defensive:

- Match the script by `src$="/edit-on-github.js"` so a hand-included `<script>` also counts.
- Skip the sibling insertion when a `<edit-on-github>` already exists anywhere in the document.

Verified locally on the preview server: `examples/Accept/Shortest.html` now renders one banner with no console errors; `course/COBOLIntro.html` (which only uses `<copyright-notice>` and relies on the auto-injection) still renders one banner.

## Test plan

- [ ] Visit an example page (e.g. `/examples/Accept/Shortest.html`) — one "Help improve this page" footer, no console errors.
- [ ] Visit a course page (e.g. `/course/COBOLIntro.html`) — one footer (no regression of auto-injection).
- [ ] Visit `/index.html` — no footer (page intentionally omits `<copyright-notice>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)