### PR TITLE
fix: reserve right padding so Copy button no longer overlays code

### DIFF
--- a/course/Resources/css/course.css
+++ b/course/Resources/css/course.css
@@ -213,6 +213,15 @@ body code[class*="language-"] {
 	overflow-wrap: break-word;
 }
 
+/* Reserve room on the right for the absolutely-positioned .copy-button
+   injected by components/copy-button.js (top: 0.4em; right: 0.4em). Without
+   this, short one-line snippets and any line that reaches the right edge
+   render directly under the button. 4em comfortably clears the button at
+   its mobile tap-target size (50×44 from PR #606). */
+body pre[class*="language-"] {
+	padding-right: 4em;
+}
+
 body {
 	-webkit-text-size-adjust: 100%;
 }


### PR DESCRIPTION
## Summary

`components/copy-button.js` absolutely-positions the Copy button at `top: 0.4em; right: 0.4em` inside every Prism `<pre>`. Short snippets (`ACCEPT Num1.`) and any line that reaches the right edge render directly under the button. PR #606 made the button larger on touch devices (50×44), so the overlap is more visible now.

Add `padding-right: 4em` to `body pre[class*="language-"]`. The code column never extends into the button's footprint at any viewport size. The `body` prefix bumps specificity above Prism's own `pre[class*="language-"]` rule so the override works regardless of stylesheet load order.

## Test plan

- [ ] Open a lesson page with short snippets (e.g. `/course/COBOLIntro.html`, scroll to "Program Statements and Data Items") — `ACCEPT Num1.` no longer renders under the Copy button.
- [ ] Lines that filled the previous width now wrap one column earlier; no horizontal scroll.
- [ ] Copy button itself still works (click → "Copied!").

🤖 Generated with [Claude Code](https://claude.com/claude-code)