### PR TITLE
fix: switch search placeholder to compact form on mobile viewports

### DIFF
--- a/components/site-search.js
+++ b/components/site-search.js
@@ -43,7 +43,12 @@ class SiteSearch extends HTMLElement {
 	#pointer = -1;
 	#listboxId = "";
 
-	static #SHORT_MQL = window.matchMedia("(max-width: 360px)");
+	// Show the long placeholder only when the input is wide enough to display
+	// it without truncation. Below this, the (Ctrl+K) hint and even
+	// "exercises, examples" get clipped — and Ctrl+K is irrelevant on touch
+	// devices anyway. iPhone SE / Pixel-class phones (≤ 600 px) fall back to
+	// the compact "Search…" placeholder.
+	static #SHORT_MQL = window.matchMedia("(max-width: 600px)");
 	static #FULL_PLACEHOLDER = "Search lessons, exercises, examples… (Ctrl+K)";
 	static #SHORT_PLACEHOLDER = "Search…";
 


### PR DESCRIPTION
## Summary

At iPhone SE width (375 px) the site-search input is only ~250 px wide, so the full placeholder `Search lessons, exercises, examples… (Ctrl+K)` truncates to `Search lessons, exercises, examp` — and the `(Ctrl+K)` keyboard hint isn't reachable on touch anyway.

Raise the `SHORT_MQL` breakpoint from `max-width: 360px` to `max-width: 600px`. iPhone SE / Pixel-class phones now show the compact `Search…` placeholder while desktop users (≥ 601 px) keep the descriptive form with the keyboard hint.

## Test plan

- [ ] Resize browser to ≤ 600 px — placeholder reads `Search…` and is fully visible.
- [ ] Resize to ≥ 601 px — placeholder reads `Search lessons, exercises, examples… (Ctrl+K)` and is fully visible.
- [ ] Cmd/Ctrl+K still focuses the input at all widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)