### PR TITLE
fix: enlarge mobile tap targets to 44×44 minimum

### DIFF
--- a/course/Resources/css/course-components.css
+++ b/course/Resources/css/course-components.css
@@ -121,6 +121,9 @@
 		justify-content: center;
 		grid-column: 3;
 		grid-row: 1;
+		/* 44×44 minimum tap target (Apple HIG / WCAG 2.5.5). */
+		min-width: 44px;
+		min-height: 44px;
 		padding: 0.3em 0.5em;
 		background: none;
 		border: 1px solid var(--color-border-mute);
@@ -339,6 +342,14 @@ body :is(h1, h2, h3, h4, h5, h6) code[class*="language-"] .token {
 	height: 1.1em;
 	cursor: pointer;
 	margin: 0;
+}
+
+/* Touch devices need a larger checkbox to comfortably tap. */
+@media (pointer: coarse), (max-width: 600px) {
+	.lesson-checkbox-input {
+		width: 1.6em;
+		height: 1.6em;
+	}
 }
 
 .lesson-checkbox-meta {
@@ -1110,6 +1121,15 @@ body pre[class*="language-"] {
 	border-color: #388e3c;
 }
 
+/* Touch devices need a 44×44 minimum tap target (Apple HIG / WCAG 2.5.5). */
+@media (pointer: coarse), (max-width: 600px) {
+	.copy-button {
+		min-width: 44px;
+		min-height: 44px;
+		padding: 0.5em 0.85em;
+	}
+}
+
 /* ============================================================================
    "Run on Compiler Explorer" link button (components/run-in-ce.js)
    Visually mirrors .copy-button but rendered inline in document flow rather than
@@ -1203,6 +1223,16 @@ body pre[class*="language-"] {
 		transition:
 			background-color 0.15s,
 			color 0.15s;
+	}
+}
+
+/* Touch devices need a 44×44 minimum tap target (Apple HIG / WCAG 2.5.5);
+   the default sizing is comfortable for a mouse but cramped under a fingertip. */
+@media (pointer: coarse), (max-width: 600px) {
+	.theme-toggle__btn {
+		min-width: 44px;
+		min-height: 44px;
+		padding: 0.4em 0.6em;
 	}
 }
 


### PR DESCRIPTION
## Summary

iPhone SE crawl found four interactive controls below the Apple HIG / WCAG 2.5.5 44×44 minimum tap target:

| Target | Before | After |
|---|---|---|
| Hamburger menu | 39×33 | 44×44 |
| Theme-toggle button | 24×16 | 44×44 |
| Copy code button | 42×23 | 50×44 |
| Lesson checkbox | 15×15 | ~25×25 |

The hamburger only renders below 720 px, so its size is bumped directly inside the existing `@media (max-width: 720px)` block. The theme toggle, copy button, and lesson checkbox should stay compact when a mouse is in use, so they're scoped to `@media (pointer: coarse), (max-width: 600px)` — touch devices and small viewports get the larger sizing.

## Test plan

- [ ] Open any course page on a phone (or shrink browser to ≤ 600 px) — tap each control with a fingertip; no mis-taps.
- [ ] Open the same page on desktop with a mouse — theme-toggle and copy buttons retain their current compact sizing.
- [ ] Open a lesson page with `<lesson-checkbox>` (e.g. `/course/COBOLIntro.html`) — checkbox tap area is clearly larger on touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)