### PR TITLE
fix: resolve two pre-existing WCAG2AA a11y violations

### DIFF
--- a/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html
+++ b/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html
@@ -406,13 +406,13 @@
 						<p>The list of UL courses and their Course Codes is given in the table below.</p>
 						<div class="center-block">
 							<table class="data-table">
+								<caption>
+									UL Courses and Course Codes
+								</caption>
 								<thead>
 									<tr>
-										<th colspan="2">UL Courses and Course Codes</th>
-									</tr>
-									<tr>
-										<th>Course Code</th>
-										<th>Course Name</th>
+										<th scope="col">Course Code</th>
+										<th scope="col">Course Name</th>
 									</tr>
 								</thead>
 								<tbody>

--- a/lectures/reportwriterssweb.html
+++ b/lectures/reportwriterssweb.html
@@ -310,7 +310,7 @@ FD  SalesFile.
     : intervening entries :
 
 REPORT SECTION.
-<b><span style="color: #FF3300">RD  SalesReport</span></b>
+<b><span style="color: #e32d00">RD  SalesReport</span></b>
     CONTROLS ARE FINAL
                  CityCode
                  SalesPersonNum
@@ -1321,7 +1321,7 @@ CheckShopSales SECTION.
     USE BEFORE REPORTING ShopTotalGrp.
 PrintMajorShopsOnly.
     IF SalesTotal &lt; 10000<b>
-       <span style="color: #FF3300">SUPPRESS PRINTING</span>
+       <span style="color: #e32d00">SUPPRESS PRINTING</span>
 </b>    END-IF.
 END DECLARATIVES.</pre>
 						<hr />

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,694 +2,694 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/COBOLIntro.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/COBOLcommands.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Copy.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/DataDeclaration.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/EditedPics.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/IndexedFiles.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Inspect.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Intro2DirectAccess.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Iteration.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/RefMod.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/RelativeFiles.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/ReportWriter.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/ReportWriterSS.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Call.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro1.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro2.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro3.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro4.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro5.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro6.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Commands1.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Commands2.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Condition1.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Condition2.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Data1.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Data2.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Perform1.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Perform2.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Search2.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile1.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2a.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2b.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2c.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2d.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2e.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile3a.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables1.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables2.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables3.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables4.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables5.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables7.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables8.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Search.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Selection.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles1.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles2.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles3.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SortMerge.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/String.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Subprograms.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Tables1.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Tables2.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Unstring.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Usage.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/glossary.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/index.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Accept/ACCEPT.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Accept/HelloWorld.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Accept/Multiplier.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Conditn/Conditions.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Conditn/IterCalc.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Conditn/IterIf.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Indexed/DirectReadIdx.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Indexed/Seq2Index.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Indexed/SeqReadIdx.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Indexed/WirthMemLib.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Merge/Merge.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/MileageCount.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform1.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform2.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform3.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform4.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Relative/ReadRel.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Relative/Seq2Rel.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteA.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteB.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteFull.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteSumm.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqIns/SEQINSERT.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREAD.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREADno88.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqRpt/SEQRPT.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqUpd/SeqUpdate.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqWrite/SEQWRITE.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Sort/InputSort.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Sort/MaleSort.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Sort/SortIP.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Strings/RefMod.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Strings/UnstringFileEg.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/DateDriver.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/ValiDate.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DayDiff/DayDiffDriver.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/DriverProg.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Fickle.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/MultiplyNums.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Steadfast.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Tables/MonthTable.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/index.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/COBOLExams/COBOLExams.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/CountDown.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FileConversion/Exm-FileConversion.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FileConversion/Prg-FileConversion.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-SFbyMail/Exm-SFbyMail.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-SFbyMail/Prg-SFbyMail.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-StudFeesRpt/Exm-StudPay.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-StudFeesRpt/Prg-StudPay.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/GettingStarted.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/MonthTable.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Proj-CSISEvalform/CSISEvalForm.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqInsert.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqRead.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqReadIf.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqUpdate.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqWrite.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SortIP.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/index.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/index.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/arithmetic.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/basics1.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/basics2.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/call.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/cobintro.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/conditions.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/copy.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/design.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/direct1.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/dsr1.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/genintro.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/index.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/indexed.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/inspect.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/perform.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/relative.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/reportwriterssweb.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/reportwriterweb.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/search.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/seqfile1.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/seqfile2.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/seqfile3.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/sort.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/string.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/tables1.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/tables2.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/unstring.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/usage.html</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary

Two pre-existing accessibility violations that the full-site a11y scan surfaces whenever a shared asset changes (e.g. PR #587 edits `components/run-in-ce.js`, which triggers the full scan instead of the partial diff-scan). Fixing them here so dependent PRs aren't blocked by unrelated debt.

- **`lectures/reportwriterssweb.html`** — two `<span style="color: #FF3300">` elements (`RD SalesReport`, `SUPPRESS PRINTING`) had a 3.67:1 contrast ratio on the light background, below the 4.5:1 normal-text threshold. Darkened to `#e32d00` (4.52:1), the exact colour pa11y recommended.
- **`exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html`** — the "UL Courses and Course Codes" table used a `<th colspan="2">` spanning row above the two column headers, creating multiple `<th>` levels (WCAG H43: such tables require `headers` attributes on every `<td>`). The spanning cell is really a table title, so it's moved to a `<caption>` and the remaining header row marked `scope="col"`.

## Verification

- `npx html-validate` on both files — pass
- Partial pa11y scan (`PA11Y_PARTIAL=1`) — CAOcalculator: **0 errors**
- `#e32d00` contrast on white verified at **4.52:1** (≥ 4.5:1) via the WCAG formula

## Test plan

- [ ] CI "Validate, links, and accessibility" passes (partial scan covers both changed pages)
- [ ] Visual check: the "UL Courses" table caption renders cleanly above the table
- [ ] Visual check: the recoloured report keywords remain legible

🤖 Generated with [Claude Code](https://claude.com/claude-code)