### PR TITLE
MDN-inspired look-and-feel refresh

### DIFF
--- a/course/Resources/css/course-components.css
+++ b/course/Resources/css/course-components.css
@@ -17,7 +17,8 @@
 	column-gap: 0.75em;
 	padding: 0.25em 0.5em;
 	background-color: var(--color-bg);
-	border-bottom: 1px solid var(--color-border-mute);
+	border-bottom: 1px solid var(--color-border-soft);
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
 	box-sizing: border-box;
 }
 
@@ -68,7 +69,7 @@
 .site-nav a {
 	display: inline-block;
 	padding: 0.25em 0.6em;
-	font-family: Arial, Helvetica, sans-serif;
+	font-family: var(--font-sans);
 	font-size: 0.9em;
 	text-decoration: none;
 	color: var(--color-text);
@@ -78,7 +79,7 @@
 }
 
 .site-nav a:hover {
-	background-color: var(--color-border-mute);
+	background-color: var(--color-cell-label-bg);
 }
 
 .site-nav a[data-active] {
@@ -137,7 +138,7 @@
 	}
 
 	.site-header__hamburger:hover {
-		background-color: var(--color-border-mute);
+		background-color: var(--color-cell-label-bg);
 	}
 
 	.site-header__hamburger:focus-visible {
@@ -161,14 +162,14 @@
 	.site-nav-mobile a {
 		display: block;
 		padding: 0.5em 0.75em;
-		font-family: Arial, Helvetica, sans-serif;
+		font-family: var(--font-sans);
 		font-size: 0.95em;
 		text-decoration: none;
 		color: var(--color-text);
 	}
 
 	.site-nav-mobile a:hover {
-		background-color: var(--color-border-mute);
+		background-color: var(--color-cell-label-bg);
 	}
 
 	.site-nav-mobile a[data-active] {
@@ -210,7 +211,7 @@ nav[aria-label="Breadcrumb"] {
    colour override. */
 .page-hero-reading-time {
 	margin: 0.1em 0 0;
-	font-family: Arial, Helvetica, sans-serif;
+	font-family: var(--font-sans);
 	font-size: 0.8em;
 	opacity: 0.65;
 }
@@ -323,7 +324,7 @@ dl.index-grid.bullet-orange {
    neighbour links are present; text-align stays inside in case the row wraps. */
 .lesson-nav-position {
 	font-size: 0.85em;
-	font-family: Arial, Helvetica, sans-serif;
+	font-family: var(--font-sans);
 	color: var(--color-panel-text);
 	font-weight: bold;
 	letter-spacing: 0.04em;
@@ -424,7 +425,7 @@ dl.index-grid.bullet-orange {
 }
 
 .course-progress-reset {
-	font-family: Arial, Helvetica, sans-serif;
+	font-family: var(--font-sans);
 	font-size: 0.8em;
 	font-weight: bold;
 	letter-spacing: 0.04em;
@@ -488,7 +489,7 @@ dl.index-grid.bullet-orange {
 
 ul.construct-list {
 	list-style-type: disc;
-	font-family: Arial, Helvetica, sans-serif;
+	font-family: var(--font-sans);
 	font-weight: bold;
 	color: var(--color-emphasis);
 	font-size: 1.5em;
@@ -910,8 +911,11 @@ details[open].saq-reveal summary::before {
 	max-width: 100%;
 	margin-left: auto;
 	margin-right: auto;
-	border: 1px solid;
+	border: 1px solid var(--color-border-soft);
+	border-radius: var(--radius);
+	box-shadow: var(--shadow-card);
 	padding: 1px;
+	overflow: hidden;
 	box-sizing: border-box;
 }
 
@@ -991,7 +995,7 @@ details[open].saq-reveal summary::before {
 	width: 22px;
 	height: 21px;
 	border-radius: 3px;
-	font-family: Arial, Helvetica, sans-serif;
+	font-family: var(--font-sans);
 	font-size: 12px;
 	font-weight: bold;
 	color: #fff;
@@ -1431,7 +1435,7 @@ dl.exam-meta {
 
 dl.exam-meta dt {
 	font-weight: bold;
-	font-family: Arial, Helvetica, sans-serif;
+	font-family: var(--font-sans);
 	color: var(--color-panel-text);
 }
 
@@ -1499,7 +1503,7 @@ figure.example-run {
 figure.example-run figcaption {
 	background-color: var(--color-panel-bg);
 	color: var(--color-panel-text);
-	font-family: Arial, Helvetica, sans-serif;
+	font-family: var(--font-sans);
 	font-weight: bold;
 	padding: 4px 10px;
 	border-bottom: 1px solid;
@@ -1537,7 +1541,7 @@ related-content {
 }
 
 .related-heading {
-	font-family: Arial, Helvetica, sans-serif;
+	font-family: var(--font-sans);
 	font-size: 1em;
 	font-weight: bold;
 	margin: 0 0 0.4em;
@@ -1550,7 +1554,7 @@ related-content {
 }
 
 .related-group-label {
-	font-family: Arial, Helvetica, sans-serif;
+	font-family: var(--font-sans);
 	font-size: 0.85em;
 	font-weight: bold;
 	margin: 0 0 0.2em;
@@ -1597,7 +1601,7 @@ lesson-toc {
 }
 
 .page-toc-heading {
-	font-family: Arial, Helvetica, sans-serif;
+	font-family: var(--font-sans);
 	font-size: 0.9em;
 	font-weight: bold;
 	text-transform: uppercase;
@@ -1664,6 +1668,9 @@ lesson-toc {
 		column-gap: 2em;
 		max-width: 947px;
 		border: none;
+		border-radius: 0;
+		box-shadow: none;
+		overflow: visible;
 	}
 
 	.page-wrapper:has(page-toc) > *:not(page-toc) {
@@ -1936,7 +1943,7 @@ edit-on-github {
 
 .edit-on-github-heading {
 	margin: 0 0 0.25em;
-	font-family: Arial, Helvetica, sans-serif;
+	font-family: var(--font-sans);
 	font-size: 0.9em;
 	font-weight: bold;
 	text-transform: uppercase;
@@ -1995,7 +2002,7 @@ page-breadcrumbs {
 	   sticky-stacked at the top of the viewport. */
 	z-index: 199;
 	background-color: var(--color-bg);
-	border-bottom: 1px solid var(--color-border-mute);
+	border-bottom: 1px solid var(--color-border-soft);
 	box-sizing: border-box;
 }
 
@@ -2154,7 +2161,7 @@ exercises-sidebar {
 }
 
 .course-sidebar-heading {
-	font-family: Arial, Helvetica, sans-serif;
+	font-family: var(--font-sans);
 	font-size: 0.9em;
 	font-weight: bold;
 	text-transform: uppercase;
@@ -2184,7 +2191,7 @@ exercises-sidebar {
 }
 
 .course-sidebar-topic-label {
-	font-family: Arial, Helvetica, sans-serif;
+	font-family: var(--font-sans);
 	font-size: 0.85em;
 	font-weight: bold;
 	text-transform: uppercase;
@@ -2273,6 +2280,9 @@ exercises-sidebar {
 		column-gap: 2em;
 		max-width: 967px;
 		border: none;
+		border-radius: 0;
+		box-shadow: none;
+		overflow: visible;
 		align-items: start;
 	}
 
@@ -2388,7 +2398,7 @@ exercises-sidebar {
 	padding: 4px 8px;
 	border: 1px solid var(--color-border-mute);
 	border-radius: 3px;
-	font-family: sans-serif;
+	font-family: var(--font-sans);
 	font-size: 0.85rem;
 	text-decoration: none;
 	color: var(--color-text);

--- a/course/Resources/css/course.css
+++ b/course/Resources/css/course.css
@@ -1,16 +1,30 @@
 :root {
 	color-scheme: light dark;
 
+	/* Type stacks. A system-UI-first sans (the same family MDN renders for most
+	   users) replaces the browser-default serif for body copy and chrome; a
+	   modern monospace stack handles code. Routed through tokens so every
+	   component picks up the same fonts. */
+	--font-sans: system-ui, -apple-system, "Segoe UI", Roboto, Inter, "Helvetica Neue", Arial, sans-serif;
+	--font-mono: ui-monospace, "SF Mono", "Cascadia Code", "Roboto Mono", Consolas, "Liberation Mono", Menlo, monospace;
+
+	/* Corner radii for framed surfaces (content frame, cards, code blocks). */
+	--radius-sm: 4px;
+	--radius: 8px;
+
+	/* Soft elevation shadow for the content frame and pop-overs. */
+	--shadow-card: 0 1px 2px rgba(0, 0, 0, 0.04), 0 4px 16px rgba(0, 0, 0, 0.06);
+
 	--color-bg: #ffffff;
-	--color-text: #000000;
+	--color-text: #1b1b1b;
 
 	--color-link: #1d4ed8;
 	--color-link-visited: #6366cc;
 	--color-link-active: #0b1f5e;
 
 	--color-header-bg: #993300;
-	--color-header-text: #ffff00;
-	--color-panel-bg: #ffffcc;
+	--color-header-text: #ffe066;
+	--color-panel-bg: #fdf3e3;
 	--color-panel-text: #800000;
 	--color-code-bg: #e1ffe1;
 	--color-results-bg: #ddffff;
@@ -148,7 +162,33 @@ body {
 	margin: 0;
 	background-color: var(--color-bg);
 	color: var(--color-text);
-	line-height: 1.55;
+	font-family: var(--font-sans);
+	font-size: 16px;
+	line-height: 1.6;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	text-rendering: optimizeLegibility;
+}
+
+/* Headings: tighter leading and a touch more weight than the body — the
+   MDN content rhythm. They inherit --font-sans from body. */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+	line-height: 1.25;
+	font-weight: 700;
+}
+
+/* Monospace everywhere code appears, including legacy <tt>. */
+pre,
+code,
+kbd,
+samp,
+tt {
+	font-family: var(--font-mono);
 }
 
 a:link {
@@ -218,13 +258,24 @@ body code[class*="language-"] {
 	overflow-wrap: break-word;
 }
 
+/* The `body` prefix lifts specificity to (0,1,2) so these win over
+   prism.min.css's `pre[class*="language-"]` (0,1,1), routing Prism blocks
+   through the same mono stack as the rest of the site. */
+body pre[class*="language-"],
+body code[class*="language-"] {
+	font-family: var(--font-mono);
+}
+
 /* Reserve room on the right for the absolutely-positioned .copy-button
    injected by components/copy-button.js (top: 0.4em; right: 0.4em). Without
    this, short one-line snippets and any line that reaches the right edge
    render directly under the button. 4em comfortably clears the button at
-   its mobile tap-target size (50×44 from PR #606). */
+   its mobile tap-target size (50×44 from PR #606). The soft border + radius
+   give the code block the rounded card look used elsewhere on the page. */
 body pre[class*="language-"] {
 	padding-right: 4em;
+	border-radius: var(--radius);
+	border: 1px solid var(--color-border-soft);
 }
 
 body {
@@ -403,22 +454,25 @@ td[bgcolor="#990000" i] h2,
 tr[bgcolor="#993300" i] h2,
 tr[bgcolor="#990000" i] h2 {
 	color: var(--color-header-text);
-	font-family: Arial, Helvetica, sans-serif;
+	font-family: var(--font-sans);
 }
 
 td[bgcolor="#FFFFCC" i] h3,
 td[bgcolor="#FFFFCC" i] h4 {
 	color: var(--color-panel-text);
-	font-family: Arial, Helvetica, sans-serif;
+	font-family: var(--font-sans);
 }
 
 /* Shared course-page layout */
 
 .page-wrapper {
 	max-width: 715px;
-	margin: 0 auto;
-	border: 1px solid;
+	margin: 1.5em auto;
+	border: 1px solid var(--color-border-soft);
+	border-radius: var(--radius);
+	box-shadow: var(--shadow-card);
 	box-sizing: border-box;
+	overflow: hidden;
 }
 
 .page-content {
@@ -453,7 +507,7 @@ td[bgcolor="#FFFFCC" i] h4 {
 .section-header h2,
 .section-header h3 {
 	color: var(--color-header-text);
-	font-family: Arial, Helvetica, sans-serif;
+	font-family: var(--font-sans);
 	margin: 0.3em 0;
 }
 
@@ -466,7 +520,7 @@ td[bgcolor="#FFFFCC" i] h4 {
 .section-sidebar h3,
 .section-sidebar h4 {
 	color: var(--color-panel-text);
-	font-family: Arial, Helvetica, sans-serif;
+	font-family: var(--font-sans);
 }
 
 .section-content {

--- a/exercises/index.html
+++ b/exercises/index.html
@@ -189,8 +189,7 @@
 								outstanding.<br />
 								(Indexed files, Print files, <code class="language-cobol">READ..NEXT RECORD</code>,
 								<code class="language-cobol">START</code>, <code class="language-cobol">WRITE</code>,
-								<code class="language-cobol">REWRITE</code>,
-								<code class="language-cobol">IF</code>,<br />
+								<code class="language-cobol">REWRITE</code>, <code class="language-cobol">IF</code>,
 								<code class="language-cobol">PERFORM</code>, <code class="language-cobol">ADD</code>,
 								<code class="language-cobol">SUBTRACT</code>)
 							</p>


### PR DESCRIPTION
## Summary

Refreshes the site's design toward MDN's clean documentation aesthetic. The biggest shift is **typography**: the body text moves from the browser-default serif (Times) to a system-UI sans stack, and code is routed through a modern monospace stack. The retro accents are calmed (softer amber header text, a gentle cream replacing the loud `#ffffcc` panels), surfaces gain rounded corners + a subtle shadow, and a few heavy grey hover/divider treatments are softened.

Everything stays within the existing design-token system — the contrast-audited token *roles*, dark-mode parity, and print stylesheet are all preserved. Changes are confined to the two shared stylesheets (`course.css`, `course-components.css`) plus one small content fix; no generated files or page structure were touched.

### Typography
- System-UI sans stack via a new `--font-sans` token; modern monospace via `--font-mono` (applied to Prism blocks through a specificity-matched rule).
- Font smoothing, 16px/1.6 body rhythm, tighter heading leading.
- Unified the scattered `Arial, Helvetica, sans-serif` declarations onto `--font-sans`.

### Palette
- Body text softened to `#1b1b1b` (MDN's text colour).
- Pure-yellow header text (`#ffff00`) → warm amber (`#ffe066`), matching dark mode.
- Loud `#ffffcc` panels → gentle cream (`#fdf3e3`).

### Surfaces & framing
- Rounded/softened content frame, course-content box, code blocks, and cards, with a subtle elevation shadow; framing cleared on the wide-desktop multi-column grid so it doesn't double up.
- Faint shadow under the sticky header; softer header/breadcrumb dividers; heavy grey nav/hamburger hover replaced with a soft tint.

### Content fix
- Removed a stray hand-authored `<br>` inside the Student Fees Report keyword list in `exercises/index.html`. It was placed to balance the list under the old serif metrics; with the new font it stranded a short `REWRITE, IF,` line. The list now wraps naturally. (This was the "unexpected breakline" surfaced during review.)

## Screenshots

Verified in the preview server across **homepage, course index, lesson pages, exercises index, and example pages**, in **light + dark** modes and at **desktop + mobile** widths.

- **Before:** serif body text; loud pure-yellow-on-brown header bars; saturated `#ffffcc` yellow panels; hard black 1px frames.
- **After:** clean sans-serif type; calm amber header text; soft cream panels; rounded cards with subtle shadows; monospace code in rounded blocks.

## Checklist

- [x] `npm run validate` passes
- [x] `npm run links` passes (575 links scanned, none broken — via `linkinator` against the live preview, the documented Windows fallback)
- [x] `npm run format:check` passes for all files in this PR (the only remaining warning is `CLAUDE.md`, which is pre-existing on `master` and untouched here)
- [x] `npm run a11y` passes locally — `pa11y-ci` (WCAG2AA) ran clean (0 errors) on representative pages across every affected template, confirming the new colour tokens keep AA contrast in light and dark
