### PR TITLE
refactor(scripts): share HTML escape / text helpers

### DIFF
--- a/scripts/build-examples.ts
+++ b/scripts/build-examples.ts
@@ -18,6 +18,9 @@
 import fs from "fs";
 import path from "path";
 
+import { escapeAttr, escapeHtml } from "./lib/html-text.js";
+import { readJson } from "./lib/json.js";
+
 const ROOT = path.resolve(__dirname, "..");
 const EXAMPLES_DIR = path.join(ROOT, "examples");
 const BASE_URL = "https://bushidocodes.github.io/limerick-cobol/";
@@ -38,7 +41,7 @@ interface CrossLinksData {
 	pairs?: Record<string, CrossLink>;
 }
 
-const CROSS_LINKS: CrossLinksData = JSON.parse(fs.readFileSync(path.join(__dirname, "cross-links.json"), "utf8"));
+const CROSS_LINKS = readJson<CrossLinksData>(path.join(__dirname, "cross-links.json"));
 const MAX_RELATED_PER_GROUP = 4;
 
 // Maps the first path segment of each example to its sidebar topic. The order
@@ -427,14 +430,6 @@ const MANIFEST: ManifestEntry[] = [
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function escapeHtml(str: string): string {
-	return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-}
-
-function escapeAttr(str: string): string {
-	return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
-}
 
 /** Truncate description to ≤155 chars, breaking at a word boundary. */
 function truncate(text: string, max = 155): string {

--- a/scripts/build-lesson-index.ts
+++ b/scripts/build-lesson-index.ts
@@ -12,6 +12,7 @@
 import fs from "fs";
 import path from "path";
 
+import { escapeHtml } from "./lib/html-text.js";
 import { readJson } from "./lib/json.js";
 
 const REPO_ROOT = path.resolve(__dirname, "..");
@@ -51,17 +52,13 @@ function slugify(s: string): string {
 		.replace(/^-+|-+$/g, "");
 }
 
-function escapeHTML(s: string): string {
-	return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-}
-
 function buildTopicsHTML(topics: Topic[]): string {
 	return topics
 		.map((topic, i) => {
 			const isLast = i === topics.length - 1;
 			const slug = slugify(topic.label);
 			const description = topic.description
-				? `<p class="topic-description">${escapeHTML(topic.description)}</p>`
+				? `<p class="topic-description">${escapeHtml(topic.description)}</p>`
 				: "";
 			const links = topic.links
 				.map(
@@ -70,7 +67,7 @@ function buildTopicsHTML(topics: Topic[]): string {
 				)
 				.join("");
 			const divider = isLast ? "" : `<div class="topic-divider"></div>`;
-			return `<h2 class="topic-label" id="${slug}">${escapeHTML(topic.label)}</h2><div class="topic-links">${description}${links}</div>${divider}`;
+			return `<h2 class="topic-label" id="${slug}">${escapeHtml(topic.label)}</h2><div class="topic-links">${description}${links}</div>${divider}`;
 		})
 		.join("");
 }

--- a/scripts/build-search-index.ts
+++ b/scripts/build-search-index.ts
@@ -16,6 +16,7 @@ import fs from "fs";
 import path from "path";
 
 import { collectHtmlFiles } from "./lib/html-files.js";
+import { collapseWhitespace, decodeEntities } from "./lib/html-text.js";
 
 const REPO_ROOT = path.resolve(__dirname, "..");
 const OUTPUT_PATH = path.join(REPO_ROOT, "search-index.json");
@@ -28,20 +29,6 @@ interface SearchEntry {
 	t: string;
 	d: string;
 	s: string;
-}
-
-function decodeEntities(s: string): string {
-	return s
-		.replace(/&lt;/g, "<")
-		.replace(/&gt;/g, ">")
-		.replace(/&quot;/g, '"')
-		.replace(/&#39;/g, "'")
-		.replace(/&nbsp;/g, " ")
-		.replace(/&amp;/g, "&");
-}
-
-function collapseWhitespace(s: string): string {
-	return s.replace(/\s+/g, " ").trim();
 }
 
 function extractTitle(html: string): string {

--- a/scripts/generate-og-images.ts
+++ b/scripts/generate-og-images.ts
@@ -13,6 +13,8 @@ import { Resvg } from "@resvg/resvg-js";
 import fs from "fs";
 import path from "path";
 
+import { escapeHtml } from "./lib/html-text.js";
+
 const OUT_DIR = path.resolve(__dirname, "../pics/og");
 const WIDTH = 1200;
 const HEIGHT = 630;
@@ -24,10 +26,6 @@ const SECTIONS = [
 	{ id: "exercises", label: "Exercises", subtitle: "Hands-on COBOL programming practice" },
 	{ id: "lectures", label: "Lectures", subtitle: "COBOL programming slide presentations" },
 ];
-
-function esc(str: string): string {
-	return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-}
 
 function buildSvg(label: string, subtitle: string): string {
 	return `<?xml version="1.0" encoding="UTF-8"?>
@@ -57,10 +55,10 @@ function buildSvg(label: string, subtitle: string): string {
   <rect x="80" y="195" width="1040" height="2" fill="#1976D2" opacity="0.5"/>
 
   <!-- Section heading -->
-  <text x="80" y="355" font-family="sans-serif" font-size="90" fill="#FFFFFF" font-weight="900">${esc(label)}</text>
+  <text x="80" y="355" font-family="sans-serif" font-size="90" fill="#FFFFFF" font-weight="900">${escapeHtml(label)}</text>
 
   <!-- Subtitle -->
-  <text x="80" y="435" font-family="sans-serif" font-size="34" fill="#90CAF9">${esc(subtitle)}</text>
+  <text x="80" y="435" font-family="sans-serif" font-size="34" fill="#90CAF9">${escapeHtml(subtitle)}</text>
 
   <!-- Bottom accent bar -->
   <rect x="80" y="564" width="140" height="6" fill="#42A5F5" rx="3"/>

--- a/scripts/inject-cross-links.ts
+++ b/scripts/inject-cross-links.ts
@@ -23,6 +23,8 @@
 import fs from "fs";
 import path from "path";
 
+import { readJson } from "./lib/json.js";
+
 const REPO_ROOT = path.resolve(__dirname, "..");
 const CROSS_LINKS_PATH = path.join(__dirname, "cross-links.json");
 const MAX_ITEMS_PER_GROUP = 4;
@@ -48,7 +50,7 @@ interface PageLinks {
 	exercises: CrossLink[];
 }
 
-const data: CrossLinksData = JSON.parse(fs.readFileSync(CROSS_LINKS_PATH, "utf8"));
+const data = readJson<CrossLinksData>(CROSS_LINKS_PATH);
 
 function resolvePageLinks(filePath: string): PageLinks {
 	const familyNames = data.files[filePath] || [];

--- a/scripts/lib/html-text.ts
+++ b/scripts/lib/html-text.ts
@@ -1,0 +1,25 @@
+/** Escape `&`, `<`, `>` for use in HTML/XML text content. */
+export function escapeHtml(s: string): string {
+	return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/** Escape `&`, `<`, `>`, `"` for use inside a double-quoted attribute value. */
+export function escapeAttr(s: string): string {
+	return escapeHtml(s).replace(/"/g, "&quot;");
+}
+
+/** Decode the small set of named/numeric entities the extractors care about. */
+export function decodeEntities(s: string): string {
+	return s
+		.replace(/&lt;/g, "<")
+		.replace(/&gt;/g, ">")
+		.replace(/&quot;/g, '"')
+		.replace(/&#39;/g, "'")
+		.replace(/&nbsp;/g, " ")
+		.replace(/&amp;/g, "&");
+}
+
+/** Collapse runs of whitespace to a single space and trim the ends. */
+export function collapseWhitespace(s: string): string {
+	return s.replace(/\s+/g, " ").trim();
+}


### PR DESCRIPTION
## What

Adds `scripts/lib/html-text.ts` and routes duplicated string helpers through it:

| Helper | Replaces | In |
| --- | --- | --- |
| `escapeHtml` (`&<>`) | `escapeHtml` / `escapeHTML` / `esc` | `build-examples`, `build-lesson-index`, `generate-og-images` |
| `escapeAttr` (`&<>"`) | local copy | `build-examples` |
| `decodeEntities`, `collapseWhitespace` | local copies | `build-search-index` |

Also routes the two `cross-links.json` loads (`build-examples`, `inject-cross-links`) through `readJson<T>()` from the shared lib.

## Deliberate non-change

I **dropped** the originally-considered cross-link "map-accumulate" dedup (`inject-cross-links` vs `build-examples`). The two resolvers genuinely differ — pair front-loading, `escapeAttr` wrapping, path base, and markup indentation — so only the trivial inner `add` loop is common. Extracting just that would be marginal and risk a behaviour change, so per the repo's "quality over quota" rule it's left alone.

## Verification

- `npm run typecheck` passes.
- `check:examples`, `check:search-index`, `check:lesson-index` reproduce byte-identical output; `build:og-images` regenerates identical PNGs.
- `inject-cross-links` emits the same pre-prettier markup as before. (It has pre-existing, prettier-dependent drift vs the committed HTML — confirmed identical with and without this change — which is why it's not in the `check` suite.)

## ⚠️ Stacked PR

Branches off `refactor/scripts-shared-lib` (#659). **Merge #659 first**, then this targets `master` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)