### PR TITLE
MDN refresh phase 2: soften loud code/results surfaces

### DIFF
--- a/course/Resources/css/course.css
+++ b/course/Resources/css/course.css
@@ -26,8 +26,8 @@
 	--color-header-text: #ffe066;
 	--color-panel-bg: #fdf3e3;
 	--color-panel-text: #800000;
-	--color-code-bg: #e1ffe1;
-	--color-results-bg: #ddffff;
+	--color-code-bg: #edf7ed;
+	--color-results-bg: #eaf4fb;
 	--color-cell-label-bg: #e8e8e8;
 	--color-emphasis: #000099;
 
@@ -848,8 +848,8 @@ body .token.function {
 		--color-header-text: #ffff00;
 		--color-panel-bg: #ffffcc;
 		--color-panel-text: #800000;
-		--color-code-bg: #e1ffe1;
-		--color-results-bg: #ddffff;
+		--color-code-bg: #edf7ed;
+		--color-results-bg: #eaf4fb;
 		--color-cell-label-bg: #e8e8e8;
 		--color-emphasis: #000099;
 		--color-border-soft: #cccccc;


### PR DESCRIPTION
## Summary

Follow-up to the [MDN look-and-feel refresh (#665)](https://github.com/bushidocodes/limerick-cobol/pull/665). Phase 1 calmed the body typography and the pervasive panel yellow; this phase tackles the two remaining loud retro surfaces — the saturated mint **code** background and cyan **results** background — by moving them to gentle MDN-style note-card tints.

| Token | Used by | Before | After |
| --- | --- | --- | --- |
| `--color-code-bg` | `.code-record` headers, `.spec-block`, `.condition-types-box`, legacy `bgcolor="#E1FFE1"` remaps | `#e1ffe1` (mint) | `#edf7ed` |
| `--color-results-bg` | `figure.example-run` "Terminal" body, `.results-box`, legacy `bgcolor="#DDFFFF"` remaps | `#ddffff` (cyan) | `#eaf4fb` |

Each keeps a subtle hue association (green = code, blue = results) while shedding the loud saturation. Light mode **and** the print stylesheet are updated together; the dark-mode tokens are deliberately left unchanged (they were already muted). Total diff is four hex values.

## Screenshots

Verified in the preview across course pages (`DataDeclaration` code-records) and exercise pages (`CountDown` "Terminal" example-run), in light and dark.

- **Before:** saturated mint code-record headers; bright cyan terminal/results panels.
- **After:** soft green code surfaces and soft blue results surfaces that read as quiet note cards; dark mode unchanged.

## Checklist

- [x] `npm run validate` passes
- [x] `npm run links` passes — N/A this PR (no `href`/`src` changed; diff is colour-token values only)
- [x] `npm run format:check` passes for files in this PR (only remaining warning is `CLAUDE.md`, pre-existing on `master`)
- [x] `npm run a11y` passes locally — `pa11y-ci` (WCAG2AA) ran clean (0 errors) on the affected pages; dark text on the new tints stays well above AA
