### PR TITLE
refactor(components): tidy syntax + fix site-search listener leak

### DIFF
--- a/components/exercises-nav.js
+++ b/components/exercises-nav.js
@@ -38,8 +38,6 @@ class ExercisesNav extends HTMLElement {
 
 		this.innerHTML = `<nav class="lesson-nav" aria-label="Exercise navigation">${prevHTML}${positionHTML}${nextHTML}</nav>`;
 	}
-
-	disconnectedCallback() {}
 }
 
 customElements.define("exercises-nav", ExercisesNav);

--- a/components/lesson-nav.js
+++ b/components/lesson-nav.js
@@ -28,7 +28,7 @@ class LessonNav extends HTMLElement {
 
 		// Determine the current page filename from the URL path.
 		const segments = window.location.pathname.split("/");
-		const currentFile = segments[segments.length - 1];
+		const currentFile = segments.at(-1);
 
 		const index = LESSONS.findIndex((l) => l.file === currentFile);
 		if (index === -1) {
@@ -52,8 +52,6 @@ class LessonNav extends HTMLElement {
 
 		this.innerHTML = `<nav class="lesson-nav" aria-label="Lesson navigation">${prevHTML}${positionHTML}${nextHTML}</nav>`;
 	}
-
-	disconnectedCallback() {}
 }
 
 customElements.define("lesson-nav", LessonNav);

--- a/components/page-hero.js
+++ b/components/page-hero.js
@@ -24,8 +24,6 @@ class PageHero extends HTMLElement {
 			this.querySelector(".page-hero-reading-time").textContent = `~${readingTime} read`;
 		}
 	}
-
-	disconnectedCallback() {}
 }
 
 customElements.define("page-hero", PageHero);

--- a/components/related-content.js
+++ b/components/related-content.js
@@ -52,8 +52,6 @@ class RelatedContent extends HTMLElement {
 		</aside>`;
 	}
 
-	disconnectedCallback() {}
-
 	/** Parse "path1.html|Label 1, path2.html|Label 2" into [{href, title}]. */
 	_parseLinks(raw) {
 		return raw

--- a/components/site-search.js
+++ b/components/site-search.js
@@ -42,6 +42,7 @@ class SiteSearch extends HTMLElement {
 	#status = null;
 	#pointer = -1;
 	#listboxId = "";
+	#abort = null;
 
 	// Show the long placeholder only when the input is wide enough to display
 	// it without truncation. Below this, the (Ctrl+K) hint and even
@@ -84,29 +85,45 @@ class SiteSearch extends HTMLElement {
 		this.#results = this.querySelector(".site-search__results");
 		this.#status = this.querySelector(".site-search__status");
 
+		// All instance listeners share one signal so disconnectedCallback can
+		// detach them in one shot — notably the change listener on the static
+		// #SHORT_MQL media query, which would otherwise outlive the element.
+		this.#abort = new AbortController();
+		const { signal } = this.#abort;
+
 		const updatePlaceholder = () => {
 			this.#input.placeholder = SiteSearch.#SHORT_MQL.matches
 				? SiteSearch.#SHORT_PLACEHOLDER
 				: SiteSearch.#FULL_PLACEHOLDER;
 		};
 		updatePlaceholder();
-		SiteSearch.#SHORT_MQL.addEventListener("change", updatePlaceholder);
+		SiteSearch.#SHORT_MQL.addEventListener("change", updatePlaceholder, { signal });
 
-		this.#input.addEventListener("focus", () => this.#ensureLoaded());
-		this.#input.addEventListener("input", () => this.#render());
-		this.#input.addEventListener("keydown", (e) => this.#onInputKeydown(e));
-		this.#input.addEventListener("blur", () => {
-			// Allow click on a result to fire before closing.
-			window.setTimeout(() => {
-				if (!this.contains(document.activeElement)) this.#close();
-			}, 120);
-		});
+		this.#input.addEventListener("focus", () => this.#ensureLoaded(), { signal });
+		this.#input.addEventListener("input", () => this.#render(), { signal });
+		this.#input.addEventListener("keydown", (e) => this.#onInputKeydown(e), { signal });
+		this.#input.addEventListener(
+			"blur",
+			() => {
+				// Allow click on a result to fire before closing.
+				window.setTimeout(() => {
+					if (!this.contains(document.activeElement)) this.#close();
+				}, 120);
+			},
+			{ signal },
+		);
 
 		// Avoid double-binding when the element is placed more than once.
+		// The global Ctrl/Cmd+K handler is intentionally process-wide (it serves
+		// every instance), so it is not tied to this element's abort signal.
 		if (!globalKeyBound) {
 			document.addEventListener("keydown", SiteSearch.#onGlobalKeydown);
 			globalKeyBound = true;
 		}
+	}
+
+	disconnectedCallback() {
+		this.#abort?.abort();
 	}
 
 	/** Focus the first site-search input on the page. Used by Cmd/Ctrl+K. */
@@ -290,7 +307,7 @@ class SiteSearch extends HTMLElement {
 		items.forEach((el, i) => {
 			const active = i === idx;
 			el.classList.toggle("site-search__result--active", active);
-			el.setAttribute("aria-selected", active ? "true" : "false");
+			el.setAttribute("aria-selected", String(active));
 		});
 		const current = items[idx];
 		if (current) {


### PR DESCRIPTION
## What

Behaviour-preserving component cleanups that need **no** ES-module conversion and **no** HTML changes:

- Remove four empty no-op `disconnectedCallback() {}` stubs (`exercises-nav`, `lesson-nav`, `page-hero`, `related-content`).
- `lesson-nav`: `segments[segments.length - 1]` → `segments.at(-1)`.
- `site-search`: `active ? "true" : "false"` → `String(active)`.
- `site-search`: route instance listeners through an `AbortController`, detached in `disconnectedCallback`.

## The one real bug fix

`site-search` attaches a `change` listener to the **static** `#SHORT_MQL` media query (`SiteSearch.#SHORT_MQL.addEventListener("change", updatePlaceholder)`). Because `#SHORT_MQL` is a class-static `MediaQueryList` and `updatePlaceholder` closes over `this`, every connected instance left a listener (and a reference to the element) on it forever. Now all instance listeners share one `AbortController` signal and are cleaned up on disconnect. The global Ctrl/Cmd+K handler is intentionally process-wide and stays off the signal.

## Verification (preview server)

- Course + exercise pages render: `page-hero`, breadcrumbs, `lesson-nav` ("Lesson 1 of 25"), `exercises-nav` ("Exercise 13 of 29"), `related-content` (8 links).
- `site-search`: lazy-loads `search-index.json`, filters ("indexed" → 6 results), and `ArrowDown` drives `aria-selected` `false`→`true`.
- No console warnings or errors.

First of the component-side PRs. The remaining two (shared util module + sidebar factory) involve converting components to ES modules and are sent separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)