### PR TITLE
refactor(scripts): modern ES2022 string syntax

### DIFF
--- a/scripts/add-reading-time.ts
+++ b/scripts/add-reading-time.ts
@@ -26,8 +26,7 @@ const LESSON_FILES = tutorialSequence(readJson<LessonManifest>(MANIFEST_PATH)).m
 
 /** Extract visible text from the <body> element, stripping scripts and tags. */
 function extractBodyText(html: string): string {
-	const bodyMatch = html.match(/<body[^>]*>([\s\S]*)<\/body>/i);
-	const body = bodyMatch ? bodyMatch[1] : html;
+	const body = html.match(/<body[^>]*>([\s\S]*)<\/body>/i)?.[1] ?? html;
 	return body
 		.replace(/<script[\s\S]*?<\/script(?:\s[^>]*)?>/gi, " ")
 		.replace(/<style[\s\S]*?<\/style(?:\s[^>]*)?>/gi, " ")

--- a/scripts/build-examples.ts
+++ b/scripts/build-examples.ts
@@ -534,7 +534,7 @@ function relatedContentHtml(relFile: string): string {
 	const fromDir = path.dirname(path.join(ROOT, key));
 	const toRelHref = (repoRelTarget: string): string => {
 		const abs = path.join(ROOT, repoRelTarget);
-		return path.relative(fromDir, abs).split(path.sep).join("/");
+		return path.relative(fromDir, abs).replaceAll(path.sep, "/");
 	};
 
 	const formatGroup = (map: Map<string, string>): string => {

--- a/scripts/build-search-index.ts
+++ b/scripts/build-search-index.ts
@@ -32,8 +32,8 @@ interface SearchEntry {
 }
 
 function extractTitle(html: string): string {
-	const m = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
-	return m ? collapseWhitespace(decodeEntities(m[1])) : "";
+	const title = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)?.[1];
+	return title !== undefined ? collapseWhitespace(decodeEntities(title)) : "";
 }
 
 function extractMetaDescription(html: string): string {
@@ -42,8 +42,8 @@ function extractMetaDescription(html: string): string {
 	while ((m = metaRe.exec(html))) {
 		const tag = m[0];
 		if (!/\bname\s*=\s*["']description["']/i.test(tag)) continue;
-		const c = tag.match(/\bcontent\s*=\s*["']([^"']*)["']/i);
-		if (c) return collapseWhitespace(decodeEntities(c[1]));
+		const content = tag.match(/\bcontent\s*=\s*["']([^"']*)["']/i)?.[1];
+		if (content !== undefined) return collapseWhitespace(decodeEntities(content));
 	}
 	return "";
 }

--- a/scripts/check-img-dimensions.ts
+++ b/scripts/check-img-dimensions.ts
@@ -21,8 +21,7 @@ for (const dir of SCAN_DIRS) {
 			const missingHeight = !/\bheight\s*=/i.test(tag);
 			if (missingWidth || missingHeight) {
 				const missing = [missingWidth && "width", missingHeight && "height"].filter(Boolean).join(", ");
-				const srcMatch = tag.match(/\bsrc\s*=\s*["']([^"']+)["']/i);
-				const src = srcMatch ? srcMatch[1] : "(unknown src)";
+				const src = tag.match(/\bsrc\s*=\s*["']([^"']+)["']/i)?.[1] ?? "(unknown src)";
 				console.error(`${path.relative(ROOT, file)}: <img src="${src}"> missing ${missing}`);
 				violations++;
 			}

--- a/scripts/generate-lesson-jsonld.ts
+++ b/scripts/generate-lesson-jsonld.ts
@@ -39,14 +39,12 @@ const LESSON_SEQUENCE = tutorialSequence(readJson<LessonManifest>(MANIFEST_PATH)
 
 /** Extract <meta name="description" content="..."> value from raw HTML. */
 function extractDescription(html: string): string {
-	const m = html.match(/<meta\s+name="description"\s+content="([^"]+)"/);
-	return m ? m[1] : "";
+	return html.match(/<meta\s+name="description"\s+content="([^"]+)"/)?.[1] ?? "";
 }
 
 /** Extract <link rel="canonical" href="..."> value from raw HTML. */
 function extractCanonical(html: string): string {
-	const m = html.match(/<link\s+rel="canonical"\s+href="([^"]+)"/);
-	return m ? m[1] : "";
+	return html.match(/<link\s+rel="canonical"\s+href="([^"]+)"/)?.[1] ?? "";
 }
 
 /**

--- a/scripts/inject-cross-links.ts
+++ b/scripts/inject-cross-links.ts
@@ -112,7 +112,7 @@ function toRelativeHref(fromFile: string, toFile: string): string {
 	const fromDir = path.dirname(path.join(REPO_ROOT, fromFile));
 	const toAbs = path.join(REPO_ROOT, toFile);
 	const rel = path.relative(fromDir, toAbs);
-	return rel.split(path.sep).join("/");
+	return rel.replaceAll(path.sep, "/");
 }
 
 function formatGroupAttribute(fromFile: string, items: CrossLink[]): string {


### PR DESCRIPTION
## What

Small, behaviour-preserving syntax modernizations in the build scripts:

- `rel.split(path.sep).join("/")` → `rel.replaceAll(path.sep, "/")` (`inject-cross-links`, `build-examples`).
- Collapse `const m = x.match(re); return m ? m[1] : d` into `x.match(re)?.[1] ?? d` for the description / canonical / body / title / meta extractors.

## Correctness note

In `build-search-index` the matched group can legitimately be the empty string (`<title></title>`, empty `content=""`). The original branched on `if (m)` / `if (c)` — *match found*, not *non-empty*. The optional-chaining versions test `!== undefined` rather than truthiness to preserve that exactly. (A naive `?? ""` / `if (content)` would have been a behaviour change.)

## Verification

- `npm run typecheck` passes.
- `check:search-index`, `check:lesson-jsonld`, `check:reading-time`, `check:examples`, `check:img-dims` all reproduce byte-identical output.

Third of the scripts/ dedup series — #659 and #660 are already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)