### PR TITLE
refactor(components): extract shared sidebar render factory

### DIFF
--- a/components/course-sidebar.js
+++ b/components/course-sidebar.js
@@ -23,6 +23,7 @@
 
 import { siteBaseUrl } from "./util/base.js";
 import { onReady } from "./util/dom.js";
+import { renderSidebar } from "./util/sidebar.js";
 
 (function () {
 	const baseUrl = siteBaseUrl(import.meta.url);
@@ -54,57 +55,15 @@ import { onReady } from "./util/dom.js";
 
 	function render(host, manifest) {
 		const cur = currentPath();
-
-		const nav = document.createElement("nav");
-		nav.className = "course-sidebar";
-		nav.setAttribute("aria-label", "Course outline");
-
-		const heading = document.createElement("p");
-		heading.className = "course-sidebar-heading";
-		const headingLink = document.createElement("a");
-		headingLink.href = courseHomeUrl;
-		headingLink.textContent = "COBOL Course";
-		heading.appendChild(headingLink);
-		nav.appendChild(heading);
-
-		const list = document.createElement("ol");
-		list.className = "course-sidebar-topics";
-
-		for (const topic of manifest.topics) {
-			const topicLi = document.createElement("li");
-			topicLi.className = "course-sidebar-topic";
-
-			const topicLabel = document.createElement("p");
-			topicLabel.className = "course-sidebar-topic-label";
-			topicLabel.textContent = topic.label;
-			topicLi.appendChild(topicLabel);
-
-			const linksUl = document.createElement("ul");
-			linksUl.className = "course-sidebar-links";
-
-			let topicHasActive = false;
-			for (const link of topic.links) {
-				const li = document.createElement("li");
-				li.className = `course-sidebar-link course-sidebar-link--${link.type}`;
-				const a = document.createElement("a");
-				a.href = new URL(link.file, manifestUrl).toString();
-				a.textContent = link.title;
-				if (resolvePath(link.file) === cur) {
-					a.setAttribute("data-active", "");
-					a.setAttribute("aria-current", "page");
-					topicHasActive = true;
-				}
-				li.appendChild(a);
-				linksUl.appendChild(li);
-			}
-
-			if (topicHasActive) topicLi.setAttribute("data-active-topic", "");
-			topicLi.appendChild(linksUl);
-			list.appendChild(topicLi);
-		}
-
-		nav.appendChild(list);
-		host.appendChild(nav);
+		renderSidebar(host, {
+			ariaLabel: "Course outline",
+			homeUrl: courseHomeUrl,
+			homeLabel: "COBOL Course",
+			topics: manifest.topics,
+			hrefFor: (link) => new URL(link.file, manifestUrl).toString(),
+			isActive: (link) => resolvePath(link.file) === cur,
+			linkClass: (link) => `course-sidebar-link course-sidebar-link--${link.type}`,
+		});
 	}
 
 	class CourseSidebar extends HTMLElement {

--- a/components/examples-sidebar.js
+++ b/components/examples-sidebar.js
@@ -16,6 +16,7 @@
 
 import { siteBaseUrl } from "./util/base.js";
 import { onReady } from "./util/dom.js";
+import { renderSidebar } from "./util/sidebar.js";
 
 (function () {
 	const baseUrl = siteBaseUrl(import.meta.url);
@@ -40,57 +41,14 @@ import { onReady } from "./util/dom.js";
 
 	function render(host, manifest) {
 		const cur = currentPath();
-
-		const nav = document.createElement("nav");
-		nav.className = "course-sidebar";
-		nav.setAttribute("aria-label", "Examples outline");
-
-		const heading = document.createElement("p");
-		heading.className = "course-sidebar-heading";
-		const headingLink = document.createElement("a");
-		headingLink.href = examplesHomeUrl;
-		headingLink.textContent = "COBOL Examples";
-		heading.appendChild(headingLink);
-		nav.appendChild(heading);
-
-		const list = document.createElement("ol");
-		list.className = "course-sidebar-topics";
-
-		for (const topic of manifest.topics) {
-			const topicLi = document.createElement("li");
-			topicLi.className = "course-sidebar-topic";
-
-			const topicLabel = document.createElement("p");
-			topicLabel.className = "course-sidebar-topic-label";
-			topicLabel.textContent = topic.label;
-			topicLi.appendChild(topicLabel);
-
-			const linksUl = document.createElement("ul");
-			linksUl.className = "course-sidebar-links";
-
-			let topicHasActive = false;
-			for (const link of topic.links) {
-				const li = document.createElement("li");
-				li.className = "course-sidebar-link";
-				const a = document.createElement("a");
-				a.href = new URL(link.file, manifestUrl).toString();
-				a.textContent = link.title;
-				if (resolvePath(link.file) === cur) {
-					a.setAttribute("data-active", "");
-					a.setAttribute("aria-current", "page");
-					topicHasActive = true;
-				}
-				li.appendChild(a);
-				linksUl.appendChild(li);
-			}
-
-			if (topicHasActive) topicLi.setAttribute("data-active-topic", "");
-			topicLi.appendChild(linksUl);
-			list.appendChild(topicLi);
-		}
-
-		nav.appendChild(list);
-		host.appendChild(nav);
+		renderSidebar(host, {
+			ariaLabel: "Examples outline",
+			homeUrl: examplesHomeUrl,
+			homeLabel: "COBOL Examples",
+			topics: manifest.topics,
+			hrefFor: (link) => new URL(link.file, manifestUrl).toString(),
+			isActive: (link) => resolvePath(link.file) === cur,
+		});
 	}
 
 	class ExamplesSidebar extends HTMLElement {

--- a/components/exercises-sidebar.js
+++ b/components/exercises-sidebar.js
@@ -16,6 +16,7 @@
 
 import { siteBaseUrl } from "./util/base.js";
 import { onReady } from "./util/dom.js";
+import { renderSidebar } from "./util/sidebar.js";
 
 (function () {
 	const baseUrl = siteBaseUrl(import.meta.url);
@@ -54,57 +55,14 @@ import { onReady } from "./util/dom.js";
 
 	function render(host, topics) {
 		const cur = currentPath();
-
-		const nav = document.createElement("nav");
-		nav.className = "course-sidebar";
-		nav.setAttribute("aria-label", "Exercises outline");
-
-		const heading = document.createElement("p");
-		heading.className = "course-sidebar-heading";
-		const headingLink = document.createElement("a");
-		headingLink.href = exercisesHomeUrl;
-		headingLink.textContent = "COBOL Exercises";
-		heading.appendChild(headingLink);
-		nav.appendChild(heading);
-
-		const list = document.createElement("ol");
-		list.className = "course-sidebar-topics";
-
-		for (const topic of topics) {
-			const topicLi = document.createElement("li");
-			topicLi.className = "course-sidebar-topic";
-
-			const topicLabel = document.createElement("p");
-			topicLabel.className = "course-sidebar-topic-label";
-			topicLabel.textContent = topic.label;
-			topicLi.appendChild(topicLabel);
-
-			const linksUl = document.createElement("ul");
-			linksUl.className = "course-sidebar-links";
-
-			let topicHasActive = false;
-			for (const link of topic.links) {
-				const li = document.createElement("li");
-				li.className = "course-sidebar-link";
-				const a = document.createElement("a");
-				a.href = new URL(link.file, exercisesRootUrl).toString();
-				a.textContent = link.title;
-				if (resolvePath(link.file) === cur) {
-					a.setAttribute("data-active", "");
-					a.setAttribute("aria-current", "page");
-					topicHasActive = true;
-				}
-				li.appendChild(a);
-				linksUl.appendChild(li);
-			}
-
-			if (topicHasActive) topicLi.setAttribute("data-active-topic", "");
-			topicLi.appendChild(linksUl);
-			list.appendChild(topicLi);
-		}
-
-		nav.appendChild(list);
-		host.appendChild(nav);
+		renderSidebar(host, {
+			ariaLabel: "Exercises outline",
+			homeUrl: exercisesHomeUrl,
+			homeLabel: "COBOL Exercises",
+			topics,
+			hrefFor: (link) => new URL(link.file, exercisesRootUrl).toString(),
+			isActive: (link) => resolvePath(link.file) === cur,
+		});
 	}
 
 	class ExercisesSidebar extends HTMLElement {

--- a/components/util/dom.js
+++ b/components/util/dom.js
@@ -8,3 +8,23 @@ export function onReady(fn) {
 		fn();
 	}
 }
+
+// Terse element builder. `props` keys: `class` → className, `text` →
+// textContent, anything else → setAttribute (a `true` value sets a bare
+// boolean attribute). `children` may be a single node or an array; falsy
+// entries are skipped. Replaces the createElement + className + textContent +
+// setAttribute boilerplate the components otherwise repeat.
+export function createEl(tag, props = {}, children = []) {
+	const el = document.createElement(tag);
+	for (const [key, value] of Object.entries(props)) {
+		if (value == null || value === false) continue;
+		if (key === "class") el.className = value;
+		else if (key === "text") el.textContent = value;
+		else if (value === true) el.setAttribute(key, "");
+		else el.setAttribute(key, value);
+	}
+	for (const child of Array.isArray(children) ? children : [children]) {
+		if (child) el.appendChild(child);
+	}
+	return el;
+}

--- a/components/util/sidebar.js
+++ b/components/util/sidebar.js
@@ -1,0 +1,52 @@
+import { createEl } from "./dom.js";
+
+// Shared renderer for the three left-rail outline sidebars (course, examples,
+// exercises). They produce identical markup — a heading link plus topic groups
+// of links, with the current page marked [data-active] / aria-current — and
+// differ only in their labels, link targets, and active-page test. Those
+// differences are injected via `config`:
+//
+//   ariaLabel  — nav aria-label
+//   homeUrl    — href for the heading link
+//   homeLabel  — text for the heading link
+//   topics     — [{ label, links: [{ file, title, ... }] }]
+//   hrefFor    — (link) => string, the anchor href
+//   isActive   — (link) => boolean, whether this link is the current page
+//   linkClass  — (link) => string, the <li> class (optional; defaults to
+//                "course-sidebar-link")
+//
+// All three rails reuse the .course-sidebar* class names so one CSS ruleset
+// styles them, hence the shared "course-sidebar" markup regardless of section.
+export function renderSidebar(host, config) {
+	const { ariaLabel, homeUrl, homeLabel, topics, hrefFor, isActive, linkClass } = config;
+
+	const nav = createEl("nav", { class: "course-sidebar", "aria-label": ariaLabel }, [
+		createEl("p", { class: "course-sidebar-heading" }, [createEl("a", { href: homeUrl, text: homeLabel })]),
+	]);
+
+	const list = createEl("ol", { class: "course-sidebar-topics" });
+
+	for (const topic of topics) {
+		const linksUl = createEl("ul", { class: "course-sidebar-links" });
+		let topicHasActive = false;
+
+		for (const link of topic.links) {
+			const a = createEl("a", { href: hrefFor(link), text: link.title });
+			if (isActive(link)) {
+				a.setAttribute("data-active", "");
+				a.setAttribute("aria-current", "page");
+				topicHasActive = true;
+			}
+			linksUl.appendChild(createEl("li", { class: linkClass ? linkClass(link) : "course-sidebar-link" }, [a]));
+		}
+
+		const topicLi = createEl("li", { class: "course-sidebar-topic", "data-active-topic": topicHasActive }, [
+			createEl("p", { class: "course-sidebar-topic-label", text: topic.label }),
+			linksUl,
+		]);
+		list.appendChild(topicLi);
+	}
+
+	nav.appendChild(list);
+	host.appendChild(nav);
+}


### PR DESCRIPTION
## What

The course / examples / exercises sidebars produced **identical** markup — a heading link plus topic groups of links, with the current page marked `[data-active]` / `aria-current` — differing only in labels, link targets, and the active-page test. This hoists that into `components/util/sidebar.js`:

- **`renderSidebar(host, config)`** builds the shared `.course-sidebar` markup. Each sidebar passes `ariaLabel` / `homeUrl` / `homeLabel` / `topics` / `hrefFor` / `isActive` / `linkClass`.
- **`createEl(tag, props, children)`** (new, in `util/dom.js`) replaces the `createElement` + `className` + `textContent` + `setAttribute` boilerplate.

Removes ~150 lines of duplicated DOM construction (sidebars −105 net). **No new `<script>` tag changes** — the three sidebars are already ES modules from #663.

## Verification (preview server)

All three sidebars render with **identical structure**, correct base URLs, and active-page highlighting:
- **course** (`/course/Iteration.html`): 36 links, 11 topic groups, the `course-sidebar-link--tutorial` type classes preserved, `data-active-topic` set, active link `aria-current="page"`.
- **examples** (deep `/examples/SubProg/DateValid/ValiDate.html`): 42 links, plain `course-sidebar-link` class, active = current page.
- **exercises** (`/exercises/Exm-CSISEmailDomain/…`): 30 links, 3 groups, `data-active-topic`, active = current.
- No console errors.

## ⚠️ Stacked PR

Branches off `refactor/component-es-modules` (#663). **Merge #663 first**, then this retargets `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)