### PR TITLE
style: set body line-height to 1.55 for readable body text

### DIFF
--- a/course/Resources/css/course.css
+++ b/course/Resources/css/course.css
@@ -143,6 +143,7 @@ body {
 	margin: 0;
 	background-color: var(--color-bg);
 	color: var(--color-text);
+	line-height: 1.55;
 }
 
 a:link {


### PR DESCRIPTION
## Summary

Body text inherits `line-height: normal` (~1.2 in Times New Roman), which packs lines tightly enough to be hard to read on narrow screens. iPhone SE crawl showed paragraph leading at 17.1px on a 16px base — well below typical 1.5–1.6 reading-typography defaults.

Set `line-height: 1.55` on `body`. Paragraph leading becomes ~24.8px without affecting headings, code blocks, or anything else that sets its own line-height.

## Test plan

- [ ] Open any lesson page (e.g. `/course/COBOLIntro.html`) on mobile — paragraph text is noticeably more spaced.
- [ ] Code blocks (`pre[class*="language-"]`) still render at their own 1.35 line-height.
- [ ] `npm run validate` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)