### PR TITLE
fix: prevent stray horizontal scrollbar in search results dropdown

### DIFF
--- a/course/Resources/css/course-components.css
+++ b/course/Resources/css/course-components.css
@@ -1731,6 +1731,11 @@ copyright-notice .left {
 	top: 100%;
 	margin-top: 4px;
 	max-height: 60vh;
+	/* Both axes must be explicit. Setting only overflow-y leaves overflow-x at
+	   the spec-mandated computed value of `auto` (whenever the other axis is
+	   non-visible), which on narrow viewports caused a stray horizontal
+	   scrollbar under long result rows. */
+	overflow-x: hidden;
 	overflow-y: auto;
 	background-color: var(--color-bg);
 	border: 1px solid var(--color-border-mute);
@@ -1770,6 +1775,11 @@ copyright-notice .left {
 .site-search__result-title {
 	font-weight: bold;
 	color: var(--color-link);
+	/* Allow the flex item to shrink and wrap when titles outgrow the dropdown
+	   width (the surrounding row is display: flex, which sets min-width: auto
+	   on its children by default). */
+	min-width: 0;
+	overflow-wrap: anywhere;
 }
 
 .site-search__result-section {


### PR DESCRIPTION
## Summary

iPhone SE crawl found a horizontal scrollbar in the site-search results popup. Root cause: the `.site-search__results` block only set `overflow-y: auto`. Per CSS spec, when one overflow axis is non-`visible`, the other axis is forced to `auto` too — so the dropdown picked up an unwanted horizontal scroller on narrow viewports.

Explicitly set `overflow-x: hidden`, and give result titles `min-width: 0; overflow-wrap: anywhere` so a long word in a flex child can wrap rather than push the row past the container width.

## Test plan

- [ ] At 375 px width, open the search box, type `cobol` — dropdown shows results without a horizontal scrollbar at the bottom.
- [ ] Result titles that are wider than the dropdown wrap onto the next line instead of overflowing.
- [ ] Vertical scrolling within the dropdown still works when results exceed 60vh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)