### PR TITLE
refactor: derive lesson sequence from lesson-manifest.json in add-prev-next-links and add-reading-time

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -139,7 +139,7 @@
 				<page-toc></page-toc>
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="The Structure of COBOL Programs" reading-time="26 min"></page-hero>
+						<page-hero title="The Structure of COBOL Programs" reading-time="25 min"></page-hero>
 						<hr />
 						<lesson-toc></lesson-toc>
 					</div>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -116,7 +116,7 @@
 				<!-- Introduction -->
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="Basic Procedure Division Commands" reading-time="14 min"></page-hero>
+						<page-hero title="Basic Procedure Division Commands" reading-time="13 min"></page-hero>
 						<hr />
 						<lesson-toc></lesson-toc>
 					</div>

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -115,7 +115,7 @@
 				<page-toc></page-toc>
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="Edited Pictures" reading-time="14 min"></page-hero>
+						<page-hero title="Edited Pictures" reading-time="13 min"></page-hero>
 						<hr />
 						<lesson-toc></lesson-toc>
 					</div>

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -120,7 +120,7 @@
 				<page-toc></page-toc>
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="Indexed Files" reading-time="19 min"></page-hero>
+						<page-hero title="Indexed Files" reading-time="18 min"></page-hero>
 						<hr />
 						<lesson-toc></lesson-toc>
 						<!-- Introduction -->

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -114,7 +114,7 @@
 				<page-toc></page-toc>
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="INSPECT" reading-time="8 min"></page-hero>
+						<page-hero title="INSPECT" reading-time="7 min"></page-hero>
 						<hr />
 						<lesson-toc></lesson-toc>
 					</div>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -130,7 +130,7 @@
 				<page-toc></page-toc>
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="Iteration in COBOL" reading-time="21 min"></page-hero>
+						<page-hero title="Iteration in COBOL" reading-time="20 min"></page-hero>
 						<hr />
 						<lesson-toc></lesson-toc>
 					</div>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -116,7 +116,7 @@
 					<div class="section-full">
 						<page-hero
 							title="Reference Modification and Intrinsic Functions"
-							reading-time="15 min"
+							reading-time="14 min"
 						></page-hero>
 						<hr />
 						<lesson-toc></lesson-toc>

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -115,7 +115,7 @@
 				<page-toc></page-toc>
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="Report Writer by Example" reading-time="19 min"></page-hero>
+						<page-hero title="Report Writer by Example" reading-time="18 min"></page-hero>
 						<hr />
 						<lesson-toc></lesson-toc>
 					</div>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -114,7 +114,7 @@
 				<page-toc></page-toc>
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="Report Writer Syntax and Semantics" reading-time="20 min"></page-hero>
+						<page-hero title="Report Writer Syntax and Semantics" reading-time="19 min"></page-hero>
 						<hr />
 						<lesson-toc></lesson-toc>
 					</div>

--- a/course/Search.html
+++ b/course/Search.html
@@ -115,7 +115,7 @@
 				<page-toc></page-toc>
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="Searching Tables" reading-time="21 min"></page-hero>
+						<page-hero title="Searching Tables" reading-time="20 min"></page-hero>
 						<hr />
 						<lesson-toc></lesson-toc>
 					</div>

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -128,7 +128,7 @@
 				<!-- Header / TOC + Introduction section -->
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="Selection in COBOL" reading-time="21 min"></page-hero>
+						<page-hero title="Selection in COBOL" reading-time="20 min"></page-hero>
 						<hr />
 						<lesson-toc></lesson-toc>
 					</div>

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -115,7 +115,7 @@
 				<page-toc></page-toc>
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="Introduction to Sequential Files" reading-time="16 min"></page-hero>
+						<page-hero title="Introduction to Sequential Files" reading-time="15 min"></page-hero>
 						<hr />
 						<lesson-toc></lesson-toc>
 					</div>

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -117,7 +117,7 @@
 					<div class="section-full">
 						<page-hero
 							title="COBOL Print Files and Variable-Length Records"
-							reading-time="19 min"
+							reading-time="18 min"
 						></page-hero>
 						<hr />
 						<lesson-toc></lesson-toc>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -116,7 +116,7 @@
 				<!-- Introduction -->
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="Sorting and Merging" reading-time="27 min"></page-hero>
+						<page-hero title="Sorting and Merging" reading-time="26 min"></page-hero>
 						<hr />
 						<lesson-toc></lesson-toc>
 					</div>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -115,7 +115,7 @@
 				<page-toc></page-toc>
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="Contained and External Sub-Programs" reading-time="22 min"></page-hero>
+						<page-hero title="Contained and External Sub-Programs" reading-time="21 min"></page-hero>
 						<hr />
 						<lesson-toc></lesson-toc>
 					</div>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -115,7 +115,7 @@
 				<page-toc></page-toc>
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="Using Tables" reading-time="11 min"></page-hero>
+						<page-hero title="Using Tables" reading-time="10 min"></page-hero>
 						<hr />
 						<lesson-toc></lesson-toc>
 					</div>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -153,7 +153,7 @@
 				<page-toc></page-toc>
 				<div class="section-grid">
 					<div class="section-full">
-						<page-hero title="Creating Tables - Syntax and Semantics" reading-time="27 min"></page-hero>
+						<page-hero title="Creating Tables - Syntax and Semantics" reading-time="26 min"></page-hero>
 						<hr />
 						<lesson-toc></lesson-toc>
 					</div>

--- a/scripts/add-prev-next-links.js
+++ b/scripts/add-prev-next-links.js
@@ -18,36 +18,20 @@ const path = require("path");
 
 const REPO_ROOT = path.resolve(__dirname, "..");
 const COURSE_DIR = path.join(REPO_ROOT, "course");
+const MANIFEST_PATH = path.join(COURSE_DIR, "lesson-manifest.json");
 const BASE_URL = "https://bushidocodes.github.io/limerick-cobol/course/";
 
-// Lesson sequence — mirrors the array in components/lesson-progress.js.
-const LESSON_SEQUENCE = [
-	{ file: "COBOLIntro.html" },
-	{ file: "DataDeclaration.html" },
-	{ file: "COBOLcommands.html" },
-	{ file: "Selection.html" },
-	{ file: "Iteration.html" },
-	{ file: "SequentialFiles1.html" },
-	{ file: "SequentialFiles2.html" },
-	{ file: "EditedPics.html" },
-	{ file: "Usage.html" },
-	{ file: "SequentialFiles3.html" },
-	{ file: "SortMerge.html" },
-	{ file: "Intro2DirectAccess.html" },
-	{ file: "RelativeFiles.html" },
-	{ file: "IndexedFiles.html" },
-	{ file: "Tables1.html" },
-	{ file: "Tables2.html" },
-	{ file: "Search.html" },
-	{ file: "Subprograms.html" },
-	{ file: "Copy.html" },
-	{ file: "Inspect.html" },
-	{ file: "String.html" },
-	{ file: "Unstring.html" },
-	{ file: "RefMod.html" },
-	{ file: "ReportWriter.html" },
-	{ file: "ReportWriterSS.html" },
-];
+const manifest = JSON.parse(fs.readFileSync(MANIFEST_PATH, "utf8"));
+const _seen = new Set();
+const LESSON_SEQUENCE = [];
+for (const topic of manifest.topics) {
+	for (const link of topic.links) {
+		if (link.type === "tutorial" && !_seen.has(link.file)) {
+			_seen.add(link.file);
+			LESSON_SEQUENCE.push({ file: link.file });
+		}
+	}
+}
 
 /**
  * Build the prev/next link tag block to inject.

--- a/scripts/add-reading-time.js
+++ b/scripts/add-reading-time.js
@@ -17,37 +17,21 @@ const path = require("path");
 
 const REPO_ROOT = path.resolve(__dirname, "..");
 const COURSE_DIR = path.join(REPO_ROOT, "course");
+const MANIFEST_PATH = path.join(COURSE_DIR, "lesson-manifest.json");
 
 const WPM = 200;
 
-// Mirrors LESSON_SEQUENCE in generate-lesson-jsonld.js.
-const LESSON_FILES = [
-	"COBOLIntro.html",
-	"DataDeclaration.html",
-	"COBOLcommands.html",
-	"Selection.html",
-	"Iteration.html",
-	"SequentialFiles1.html",
-	"SequentialFiles2.html",
-	"EditedPics.html",
-	"Usage.html",
-	"SequentialFiles3.html",
-	"SortMerge.html",
-	"Intro2DirectAccess.html",
-	"RelativeFiles.html",
-	"IndexedFiles.html",
-	"Tables1.html",
-	"Tables2.html",
-	"Search.html",
-	"Subprograms.html",
-	"Copy.html",
-	"Inspect.html",
-	"String.html",
-	"Unstring.html",
-	"RefMod.html",
-	"ReportWriter.html",
-	"ReportWriterSS.html",
-];
+const manifest = JSON.parse(fs.readFileSync(MANIFEST_PATH, "utf8"));
+const _seen = new Set();
+const LESSON_FILES = [];
+for (const topic of manifest.topics) {
+	for (const link of topic.links) {
+		if (link.type === "tutorial" && !_seen.has(link.file)) {
+			_seen.add(link.file);
+			LESSON_FILES.push(link.file);
+		}
+	}
+}
 
 /** Extract visible text from the <body> element, stripping scripts and tags. */
 function extractBodyText(html) {


### PR DESCRIPTION
## Summary

- `add-prev-next-links.js` and `add-reading-time.js` both hardcoded the 25-lesson sequence as a static array, which silently produces wrong output when lessons are added to `course/lesson-manifest.json`
- Both scripts now derive the sequence dynamically from `lesson-manifest.json`, using the same pattern already in `generate-lesson-jsonld.js`
- Reading-time values for all lesson pages were regenerated as part of running the updated script

## Test plan

- [x] `node scripts/add-prev-next-links.js` — all 25 lessons OK
- [x] `node scripts/add-reading-time.js` — all 25 lessons OK
- [x] `npm run validate` passes

Fixes #636

🤖 Generated with [Claude Code](https://claude.com/claude-code)