### PR TITLE
fix(security): harden HTML-stripping regexes in add-reading-time

### DIFF
--- a/scripts/add-reading-time.js
+++ b/scripts/add-reading-time.js
@@ -37,10 +37,10 @@ for (const topic of manifest.topics) {
 function extractBodyText(html) {
 	const bodyMatch = html.match(/<body[^>]*>([\s\S]*)<\/body>/i);
 	const body = bodyMatch ? bodyMatch[1] : html;
-	return body // codeql[js/bad-tag-filter]
-		.replace(/<script[\s\S]*?<\/script>/gi, " ")
-		.replace(/<style[\s\S]*?<\/style>/gi, " ")
-		.replace(/<!--[\s\S]*?-->/g, " ")
+	return body
+		.replace(/<script[\s\S]*?<\/script(?:\s[^>]*)?>/gi, " ")
+		.replace(/<style[\s\S]*?<\/style(?:\s[^>]*)?>/gi, " ")
+		.replace(/<!--[\s\S]*?--!?>/g, " ")
 		.replace(/<[^>]+>/g, " ")
 		.replace(/&[a-zA-Z]+;/g, " ")
 		.replace(/&#?\w+;/g, " ")


### PR DESCRIPTION
## Summary

Fixes CodeQL security alert [js/bad-tag-filter #5](https://github.com/bushidocodes/limerick-cobol/security/code-scanning/5).

- `</script>` and `</style>` patterns updated to also match closing tags with trailing attributes (e.g. `</script foo="bar">`, `</script >`) — a form browsers accept even though it is technically malformed HTML
- HTML comment pattern updated to match `--!>` endings in addition to `-->`
- Removed a `// codeql[js/bad-tag-filter]` suppression comment that was on the line *before* the flagged expression and therefore never suppressed anything

The function processes only the site's own trusted HTML files (build-time word counting), but the patterns are now correct regardless of context.

## Test plan

- [x] `node scripts/add-reading-time.js` runs cleanly across all 20 course lessons with no errors
- [x] Only `scripts/add-reading-time.js` is modified (no spurious reading-time attribute changes)
- [x] CodeQL should clear alert #5 on next scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)