### PR TITLE
docs: replace remaining NetExpress command/compiler references

### DIFF
--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -311,9 +311,7 @@ Enter key : 1=VideoCode, 2=VideoTitle -&gt;2
 									></iframe>
 								</p>
 								<p>Below we see the results produced by a number of runs of the program.</p>
-								<pre
-									class="language-cobol"
-								><code class="language-cobol">Reading directly by VideoCode:
+								<pre class="language-cobol"><code class="language-cobol">Reading directly by VideoCode:
 Chose key VideoCode = 1,  VideoTitle = 2 -&gt;  1
 Enter Video Code (5 digits) -&gt; 02121
 02121    DIRTY DANCING                               04

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -223,7 +223,7 @@
 								<p>Below we see the results produced by two runs of the program.</p>
 								<pre
 									class="language-cobol"
-								><code class="language-cobol">RUN OF INDEX-EG2.EXE USING VIDEOCODE KEY
+								><code class="language-cobol">Reading sequentially by VideoCode (the primary key):
 Enter key : 1=VideoCode, 2=VideoTitle -&gt;1
 00121  FLIGHT OF THE CONDOR, THE     03
 00333  PREDATOR                      02
@@ -254,7 +254,7 @@ Enter key : 1=VideoCode, 2=VideoTitle -&gt;1
 
 
 
-RUN OF INDEX-EG2 USING VIDEOTITLE KEY
+Reading sequentially by VideoTitle (the alternate key):
 Enter key : 1=VideoCode, 2=VideoTitle -&gt;2
 17001  ALIEN                         07
 17002  ALIENS                        07
@@ -313,27 +313,27 @@ Enter key : 1=VideoCode, 2=VideoTitle -&gt;2
 								<p>Below we see the results produced by a number of runs of the program.</p>
 								<pre
 									class="language-cobol"
-								><code class="language-cobol">RUN OF INDEX-EG3.EXE USING VIDEOCODE
+								><code class="language-cobol">Reading directly by VideoCode:
 Chose key VideoCode = 1,  VideoTitle = 2 -&gt;  1
 Enter Video Code (5 digits) -&gt; 02121
 02121    DIRTY DANCING                               04
 
-RUN OF INDEX-EG3.EXE USING VIDEOCODE
+Reading directly by VideoCode:
 Chose key VideoCode = 1,  VideoTitle = 2 -&gt;  1
 Enter Video Code (5 digits) -&gt; 05051
 05051    OVERBOARD                                   01
 
-RUN OF INDEX-EG3.EXE USING VIDEOTITLE
+Reading directly by VideoTitle:
 Chose key VideoCode = 1,  VideoTitle = 2 -&gt;  2
 Enter Video Title (40 chars) -&gt; OVERBOARD
 05051    OVERBOARD                                   01
 
-RUN OF INDEX-EG3.EXE USING VIDEOTITLE
+Reading directly by VideoTitle:
 Chose key VideoCode = 1,  VideoTitle = 2 -&gt;  2
 Enter Video Title (40 chars) -&gt; DIRTY DANCING
 02121    DIRTY DANCING                               04
 
-RUN OF INDEX-EG3.EXE USING NON EXISTENT VIDEOCODE
+Reading directly by a VideoCode that does not exist:
 Chose key VideoCode = 1,  VideoTitle = 2 -&gt;  1
 Enter Video Code (5 digits) -&gt; 44444
 VIDEO STATUS :- 23</code></pre>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -363,7 +363,7 @@
 								<span class="i-detail" aria-hidden="true">🔍</span>
 							</p>
 							<p>
-								Although Netexpress does allow recursive Performs, this is a nonstandard extension.
+								Although some COBOL compilers allow recursive Performs, this is a nonstandard extension.
 								Please do not take advantage of it..
 							</p>
 						</aside>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -364,7 +364,7 @@
 							</p>
 							<p>
 								Although some COBOL compilers allow recursive Performs, this is a nonstandard extension.
-								Please do not take advantage of it..
+								Please do not take advantage of it.
 							</p>
 						</aside>
 					</div>


### PR DESCRIPTION
## Summary

A further pass on the Micro Focus NetExpress → GnuCOBOL cleanup, covering two course pages the earlier sweeps (#626, #628) didn't touch.

- **`course/IndexedFiles.html`:** the indexed-file example-output blocks were headed with NetExpress command syntax — `RUN OF INDEX-EG2.EXE USING VIDEOCODE KEY`, `RUN OF INDEX-EG3.EXE USING VIDEOTITLE`, etc. GnuCOBOL has no `RUN OF program.EXE` command, so the 7 headers are replaced with neutral run labels ("Reading sequentially by VideoCode (the primary key):", "Reading directly by a VideoCode that does not exist:", …). These lines are just descriptive separators within sample output — the program prompts for the key interactively — so no fabricated command line is introduced.
- **`course/Iteration.html`:** the recursive-PERFORM caveat now reads "Although some COBOL compilers allow recursive Performs…" instead of naming Netexpress.

## Deliberately out of scope

- The **"MicroFocus Ltd."** entry in `course/COBOLIntro.html` is a bibliography citation (publisher of a referenced article) — not altered.
- The numerous **"animated / animation icon"** references are teaching-aid GIFs, not the NetExpress Animator debugger.
- Dated **"OO-COBOL coming standard"** language is a separate language-modernization concern.

## Validation

- `npx html-validate` on both pages — passes (exit 0).
- Verified in the preview browser: IndexedFiles renders all 7 new run labels with no remaining `RUN OF` / `.EXE`, and Iteration shows the vendor-neutral wording.

Fixes #629

## Test plan

- [ ] Confirm the IndexedFiles run labels read clearly as separators within the example output.
- [ ] Confirm "some COBOL compilers" is the phrasing you want for the recursive-PERFORM note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)