### PR TITLE
fix: address all open Dependabot and code-scanning security alerts

### DIFF
--- a/.claude/scripts/convert_toc.py
+++ b/.claude/scripts/convert_toc.py
@@ -64,12 +64,10 @@ TOC_UL_RE = re.compile(
     re.DOTALL | re.IGNORECASE,
 )
 LI_RE = re.compile(r'<li\b[^>]*>(.*?)</li>', re.DOTALL | re.IGNORECASE)
-# Trailing <br>/<br/> sequences (possibly nested in stray empty </font>, </b>,
-# whitespace, etc.) at the end of a block of content.
-TRAILING_BR_RE = re.compile(
-    r'(?:\s*<br\s*/?\s*>)+\s*$',
-    re.IGNORECASE,
-)
+# Matches a single trailing <br> tag (with optional whitespace) at the end of a
+# string.  Used iteratively in strip_trailing_brs_in_block() rather than as a
+# repeating group so that nested quantifiers don't create a ReDoS risk.
+_SINGLE_TRAILING_BR_RE = re.compile(r'\s*<br\s*/?>\s*$', re.IGNORECASE)
 
 
 def toc_css(ball_url: str) -> str:
@@ -136,7 +134,11 @@ def strip_trailing_brs_in_block(content: str) -> str:
         if open_re.search(inside):
             return open_re.sub('', inside).rstrip()
         return inside + m.group(2)
-    return TRAILING_BR_RE.sub('', content)
+    prev = None
+    while content != prev:
+        prev = content
+        content = _SINGLE_TRAILING_BR_RE.sub('', content)
+    return content
 
 
 WRAPPER_RE = re.compile(

--- a/components/site-header.js
+++ b/components/site-header.js
@@ -48,35 +48,68 @@
 	ensureScript("breadcrumbs.js");
 	ensureScript("course-sidebar.js");
 
-	function buildNavItems() {
-		const path = location.pathname;
-		return NAV_SECTIONS.map((s) => {
-			const isActive = new RegExp("/" + s.dir + "/").test(path);
-			const attrs = isActive ? ' data-active aria-current="page"' : "";
-			return `<li><a href="${baseUrl}${s.entry}"${attrs}>${s.label}</a></li>`;
-		}).join("");
-	}
-
-	function buildNavHTML() {
-		return `<nav class="site-nav" aria-label="Primary"><ul>${buildNavItems()}</ul></nav>`;
+	function buildNavUl() {
+		const navPath = location.pathname;
+		const ul = document.createElement("ul");
+		NAV_SECTIONS.forEach((s) => {
+			const isActive = new RegExp("/" + s.dir + "/").test(navPath);
+			const li = document.createElement("li");
+			const a = document.createElement("a");
+			a.href = baseUrl + s.entry;
+			if (isActive) {
+				a.setAttribute("data-active", "");
+				a.setAttribute("aria-current", "page");
+			}
+			a.textContent = s.label;
+			li.appendChild(a);
+			ul.appendChild(li);
+		});
+		return ul;
 	}
 
 	function inject() {
 		if (document.querySelector(".site-header")) return;
 		const header = document.createElement("header");
 		header.className = "site-header";
-		header.innerHTML =
-			`<a class="site-header__logo" href="${homeUrl}">` +
-			`<img src="${faviconUrl}" alt="COBOL Tutorial" width="32" height="28">` +
-			`</a>${buildNavHTML()}<site-search></site-search>` +
-			`<button class="site-header__hamburger" type="button" ` +
-			`aria-expanded="false" aria-controls="${MOBILE_NAV_ID}" ` +
-			`aria-label="Open navigation">` +
-			`<span aria-hidden="true">&#9776;</span>` +
-			`</button>` +
-			`<nav id="${MOBILE_NAV_ID}" class="site-nav-mobile" aria-label="Primary" hidden>` +
-			`<ul>${buildNavItems()}</ul>` +
-			`</nav>`;
+
+		const logo = document.createElement("a");
+		logo.className = "site-header__logo";
+		logo.href = homeUrl;
+		const logoImg = document.createElement("img");
+		logoImg.src = faviconUrl;
+		logoImg.alt = "COBOL Tutorial";
+		logoImg.width = 32;
+		logoImg.height = 28;
+		logo.appendChild(logoImg);
+		header.appendChild(logo);
+
+		const nav = document.createElement("nav");
+		nav.className = "site-nav";
+		nav.setAttribute("aria-label", "Primary");
+		nav.appendChild(buildNavUl());
+		header.appendChild(nav);
+
+		header.appendChild(document.createElement("site-search"));
+
+		const btn = document.createElement("button");
+		btn.className = "site-header__hamburger";
+		btn.type = "button";
+		btn.setAttribute("aria-expanded", "false");
+		btn.setAttribute("aria-controls", MOBILE_NAV_ID);
+		btn.setAttribute("aria-label", "Open navigation");
+		const hamburgerSpan = document.createElement("span");
+		hamburgerSpan.setAttribute("aria-hidden", "true");
+		hamburgerSpan.textContent = "☰";
+		btn.appendChild(hamburgerSpan);
+		header.appendChild(btn);
+
+		const mobileNav = document.createElement("nav");
+		mobileNav.id = MOBILE_NAV_ID;
+		mobileNav.className = "site-nav-mobile";
+		mobileNav.setAttribute("aria-label", "Primary");
+		mobileNav.hidden = true;
+		mobileNav.appendChild(buildNavUl());
+		header.appendChild(mobileNav);
 
 		const skipLink = document.body.querySelector("a.skip-link");
 		if (skipLink) {
@@ -84,9 +117,6 @@
 		} else {
 			document.body.prepend(header);
 		}
-
-		const btn = header.querySelector(".site-header__hamburger");
-		const mobileNav = header.querySelector(`#${MOBILE_NAV_ID}`);
 
 		function openMenu() {
 			mobileNav.removeAttribute("hidden");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  undici: '>=7.28.0'
+  form-data: '>=4.0.6'
+  js-yaml: '>=4.2.0'
+  qs: '>=6.15.2'
+
 importers:
 
   .:
@@ -542,8 +548,8 @@ packages:
       debug:
         optional: true
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   fs.realpath@1.0.0:
@@ -609,6 +615,10 @@ packages:
 
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   he@1.2.0:
@@ -720,8 +730,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   json-parse-even-better-errors@2.3.1:
@@ -984,8 +994,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   require-directory@2.1.1:
@@ -1130,13 +1140,9 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
-  undici@6.25.0:
-    resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
-    engines: {node: '>=18.17'}
-
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
-    engines: {node: '>=20.18.1'}
+  undici@8.5.0:
+    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
+    engines: {node: '>=22.19.0'}
 
   union@0.5.0:
     resolution: {integrity: sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==}
@@ -1376,7 +1382,7 @@ snapshots:
   axios@1.16.1(debug@4.4.3):
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.3)
-      form-data: 4.0.5
+      form-data: 4.0.6
       https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -1489,7 +1495,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 6.25.0
+      undici: 8.5.0
       whatwg-mimetype: 4.0.0
 
   chromium-bidi@14.0.0(devtools-protocol@0.0.1608973):
@@ -1524,7 +1530,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       parse-json: 5.2.0
 
   cross-spawn@7.0.6:
@@ -1687,12 +1693,12 @@ snapshots:
     optionalDependencies:
       debug: 4.4.3
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   fs.realpath@1.0.0: {}
@@ -1769,6 +1775,10 @@ snapshots:
       has-symbols: 1.1.0
 
   hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -1893,7 +1903,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 
@@ -1920,7 +1930,7 @@ snapshots:
       meow: 14.1.0
       mime: 4.1.0
       srcset: 5.0.3
-      undici: 7.25.0
+      undici: 8.5.0
 
   lodash@4.18.1: {}
 
@@ -2190,7 +2200,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  qs@6.15.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -2360,13 +2370,11 @@ snapshots:
   undici-types@7.19.2:
     optional: true
 
-  undici@6.25.0: {}
-
-  undici@7.25.0: {}
+  undici@8.5.0: {}
 
   union@0.5.0:
     dependencies:
-      qs: 6.15.1
+      qs: 6.15.2
 
   url-join@4.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,8 @@
 allowBuilds:
     puppeteer: true
+
+overrides:
+    undici: ">=7.28.0"
+    form-data: ">=4.0.6"
+    js-yaml: ">=4.2.0"
+    qs: ">=6.15.2"

--- a/scripts/add-reading-time.js
+++ b/scripts/add-reading-time.js
@@ -37,7 +37,7 @@ for (const topic of manifest.topics) {
 function extractBodyText(html) {
 	const bodyMatch = html.match(/<body[^>]*>([\s\S]*)<\/body>/i);
 	const body = bodyMatch ? bodyMatch[1] : html;
-	return body
+	return body // codeql[js/bad-tag-filter]
 		.replace(/<script[\s\S]*?<\/script>/gi, " ")
 		.replace(/<style[\s\S]*?<\/style>/gi, " ")
 		.replace(/<!--[\s\S]*?-->/g, " ")

--- a/scripts/build-search-index.js
+++ b/scripts/build-search-index.js
@@ -37,12 +37,12 @@ function collectHtmlFiles(dir) {
 
 function decodeEntities(s) {
 	return s
-		.replace(/&amp;/g, "&")
 		.replace(/&lt;/g, "<")
 		.replace(/&gt;/g, ">")
 		.replace(/&quot;/g, '"')
 		.replace(/&#39;/g, "'")
-		.replace(/&nbsp;/g, " ");
+		.replace(/&nbsp;/g, " ")
+		.replace(/&amp;/g, "&");
 }
 
 function collapseWhitespace(s) {

--- a/scripts/check-assets.js
+++ b/scripts/check-assets.js
@@ -113,12 +113,12 @@ function extractCssRefs(css) {
 function decodeHtmlEntities(str) {
 	// Decode the handful of entities that commonly appear in href/src values.
 	return str
-		.replace(/&amp;/g, "&")
 		.replace(/&lt;/g, "<")
 		.replace(/&gt;/g, ">")
 		.replace(/&quot;/g, '"')
 		.replace(/&#(\d+);/g, (_, code) => String.fromCharCode(Number(code)))
-		.replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)));
+		.replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
+		.replace(/&amp;/g, "&");
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/migrations/add-page-meta.js
+++ b/scripts/migrations/add-page-meta.js
@@ -38,13 +38,13 @@ function stripTags(html) {
 
 function decodeEntities(str) {
 	return str
-		.replace(/&amp;/g, "&")
 		.replace(/&lt;/g, "<")
 		.replace(/&gt;/g, ">")
 		.replace(/&quot;/g, '"')
 		.replace(/&apos;/g, "'")
 		.replace(/&nbsp;/g, " ")
-		.replace(/&#(\d+);/g, (_, n) => String.fromCharCode(parseInt(n, 10)));
+		.replace(/&#(\d+);/g, (_, n) => String.fromCharCode(parseInt(n, 10)))
+		.replace(/&amp;/g, "&");
 }
 
 function cleanText(html) {

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,694 +2,694 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/COBOLIntro.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/COBOLcommands.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Copy.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/DataDeclaration.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/EditedPics.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/IndexedFiles.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Inspect.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Intro2DirectAccess.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Iteration.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/RefMod.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/RelativeFiles.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/ReportWriter.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/ReportWriterSS.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Call.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro1.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro2.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro3.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro4.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro5.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-CobIntro6.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Commands1.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Commands2.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Condition1.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Condition2.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Data1.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Data2.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Perform1.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Perform2.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Search2.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile1.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2a.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2b.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2c.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2d.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile2e.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-SeqFile3a.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables1.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables2.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables3.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables4.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables5.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables7.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Tables8.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Search.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Selection.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles1.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles2.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SequentialFiles3.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/SortMerge.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/String.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Subprograms.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Tables1.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Tables2.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Unstring.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/Usage.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/glossary.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/course/index.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Accept/ACCEPT.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Accept/HelloWorld.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Accept/Multiplier.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Conditn/Conditions.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Conditn/IterCalc.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Conditn/IterIf.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Indexed/DirectReadIdx.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Indexed/Seq2Index.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Indexed/SeqReadIdx.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Indexed/WirthMemLib.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Merge/Merge.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/MileageCount.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform1.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform2.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform3.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Perform/Perform4.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Relative/ReadRel.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Relative/Seq2Rel.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteA.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteB.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteFull.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/ReportWriter/RepWriteSumm.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqIns/SEQINSERT.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREAD.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqRead/SEQREADno88.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqRpt/SEQRPT.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqUpd/SeqUpdate.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SeqWrite/SEQWRITE.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Sort/InputSort.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Sort/MaleSort.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Sort/SortIP.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Strings/RefMod.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Strings/UnstringFileEg.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/DateDriver.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DateValid/ValiDate.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/DayDiff/DayDiffDriver.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/DriverProg.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Fickle.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/MultiplyNums.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/SubProg/Multiply/Steadfast.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/Tables/MonthTable.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/examples/index.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/COBOLExams/COBOLExams.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/CountDown.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FileConversion/Exm-FileConversion.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FileConversion/Prg-FileConversion.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-SFbyMail/Exm-SFbyMail.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-SFbyMail/Prg-SFbyMail.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-StudFeesRpt/Exm-StudPay.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-StudFeesRpt/Prg-StudPay.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/GettingStarted.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/MonthTable.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/Proj-CSISEvalform/CSISEvalForm.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqInsert.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqRead.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqReadIf.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqUpdate.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SeqWrite.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/SortIP.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/exercises/index.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/index.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/arithmetic.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/basics1.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/basics2.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/call.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/cobintro.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/conditions.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/copy.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/design.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/direct1.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/dsr1.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/genintro.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/index.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/indexed.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/inspect.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/perform.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/relative.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/reportwriterssweb.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/reportwriterweb.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/search.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/seqfile1.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/seqfile2.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/seqfile3.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/sort.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/string.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/tables1.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/tables2.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/unstring.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
   <url>
     <loc>https://bushidocodes.github.io/limerick-cobol/lectures/usage.html</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-20</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary

- **Dependabot (5 alerts):** added `overrides` block to `pnpm-workspace.yaml` to force minimum safe versions of four transitively-pulled packages: `undici >=7.28.0`, `form-data >=4.0.6`, `js-yaml >=4.2.0`, `qs >=6.15.2`. Lock file updated.
- **`js/xss-through-dom` (site-header.js #6):** replaced the `header.innerHTML = …` block with explicit DOM API calls (`createElement`/`setAttribute`/`textContent`) so URL values derived from `script.src` never flow through innerHTML.
- **`js/bad-tag-filter` (add-reading-time.js #5):** added `// codeql[js/bad-tag-filter]` suppression at the flagged line — this function extracts plain text from trusted local HTML files for word-count estimation, not a security sanitizer.
- **`js/double-escaping` (build-search-index.js #2, check-assets.js #3, migrations/add-page-meta.js #4):** moved `&amp;` decode to last in all three `decodeEntities` helpers so that `&amp;lt;` only resolves to `&lt;` (a literal string), never double-decodes to `<`.
- **`py/redos` (convert_toc.py #1):** replaced the nested-quantifier `TRAILING_BR_RE` with `_SINGLE_TRAILING_BR_RE` (matches one `<br>` at a time) applied in a `while`-loop to avoid catastrophic backtracking.

## Test plan

- [ ] CI HTML validation passes (`npm run validate`)
- [ ] Dependabot alerts close automatically once the lock file is merged
- [ ] Code-scanning re-runs and the six alerts resolve (suppression comment for #5, code fixes for the rest)
- [ ] Site header renders correctly in browser (verified locally via accessibility tree snapshot — logo, primary nav with all 4 links, search present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)