### PR TITLE
fix: remove duplicate stale JSON-LD block from Iteration.html

### DIFF
--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -48,6 +48,21 @@
 				"learningResourceType": "Tutorial"
 			}
 		</script>
+		<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "LearningResource",
+				"name": "COBOL Iteration Constructs",
+				"description": "A tutorial covering COBOL iteration constructs including PERFORM..Proc, PERFORM..THRU, PERFORM..TIMES, PERFORM..UNTIL, and PERFORM..VARYING.",
+				"url": "https://bushidocodes.github.io/limerick-cobol/course/Iteration.html",
+				"learningResourceType": "Tutorial",
+				"educationalLevel": "Beginner",
+				"isPartOf": {
+					"@type": "Course",
+					"url": "https://bushidocodes.github.io/limerick-cobol/course/index.html"
+				}
+			}
+		</script>
 		<title>Iteration in COBOL</title>
 		<meta
 			name="description"

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -48,21 +48,6 @@
 				"learningResourceType": "Tutorial"
 			}
 		</script>
-		<script type="application/ld+json">
-			{
-				"@context": "https://schema.org",
-				"@type": "LearningResource",
-				"name": "COBOL Iteration Constructs",
-				"description": "A tutorial covering COBOL iteration constructs including PERFORM..Proc, PERFORM..THRU, PERFORM..TIMES, PERFORM..UNTIL, and PERFORM..VARYING.",
-				"url": "https://www.csis.ul.ie/cobol/course/Iteration.html",
-				"learningResourceType": "Tutorial",
-				"educationalLevel": "Beginner",
-				"isPartOf": {
-					"@type": "Course",
-					"url": "https://www.csis.ul.ie/cobol/course/index.html"
-				}
-			}
-		</script>
 		<title>Iteration in COBOL</title>
 		<meta
 			name="description"

--- a/course/lesson-meta.json
+++ b/course/lesson-meta.json
@@ -143,21 +143,21 @@
 		"position": 21,
 		"file": "String.html",
 		"title": "String",
-		"description": "The aim of this unit is to provide to provide you with a solid understanding of the STRING verb.",
+		"description": "The aim of this unit is to provide you with a solid understanding of the STRING verb.",
 		"url": "https://bushidocodes.github.io/limerick-cobol/course/String.html"
 	},
 	{
 		"position": 22,
 		"file": "Unstring.html",
 		"title": "Unstring",
-		"description": "The aim of this unit is to provide to provide you with a solid understanding of the UNSTRING verb.",
+		"description": "The aim of this unit is to provide you with a solid understanding of the UNSTRING verb.",
 		"url": "https://bushidocodes.github.io/limerick-cobol/course/unstring.html"
 	},
 	{
 		"position": 23,
 		"file": "RefMod.html",
 		"title": "Reference modification and Intrinsic Functions",
-		"description": "The aim of this unit is to provide to provide you with a solid understanding of string manipulation using Reference Modification. It will also introduce",
+		"description": "The aim of this unit is to provide you with a solid understanding of string manipulation using Reference Modification. It will also introduce",
 		"url": "https://bushidocodes.github.io/limerick-cobol/course/RefMod.html"
 	},
 	{

--- a/scripts/generate-lesson-jsonld.js
+++ b/scripts/generate-lesson-jsonld.js
@@ -96,7 +96,7 @@ function buildJsonLdBlock(entry) {
 function injectJsonLd(html, block) {
 	// Strip existing LearningResource block (idempotency).
 	html = html.replace(
-		/\t\t<script type="application\/ld\+json">\n\t\t\t\{[\s\S]*?"@type": "LearningResource"[\s\S]*?<\/script>\n/,
+		/\t\t<script type="application\/ld\+json">\n\t\t\t\{[\s\S]*?"@type": "LearningResource"[\s\S]*?<\/script>\n/g,
 		"",
 	);
 


### PR DESCRIPTION
## Summary

- Removes the legacy `LearningResource` JSON-LD block from `course/Iteration.html` that pointed to the dead `csis.ul.ie` domain
- Fixes the root cause in `scripts/generate-lesson-jsonld.js`: adds the `/g` flag to the idempotency regex so **all** pre-existing `LearningResource` blocks are stripped before re-injection (previously only the first match was removed, leaving any second legacy block untouched)

## Test plan

- [x] `node scripts/generate-lesson-jsonld.js` runs cleanly (25 entries written)
- [x] `course/Iteration.html` now has exactly one `application/ld+json` block
- [x] `npm run validate` passes

Fixes #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)