### PR TITLE
chore: remove duplicate JSON-LD block from course/Iteration.html

### DIFF
--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -48,21 +48,6 @@
 				"learningResourceType": "Tutorial"
 			}
 		</script>
-		<script type="application/ld+json">
-			{
-				"@context": "https://schema.org",
-				"@type": "LearningResource",
-				"name": "COBOL Iteration Constructs",
-				"description": "A tutorial covering COBOL iteration constructs including PERFORM..Proc, PERFORM..THRU, PERFORM..TIMES, PERFORM..UNTIL, and PERFORM..VARYING.",
-				"url": "https://bushidocodes.github.io/limerick-cobol/course/Iteration.html",
-				"learningResourceType": "Tutorial",
-				"educationalLevel": "Beginner",
-				"isPartOf": {
-					"@type": "Course",
-					"url": "https://bushidocodes.github.io/limerick-cobol/course/index.html"
-				}
-			}
-		</script>
 		<title>Iteration in COBOL</title>
 		<meta
 			name="description"


### PR DESCRIPTION
## What

Removes a stale, hand-authored `LearningResource` JSON-LD block from `course/Iteration.html`, leaving only the canonical block emitted by `scripts/generate-lesson-jsonld.ts`.

## Why

The page's `<head>` contained **two** `<script type="application/ld+json">` LearningResource blocks. The first is the canonical generated block; the second was a stale hand-authored duplicate with divergent fields (`educationalLevel: "Beginner"` capitalized, missing `provider`/`inLanguage`/`position`, and an `isPartOf` without a `name`). Duplicate structured-data blocks are redundant and the stale one can confuse crawlers.

## How

Ran `npm run build:lesson-jsonld`. The generator's strip regex removes all LearningResource blocks then re-injects a single canonical one, so the duplicate is dropped automatically — no manual editing of the generated file.

## Verification

- `git diff course/Iteration.html` shows only the 15-line stale duplicate removed; `course/lesson-meta.json` was already current (no change).
- `npx html-validate course/Iteration.html` passes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)