### PR TITLE
style: align Simple Programming Exercises layout with other sections

### DIFF
--- a/exercises/index.html
+++ b/exercises/index.html
@@ -129,14 +129,14 @@
 							<p>Exercise to load, compile, run and alter an existing program.</p>
 						</dd>
 						<dt>
-							<span class="ball-blue" aria-hidden="true"></span
-							><a href="CountDown.html">CountDown</a>
+							<span class="ball-blue" aria-hidden="true"></span><a href="CountDown.html">CountDown</a>
 						</dt>
 						<dd>
 							<p>
 								Exercise using the <code class="language-cobol">ACCEPT</code>,
-								<code class="language-cobol">DISPLAY</code>, <code class="language-cobol">PERFORM</code>
-								... <code class="language-cobol">TIMES</code>,
+								<code class="language-cobol">DISPLAY</code>,
+								<code class="language-cobol">PERFORM</code> ...
+								<code class="language-cobol">TIMES</code>,
 								<code class="language-cobol">COMPUTE</code> and <code class="language-cobol">IF</code>.
 							</p>
 						</dd>
@@ -202,8 +202,7 @@
 							</p>
 						</dd>
 						<dt>
-							<span class="ball-blue" aria-hidden="true"></span
-							><a href="MonthTable.html">Using Tables</a>
+							<span class="ball-blue" aria-hidden="true"></span><a href="MonthTable.html">Using Tables</a>
 						</dt>
 						<dd>
 							<p><code class="language-cobol">READ</code>, pre-defined Tables, Tables.</p>

--- a/exercises/index.html
+++ b/exercises/index.html
@@ -54,14 +54,6 @@
 			content="These pages contain COBOL programming exercises with sample answers. Where required, test data files are also supplied."
 		/>
 		<style type="text/css">
-			/* Page-specific: exercises use a red bullet instead of course.css's green */
-			ul.toc {
-				list-style-type: disc;
-			}
-
-			ul.toc ::marker {
-				color: #cc3300;
-			}
 			/* Decorative disc bullet — replaces BallGreenG.gif (13×13 px) */
 			.ball-green {
 				display: inline-block;
@@ -127,59 +119,96 @@
 						complete, we allow the students 4 weeks to do it.
 					</p>
 					<hr />
-					<nav aria-label="Simple programming exercises">
-						<h2>Simple Programming Exercises</h2>
-						<ul class="toc">
-							<li>
-								<a href="GettingStarted.html">Getting Started</a> - Exercise to load, compile, run and
-								alter an existing program.
-							</li>
-							<li>
-								<a href="CountDown.html">CountDown</a> - Exercise using the
-								<code class="language-cobol">ACCEPT</code>, <code class="language-cobol">DISPLAY</code>,
-								<code class="language-cobol">PERFORM</code> ...
-								<code class="language-cobol">TIMES</code>,
-								<code class="language-cobol">COMPUTE</code> and <code class="language-cobol">IF</code> .
-							</li>
-							<li>
-								<a href="SeqRead.html">Reading Sequential Files</a>&nbsp; -
+					<h2>Simple Programming Exercises</h2>
+					<dl class="index-grid">
+						<dt>
+							<span class="ball-blue" aria-hidden="true"></span
+							><a href="GettingStarted.html">Getting Started</a>
+						</dt>
+						<dd>
+							<p>Exercise to load, compile, run and alter an existing program.</p>
+						</dd>
+						<dt>
+							<span class="ball-blue" aria-hidden="true"></span
+							><a href="CountDown.html">CountDown</a>
+						</dt>
+						<dd>
+							<p>
+								Exercise using the <code class="language-cobol">ACCEPT</code>,
+								<code class="language-cobol">DISPLAY</code>, <code class="language-cobol">PERFORM</code>
+								... <code class="language-cobol">TIMES</code>,
+								<code class="language-cobol">COMPUTE</code> and <code class="language-cobol">IF</code>.
+							</p>
+						</dd>
+						<dt>
+							<span class="ball-blue" aria-hidden="true"></span
+							><a href="SeqRead.html">Reading Sequential Files</a>
+						</dt>
+						<dd>
+							<p>
 								<code class="language-cobol">READ</code>,
 								<code class="language-cobol">PERFORM.. UNTIL</code>,
 								<code class="language-cobol">DISPLAY</code>
-							</li>
-							<li>
-								<a href="SeqReadIf.html">Counting records in a Sequential File</a> -
+							</p>
+						</dd>
+						<dt>
+							<span class="ball-blue" aria-hidden="true"></span
+							><a href="SeqReadIf.html">Counting records in a Sequential File</a>
+						</dt>
+						<dd>
+							<p>
 								<code class="language-cobol">READ</code>,
 								<code class="language-cobol">PERFORM..UNTIL</code>,
 								<code class="language-cobol">DISPLAY</code>, <code class="language-cobol">IF</code>,
 								<code class="language-cobol">COMPUTE</code>
-							</li>
-							<li>
-								<a href="SeqWrite.html">Writing to a Sequential File</a> -
+							</p>
+						</dd>
+						<dt>
+							<span class="ball-blue" aria-hidden="true"></span
+							><a href="SeqWrite.html">Writing to a Sequential File</a>
+						</dt>
+						<dd>
+							<p>
 								<code class="language-cobol">ACCEPT</code>, <code class="language-cobol">DISPLAY</code>,
 								<code class="language-cobol">WRITE</code>,
-								<code class="language-cobol">PERFORM..UNTIL</code>,
-							</li>
-							<li>
-								<a href="SeqInsert.html">Inserting records into a Sequential File</a> -
+								<code class="language-cobol">PERFORM..UNTIL</code>
+							</p>
+						</dd>
+						<dt>
+							<span class="ball-blue" aria-hidden="true"></span
+							><a href="SeqInsert.html">Inserting records into a Sequential File</a>
+						</dt>
+						<dd>
+							<p>
 								<code class="language-cobol">READ</code>, <code class="language-cobol">WRITE</code>,
-								<code class="language-cobol">PERFORM.. UNTIL</code>.
-							</li>
-							<li>
-								<a href="SeqUpdate.html">Updating records in a Sequential File</a> -
-								<code class="language-cobol">READ</code>, <code class="language-cobol">WRITE</code>.
-							</li>
-							<li>
-								<a href="SortIP.html">Sorting a Sequential File</a> -
+								<code class="language-cobol">PERFORM.. UNTIL</code>
+							</p>
+						</dd>
+						<dt>
+							<span class="ball-blue" aria-hidden="true"></span
+							><a href="SeqUpdate.html">Updating records in a Sequential File</a>
+						</dt>
+						<dd>
+							<p><code class="language-cobol">READ</code>, <code class="language-cobol">WRITE</code></p>
+						</dd>
+						<dt>
+							<span class="ball-blue" aria-hidden="true"></span
+							><a href="SortIP.html">Sorting a Sequential File</a>
+						</dt>
+						<dd>
+							<p>
 								<code class="language-cobol">SORT</code>, <code class="language-cobol">READ</code>,
 								<code class="language-cobol">RELEASE</code>, Input Procedure.
-							</li>
-							<li>
-								<a href="MonthTable.html">Using Tables</a> - <code class="language-cobol">READ</code>,
-								pre-defined Tables, Tables.
-							</li>
-						</ul>
-					</nav>
+							</p>
+						</dd>
+						<dt>
+							<span class="ball-blue" aria-hidden="true"></span
+							><a href="MonthTable.html">Using Tables</a>
+						</dt>
+						<dd>
+							<p><code class="language-cobol">READ</code>, pre-defined Tables, Tables.</p>
+						</dd>
+					</dl>
 					<hr />
 					<h2>Programming Exam Specifications</h2>
 					<dl class="index-grid">


### PR DESCRIPTION
## Summary

`exercises/index.html` rendered three sections with three different markup patterns:

| Section                          | Markup                       | Bullet     |
|---|---|---|
| Simple Programming Exercises     | `ul.toc` with `" - desc"` runs | red disc (`::marker`) |
| Programming Exam Specifications  | `dl.index-grid` (dt + dd)    | green ball (`<span class="ball-green">`) |
| Programming Project Specifications | `dl.index-grid` (dt + dd)    | orange ball (`<span class="ball-orange">`) |

Same page, three layouts. Convert the first section to the same `dl.index-grid` / dt / dd pattern, dropping the inline " - " separator (the dd column carries the description role now). Use `.ball-blue` (already defined in `course-components.css`) as the marker so it's distinct from the green / orange used by the other two sections.

Also delete the now-dead inline `ul.toc { list-style: disc }` + red `::marker` overrides — this page no longer renders any `ul.toc`.

## Test plan

- [ ] Open `/exercises/index.html` on desktop — all three sections render as a two-column grid (marker + bold link in the left column, description in the right). Blue / green / orange balls make the three sections visually distinct.
- [ ] Resize to ≤ 600 px — each section collapses to a single column (the existing `dl.index-grid` mobile rule kicks in), so all three behave the same way.
- [ ] `npm run validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)