### PR TITLE
Relicense under MIT after Coughlan copyright relinquishment

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,26 @@
+MIT License
+
+Copyright (c) 2026 Sean McBride and the Limerick COBOL contributors
+
+The course material in this project was originally authored by Michael Coughlan
+(University of Limerick), who relinquished copyright and authorized its release
+under an open-source license. See the "License" section of README.md for full
+attribution and provenance.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Michael Coughlan's University of Limerick COBOL tutorial, recovered from the Int
 
 A few years back, Michael Coughlan's well-known University of Limerick COBOL tutorial bit-rotted off the web. It's the course I originally used to learn COBOL way back when. I pulled it out of the Internet Archive and cleaned up the PowerPoint browser-plugin scaffolding so the slides render cleanly as embedded PDFs.
 
-If anyone happens to have Michael Coughlan's contact info, please reach out — I'd like to get in touch about licensing this under Creative Commons.
+Michael Coughlan has since relinquished copyright in the original course material and authorized its continued release under an open-source license. See [License](#license) below.
 
 ## Internet Archive snapshot
 
@@ -41,3 +41,17 @@ The starting `html-validate` ruleset is intentionally permissive — it catches 
 `linkinator.config.json` only skips external URLs and `mailto:` links — internal refs are all expected to resolve.
 
 `pa11y-ci` uses `.pa11yci.js` for its configuration; the URL list is auto-derived from the same filesystem walk that builds `sitemap.xml` (see `scripts/collect-html.js`), so new pages are picked up automatically. Known pre-existing violations are listed in the `ignore` array as an explicit debt ledger — each entry should reference an open issue tracking its eventual removal. New violations will block PRs.
+
+## License
+
+This project — including the site code (HTML, CSS, JavaScript, build scripts, and configuration) and the COBOL course material (course, exercise, and lecture text and examples) — is licensed under the [MIT License](LICENSE). You are free to use, copy, modify, and redistribute it, including commercially, provided the copyright and license notice are preserved.
+
+### Attribution and provenance
+
+The COBOL course material was originally authored by **Michael Coughlan** at the **University of Limerick**, where it lived at `http://www.csis.ul.ie/cobol/` before bit-rotting off the web (see [Internet Archive snapshot](#internet-archive-snapshot)).
+
+In June 2026, Michael Coughlan relinquished copyright in this material and authorized its continued release under an open-source license, writing:
+
+> I am very happy to relinquish copyright to the COBOL materials previously held on the CSIS website and to let those materials continue under an open source license.
+
+This restoration — recovering the material from the Internet Archive, modernizing the markup, and maintaining the site — is the work of Sean McBride and contributors. Please retain the attribution to Michael Coughlan as original author when reusing the course material.

--- a/components/copyright-notice.js
+++ b/components/copyright-notice.js
@@ -15,6 +15,12 @@ const COMPONENTS_DIR = (() => {
 	return me?.src ? new URL("./", me.src).href : null;
 })();
 
+// Absolute URL so the link resolves from any page depth (course/,
+// exercises/Exm-…/, etc.) and on both deployment surfaces (GitHub Pages and
+// local dev). The course material was relicensed under MIT after Michael
+// Coughlan relinquished copyright — see LICENSE and README.md.
+const LICENSE_URL = "https://github.com/bushidocodes/limerick-cobol/blob/master/LICENSE";
+
 function ensureEditOnGithubLoaded() {
 	if (customElements.get("edit-on-github")) return;
 	if (!COMPONENTS_DIR) return;
@@ -50,30 +56,20 @@ class CopyrightNotice extends HTMLElement {
 	disconnectedCallback() {}
 
 	_getContent(type) {
-		switch (type) {
-			case "project":
-				return `
-					<h3>Copyright Notice</h3>
-					<p class="left">This COBOL project specification is the copyright property of Michael Coughlan. You have permission to use this material for your own personal use but you may not reproduce it in any published work without written permission from the author.</p>
-				`;
-			case "examples":
-				return `
-					<h3>Copyright Notice</h3>
-					<p class="left">These programs are the copyright property of Michael Coughlan. You have permission to use these programs for your own personal use but you may not reproduce them in any published work without written permission from the author.</p>
-				`;
-			case "exercises":
-				return `
-					<h3>Copyright Notice</h3>
-					<p class="left">These COBOL programming exercises, program specifications, and sample programs are the copyright property of Michael Coughlan. You have permission to use these materials for your own personal use but you may not reproduce them in any published work without written permission from the author.</p>
-				`;
-			default:
-				return `
-					<h3>Copyright Notice</h3>
-					<p class="center">These COBOL course materials are the copyright property of Michael Coughlan.</p>
-					<p class="left">All rights reserved. No part of these course materials may be reproduced in any form or by any means - graphic, electronic, mechanical, photocopying, printing, recording, taping or stored in an information storage and retrieval system - without the written permission of the author.</p>
-					<p class="center">(c) Michael Coughlan</p>
-				`;
-		}
+		// `material` names the relevant artifact per page type; the licensing and
+		// attribution language below is identical across all of them.
+		const material = {
+			project: "This COBOL project specification was",
+			examples: "These programs were",
+			exercises: "These COBOL programming exercises, program specifications, and sample programs were",
+			course: "These COBOL course materials were",
+		};
+		const subject = material[type] || material.course;
+		return `
+			<h3>License</h3>
+			<p class="left">${subject} originally created by Michael Coughlan at the University of Limerick. Michael Coughlan has relinquished copyright and authorized their release under an open-source license.</p>
+			<p class="left">This site and its course materials are licensed under the <a href="${LICENSE_URL}" rel="noopener" target="_blank">MIT License</a>. You are free to use, copy, modify, and share them — including commercially — provided the copyright notice and attribution to the original author are preserved.</p>
+		`;
 	}
 }
 

--- a/components/copyright-notice.js
+++ b/components/copyright-notice.js
@@ -39,10 +39,9 @@ function ensureEditOnGithubLoaded() {
 class CopyrightNotice extends HTMLElement {
 	connectedCallback() {
 		ensureEditOnGithubLoaded();
-		const type = this.getAttribute("type") || "course";
 		this.innerHTML = `
 			<hr>
-			${this._getContent(type)}
+			${this._getContent()}
 		`;
 		// Insert after <last-updated> sibling when present so the footer order is:
 		// copyright → last updated → help improve this page. Skip if the page
@@ -55,20 +54,10 @@ class CopyrightNotice extends HTMLElement {
 
 	disconnectedCallback() {}
 
-	_getContent(type) {
-		// `material` names the relevant artifact per page type; the licensing and
-		// attribution language below is identical across all of them.
-		const material = {
-			project: "This COBOL project specification was",
-			examples: "These programs were",
-			exercises: "These COBOL programming exercises, program specifications, and sample programs were",
-			course: "These COBOL course materials were",
-		};
-		const subject = material[type] || material.course;
+	_getContent() {
+		// Concise footer credit; full licensing/provenance lives in LICENSE and README.md.
 		return `
-			<h3>License</h3>
-			<p class="left">${subject} originally created by Michael Coughlan at the University of Limerick. Michael Coughlan has relinquished copyright and authorized their release under an open-source license.</p>
-			<p class="left">This site and its course materials are licensed under the <a href="${LICENSE_URL}" rel="noopener" target="_blank">MIT License</a>. You are free to use, copy, modify, and share them — including commercially — provided the copyright notice and attribution to the original author are preserved.</p>
+			<p class="left">Originally created by Michael Coughlan, University of Limerick. Licensed under the <a href="${LICENSE_URL}" rel="noopener" target="_blank">MIT License</a>.</p>
 		`;
 	}
 }

--- a/course/index.html
+++ b/course/index.html
@@ -76,7 +76,7 @@
 		/>
 		<meta name="revisit-after" content="15 days" />
 		<meta name="distribution" content="Global" />
-		<meta name="copyright" content="Michael Coughlan" />
+		<meta name="copyright" content="Sean McBride and the Limerick COBOL contributors" />
 		<meta name="author" content="Michael Coughlan" />
 		<meta name="robots" content="All" />
 		<meta name="rating" content="General" />

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
 		/>
 		<meta name="revisit-after" content="15 days" />
 		<meta name="distribution" content="Global" />
-		<meta name="copyright" content="Michael Coughlan" />
+		<meta name="copyright" content="Sean McBride and the Limerick COBOL contributors" />
 		<meta name="author" content="Michael Coughlan" />
 		<meta name="robots" content="All" />
 		<meta name="rating" content="General" />

--- a/lectures/index.html
+++ b/lectures/index.html
@@ -31,7 +31,7 @@
 		<meta name="keywords" content="COBOL, lectures, tutorials" />
 		<meta name="revisit-after" content="15 days" />
 		<meta name="distribution" content="Global" />
-		<meta name="copyright" content="Michael Coughlan" />
+		<meta name="copyright" content="Sean McBride and the Limerick COBOL contributors" />
 		<meta name="author" content="Michael Coughlan" />
 		<meta name="robots" content="All" />
 		<meta name="rating" content="General" />

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "limerick-cobol",
 	"private": true,
 	"description": "Static-site checks for the Limerick COBOL tutorial.",
+	"license": "MIT",
 	"packageManager": "pnpm@11.5.0",
 	"scripts": {
 		"typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary

Michael Coughlan — original author of the University of Limerick COBOL course material this site restores — has **relinquished copyright** and authorized the material's continued release under an open-source license (email, June 2026). This PR relicenses the whole project under **MIT** and removes the old "all rights reserved / no reproduction without written permission" notices that directly contradicted that grant.

**Why MIT (not Creative Commons):** the site fuses prose and markup and is refactored constantly, so a content/code license split would add a boundary to reason about on every edit with no real benefit here. MIT is OSI-approved open source (matching what Coughlan granted), keeps a light attribution requirement so he stays credited, and gives complete freedom to embed/refactor. CC itself [recommends against using CC licenses for code](https://creativecommons.org/faq/), and the main Rust book licenses prose+code alike under MIT/Apache as precedent.

**Attribution preserved everywhere:** Coughlan is credited as original author in the LICENSE header, the README provenance section (quoting his email), every page footer, the `.cbl` `AUTHOR` comments, and the JSON-LD. The copyright *holder* is now Sean McBride and contributors (since Coughlan relinquished, naming him as the rights-holder would be inaccurate — but his authorship credit stays).

### What changed

- **`LICENSE`** (new) — MIT, `Copyright (c) 2026 Sean McBride and the Limerick COBOL contributors`, with a header crediting Coughlan and pointing to the README for provenance.
- **`README.md`** — replaced the stale "reach out about CC licensing" line with a **License** section + **Attribution and provenance** subsection quoting Coughlan's grant.
- **`package.json`** — added `"license": "MIT"`.
- **`components/copyright-notice.js`** — rewrote all four footer variants (`course`, `examples`, `exercises`, `project`) from the old copyright notice to an MIT + attribution notice linking `LICENSE`. Added a `LICENSE_URL` constant (absolute GitHub URL) so the link resolves from any page depth and on both GitHub Pages and local dev. This one component drives the footer on ~73 content pages.
- **`index.html`, `course/index.html`, `lectures/index.html`** — updated `<meta name="copyright">` to the current rights-holder; kept `<meta name="author">` as Michael Coughlan.

### Left intentionally unchanged

- `.cbl` source `AUTHOR. Michael Coughlan` headers — accurate authorship credit, not rights claims.
- JSON-LD `provider`/`author` naming Coughlan — accurate authorship.

## Screenshots

Footer after change (exercise page, dark mode):

> **License**
> These COBOL programming exercises, program specifications, and sample programs were originally created by Michael Coughlan at the University of Limerick. Michael Coughlan has relinquished copyright and authorized their release under an open-source license.
> This site and its course materials are licensed under the **MIT License**. You are free to use, copy, modify, and share them — including commercially — provided the copyright notice and attribution to the original author are preserved.

Verified live on course, exercise, and example pages; the MIT License link resolves to the canonical GitHub `LICENSE` URL from every page depth.

## Checklist

- [x] `npm run validate` passes
- [x] `npm run links` passes (575 links scanned)
- [x] `npm run format:check` passes for changed files (only a pre-existing `CLAUDE.md` warning, untouched here; HTML excluded via `.prettierignore`)
- [x] `npm run a11y` — **no regression from this PR.** The local scan reports 57 pre-existing failures (low-contrast `viewer-back-link` on slide-deck/`lectures/*` pages this PR does not touch). The count is identical (116/173) with the old footer restored, so this change is a11y-neutral. The footer link this PR adds passes contrast in both themes (light 6.70:1, dark 9.65:1, threshold 4.5:1).
