### PR TITLE
fix: add aria-labels to View and Download links on examples index

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -161,7 +161,9 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Accept/ShortestProgram.cbl" aria-label="Download ShortestProgram.cbl">Download</a><br />
+										<a href="Accept/ShortestProgram.cbl" aria-label="Download ShortestProgram.cbl"
+											>Download</a
+										><br />
 										<a href="Accept/Shortest.html" aria-label="View Shortest.html">View</a>
 									</div>
 								</td>
@@ -186,7 +188,9 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Accept/AcceptAndDisplay.cbl" aria-label="Download AcceptAndDisplay.cbl">Download</a><br />
+										<a href="Accept/AcceptAndDisplay.cbl" aria-label="Download AcceptAndDisplay.cbl"
+											>Download</a
+										><br />
 										<a href="Accept/ACCEPT.html" aria-label="View ACCEPT.html">View</a>
 									</div>
 								</td>
@@ -208,7 +212,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Accept/Multiplier.cbl" aria-label="Download Multiplier.cbl">Download</a><br />
+										<a href="Accept/Multiplier.cbl" aria-label="Download Multiplier.cbl">Download</a
+										><br />
 										<a href="Accept/Multiplier.html" aria-label="View Multiplier.html">View</a>
 									</div>
 								</td>
@@ -248,7 +253,9 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Conditn/Iteration-If.cbl" aria-label="Download Iteration-If.cbl">Download</a><br />
+										<a href="Conditn/Iteration-If.cbl" aria-label="Download Iteration-If.cbl"
+											>Download</a
+										><br />
 										<a href="Conditn/IterIf.html" aria-label="View IterIf.html">View</a>
 									</div>
 								</td>
@@ -266,7 +273,9 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Conditn/CONDITIONS.cbl" aria-label="Download CONDITIONS.cbl">Download</a><br />
+										<a href="Conditn/CONDITIONS.cbl" aria-label="Download CONDITIONS.cbl"
+											>Download</a
+										><br />
 										<a href="Conditn/Conditions.html" aria-label="View Conditions.html">View</a>
 									</div>
 								</td>
@@ -286,7 +295,9 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Perform/PerformFormat1.cbl" aria-label="Download PerformFormat1.cbl">Download</a><br />
+										<a href="Perform/PerformFormat1.cbl" aria-label="Download PerformFormat1.cbl"
+											>Download</a
+										><br />
 										<a href="Perform/Perform1.html" aria-label="View Perform1.html">View</a>
 									</div>
 								</td>
@@ -306,7 +317,9 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Perform/PerformFormat1.cbl" aria-label="Download PerformFormat1.cbl">Download</a><br />
+										<a href="Perform/PerformFormat1.cbl" aria-label="Download PerformFormat1.cbl"
+											>Download</a
+										><br />
 										<a href="Perform/Perform2.html" aria-label="View Perform2.html">View</a>
 									</div>
 								</td>
@@ -331,7 +344,9 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Perform/PerformFormat3.cbl" aria-label="Download PerformFormat3.cbl">Download</a><br />
+										<a href="Perform/PerformFormat3.cbl" aria-label="Download PerformFormat3.cbl"
+											>Download</a
+										><br />
 										<a href="Perform/Perform3.html" aria-label="View Perform3.html">View</a>
 									</div>
 								</td>
@@ -352,7 +367,9 @@
 									</div>
 								</td>
 								<td>
-									<a href="Perform/PerformFormat4.cbl" aria-label="Download PerformFormat4.cbl">Download</a><br />
+									<a href="Perform/PerformFormat4.cbl" aria-label="Download PerformFormat4.cbl"
+										>Download</a
+									><br />
 									<a href="Perform/Perform4.html" aria-label="View Perform4.html">View</a>
 								</td>
 							</tr>
@@ -372,7 +389,9 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Perform/MileageCounter.cbl" aria-label="Download MileageCounter.cbl">Download</a><br />
+										<a href="Perform/MileageCounter.cbl" aria-label="Download MileageCounter.cbl"
+											>Download</a
+										><br />
 										<a href="Perform/MileageCount.html" aria-label="View MileageCount.html">View</a>
 									</div>
 								</td>
@@ -410,7 +429,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="SeqWrite/SEQWRITE.cbl" aria-label="Download SEQWRITE.cbl">Download</a><br />
+										<a href="SeqWrite/SEQWRITE.cbl" aria-label="Download SEQWRITE.cbl">Download</a
+										><br />
 										<a href="SeqWrite/SEQWRITE.html" aria-label="View SEQWRITE.html">View</a>
 									</div>
 								</td>
@@ -435,7 +455,9 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="SeqRead/SeqreadNo88.cbl" aria-label="Download SeqreadNo88.cbl">Download</a><br />
+										<a href="SeqRead/SeqreadNo88.cbl" aria-label="Download SeqreadNo88.cbl"
+											>Download</a
+										><br />
 										<a href="SeqRead/SEQREADno88.html" aria-label="View SEQREADno88.html">View</a>
 									</div>
 								</td>
@@ -462,7 +484,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="SeqRead/Seqread.cbl" aria-label="Download Seqread.cbl">Download</a><br />
+										<a href="SeqRead/Seqread.cbl" aria-label="Download Seqread.cbl">Download</a
+										><br />
 										<a href="SeqRead/SEQREAD.html" aria-label="View SEQREAD.html">View</a>
 									</div>
 								</td>
@@ -488,7 +511,9 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="SeqIns/InsertRecords.cbl" aria-label="Download InsertRecords.cbl">Download</a><br />
+										<a href="SeqIns/InsertRecords.cbl" aria-label="Download InsertRecords.cbl"
+											>Download</a
+										><br />
 										<a href="SeqIns/SEQINSERT.html" aria-label="View SEQINSERT.html">View</a>
 									</div>
 								</td>
@@ -512,7 +537,11 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="SeqRpt/StudentNumbersReport.cbl" aria-label="Download StudentNumbersReport.cbl">Download</a><br />
+										<a
+											href="SeqRpt/StudentNumbersReport.cbl"
+											aria-label="Download StudentNumbersReport.cbl"
+											>Download</a
+										><br />
 										<a href="SeqRpt/SEQRPT.html" aria-label="View SEQRPT.html">View</a>
 									</div>
 								</td>
@@ -540,7 +569,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="SeqUpd/SeqUpdate.cbl" aria-label="Download SeqUpdate.cbl">Download</a><br />
+										<a href="SeqUpd/SeqUpdate.cbl" aria-label="Download SeqUpdate.cbl">Download</a
+										><br />
 										<a href="SeqUpd/SeqUpdate.html" aria-label="View SeqUpdate.html">View</a>
 									</div>
 								</td>
@@ -575,7 +605,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Sort/InputSORT.cbl" aria-label="Download InputSORT.cbl">Download</a><br />
+										<a href="Sort/InputSORT.cbl" aria-label="Download InputSORT.cbl">Download</a
+										><br />
 										<a href="Sort/InputSort.html" aria-label="View InputSort.html">View</a>
 									</div>
 								</td>
@@ -597,7 +628,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Sort/MaleSORT.cbl" aria-label="Download MaleSORT.cbl">Download</a><br />
+										<a href="Sort/MaleSORT.cbl" aria-label="Download MaleSORT.cbl">Download</a
+										><br />
 										<a href="Sort/MaleSort.html" aria-label="View MaleSort.html">View</a>
 									</div>
 								</td>
@@ -621,7 +653,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Merge/MergeFiles.cbl" aria-label="Download MergeFiles.cbl">Download</a><br />
+										<a href="Merge/MergeFiles.cbl" aria-label="Download MergeFiles.cbl">Download</a
+										><br />
 										<a href="Merge/Merge.html" aria-label="View Merge.html">View</a>
 									</div>
 								</td>
@@ -649,8 +682,16 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="../exercises/Exm-AromaSalesRpt/AromaSalesRpt.cbl" aria-label="Download AromaSalesRpt.cbl">Download</a><br />
-										<a href="../exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html" aria-label="View Prg-AromaSalesSummaryRpt.html">View</a>
+										<a
+											href="../exercises/Exm-AromaSalesRpt/AromaSalesRpt.cbl"
+											aria-label="Download AromaSalesRpt.cbl"
+											>Download</a
+										><br />
+										<a
+											href="../exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html"
+											aria-label="View Prg-AromaSalesSummaryRpt.html"
+											>View</a
+										>
 									</div>
 								</td>
 							</tr>
@@ -676,9 +717,16 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="../exercises/Exm-CSISEmailDomain/CSISEmailDomain.cbl" aria-label="Download CSISEmailDomain.cbl">Download</a
+										<a
+											href="../exercises/Exm-CSISEmailDomain/CSISEmailDomain.cbl"
+											aria-label="Download CSISEmailDomain.cbl"
+											>Download</a
 										><br />
-										<a href="../exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html" aria-label="View Prg-CSISEmailDomain.html">View</a>
+										<a
+											href="../exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html"
+											aria-label="View Prg-CSISEmailDomain.html"
+											>View</a
+										>
 									</div>
 								</td>
 							</tr>
@@ -702,8 +750,16 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="../exercises/Exm-BestSellersRpt/BestSellers.cbl" aria-label="Download BestSellers.cbl">Download</a><br />
-										<a href="../exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html" aria-label="View Prg-FolioBestSellersRpt.html">View</a>
+										<a
+											href="../exercises/Exm-BestSellersRpt/BestSellers.cbl"
+											aria-label="Download BestSellers.cbl"
+											>Download</a
+										><br />
+										<a
+											href="../exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html"
+											aria-label="View Prg-FolioBestSellersRpt.html"
+											>View</a
+										>
 									</div>
 								</td>
 							</tr>
@@ -725,8 +781,16 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="../exercises/Exm-DueSubsRpt/DueSubsRpt.cbl" aria-label="Download DueSubsRpt.cbl">Download</a><br />
-										<a href="../exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html" aria-label="View Prg-DueSubsRpt.html">View</a>
+										<a
+											href="../exercises/Exm-DueSubsRpt/DueSubsRpt.cbl"
+											aria-label="Download DueSubsRpt.cbl"
+											>Download</a
+										><br />
+										<a
+											href="../exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html"
+											aria-label="View Prg-DueSubsRpt.html"
+											>View</a
+										>
 									</div>
 								</td>
 							</tr>
@@ -768,7 +832,9 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Relative/Seq2Rel.cbl" aria-label="Download Seq2Rel.cbl">Download<br /></a>
+										<a href="Relative/Seq2Rel.cbl" aria-label="Download Seq2Rel.cbl"
+											>Download<br
+										/></a>
 										<a href="Relative/Seq2Rel.html" aria-label="View Seq2Rel.html">View</a>
 									</div>
 								</td>
@@ -794,7 +860,9 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Relative/ReadRelative.cbl" aria-label="Download ReadRelative.cbl">Download<br /></a>
+										<a href="Relative/ReadRelative.cbl" aria-label="Download ReadRelative.cbl"
+											>Download<br
+										/></a>
 										<a href="Relative/ReadRel.html" aria-label="View ReadRel.html">View</a>
 									</div>
 								</td>
@@ -820,7 +888,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Indexed/Seq2Index.cbl" aria-label="Download Seq2Index.cbl">Download</a><br />
+										<a href="Indexed/Seq2Index.cbl" aria-label="Download Seq2Index.cbl">Download</a
+										><br />
 										<a href="Indexed/Seq2Index.html" aria-label="View Seq2Index.html">View</a>
 									</div>
 								</td>
@@ -840,8 +909,12 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Indexed/DirectReadIdx.cbl" aria-label="Download DirectReadIdx.cbl">Download</a><br />
-										<a href="Indexed/DirectReadIdx.html" aria-label="View DirectReadIdx.html">View</a>
+										<a href="Indexed/DirectReadIdx.cbl" aria-label="Download DirectReadIdx.cbl"
+											>Download</a
+										><br />
+										<a href="Indexed/DirectReadIdx.html" aria-label="View DirectReadIdx.html"
+											>View</a
+										>
 									</div>
 								</td>
 							</tr>
@@ -861,7 +934,9 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Indexed/SeqReadIdx.cbl" aria-label="Download SeqReadIdx.cbl">Download</a><br />
+										<a href="Indexed/SeqReadIdx.cbl" aria-label="Download SeqReadIdx.cbl"
+											>Download</a
+										><br />
 										<a href="Indexed/SeqReadIdx.html" aria-label="View SeqReadIdx.html">View</a>
 									</div>
 								</td>
@@ -896,8 +971,16 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="../exercises/Exm-StudFeesRpt/STUDFEES.cbl" aria-label="Download STUDFEES.cbl">Download</a><br />
-										<a href="../exercises/Exm-StudFeesRpt/Prg-StudPay.html" aria-label="View Prg-StudPay.html">View</a>
+										<a
+											href="../exercises/Exm-StudFeesRpt/STUDFEES.cbl"
+											aria-label="Download STUDFEES.cbl"
+											>Download</a
+										><br />
+										<a
+											href="../exercises/Exm-StudFeesRpt/Prg-StudPay.html"
+											aria-label="View Prg-StudPay.html"
+											>View</a
+										>
 									</div>
 								</td>
 							</tr>
@@ -933,12 +1016,15 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="../exercises/Exm-AromaOilFileMainRpt/Aroma96exam.cbl" aria-label="Download Aroma96exam.cbl">Download</a
+										<a
+											href="../exercises/Exm-AromaOilFileMainRpt/Aroma96exam.cbl"
+											aria-label="Download Aroma96exam.cbl"
+											>Download</a
 										><br />
 										<a
-	href="../exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html"
-	aria-label="View Prg-AromaOilFileMainRpt.html"
->View</a
+											href="../exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html"
+											aria-label="View Prg-AromaOilFileMainRpt.html"
+											>View</a
 										>
 									</div>
 								</td>
@@ -974,12 +1060,15 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="../exercises/Exm-BookshopLectReqRpt/BookshopRpt91.cbl" aria-label="Download BookshopRpt91.cbl">Download</a
+										<a
+											href="../exercises/Exm-BookshopLectReqRpt/BookshopRpt91.cbl"
+											aria-label="Download BookshopRpt91.cbl"
+											>Download</a
 										><br />
 										<a
-	href="../exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html"
-	aria-label="View Prg-BookshopLectReqRpt.html"
->View</a
+											href="../exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html"
+											aria-label="View Prg-BookshopLectReqRpt.html"
+											>View</a
 										>
 									</div>
 								</td>
@@ -1015,9 +1104,16 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="../exercises/Exm-RoyaltyPaymentsRpt/LibRoyaltyRpt.cbl" aria-label="Download LibRoyaltyRpt.cbl">Download</a
+										<a
+											href="../exercises/Exm-RoyaltyPaymentsRpt/LibRoyaltyRpt.cbl"
+											aria-label="Download LibRoyaltyRpt.cbl"
+											>Download</a
 										><br />
-										<a href="../exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html" aria-label="View Prg-LibRoyaltyRpt.html">View</a>
+										<a
+											href="../exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html"
+											aria-label="View Prg-LibRoyaltyRpt.html"
+											>View</a
+										>
 									</div>
 								</td>
 							</tr>
@@ -1044,8 +1140,16 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="../exercises/Exm-TopSupplierRpt/TopSupplierRpt.cbl" aria-label="Download TopSupplierRpt.cbl">Download</a><br />
-										<a href="../exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html" aria-label="View Prg-TopSupplierRpt.html">View</a>
+										<a
+											href="../exercises/Exm-TopSupplierRpt/TopSupplierRpt.cbl"
+											aria-label="Download TopSupplierRpt.cbl"
+											>Download</a
+										><br />
+										<a
+											href="../exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html"
+											aria-label="View Prg-TopSupplierRpt.html"
+											>View</a
+										>
 									</div>
 								</td>
 							</tr>
@@ -1087,8 +1191,12 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="SubProg/Multiply/DriverProg.cbl" aria-label="Download DriverProg.cbl">Download</a><br />
-										<a href="SubProg/Multiply/DriverProg.html" aria-label="View DriverProg.html">View</a>
+										<a href="SubProg/Multiply/DriverProg.cbl" aria-label="Download DriverProg.cbl"
+											>Download</a
+										><br />
+										<a href="SubProg/Multiply/DriverProg.html" aria-label="View DriverProg.html"
+											>View</a
+										>
 									</div>
 								</td>
 							</tr>
@@ -1111,8 +1219,14 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="SubProg/Multiply/MultiplyNums.cbl" aria-label="Download MultiplyNums.cbl">Download</a><br />
-										<a href="SubProg/Multiply/MultiplyNums.html" aria-label="View MultiplyNums.html">View</a>
+										<a
+											href="SubProg/Multiply/MultiplyNums.cbl"
+											aria-label="Download MultiplyNums.cbl"
+											>Download</a
+										><br />
+										<a href="SubProg/Multiply/MultiplyNums.html" aria-label="View MultiplyNums.html"
+											>View</a
+										>
 									</div>
 								</td>
 							</tr>
@@ -1134,7 +1248,9 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="SubProg/Multiply/Fickle.cbl" aria-label="Download Fickle.cbl">Download<br /></a>
+										<a href="SubProg/Multiply/Fickle.cbl" aria-label="Download Fickle.cbl"
+											>Download<br
+										/></a>
 										<a href="SubProg/Multiply/Fickle.html" aria-label="View Fickle.html">View</a>
 									</div>
 								</td>
@@ -1156,8 +1272,12 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="SubProg/Multiply/Steadfast.cbl" aria-label="Download Steadfast.cbl">Download</a><br />
-										<a href="SubProg/Multiply/Steadfast.html" aria-label="View Steadfast.html">View</a>
+										<a href="SubProg/Multiply/Steadfast.cbl" aria-label="Download Steadfast.cbl"
+											>Download</a
+										><br />
+										<a href="SubProg/Multiply/Steadfast.html" aria-label="View Steadfast.html"
+											>View</a
+										>
 									</div>
 								</td>
 							</tr>
@@ -1180,8 +1300,12 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="SubProg/DateValid/DateDriver.cbl" aria-label="Download DateDriver.cbl">Download</a><br />
-										<a href="SubProg/DateValid/DateDriver.html" aria-label="View DateDriver.html">View</a>
+										<a href="SubProg/DateValid/DateDriver.cbl" aria-label="Download DateDriver.cbl"
+											>Download</a
+										><br />
+										<a href="SubProg/DateValid/DateDriver.html" aria-label="View DateDriver.html"
+											>View</a
+										>
 									</div>
 								</td>
 							</tr>
@@ -1207,8 +1331,12 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="SubProg/DateValid/Validate.cbl" aria-label="Download Validate.cbl">Download</a><br />
-										<a href="SubProg/DateValid/ValiDate.html" aria-label="View ValiDate.html">View</a>
+										<a href="SubProg/DateValid/Validate.cbl" aria-label="Download Validate.cbl"
+											>Download</a
+										><br />
+										<a href="SubProg/DateValid/ValiDate.html" aria-label="View ValiDate.html"
+											>View</a
+										>
 									</div>
 								</td>
 							</tr>
@@ -1234,8 +1362,16 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="SubProg/DayDiff/DayDiffDriver.cbl" aria-label="Download DayDiffDriver.cbl">Download</a><br />
-										<a href="SubProg/DayDiff/DayDiffDriver.html" aria-label="View DayDiffDriver.html">View</a>
+										<a
+											href="SubProg/DayDiff/DayDiffDriver.cbl"
+											aria-label="Download DayDiffDriver.cbl"
+											>Download</a
+										><br />
+										<a
+											href="SubProg/DayDiff/DayDiffDriver.html"
+											aria-label="View DayDiffDriver.html"
+											>View</a
+										>
 									</div>
 								</td>
 							</tr>
@@ -1272,8 +1408,16 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="../exercises/Exm-AcmeStockReorder/Acme99.cbl" aria-label="Download Acme99.cbl">Download</a><br />
-										<a href="../exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html" aria-label="View Prg-AcmeStockReorder.html">View</a>
+										<a
+											href="../exercises/Exm-AcmeStockReorder/Acme99.cbl"
+											aria-label="Download Acme99.cbl"
+											>Download</a
+										><br />
+										<a
+											href="../exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html"
+											aria-label="View Prg-AcmeStockReorder.html"
+											>View</a
+										>
 									</div>
 								</td>
 							</tr>
@@ -1301,8 +1445,16 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="../exercises/Exm-SFbyMail/sfbymail.cbl" aria-label="Download sfbymail.cbl">Download</a><br />
-										<a href="../exercises/Exm-SFbyMail/Prg-SFbyMail.html" aria-label="View Prg-SFbyMail.html">View</a>
+										<a
+											href="../exercises/Exm-SFbyMail/sfbymail.cbl"
+											aria-label="Download sfbymail.cbl"
+											>Download</a
+										><br />
+										<a
+											href="../exercises/Exm-SFbyMail/Prg-SFbyMail.html"
+											aria-label="View Prg-SFbyMail.html"
+											>View</a
+										>
 									</div>
 								</td>
 							</tr>
@@ -1344,7 +1496,9 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Strings/RefModification.cbl" aria-label="Download RefModification.cbl">Download</a><br />
+										<a href="Strings/RefModification.cbl" aria-label="Download RefModification.cbl"
+											>Download</a
+										><br />
 										<a href="Strings/RefMod.html" aria-label="View RefMod.html">View</a>
 									</div>
 								</td>
@@ -1366,8 +1520,12 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Strings/UnstringFileEg.cbl" aria-label="Download UnstringFileEg.cbl">Download</a><br />
-										<a href="Strings/UnstringFileEg.html" aria-label="View UnstringFileEg.html">View</a>
+										<a href="Strings/UnstringFileEg.cbl" aria-label="Download UnstringFileEg.cbl"
+											>Download</a
+										><br />
+										<a href="Strings/UnstringFileEg.html" aria-label="View UnstringFileEg.html"
+											>View</a
+										>
 									</div>
 								</td>
 							</tr>
@@ -1398,8 +1556,16 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="../exercises/Exm-FileConversion/FileConv.cbl" aria-label="Download FileConv.cbl">Download</a><br />
-										<a href="../exercises/Exm-FileConversion/Prg-FileConversion.html" aria-label="View Prg-FileConversion.html">View</a>
+										<a
+											href="../exercises/Exm-FileConversion/FileConv.cbl"
+											aria-label="Download FileConv.cbl"
+											>Download</a
+										><br />
+										<a
+											href="../exercises/Exm-FileConversion/Prg-FileConversion.html"
+											aria-label="View Prg-FileConversion.html"
+											>View</a
+										>
 									</div>
 								</td>
 							</tr>
@@ -1436,7 +1602,11 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="ReportWriter/ReportExampleA.cbl" aria-label="Download ReportExampleA.cbl">Download<br /></a>
+										<a
+											href="ReportWriter/ReportExampleA.cbl"
+											aria-label="Download ReportExampleA.cbl"
+											>Download<br
+										/></a>
 										<a href="ReportWriter/RepWriteA.html" aria-label="View RepWriteA.html">View</a>
 									</div>
 								</td>
@@ -1460,7 +1630,11 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="ReportWriter/ReportExampleB.cbl" aria-label="Download ReportExampleB.cbl">Download</a><br />
+										<a
+											href="ReportWriter/ReportExampleB.cbl"
+											aria-label="Download ReportExampleB.cbl"
+											>Download</a
+										><br />
 										<a href="ReportWriter/RepWriteB.html" aria-label="View RepWriteB.html">View</a>
 									</div>
 								</td>
@@ -1485,8 +1659,14 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="ReportWriter/ReportExampleFull.cbl" aria-label="Download ReportExampleFull.cbl">Download</a><br />
-										<a href="ReportWriter/RepWriteFull.html" aria-label="View RepWriteFull.html">View</a>
+										<a
+											href="ReportWriter/ReportExampleFull.cbl"
+											aria-label="Download ReportExampleFull.cbl"
+											>Download</a
+										><br />
+										<a href="ReportWriter/RepWriteFull.html" aria-label="View RepWriteFull.html"
+											>View</a
+										>
 									</div>
 								</td>
 							</tr>
@@ -1510,8 +1690,14 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="ReportWriter/ReportExampleSummary.cbl" aria-label="Download ReportExampleSummary.cbl">Download</a><br />
-										<a href="ReportWriter/RepWriteSumm.html" aria-label="View RepWriteSumm.html">View</a>
+										<a
+											href="ReportWriter/ReportExampleSummary.cbl"
+											aria-label="Download ReportExampleSummary.cbl"
+											>Download</a
+										><br />
+										<a href="ReportWriter/RepWriteSumm.html" aria-label="View RepWriteSumm.html"
+											>View</a
+										>
 									</div>
 								</td>
 							</tr>
@@ -1553,7 +1739,9 @@
 								<td>
 									<div style="text-align: center">
 										<p>
-											<a href="Tables/MonthTable.cbl" aria-label="Download MonthTable.cbl">Download</a><br />
+											<a href="Tables/MonthTable.cbl" aria-label="Download MonthTable.cbl"
+												>Download</a
+											><br />
 											<a href="Tables/MonthTable.html" aria-label="View MonthTable.html">View</a>
 										</p>
 									</div>
@@ -1582,8 +1770,16 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="../exercises/Exm-FlyByNightTravel/FlyByNight.cbl" aria-label="Download FlyByNight.cbl">Download</a><br />
-										<a href="../exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html" aria-label="View Prg-FlyByNight.html">View</a>
+										<a
+											href="../exercises/Exm-FlyByNightTravel/FlyByNight.cbl"
+											aria-label="Download FlyByNight.cbl"
+											>Download</a
+										><br />
+										<a
+											href="../exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html"
+											aria-label="View Prg-FlyByNight.html"
+											>View</a
+										>
 									</div>
 								</td>
 							</tr>
@@ -1609,8 +1805,16 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="../exercises/Exm-USSRshipRpt/USSRSHIP.cbl" aria-label="Download USSRSHIP.cbl">Download</a><br />
-										<a href="../exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html" aria-label="View Prg-USSRshipRpt.html">View</a>
+										<a
+											href="../exercises/Exm-USSRshipRpt/USSRSHIP.cbl"
+											aria-label="Download USSRSHIP.cbl"
+											>Download</a
+										><br />
+										<a
+											href="../exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html"
+											aria-label="View Prg-USSRshipRpt.html"
+											>View</a
+										>
 									</div>
 								</td>
 							</tr>

--- a/examples/index.html
+++ b/examples/index.html
@@ -161,8 +161,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Accept/ShortestProgram.cbl">Download</a><br />
-										<a href="Accept/Shortest.html">View</a>
+										<a href="Accept/ShortestProgram.cbl" aria-label="Download ShortestProgram.cbl">Download</a><br />
+										<a href="Accept/Shortest.html" aria-label="View Shortest.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -186,8 +186,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Accept/AcceptAndDisplay.cbl">Download</a><br />
-										<a href="Accept/ACCEPT.html">View</a>
+										<a href="Accept/AcceptAndDisplay.cbl" aria-label="Download AcceptAndDisplay.cbl">Download</a><br />
+										<a href="Accept/ACCEPT.html" aria-label="View ACCEPT.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -208,8 +208,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Accept/Multiplier.cbl">Download</a><br />
-										<a href="Accept/Multiplier.html">View</a>
+										<a href="Accept/Multiplier.cbl" aria-label="Download Multiplier.cbl">Download</a><br />
+										<a href="Accept/Multiplier.html" aria-label="View Multiplier.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -248,8 +248,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Conditn/Iteration-If.cbl">Download</a><br />
-										<a href="Conditn/IterIf.html">View</a>
+										<a href="Conditn/Iteration-If.cbl" aria-label="Download Iteration-If.cbl">Download</a><br />
+										<a href="Conditn/IterIf.html" aria-label="View IterIf.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -266,8 +266,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Conditn/CONDITIONS.cbl">Download</a><br />
-										<a href="Conditn/Conditions.html">View</a>
+										<a href="Conditn/CONDITIONS.cbl" aria-label="Download CONDITIONS.cbl">Download</a><br />
+										<a href="Conditn/Conditions.html" aria-label="View Conditions.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -286,8 +286,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Perform/PerformFormat1.cbl">Download</a><br />
-										<a href="Perform/Perform1.html">View</a>
+										<a href="Perform/PerformFormat1.cbl" aria-label="Download PerformFormat1.cbl">Download</a><br />
+										<a href="Perform/Perform1.html" aria-label="View Perform1.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -306,8 +306,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Perform/PerformFormat1.cbl">Download</a><br />
-										<a href="Perform/Perform2.html">View</a>
+										<a href="Perform/PerformFormat1.cbl" aria-label="Download PerformFormat1.cbl">Download</a><br />
+										<a href="Perform/Perform2.html" aria-label="View Perform2.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -331,8 +331,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Perform/PerformFormat3.cbl">Download</a><br />
-										<a href="Perform/Perform3.html">View</a>
+										<a href="Perform/PerformFormat3.cbl" aria-label="Download PerformFormat3.cbl">Download</a><br />
+										<a href="Perform/Perform3.html" aria-label="View Perform3.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -352,8 +352,8 @@
 									</div>
 								</td>
 								<td>
-									<a href="Perform/PerformFormat4.cbl">Download</a><br />
-									<a href="Perform/Perform4.html">View</a>
+									<a href="Perform/PerformFormat4.cbl" aria-label="Download PerformFormat4.cbl">Download</a><br />
+									<a href="Perform/Perform4.html" aria-label="View Perform4.html">View</a>
 								</td>
 							</tr>
 							<tr>
@@ -372,8 +372,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Perform/MileageCounter.cbl">Download</a><br />
-										<a href="Perform/MileageCount.html">View</a>
+										<a href="Perform/MileageCounter.cbl" aria-label="Download MileageCounter.cbl">Download</a><br />
+										<a href="Perform/MileageCount.html" aria-label="View MileageCount.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -410,8 +410,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="SeqWrite/SEQWRITE.cbl">Download</a><br />
-										<a href="SeqWrite/SEQWRITE.html">View</a>
+										<a href="SeqWrite/SEQWRITE.cbl" aria-label="Download SEQWRITE.cbl">Download</a><br />
+										<a href="SeqWrite/SEQWRITE.html" aria-label="View SEQWRITE.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -435,8 +435,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="SeqRead/SeqreadNo88.cbl">Download</a><br />
-										<a href="SeqRead/SEQREADno88.html">View</a>
+										<a href="SeqRead/SeqreadNo88.cbl" aria-label="Download SeqreadNo88.cbl">Download</a><br />
+										<a href="SeqRead/SEQREADno88.html" aria-label="View SEQREADno88.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -462,8 +462,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="SeqRead/Seqread.cbl">Download</a><br />
-										<a href="SeqRead/SEQREAD.html">View</a>
+										<a href="SeqRead/Seqread.cbl" aria-label="Download Seqread.cbl">Download</a><br />
+										<a href="SeqRead/SEQREAD.html" aria-label="View SEQREAD.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -488,8 +488,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="SeqIns/InsertRecords.cbl">Download</a><br />
-										<a href="SeqIns/SEQINSERT.html">View</a>
+										<a href="SeqIns/InsertRecords.cbl" aria-label="Download InsertRecords.cbl">Download</a><br />
+										<a href="SeqIns/SEQINSERT.html" aria-label="View SEQINSERT.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -512,8 +512,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="SeqRpt/StudentNumbersReport.cbl">Download</a><br />
-										<a href="SeqRpt/SEQRPT.html">View</a>
+										<a href="SeqRpt/StudentNumbersReport.cbl" aria-label="Download StudentNumbersReport.cbl">Download</a><br />
+										<a href="SeqRpt/SEQRPT.html" aria-label="View SEQRPT.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -540,8 +540,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="SeqUpd/SeqUpdate.cbl">Download</a><br />
-										<a href="SeqUpd/SeqUpdate.html">View</a>
+										<a href="SeqUpd/SeqUpdate.cbl" aria-label="Download SeqUpdate.cbl">Download</a><br />
+										<a href="SeqUpd/SeqUpdate.html" aria-label="View SeqUpdate.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -575,8 +575,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Sort/InputSORT.cbl">Download</a><br />
-										<a href="Sort/InputSort.html">View</a>
+										<a href="Sort/InputSORT.cbl" aria-label="Download InputSORT.cbl">Download</a><br />
+										<a href="Sort/InputSort.html" aria-label="View InputSort.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -597,8 +597,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Sort/MaleSORT.cbl">Download</a><br />
-										<a href="Sort/MaleSort.html">View</a>
+										<a href="Sort/MaleSORT.cbl" aria-label="Download MaleSORT.cbl">Download</a><br />
+										<a href="Sort/MaleSort.html" aria-label="View MaleSort.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -621,8 +621,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Merge/MergeFiles.cbl">Download</a><br />
-										<a href="Merge/Merge.html">View</a>
+										<a href="Merge/MergeFiles.cbl" aria-label="Download MergeFiles.cbl">Download</a><br />
+										<a href="Merge/Merge.html" aria-label="View Merge.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -649,8 +649,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="../exercises/Exm-AromaSalesRpt/AromaSalesRpt.cbl">Download</a><br />
-										<a href="../exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html">View</a>
+										<a href="../exercises/Exm-AromaSalesRpt/AromaSalesRpt.cbl" aria-label="Download AromaSalesRpt.cbl">Download</a><br />
+										<a href="../exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html" aria-label="View Prg-AromaSalesSummaryRpt.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -676,9 +676,9 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="../exercises/Exm-CSISEmailDomain/CSISEmailDomain.cbl">Download</a
+										<a href="../exercises/Exm-CSISEmailDomain/CSISEmailDomain.cbl" aria-label="Download CSISEmailDomain.cbl">Download</a
 										><br />
-										<a href="../exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html">View</a>
+										<a href="../exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html" aria-label="View Prg-CSISEmailDomain.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -702,8 +702,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="../exercises/Exm-BestSellersRpt/BestSellers.cbl">Download</a><br />
-										<a href="../exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html">View</a>
+										<a href="../exercises/Exm-BestSellersRpt/BestSellers.cbl" aria-label="Download BestSellers.cbl">Download</a><br />
+										<a href="../exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html" aria-label="View Prg-FolioBestSellersRpt.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -725,8 +725,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="../exercises/Exm-DueSubsRpt/DueSubsRpt.cbl">Download</a><br />
-										<a href="../exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html">View</a>
+										<a href="../exercises/Exm-DueSubsRpt/DueSubsRpt.cbl" aria-label="Download DueSubsRpt.cbl">Download</a><br />
+										<a href="../exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html" aria-label="View Prg-DueSubsRpt.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -768,8 +768,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Relative/Seq2Rel.cbl">Download<br /></a>
-										<a href="Relative/Seq2Rel.html">View</a>
+										<a href="Relative/Seq2Rel.cbl" aria-label="Download Seq2Rel.cbl">Download<br /></a>
+										<a href="Relative/Seq2Rel.html" aria-label="View Seq2Rel.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -794,8 +794,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Relative/ReadRelative.cbl">Download<br /></a>
-										<a href="Relative/ReadRel.html">View</a>
+										<a href="Relative/ReadRelative.cbl" aria-label="Download ReadRelative.cbl">Download<br /></a>
+										<a href="Relative/ReadRel.html" aria-label="View ReadRel.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -820,8 +820,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Indexed/Seq2Index.cbl">Download</a><br />
-										<a href="Indexed/Seq2Index.html">View</a>
+										<a href="Indexed/Seq2Index.cbl" aria-label="Download Seq2Index.cbl">Download</a><br />
+										<a href="Indexed/Seq2Index.html" aria-label="View Seq2Index.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -840,8 +840,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Indexed/DirectReadIdx.cbl">Download</a><br />
-										<a href="Indexed/DirectReadIdx.html">View</a>
+										<a href="Indexed/DirectReadIdx.cbl" aria-label="Download DirectReadIdx.cbl">Download</a><br />
+										<a href="Indexed/DirectReadIdx.html" aria-label="View DirectReadIdx.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -861,8 +861,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Indexed/SeqReadIdx.cbl">Download</a><br />
-										<a href="Indexed/SeqReadIdx.html">View</a>
+										<a href="Indexed/SeqReadIdx.cbl" aria-label="Download SeqReadIdx.cbl">Download</a><br />
+										<a href="Indexed/SeqReadIdx.html" aria-label="View SeqReadIdx.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -896,8 +896,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="../exercises/Exm-StudFeesRpt/STUDFEES.cbl">Download</a><br />
-										<a href="../exercises/Exm-StudFeesRpt/Prg-StudPay.html">View</a>
+										<a href="../exercises/Exm-StudFeesRpt/STUDFEES.cbl" aria-label="Download STUDFEES.cbl">Download</a><br />
+										<a href="../exercises/Exm-StudFeesRpt/Prg-StudPay.html" aria-label="View Prg-StudPay.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -933,10 +933,12 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="../exercises/Exm-AromaOilFileMainRpt/Aroma96exam.cbl">Download</a
+										<a href="../exercises/Exm-AromaOilFileMainRpt/Aroma96exam.cbl" aria-label="Download Aroma96exam.cbl">Download</a
 										><br />
-										<a href="../exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html"
-											>View</a
+										<a
+	href="../exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html"
+	aria-label="View Prg-AromaOilFileMainRpt.html"
+>View</a
 										>
 									</div>
 								</td>
@@ -972,10 +974,12 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="../exercises/Exm-BookshopLectReqRpt/BookshopRpt91.cbl">Download</a
+										<a href="../exercises/Exm-BookshopLectReqRpt/BookshopRpt91.cbl" aria-label="Download BookshopRpt91.cbl">Download</a
 										><br />
-										<a href="../exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html"
-											>View</a
+										<a
+	href="../exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html"
+	aria-label="View Prg-BookshopLectReqRpt.html"
+>View</a
 										>
 									</div>
 								</td>
@@ -1011,9 +1015,9 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="../exercises/Exm-RoyaltyPaymentsRpt/LibRoyaltyRpt.cbl">Download</a
+										<a href="../exercises/Exm-RoyaltyPaymentsRpt/LibRoyaltyRpt.cbl" aria-label="Download LibRoyaltyRpt.cbl">Download</a
 										><br />
-										<a href="../exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html">View</a>
+										<a href="../exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html" aria-label="View Prg-LibRoyaltyRpt.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -1040,8 +1044,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="../exercises/Exm-TopSupplierRpt/TopSupplierRpt.cbl">Download</a><br />
-										<a href="../exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html">View</a>
+										<a href="../exercises/Exm-TopSupplierRpt/TopSupplierRpt.cbl" aria-label="Download TopSupplierRpt.cbl">Download</a><br />
+										<a href="../exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html" aria-label="View Prg-TopSupplierRpt.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -1083,8 +1087,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="SubProg/Multiply/DriverProg.cbl">Download</a><br />
-										<a href="SubProg/Multiply/DriverProg.html">View</a>
+										<a href="SubProg/Multiply/DriverProg.cbl" aria-label="Download DriverProg.cbl">Download</a><br />
+										<a href="SubProg/Multiply/DriverProg.html" aria-label="View DriverProg.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -1107,8 +1111,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="SubProg/Multiply/MultiplyNums.cbl">Download</a><br />
-										<a href="SubProg/Multiply/MultiplyNums.html">View</a>
+										<a href="SubProg/Multiply/MultiplyNums.cbl" aria-label="Download MultiplyNums.cbl">Download</a><br />
+										<a href="SubProg/Multiply/MultiplyNums.html" aria-label="View MultiplyNums.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -1130,8 +1134,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="SubProg/Multiply/Fickle.cbl">Download<br /></a>
-										<a href="SubProg/Multiply/Fickle.html">View</a>
+										<a href="SubProg/Multiply/Fickle.cbl" aria-label="Download Fickle.cbl">Download<br /></a>
+										<a href="SubProg/Multiply/Fickle.html" aria-label="View Fickle.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -1152,8 +1156,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="SubProg/Multiply/Steadfast.cbl">Download</a><br />
-										<a href="SubProg/Multiply/Steadfast.html">View</a>
+										<a href="SubProg/Multiply/Steadfast.cbl" aria-label="Download Steadfast.cbl">Download</a><br />
+										<a href="SubProg/Multiply/Steadfast.html" aria-label="View Steadfast.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -1176,8 +1180,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="SubProg/DateValid/DateDriver.cbl">Download</a><br />
-										<a href="SubProg/DateValid/DateDriver.html">View</a>
+										<a href="SubProg/DateValid/DateDriver.cbl" aria-label="Download DateDriver.cbl">Download</a><br />
+										<a href="SubProg/DateValid/DateDriver.html" aria-label="View DateDriver.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -1203,8 +1207,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="SubProg/DateValid/Validate.cbl">Download</a><br />
-										<a href="SubProg/DateValid/ValiDate.html">View</a>
+										<a href="SubProg/DateValid/Validate.cbl" aria-label="Download Validate.cbl">Download</a><br />
+										<a href="SubProg/DateValid/ValiDate.html" aria-label="View ValiDate.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -1230,8 +1234,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="SubProg/DayDiff/DayDiffDriver.cbl">Download</a><br />
-										<a href="SubProg/DayDiff/DayDiffDriver.html">View</a>
+										<a href="SubProg/DayDiff/DayDiffDriver.cbl" aria-label="Download DayDiffDriver.cbl">Download</a><br />
+										<a href="SubProg/DayDiff/DayDiffDriver.html" aria-label="View DayDiffDriver.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -1268,8 +1272,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="../exercises/Exm-AcmeStockReorder/Acme99.cbl">Download</a><br />
-										<a href="../exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html">View</a>
+										<a href="../exercises/Exm-AcmeStockReorder/Acme99.cbl" aria-label="Download Acme99.cbl">Download</a><br />
+										<a href="../exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html" aria-label="View Prg-AcmeStockReorder.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -1297,8 +1301,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="../exercises/Exm-SFbyMail/sfbymail.cbl">Download</a><br />
-										<a href="../exercises/Exm-SFbyMail/Prg-SFbyMail.html">View</a>
+										<a href="../exercises/Exm-SFbyMail/sfbymail.cbl" aria-label="Download sfbymail.cbl">Download</a><br />
+										<a href="../exercises/Exm-SFbyMail/Prg-SFbyMail.html" aria-label="View Prg-SFbyMail.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -1340,8 +1344,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Strings/RefModification.cbl">Download</a><br />
-										<a href="Strings/RefMod.html">View</a>
+										<a href="Strings/RefModification.cbl" aria-label="Download RefModification.cbl">Download</a><br />
+										<a href="Strings/RefMod.html" aria-label="View RefMod.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -1362,8 +1366,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="Strings/UnstringFileEg.cbl">Download</a><br />
-										<a href="Strings/UnstringFileEg.html">View</a>
+										<a href="Strings/UnstringFileEg.cbl" aria-label="Download UnstringFileEg.cbl">Download</a><br />
+										<a href="Strings/UnstringFileEg.html" aria-label="View UnstringFileEg.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -1394,8 +1398,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="../exercises/Exm-FileConversion/FileConv.cbl">Download</a><br />
-										<a href="../exercises/Exm-FileConversion/Prg-FileConversion.html">View</a>
+										<a href="../exercises/Exm-FileConversion/FileConv.cbl" aria-label="Download FileConv.cbl">Download</a><br />
+										<a href="../exercises/Exm-FileConversion/Prg-FileConversion.html" aria-label="View Prg-FileConversion.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -1432,8 +1436,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="ReportWriter/ReportExampleA.cbl">Download<br /></a>
-										<a href="ReportWriter/RepWriteA.html">View</a>
+										<a href="ReportWriter/ReportExampleA.cbl" aria-label="Download ReportExampleA.cbl">Download<br /></a>
+										<a href="ReportWriter/RepWriteA.html" aria-label="View RepWriteA.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -1456,8 +1460,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="ReportWriter/ReportExampleB.cbl">Download</a><br />
-										<a href="ReportWriter/RepWriteB.html">View</a>
+										<a href="ReportWriter/ReportExampleB.cbl" aria-label="Download ReportExampleB.cbl">Download</a><br />
+										<a href="ReportWriter/RepWriteB.html" aria-label="View RepWriteB.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -1481,8 +1485,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="ReportWriter/ReportExampleFull.cbl">Download</a><br />
-										<a href="ReportWriter/RepWriteFull.html">View</a>
+										<a href="ReportWriter/ReportExampleFull.cbl" aria-label="Download ReportExampleFull.cbl">Download</a><br />
+										<a href="ReportWriter/RepWriteFull.html" aria-label="View RepWriteFull.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -1506,8 +1510,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="ReportWriter/ReportExampleSummary.cbl">Download</a><br />
-										<a href="ReportWriter/RepWriteSumm.html">View</a>
+										<a href="ReportWriter/ReportExampleSummary.cbl" aria-label="Download ReportExampleSummary.cbl">Download</a><br />
+										<a href="ReportWriter/RepWriteSumm.html" aria-label="View RepWriteSumm.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -1549,8 +1553,8 @@
 								<td>
 									<div style="text-align: center">
 										<p>
-											<a href="Tables/MonthTable.cbl">Download</a><br />
-											<a href="Tables/MonthTable.html">View</a>
+											<a href="Tables/MonthTable.cbl" aria-label="Download MonthTable.cbl">Download</a><br />
+											<a href="Tables/MonthTable.html" aria-label="View MonthTable.html">View</a>
 										</p>
 									</div>
 								</td>
@@ -1578,8 +1582,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="../exercises/Exm-FlyByNightTravel/FlyByNight.cbl">Download</a><br />
-										<a href="../exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html">View</a>
+										<a href="../exercises/Exm-FlyByNightTravel/FlyByNight.cbl" aria-label="Download FlyByNight.cbl">Download</a><br />
+										<a href="../exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html" aria-label="View Prg-FlyByNight.html">View</a>
 									</div>
 								</td>
 							</tr>
@@ -1605,8 +1609,8 @@
 								</td>
 								<td>
 									<div style="text-align: center">
-										<a href="../exercises/Exm-USSRshipRpt/USSRSHIP.cbl">Download</a><br />
-										<a href="../exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html">View</a>
+										<a href="../exercises/Exm-USSRshipRpt/USSRSHIP.cbl" aria-label="Download USSRSHIP.cbl">Download</a><br />
+										<a href="../exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html" aria-label="View Prg-USSRshipRpt.html">View</a>
 									</div>
 								</td>
 							</tr>


### PR DESCRIPTION
## Summary

The 52 example rows on `examples/index.html` each have a "View" and a "Download" link. Visible text is identical row-to-row, so screen-reader users navigating by links hear "View link, Download link, View link, Download link…" with no way to distinguish them.

Add a per-link `aria-label` derived from the target filename (e.g. `aria-label="Download ShortestProgram.cbl"`, `aria-label="View Shortest.html"`) so each link has a unique accessible name. Visual rendering is unchanged.

## Test plan

- [ ] Tab through `examples/index.html` with a screen reader — each Download / View link announces a distinct, descriptive name.
- [ ] Visual page is unchanged.
- [ ] `npm run validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)