### PR TITLE
refactor(components): convert core nav to ES modules + shared helpers

### DIFF
--- a/404.html
+++ b/404.html
@@ -47,7 +47,7 @@
 		<script src="components/theme-toggle.js" defer></script>
 		<script src="components/page-hero.js" defer></script>
 		<script src="components/site-search.js" defer></script>
-		<script src="./components/site-header.js" defer></script>
+		<script src="./components/site-header.js" type="module"></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/components/breadcrumbs.js
+++ b/components/breadcrumbs.js
@@ -20,18 +20,11 @@
 // course/lesson-manifest.json, fetched after the initial render so the bar
 // shows up immediately and the leaf upgrades when the manifest resolves.
 
-(function () {
-	function computeBaseUrl() {
-		const scripts = document.querySelectorAll("script[src]");
-		for (const s of scripts) {
-			if (/components\/breadcrumbs\.js(\?|$)/.test(s.src)) {
-				return s.src.replace(/components\/breadcrumbs\.js(\?.*)?$/, "");
-			}
-		}
-		return "";
-	}
+import { siteBaseUrl } from "./util/base.js";
+import { onReady } from "./util/dom.js";
 
-	const baseUrl = computeBaseUrl();
+(function () {
+	const baseUrl = siteBaseUrl(import.meta.url);
 	const homeUrl = baseUrl + "index.html";
 	const sitePath = new URL(baseUrl || "./", location.href).pathname;
 
@@ -308,9 +301,5 @@
 		main.insertBefore(el, main.firstChild);
 	}
 
-	if (document.readyState === "loading") {
-		document.addEventListener("DOMContentLoaded", autoInject);
-	} else {
-		autoInject();
-	}
+	onReady(autoInject);
 })();

--- a/components/course-sidebar.js
+++ b/components/course-sidebar.js
@@ -21,18 +21,11 @@
 // when :has(course-sidebar) matches. Hidden below ~1100px so narrow viewports
 // fall back to the existing top-of-page lesson-toc.
 
-(function () {
-	function computeBaseUrl() {
-		const scripts = document.querySelectorAll("script[src]");
-		for (const s of scripts) {
-			if (/components\/course-sidebar\.js(\?|$)/.test(s.src)) {
-				return s.src.replace(/components\/course-sidebar\.js(\?.*)?$/, "");
-			}
-		}
-		return "";
-	}
+import { siteBaseUrl } from "./util/base.js";
+import { onReady } from "./util/dom.js";
 
-	const baseUrl = computeBaseUrl();
+(function () {
+	const baseUrl = siteBaseUrl(import.meta.url);
 	const manifestUrl = baseUrl + "course/lesson-manifest.json";
 	const courseHomeUrl = baseUrl + "course/index.html";
 
@@ -151,9 +144,5 @@
 		pageWrapper.insertBefore(el, pageWrapper.firstChild);
 	}
 
-	if (document.readyState === "loading") {
-		document.addEventListener("DOMContentLoaded", autoInject);
-	} else {
-		autoInject();
-	}
+	onReady(autoInject);
 })();

--- a/components/examples-sidebar.js
+++ b/components/examples-sidebar.js
@@ -14,18 +14,11 @@
 // Layout: shares the .page-wrapper :has(...) grid rules with course-sidebar
 // in course-components.css. Hidden below ~1100px.
 
-(function () {
-	function computeBaseUrl() {
-		const scripts = document.querySelectorAll("script[src]");
-		for (const s of scripts) {
-			if (/components\/examples-sidebar\.js(\?|$)/.test(s.src)) {
-				return s.src.replace(/components\/examples-sidebar\.js(\?.*)?$/, "");
-			}
-		}
-		return "";
-	}
+import { siteBaseUrl } from "./util/base.js";
+import { onReady } from "./util/dom.js";
 
-	const baseUrl = computeBaseUrl();
+(function () {
+	const baseUrl = siteBaseUrl(import.meta.url);
 	const manifestUrl = baseUrl + "examples/example-manifest.json";
 	const examplesHomeUrl = baseUrl + "examples/index.html";
 
@@ -133,9 +126,5 @@
 		pageWrapper.insertBefore(el, pageWrapper.firstChild);
 	}
 
-	if (document.readyState === "loading") {
-		document.addEventListener("DOMContentLoaded", autoInject);
-	} else {
-		autoInject();
-	}
+	onReady(autoInject);
 })();

--- a/components/exercises-sidebar.js
+++ b/components/exercises-sidebar.js
@@ -14,18 +14,11 @@
 // Layout: shares the .page-wrapper :has(...) grid rules with course-sidebar
 // in course-components.css. Hidden below ~1100px.
 
-(function () {
-	function computeBaseUrl() {
-		const scripts = document.querySelectorAll("script[src]");
-		for (const s of scripts) {
-			if (/components\/exercises-sidebar\.js(\?|$)/.test(s.src)) {
-				return s.src.replace(/components\/exercises-sidebar\.js(\?.*)?$/, "");
-			}
-		}
-		return "";
-	}
+import { siteBaseUrl } from "./util/base.js";
+import { onReady } from "./util/dom.js";
 
-	const baseUrl = computeBaseUrl();
+(function () {
+	const baseUrl = siteBaseUrl(import.meta.url);
 	const exercisesRootUrl = baseUrl + "exercises/";
 	const exercisesHomeUrl = exercisesRootUrl + "index.html";
 
@@ -144,9 +137,5 @@
 		pageWrapper.insertBefore(el, pageWrapper.firstChild);
 	}
 
-	if (document.readyState === "loading") {
-		document.addEventListener("DOMContentLoaded", autoInject);
-	} else {
-		autoInject();
-	}
+	onReady(autoInject);
 })();

--- a/components/site-header.js
+++ b/components/site-header.js
@@ -5,15 +5,11 @@
 //
 // Loads theme-toggle.js and site-search.js on demand if they haven't already
 // been included by the host page, so callers only need a single <script> tag.
+import { siteBaseUrl } from "./util/base.js";
+import { onReady } from "./util/dom.js";
+
 (function () {
-	const scripts = document.querySelectorAll("script[src]");
-	let baseUrl = "";
-	for (const s of scripts) {
-		if (/components\/site-header\.js(\?|$)/.test(s.src)) {
-			baseUrl = s.src.replace(/components\/site-header\.js(\?.*)?$/, "");
-			break;
-		}
-	}
+	const baseUrl = siteBaseUrl(import.meta.url);
 
 	const componentsBase = baseUrl + "components/";
 	const homeUrl = baseUrl + "index.html";
@@ -32,21 +28,24 @@
 
 	const MOBILE_NAV_ID = "site-nav-mobile";
 
-	function ensureScript(filename) {
+	function ensureScript(filename, { module = false } = {}) {
 		if (document.querySelector(`script[src*="components/${filename}"]`)) return;
 		const s = document.createElement("script");
 		s.src = componentsBase + filename;
-		s.defer = true;
+		if (module) s.type = "module";
+		else s.defer = true;
 		document.head.appendChild(s);
 	}
 
 	// theme-toggle is no longer in the site-header — it lives in the
 	// secondary breadcrumb bar (mounted by breadcrumbs.js). Still loaded
 	// here so it's available across every page that ships site-header.js.
+	// breadcrumbs.js and course-sidebar.js are ES modules and must be injected
+	// with type="module"; theme-toggle.js and site-search.js are classic scripts.
 	ensureScript("theme-toggle.js");
 	ensureScript("site-search.js");
-	ensureScript("breadcrumbs.js");
-	ensureScript("course-sidebar.js");
+	ensureScript("breadcrumbs.js", { module: true });
+	ensureScript("course-sidebar.js", { module: true });
 
 	function buildNavUl() {
 		const navPath = location.pathname;
@@ -187,9 +186,5 @@
 		}
 	}
 
-	if (document.readyState === "loading") {
-		document.addEventListener("DOMContentLoaded", inject);
-	} else {
-		inject();
-	}
+	onReady(inject);
 })();

--- a/components/util/base.js
+++ b/components/util/base.js
@@ -1,0 +1,11 @@
+// Resolve the site root URL from a component module's own location.
+//
+// `import.meta.url` for a component is `<base>/components/<name>.js`, so the
+// site root is one directory above components/. Returns an absolute URL ending
+// in "/" (e.g. "https://host/limerick-cobol/"), suitable for string-concatenating
+// section paths onto, exactly like the value the old per-component
+// `computeBaseUrl()` helpers produced by scanning <script src> tags — but
+// without the fragile regex or the dependency on the tag still being in the DOM.
+export function siteBaseUrl(moduleUrl) {
+	return new URL("../", moduleUrl).href;
+}

--- a/components/util/dom.js
+++ b/components/util/dom.js
@@ -1,0 +1,10 @@
+// Run `fn` once the DOM is ready: synchronously if parsing has already
+// finished, otherwise on DOMContentLoaded. Centralizes the readyState guard
+// that every auto-injecting component otherwise repeats verbatim.
+export function onReady(fn) {
+	if (document.readyState === "loading") {
+		document.addEventListener("DOMContentLoaded", fn, { once: true });
+	} else {
+		fn();
+	}
+}

--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -128,8 +128,8 @@
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
 		<script src="../components/lesson-toc.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
-		<script src="../components/course-sidebar.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
+		<script src="../components/course-sidebar.js" type="module"></script>
 	</head>
 
 	<body>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -104,8 +104,8 @@
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
 		<script src="../components/lesson-toc.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
-		<script src="../components/course-sidebar.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
+		<script src="../components/course-sidebar.js" type="module"></script>
 	</head>
 
 	<body>

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -109,8 +109,8 @@
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
 		<script src="../components/lesson-toc.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
-		<script src="../components/course-sidebar.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
+		<script src="../components/course-sidebar.js" type="module"></script>
 	</head>
 
 	<body>

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -104,8 +104,8 @@
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
 		<script src="../components/lesson-toc.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
-		<script src="../components/course-sidebar.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
+		<script src="../components/course-sidebar.js" type="module"></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -104,8 +104,8 @@
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
 		<script src="../components/lesson-toc.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
-		<script src="../components/course-sidebar.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
+		<script src="../components/course-sidebar.js" type="module"></script>
 	</head>
 
 	<body>

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -110,8 +110,8 @@
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
 		<script src="../components/lesson-toc.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
-		<script src="../components/course-sidebar.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
+		<script src="../components/course-sidebar.js" type="module"></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -104,8 +104,8 @@
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
 		<script src="../components/lesson-toc.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
-		<script src="../components/course-sidebar.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
+		<script src="../components/course-sidebar.js" type="module"></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -107,8 +107,8 @@
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
 		<script src="../components/lesson-toc.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
-		<script src="../components/course-sidebar.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
+		<script src="../components/course-sidebar.js" type="module"></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -104,8 +104,8 @@
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
 		<script src="../components/lesson-toc.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
-		<script src="../components/course-sidebar.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
+		<script src="../components/course-sidebar.js" type="module"></script>
 	</head>
 
 	<body>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -104,8 +104,8 @@
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
 		<script src="../components/lesson-toc.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
-		<script src="../components/course-sidebar.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
+		<script src="../components/course-sidebar.js" type="module"></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -104,8 +104,8 @@
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
 		<script src="../components/lesson-toc.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
-		<script src="../components/course-sidebar.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
+		<script src="../components/course-sidebar.js" type="module"></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -104,8 +104,8 @@
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
 		<script src="../components/lesson-toc.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
-		<script src="../components/course-sidebar.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
+		<script src="../components/course-sidebar.js" type="module"></script>
 	</head>
 
 	<body>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -103,8 +103,8 @@
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
 		<script src="../components/lesson-toc.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
-		<script src="../components/course-sidebar.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
+		<script src="../components/course-sidebar.js" type="module"></script>
 	</head>
 
 	<body>

--- a/course/Search.html
+++ b/course/Search.html
@@ -104,8 +104,8 @@
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
 		<script src="../components/lesson-toc.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
-		<script src="../components/course-sidebar.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
+		<script src="../components/course-sidebar.js" type="module"></script>
 	</head>
 
 	<body>

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -116,8 +116,8 @@
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
 		<script src="../components/lesson-toc.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
-		<script src="../components/course-sidebar.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
+		<script src="../components/course-sidebar.js" type="module"></script>
 	</head>
 
 	<body>

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -104,8 +104,8 @@
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
 		<script src="../components/lesson-toc.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
-		<script src="../components/course-sidebar.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
+		<script src="../components/course-sidebar.js" type="module"></script>
 	</head>
 
 	<body>

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -104,8 +104,8 @@
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
 		<script src="../components/lesson-toc.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
-		<script src="../components/course-sidebar.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
+		<script src="../components/course-sidebar.js" type="module"></script>
 	</head>
 
 	<body>

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -104,8 +104,8 @@
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
 		<script src="../components/lesson-toc.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
-		<script src="../components/course-sidebar.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
+		<script src="../components/course-sidebar.js" type="module"></script>
 	</head>
 
 	<body>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -104,8 +104,8 @@
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
 		<script src="../components/lesson-toc.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
-		<script src="../components/course-sidebar.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
+		<script src="../components/course-sidebar.js" type="module"></script>
 	</head>
 
 	<body>

--- a/course/String.html
+++ b/course/String.html
@@ -104,8 +104,8 @@
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
 		<script src="../components/lesson-toc.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
-		<script src="../components/course-sidebar.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
+		<script src="../components/course-sidebar.js" type="module"></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -104,8 +104,8 @@
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
 		<script src="../components/lesson-toc.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
-		<script src="../components/course-sidebar.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
+		<script src="../components/course-sidebar.js" type="module"></script>
 	</head>
 
 	<body>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -104,8 +104,8 @@
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
 		<script src="../components/lesson-toc.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
-		<script src="../components/course-sidebar.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
+		<script src="../components/course-sidebar.js" type="module"></script>
 	</head>
 
 	<body>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -142,8 +142,8 @@
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
 		<script src="../components/lesson-toc.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
-		<script src="../components/course-sidebar.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
+		<script src="../components/course-sidebar.js" type="module"></script>
 	</head>
 
 	<body>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -104,8 +104,8 @@
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
 		<script src="../components/lesson-toc.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
-		<script src="../components/course-sidebar.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
+		<script src="../components/course-sidebar.js" type="module"></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -104,8 +104,8 @@
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
 		<script src="../components/lesson-toc.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
-		<script src="../components/course-sidebar.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
+		<script src="../components/course-sidebar.js" type="module"></script>
 	</head>
 
 	<body>

--- a/course/glossary.html
+++ b/course/glossary.html
@@ -266,8 +266,8 @@
 		<script src="../components/theme-toggle.js" defer></script>
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
-		<script src="../components/course-sidebar.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
+		<script src="../components/course-sidebar.js" type="module"></script>
 		<script src="../components/last-updated.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 	</head>

--- a/course/index.html
+++ b/course/index.html
@@ -104,8 +104,8 @@
 				}
 			}
 		</style>
-		<script src="../components/site-header.js" defer></script>
-		<script src="../components/course-sidebar.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
+		<script src="../components/course-sidebar.js" type="module"></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
 	</head>

--- a/examples/Accept/ACCEPT.html
+++ b/examples/Accept/ACCEPT.html
@@ -56,8 +56,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/Accept/HelloWorld.html
+++ b/examples/Accept/HelloWorld.html
@@ -59,8 +59,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/Accept/Multiplier.html
+++ b/examples/Accept/Multiplier.html
@@ -59,8 +59,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/Conditn/Conditions.html
+++ b/examples/Conditn/Conditions.html
@@ -56,8 +56,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/Conditn/IterCalc.html
+++ b/examples/Conditn/IterCalc.html
@@ -59,8 +59,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/Conditn/IterIf.html
+++ b/examples/Conditn/IterIf.html
@@ -56,8 +56,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/Indexed/DirectReadIdx.html
+++ b/examples/Indexed/DirectReadIdx.html
@@ -62,8 +62,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/Indexed/Seq2Index.html
+++ b/examples/Indexed/Seq2Index.html
@@ -50,8 +50,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/Indexed/SeqReadIdx.html
+++ b/examples/Indexed/SeqReadIdx.html
@@ -59,8 +59,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/Indexed/WirthMemLib.html
+++ b/examples/Indexed/WirthMemLib.html
@@ -59,8 +59,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/Merge/Merge.html
+++ b/examples/Merge/Merge.html
@@ -56,8 +56,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/Perform/MileageCount.html
+++ b/examples/Perform/MileageCount.html
@@ -59,8 +59,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/Perform/Perform1.html
+++ b/examples/Perform/Perform1.html
@@ -59,8 +59,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/Perform/Perform2.html
+++ b/examples/Perform/Perform2.html
@@ -59,8 +59,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/Perform/Perform3.html
+++ b/examples/Perform/Perform3.html
@@ -59,8 +59,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/Perform/Perform4.html
+++ b/examples/Perform/Perform4.html
@@ -59,8 +59,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/Relative/ReadRel.html
+++ b/examples/Relative/ReadRel.html
@@ -59,8 +59,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/Relative/Seq2Rel.html
+++ b/examples/Relative/Seq2Rel.html
@@ -50,8 +50,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/ReportWriter/RepWriteA.html
+++ b/examples/ReportWriter/RepWriteA.html
@@ -62,8 +62,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/ReportWriter/RepWriteB.html
+++ b/examples/ReportWriter/RepWriteB.html
@@ -62,8 +62,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/ReportWriter/RepWriteFull.html
+++ b/examples/ReportWriter/RepWriteFull.html
@@ -62,8 +62,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/ReportWriter/RepWriteSumm.html
+++ b/examples/ReportWriter/RepWriteSumm.html
@@ -62,8 +62,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/SeqIns/SEQINSERT.html
+++ b/examples/SeqIns/SEQINSERT.html
@@ -59,8 +59,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/SeqRead/SEQREAD.html
+++ b/examples/SeqRead/SEQREAD.html
@@ -56,8 +56,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/SeqRead/SEQREADno88.html
+++ b/examples/SeqRead/SEQREADno88.html
@@ -59,8 +59,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/SeqRpt/SEQRPT.html
+++ b/examples/SeqRpt/SEQRPT.html
@@ -56,8 +56,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/SeqUpd/SeqUpdate.html
+++ b/examples/SeqUpd/SeqUpdate.html
@@ -59,8 +59,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/SeqWrite/SEQWRITE.html
+++ b/examples/SeqWrite/SEQWRITE.html
@@ -59,8 +59,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/Sort/InputSort.html
+++ b/examples/Sort/InputSort.html
@@ -56,8 +56,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/Sort/MaleSort.html
+++ b/examples/Sort/MaleSort.html
@@ -56,8 +56,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/Sort/SortIP.html
+++ b/examples/Sort/SortIP.html
@@ -56,8 +56,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/Strings/RefMod.html
+++ b/examples/Strings/RefMod.html
@@ -56,8 +56,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/Strings/UnstringFileEg.html
+++ b/examples/Strings/UnstringFileEg.html
@@ -62,8 +62,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/SubProg/DateValid/DateDriver.html
+++ b/examples/SubProg/DateValid/DateDriver.html
@@ -62,8 +62,8 @@
 		<script src="../../../components/page-hero.js" defer></script>
 		<script src="../../../components/related-content.js" defer></script>
 		<script src="../../../components/copy-button.js" defer></script>
-		<script src="../../../components/site-header.js" defer></script>
-		<script src="../../../components/examples-sidebar.js" defer></script>
+		<script src="../../../components/site-header.js" type="module"></script>
+		<script src="../../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../../components/copyright-notice.js" defer></script>
 		<script src="../../../components/last-updated.js" defer></script>
 		<script src="../../../components/edit-on-github.js" defer></script>

--- a/examples/SubProg/DateValid/ValiDate.html
+++ b/examples/SubProg/DateValid/ValiDate.html
@@ -62,8 +62,8 @@
 		<script src="../../../components/page-hero.js" defer></script>
 		<script src="../../../components/related-content.js" defer></script>
 		<script src="../../../components/copy-button.js" defer></script>
-		<script src="../../../components/site-header.js" defer></script>
-		<script src="../../../components/examples-sidebar.js" defer></script>
+		<script src="../../../components/site-header.js" type="module"></script>
+		<script src="../../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../../components/copyright-notice.js" defer></script>
 		<script src="../../../components/last-updated.js" defer></script>
 		<script src="../../../components/edit-on-github.js" defer></script>

--- a/examples/SubProg/DayDiff/DayDiffDriver.html
+++ b/examples/SubProg/DayDiff/DayDiffDriver.html
@@ -62,8 +62,8 @@
 		<script src="../../../components/page-hero.js" defer></script>
 		<script src="../../../components/related-content.js" defer></script>
 		<script src="../../../components/copy-button.js" defer></script>
-		<script src="../../../components/site-header.js" defer></script>
-		<script src="../../../components/examples-sidebar.js" defer></script>
+		<script src="../../../components/site-header.js" type="module"></script>
+		<script src="../../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../../components/copyright-notice.js" defer></script>
 		<script src="../../../components/last-updated.js" defer></script>
 		<script src="../../../components/edit-on-github.js" defer></script>

--- a/examples/SubProg/Multiply/DriverProg.html
+++ b/examples/SubProg/Multiply/DriverProg.html
@@ -62,8 +62,8 @@
 		<script src="../../../components/page-hero.js" defer></script>
 		<script src="../../../components/related-content.js" defer></script>
 		<script src="../../../components/copy-button.js" defer></script>
-		<script src="../../../components/site-header.js" defer></script>
-		<script src="../../../components/examples-sidebar.js" defer></script>
+		<script src="../../../components/site-header.js" type="module"></script>
+		<script src="../../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../../components/copyright-notice.js" defer></script>
 		<script src="../../../components/last-updated.js" defer></script>
 		<script src="../../../components/edit-on-github.js" defer></script>

--- a/examples/SubProg/Multiply/Fickle.html
+++ b/examples/SubProg/Multiply/Fickle.html
@@ -62,8 +62,8 @@
 		<script src="../../../components/page-hero.js" defer></script>
 		<script src="../../../components/related-content.js" defer></script>
 		<script src="../../../components/copy-button.js" defer></script>
-		<script src="../../../components/site-header.js" defer></script>
-		<script src="../../../components/examples-sidebar.js" defer></script>
+		<script src="../../../components/site-header.js" type="module"></script>
+		<script src="../../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../../components/copyright-notice.js" defer></script>
 		<script src="../../../components/last-updated.js" defer></script>
 		<script src="../../../components/edit-on-github.js" defer></script>

--- a/examples/SubProg/Multiply/MultiplyNums.html
+++ b/examples/SubProg/Multiply/MultiplyNums.html
@@ -62,8 +62,8 @@
 		<script src="../../../components/page-hero.js" defer></script>
 		<script src="../../../components/related-content.js" defer></script>
 		<script src="../../../components/copy-button.js" defer></script>
-		<script src="../../../components/site-header.js" defer></script>
-		<script src="../../../components/examples-sidebar.js" defer></script>
+		<script src="../../../components/site-header.js" type="module"></script>
+		<script src="../../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../../components/copyright-notice.js" defer></script>
 		<script src="../../../components/last-updated.js" defer></script>
 		<script src="../../../components/edit-on-github.js" defer></script>

--- a/examples/SubProg/Multiply/Steadfast.html
+++ b/examples/SubProg/Multiply/Steadfast.html
@@ -62,8 +62,8 @@
 		<script src="../../../components/page-hero.js" defer></script>
 		<script src="../../../components/related-content.js" defer></script>
 		<script src="../../../components/copy-button.js" defer></script>
-		<script src="../../../components/site-header.js" defer></script>
-		<script src="../../../components/examples-sidebar.js" defer></script>
+		<script src="../../../components/site-header.js" type="module"></script>
+		<script src="../../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../../components/copyright-notice.js" defer></script>
 		<script src="../../../components/last-updated.js" defer></script>
 		<script src="../../../components/edit-on-github.js" defer></script>

--- a/examples/Tables/MonthTable.html
+++ b/examples/Tables/MonthTable.html
@@ -59,8 +59,8 @@
 		<script src="../../components/page-hero.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/copy-button.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
-		<script src="../../components/examples-sidebar.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
+		<script src="../../components/examples-sidebar.js" type="module"></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/last-updated.js" defer></script>
 		<script src="../../components/edit-on-github.js" defer></script>

--- a/examples/index.html
+++ b/examples/index.html
@@ -59,7 +59,7 @@
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
 	</head>
 
 	<body>

--- a/exercises/COBOLExams/COBOLExams.html
+++ b/exercises/COBOLExams/COBOLExams.html
@@ -57,7 +57,7 @@
 		<script src="../../components/site-search.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/CountDown.html
+++ b/exercises/CountDown.html
@@ -42,10 +42,10 @@
 		<script src="../components/site-search.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
 		<script src="../components/last-updated.js" defer></script>
 		<script src="../components/exercise-progress.js" defer></script>
-		<script src="../components/exercises-sidebar.js" defer></script>
+		<script src="../components/exercises-sidebar.js" type="module"></script>
 		<script src="../components/exercises-nav.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html
+++ b/exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html
@@ -58,9 +58,9 @@
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/exercise-progress.js" defer></script>
-		<script src="../../components/exercises-sidebar.js" defer></script>
+		<script src="../../components/exercises-sidebar.js" type="module"></script>
 		<script src="../../components/exercises-nav.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html
+++ b/exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html
@@ -61,7 +61,7 @@
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html
+++ b/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html
@@ -58,9 +58,9 @@
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/exercise-progress.js" defer></script>
-		<script src="../../components/exercises-sidebar.js" defer></script>
+		<script src="../../components/exercises-sidebar.js" type="module"></script>
 		<script src="../../components/exercises-nav.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html
+++ b/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html
@@ -67,7 +67,7 @@
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html
+++ b/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html
@@ -58,9 +58,9 @@
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/exercise-progress.js" defer></script>
-		<script src="../../components/exercises-sidebar.js" defer></script>
+		<script src="../../components/exercises-sidebar.js" type="module"></script>
 		<script src="../../components/exercises-nav.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html
+++ b/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html
@@ -61,7 +61,7 @@
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html
+++ b/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html
@@ -58,9 +58,9 @@
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/exercise-progress.js" defer></script>
-		<script src="../../components/exercises-sidebar.js" defer></script>
+		<script src="../../components/exercises-sidebar.js" type="module"></script>
 		<script src="../../components/exercises-nav.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html
+++ b/exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html
@@ -67,7 +67,7 @@
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html
+++ b/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html
@@ -58,9 +58,9 @@
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/exercise-progress.js" defer></script>
-		<script src="../../components/exercises-sidebar.js" defer></script>
+		<script src="../../components/exercises-sidebar.js" type="module"></script>
 		<script src="../../components/exercises-nav.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html
+++ b/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html
@@ -67,7 +67,7 @@
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html
+++ b/exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html
@@ -58,9 +58,9 @@
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/exercise-progress.js" defer></script>
-		<script src="../../components/exercises-sidebar.js" defer></script>
+		<script src="../../components/exercises-sidebar.js" type="module"></script>
 		<script src="../../components/exercises-nav.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html
+++ b/exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html
@@ -61,7 +61,7 @@
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html
+++ b/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html
@@ -58,9 +58,9 @@
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/exercise-progress.js" defer></script>
-		<script src="../../components/exercises-sidebar.js" defer></script>
+		<script src="../../components/exercises-sidebar.js" type="module"></script>
 		<script src="../../components/exercises-nav.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html
+++ b/exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html
@@ -61,7 +61,7 @@
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Exm-FileConversion/Exm-FileConversion.html
+++ b/exercises/Exm-FileConversion/Exm-FileConversion.html
@@ -58,9 +58,9 @@
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/exercise-progress.js" defer></script>
-		<script src="../../components/exercises-sidebar.js" defer></script>
+		<script src="../../components/exercises-sidebar.js" type="module"></script>
 		<script src="../../components/exercises-nav.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Exm-FileConversion/Prg-FileConversion.html
+++ b/exercises/Exm-FileConversion/Prg-FileConversion.html
@@ -61,7 +61,7 @@
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html
+++ b/exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html
@@ -58,9 +58,9 @@
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/exercise-progress.js" defer></script>
-		<script src="../../components/exercises-sidebar.js" defer></script>
+		<script src="../../components/exercises-sidebar.js" type="module"></script>
 		<script src="../../components/exercises-nav.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html
+++ b/exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html
@@ -61,7 +61,7 @@
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html
+++ b/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html
@@ -58,9 +58,9 @@
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/exercise-progress.js" defer></script>
-		<script src="../../components/exercises-sidebar.js" defer></script>
+		<script src="../../components/exercises-sidebar.js" type="module"></script>
 		<script src="../../components/exercises-nav.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html
+++ b/exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html
@@ -61,7 +61,7 @@
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Exm-SFbyMail/Exm-SFbyMail.html
+++ b/exercises/Exm-SFbyMail/Exm-SFbyMail.html
@@ -58,9 +58,9 @@
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/exercise-progress.js" defer></script>
-		<script src="../../components/exercises-sidebar.js" defer></script>
+		<script src="../../components/exercises-sidebar.js" type="module"></script>
 		<script src="../../components/exercises-nav.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Exm-SFbyMail/Prg-SFbyMail.html
+++ b/exercises/Exm-SFbyMail/Prg-SFbyMail.html
@@ -61,7 +61,7 @@
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Exm-StudFeesRpt/Exm-StudPay.html
+++ b/exercises/Exm-StudFeesRpt/Exm-StudPay.html
@@ -58,9 +58,9 @@
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/exercise-progress.js" defer></script>
-		<script src="../../components/exercises-sidebar.js" defer></script>
+		<script src="../../components/exercises-sidebar.js" type="module"></script>
 		<script src="../../components/exercises-nav.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Exm-StudFeesRpt/Prg-StudPay.html
+++ b/exercises/Exm-StudFeesRpt/Prg-StudPay.html
@@ -61,7 +61,7 @@
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html
+++ b/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html
@@ -58,9 +58,9 @@
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/exercise-progress.js" defer></script>
-		<script src="../../components/exercises-sidebar.js" defer></script>
+		<script src="../../components/exercises-sidebar.js" type="module"></script>
 		<script src="../../components/exercises-nav.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html
+++ b/exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html
@@ -61,7 +61,7 @@
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html
+++ b/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html
@@ -58,9 +58,9 @@
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/exercise-progress.js" defer></script>
-		<script src="../../components/exercises-sidebar.js" defer></script>
+		<script src="../../components/exercises-sidebar.js" type="module"></script>
 		<script src="../../components/exercises-nav.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html
+++ b/exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html
@@ -61,7 +61,7 @@
 		<script src="../../components/copy-button.js" defer></script>
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/GettingStarted.html
+++ b/exercises/GettingStarted.html
@@ -54,12 +54,12 @@
 		<script src="../components/site-search.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
 		<script src="../components/last-updated.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/run-in-ce.js" defer></script>
 		<script src="../components/exercise-progress.js" defer></script>
-		<script src="../components/exercises-sidebar.js" defer></script>
+		<script src="../components/exercises-sidebar.js" type="module"></script>
 		<script src="../components/exercises-nav.js" defer></script>
 	</head>
 	<body>

--- a/exercises/MonthTable.html
+++ b/exercises/MonthTable.html
@@ -51,10 +51,10 @@
 		<script src="../components/site-search.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
 		<script src="../components/last-updated.js" defer></script>
 		<script src="../components/exercise-progress.js" defer></script>
-		<script src="../components/exercises-sidebar.js" defer></script>
+		<script src="../components/exercises-sidebar.js" type="module"></script>
 		<script src="../components/exercises-nav.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html
+++ b/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html
@@ -58,9 +58,9 @@
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/exercise-progress.js" defer></script>
-		<script src="../../components/exercises-sidebar.js" defer></script>
+		<script src="../../components/exercises-sidebar.js" type="module"></script>
 		<script src="../../components/exercises-nav.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html
+++ b/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html
@@ -58,9 +58,9 @@
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/exercise-progress.js" defer></script>
-		<script src="../../components/exercises-sidebar.js" defer></script>
+		<script src="../../components/exercises-sidebar.js" type="module"></script>
 		<script src="../../components/exercises-nav.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html
+++ b/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html
@@ -58,9 +58,9 @@
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/exercise-progress.js" defer></script>
-		<script src="../../components/exercises-sidebar.js" defer></script>
+		<script src="../../components/exercises-sidebar.js" type="module"></script>
 		<script src="../../components/exercises-nav.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html
+++ b/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html
@@ -58,9 +58,9 @@
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/exercise-progress.js" defer></script>
-		<script src="../../components/exercises-sidebar.js" defer></script>
+		<script src="../../components/exercises-sidebar.js" type="module"></script>
 		<script src="../../components/exercises-nav.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html
+++ b/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html
@@ -91,9 +91,9 @@
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/exercise-progress.js" defer></script>
-		<script src="../../components/exercises-sidebar.js" defer></script>
+		<script src="../../components/exercises-sidebar.js" type="module"></script>
 		<script src="../../components/exercises-nav.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/Proj-CSISEvalform/CSISEvalForm.html
+++ b/exercises/Proj-CSISEvalform/CSISEvalForm.html
@@ -58,9 +58,9 @@
 		<script src="../../components/copyright-notice.js" defer></script>
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/exercise-progress.js" defer></script>
-		<script src="../../components/exercises-sidebar.js" defer></script>
+		<script src="../../components/exercises-sidebar.js" type="module"></script>
 		<script src="../../components/exercises-nav.js" defer></script>
-		<script src="../../components/site-header.js" defer></script>
+		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/exercises/SeqInsert.html
+++ b/exercises/SeqInsert.html
@@ -51,10 +51,10 @@
 		<script src="../components/site-search.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
 		<script src="../components/last-updated.js" defer></script>
 		<script src="../components/exercise-progress.js" defer></script>
-		<script src="../components/exercises-sidebar.js" defer></script>
+		<script src="../components/exercises-sidebar.js" type="module"></script>
 		<script src="../components/exercises-nav.js" defer></script>
 	</head>
 	<body>

--- a/exercises/SeqRead.html
+++ b/exercises/SeqRead.html
@@ -51,10 +51,10 @@
 		<script src="../components/site-search.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
 		<script src="../components/last-updated.js" defer></script>
 		<script src="../components/exercise-progress.js" defer></script>
-		<script src="../components/exercises-sidebar.js" defer></script>
+		<script src="../components/exercises-sidebar.js" type="module"></script>
 		<script src="../components/exercises-nav.js" defer></script>
 	</head>
 	<body>

--- a/exercises/SeqReadIf.html
+++ b/exercises/SeqReadIf.html
@@ -51,10 +51,10 @@
 		<script src="../components/site-search.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
 		<script src="../components/last-updated.js" defer></script>
 		<script src="../components/exercise-progress.js" defer></script>
-		<script src="../components/exercises-sidebar.js" defer></script>
+		<script src="../components/exercises-sidebar.js" type="module"></script>
 		<script src="../components/exercises-nav.js" defer></script>
 	</head>
 	<body>

--- a/exercises/SeqUpdate.html
+++ b/exercises/SeqUpdate.html
@@ -51,10 +51,10 @@
 		<script src="../components/site-search.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
 		<script src="../components/last-updated.js" defer></script>
 		<script src="../components/exercise-progress.js" defer></script>
-		<script src="../components/exercises-sidebar.js" defer></script>
+		<script src="../components/exercises-sidebar.js" type="module"></script>
 		<script src="../components/exercises-nav.js" defer></script>
 	</head>
 	<body>

--- a/exercises/SeqWrite.html
+++ b/exercises/SeqWrite.html
@@ -51,10 +51,10 @@
 		<script src="../components/site-search.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
 		<script src="../components/last-updated.js" defer></script>
 		<script src="../components/exercise-progress.js" defer></script>
-		<script src="../components/exercises-sidebar.js" defer></script>
+		<script src="../components/exercises-sidebar.js" type="module"></script>
 		<script src="../components/exercises-nav.js" defer></script>
 	</head>
 	<body>

--- a/exercises/SortIP.html
+++ b/exercises/SortIP.html
@@ -51,10 +51,10 @@
 		<script src="../components/site-search.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
 		<script src="../components/last-updated.js" defer></script>
 		<script src="../components/exercise-progress.js" defer></script>
-		<script src="../components/exercises-sidebar.js" defer></script>
+		<script src="../components/exercises-sidebar.js" type="module"></script>
 		<script src="../components/exercises-nav.js" defer></script>
 	</head>
 	<body>

--- a/exercises/index.html
+++ b/exercises/index.html
@@ -57,7 +57,7 @@
 		<script src="../components/page-hero.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/site-search.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
 		<script src="../components/last-updated.js" defer></script>
 	</head>
 	<body>

--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
 			name="twitter:description"
 			content="COBOL programming site with a full COBOL course as well as lectures, tutorials, programming exercises, and over 50 example COBOL programs."
 		/>
-		<script src="components/site-header.js" defer></script>
+		<script src="components/site-header.js" type="module"></script>
 		<script src="components/page-hero.js" defer></script>
 		<script src="components/copyright-notice.js" defer></script>
 		<script src="components/last-updated.js" defer></script>

--- a/lectures/cs4312topics.html
+++ b/lectures/cs4312topics.html
@@ -7,7 +7,7 @@
 		<meta name="robots" content="noindex" />
 		<meta http-equiv="refresh" content="0; url=index.html" />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/index.html" />
-		<script src="../components/site-header.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
 	</head>
 	<body>
 		<p>This page has moved. <a href="index.html">Go to the lectures index.</a></p>

--- a/lectures/index.html
+++ b/lectures/index.html
@@ -90,7 +90,7 @@
 				flex-shrink: 0;
 			}
 		</style>
-		<script src="../components/site-header.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
 	</head>
 
 	<body>

--- a/lectures/reportwriterssweb.html
+++ b/lectures/reportwriterssweb.html
@@ -151,7 +151,7 @@
 		</style>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
 	</head>
 	<body id="top">
 		<div class="page-wrapper">

--- a/lectures/reportwriterweb.html
+++ b/lectures/reportwriterweb.html
@@ -140,7 +140,7 @@
 		</style>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
-		<script src="../components/site-header.js" defer></script>
+		<script src="../components/site-header.js" type="module"></script>
 	</head>
 	<body id="top">
 		<div class="page-wrapper">

--- a/scripts/build-examples.ts
+++ b/scripts/build-examples.ts
@@ -632,8 +632,8 @@ function buildPage(entry: ManifestEntry): string {
 \t\t<script src="${pfx}components/page-hero.js" defer></script>
 \t\t<script src="${pfx}components/related-content.js" defer></script>
 \t\t<script src="${pfx}components/copy-button.js" defer></script>
-\t\t<script src="${pfx}components/site-header.js" defer></script>
-\t\t<script src="${pfx}components/examples-sidebar.js" defer></script>
+\t\t<script src="${pfx}components/site-header.js" type="module"></script>
+\t\t<script src="${pfx}components/examples-sidebar.js" type="module"></script>
 \t\t<script src="${pfx}components/copyright-notice.js" defer></script>
 \t\t<script src="${pfx}components/last-updated.js" defer></script>
 \t\t<script src="${pfx}components/edit-on-github.js" defer></script>

--- a/scripts/inject-site-header.ts
+++ b/scripts/inject-site-header.ts
@@ -43,7 +43,7 @@ for (const file of collectHtmlFiles(ROOT)) {
 	}
 
 	const src = relComponentsPath(file);
-	const tag = `\t\t<script src="${src}" defer></script>`;
+	const tag = `\t\t<script src="${src}" type="module"></script>`;
 
 	// Insert just before </head>. Match the existing indentation pattern.
 	const newHtml = html.replace(/([ \t]*)<\/head>/, (_m, indent) => `${tag}\n${indent}</head>`);


### PR DESCRIPTION
## What

Converts `site-header`, `breadcrumbs`, and the three sidebars (`course`/`examples`/`exercises`) to **ES modules** so they can share two new helpers — replacing five copy-pasted implementations:

- **`components/util/base.js`** — `siteBaseUrl(import.meta.url)` returns the site root via `new URL("../", import.meta.url)`. This deletes the per-component `computeBaseUrl()` that scanned `<script src>` tags with a per-file regex (and depended on the tag still being in the DOM). `import.meta.url` is the module's own absolute URL, so the base resolves correctly at any page depth and under any deployment prefix.
- **`components/util/dom.js`** — `onReady(fn)` centralizes the `document.readyState` / `DOMContentLoaded` guard each component repeated verbatim.

## Loading mechanics (the bulk of the diff)

- The ~217 `<script defer>` tags for these components across **120 pages** are flipped to `type="module"`:
  - hand-authored pages (course/exercises/lectures/index/404) updated in place;
  - generated example pages via the `build-examples.ts` template;
  - the `site-header` tag via `inject-site-header.ts`.
  Both emitters were updated so regeneration/injection stays consistent and idempotent.
- `site-header.js`'s `ensureScript()` gained a `{ module }` option and now injects `breadcrumbs.js` + `course-sidebar.js` as `type="module"`. `theme-toggle.js` and `site-search.js` stay classic — `site-search` relies on `document.currentScript`, which is `null` in module scripts.

## Scope note

I deliberately **did not** convert `theme-toggle`/`lesson-progress`/`copyright-notice` (the storage-wrapper and ensureComponent dedups). They'd have required flipping ~257 more tags for a try/catch wrapper and a script-loader guard — a poor blast-radius/payoff trade.

## Verification (preview server, all page types)

Home, course, **deep example path**, exercise, and lecture pages all checked:
- `site-header`, `breadcrumbs`, and all three sidebars render with **correct base URLs** and active-page highlighting (e.g. deep `examples/Accept/ACCEPT.html`: logo → site root, 42 sidebar links, active = current page).
- `exercises-sidebar` still reads `window.COBOL_EXERCISES` correctly as a module (ordering preserved — classic-`defer` and non-async `module` share one ordered post-parse list).
- Search + nav work; `npm run validate` (html-validate) passes; `check:examples` and `inject-site-header` idempotent; **no console errors** on any page.

Follow-up PR will dedupe the now-shared sidebar render logic (`renderSidebar` factory + `createEl`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)