### PR TITLE
refactor(css): retire legacy bgcolor table markup for semantic classes

### DIFF
--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -697,11 +697,7 @@ The time is 14:41
 						</p>
 						<p>Division by 0 always causes a SIZE ERROR.</p>
 						<p><code class="language-cobol">ON SIZE ERROR</code> <strong>examples</strong></p>
-						<table
-							style="margin: 0 auto"
-							class="data-table"
-							width="70%"
-						>
+						<table style="margin: 0 auto" class="data-table" width="70%">
 							<tr>
 								<th class="cell-label" width="45%">
 									<div class="center-block">
@@ -1027,11 +1023,7 @@ The time is 14:41
 							arithmetic rules. That is, the expression is normally evaluated from left to right but
 							bracketing and the precedence rules shown below can change the order of evaluation.
 						</p>
-						<table
-							style="margin: 0 auto"
-							width="259"
-							class="data-table"
-						>
+						<table style="margin: 0 auto" width="259" class="data-table">
 							<tr>
 								<td class="cell-label" width="32%" style="vertical-align: top">
 									<p class="center-block">Precedence</p>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -628,7 +628,7 @@ The time is 14:41
 							adds 1 to the receiving item when the leftmost truncated digit has an absolute value of 5 or
 							greater.
 						</p>
-						<table style="margin: 0 auto" bgcolor="#E1FFE1" class="data-table" width="84%">
+						<table style="margin: 0 auto" class="data-table" width="84%">
 							<tr>
 								<td colspan="4">
 									<div class="center-block">
@@ -699,35 +699,32 @@ The time is 14:41
 						<p><code class="language-cobol">ON SIZE ERROR</code> <strong>examples</strong></p>
 						<table
 							style="margin: 0 auto"
-							bgcolor="#E1FFE1"
 							class="data-table"
-							cellpadding="5"
-							cellspacing="0"
 							width="70%"
 						>
 							<tr>
-								<th bgcolor="#FFFFCC" width="45%">
+								<th class="cell-label" width="45%">
 									<div class="center-block">
 										<strong>
 											<span class="cobol-highlight">Receiving Field</span>
 										</strong>
 									</div>
 								</th>
-								<th bgcolor="#FFFFCC" width="19%">
+								<th class="cell-label" width="19%">
 									<div class="center-block">
 										<strong>
 											<span class="cobol-highlight">Actual Result</span>
 										</strong>
 									</div>
 								</th>
-								<th bgcolor="#FFFFCC" width="22%">
+								<th class="cell-label" width="22%">
 									<div class="center-block">
 										<strong>
 											<span class="cobol-highlight">Truncated Result</span>
 										</strong>
 									</div>
 								</th>
-								<th bgcolor="#FFFFCC" width="14%">
+								<th class="cell-label" width="14%">
 									<div class="center-block">
 										<strong>
 											<span class="cobol-highlight">Size Error?</span>
@@ -1032,20 +1029,17 @@ The time is 14:41
 						</p>
 						<table
 							style="margin: 0 auto"
-							bgcolor="#E1FFE1"
-							cellpadding="7"
-							cellspacing="1"
 							width="259"
 							class="data-table"
 						>
 							<tr>
-								<td bgcolor="#FFFFCC" width="32%" style="vertical-align: top">
+								<td class="cell-label" width="32%" style="vertical-align: top">
 									<p class="center-block">Precedence</p>
 								</td>
-								<td bgcolor="#FFFFCC" width="29%" style="vertical-align: top">
+								<td class="cell-label" width="29%" style="vertical-align: top">
 									<p class="center-block">Symbol</p>
 								</td>
-								<td bgcolor="#FFFFCC" width="39%" style="vertical-align: top">
+								<td class="cell-label" width="39%" style="vertical-align: top">
 									<p class="center-block">Meaning</p>
 								</td>
 							</tr>

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -308,11 +308,7 @@
 							everything in it.
 						</p>
 						<p>The Figurative Constants are:</p>
-						<table
-							style="margin: 0 auto"
-							class="data-table"
-							width="439"
-						>
+						<table style="margin: 0 auto" class="data-table" width="439">
 							<tr>
 								<td width="47%" style="vertical-align: top">
 									<code class="language-cobol">SPACE</code> or
@@ -445,11 +441,7 @@
 							To create the required 'picture' the programmer uses a set of symbols. The most common
 							symbols used in standard picture clauses are:
 						</p>
-						<table
-							style="margin: 0 auto"
-							class="data-table"
-							width="445"
-						>
+						<table style="margin: 0 auto" class="data-table" width="445">
 							<tr>
 								<td width="14%" style="vertical-align: top">
 									<p class="center-block">

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -310,10 +310,7 @@
 						<p>The Figurative Constants are:</p>
 						<table
 							style="margin: 0 auto"
-							bgcolor="#E1FFE1"
 							class="data-table"
-							cellpadding="5"
-							cellspacing="0"
 							width="439"
 						>
 							<tr>
@@ -450,10 +447,7 @@
 						</p>
 						<table
 							style="margin: 0 auto"
-							bgcolor="#E1FFE1"
 							class="data-table"
-							cellpadding="7"
-							cellspacing="0"
 							width="445"
 						>
 							<tr>

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -179,34 +179,34 @@
 							others may require that the currency symbol "floats" up against the first non-zero digit. In
 							COBOL these things can be achieved using Edited Pictures.
 						</p>
-						<table style="margin: 0 auto" bgcolor="#E1FFE1" class="data-table" cellpadding="10" width="72%">
+						<table style="margin: 0 auto" class="data-table" width="72%">
 							<tr>
-								<td bgcolor="#FFFFCC" width="60%">Original value</td>
+								<td class="cell-label" width="60%">Original value</td>
 								<td width="40%">
 									<div class="center-block">00023456.78</div>
 								</td>
 							</tr>
 							<tr>
-								<td bgcolor="#FFFFCC" width="60%">With commas inserted</td>
+								<td class="cell-label" width="60%">With commas inserted</td>
 								<td width="40%">
 									<div class="center-block">00,023,456.78</div>
 								</td>
 							</tr>
 							<tr>
-								<td bgcolor="#FFFFCC" width="60%">Plus zero suppression</td>
+								<td class="cell-label" width="60%">Plus zero suppression</td>
 								<td width="40%">
 									<div class="center-block">23,456.78</div>
 								</td>
 							</tr>
 							<tr>
-								<td bgcolor="#FFFFCC" height="4" width="60%">Plus floating currency symbol</td>
-								<td height="4" width="40%">
+								<td class="cell-label" width="60%">Plus floating currency symbol</td>
+								<td width="40%">
 									<div class="center-block">$23,456.78</div>
 								</td>
 							</tr>
 							<tr>
-								<td bgcolor="#FFFFCC" height="4" width="60%">With anti-fraud printing</td>
-								<td height="4" width="40%">
+								<td class="cell-label" width="60%">With anti-fraud printing</td>
+								<td width="40%">
 									<div class="center-block">$***23,456.78</div>
 								</td>
 							</tr>
@@ -277,13 +277,10 @@
 						<p>COBOL permits two basic types of editing picture:</p>
 						<table
 							style="margin: 0 auto"
-							bgcolor="#E1FFE1"
-							cellpadding="7"
-							cellspacing="1"
 							width="338"
 							class="data-table"
 						>
-							<tr bgcolor="#FFFFCC">
+							<tr class="row-label">
 								<td width="32%" style="vertical-align: top">
 									<p class="center-block"><strong>Edit Symbol</strong></p>
 								</td>
@@ -412,23 +409,20 @@
 						</p>
 						<table
 							style="margin: 0 auto"
-							bgcolor="#FFFFCC"
 							class="data-table"
-							cellpadding="0"
-							cellspacing="0"
 							width="94%"
 						>
-							<tr bgcolor="#FFFFCC">
+							<tr class="row-label">
 								<th colspan="2" id="ep-t1-sg" scope="colgroup">Sending item</th>
 								<th colspan="2" id="ep-t1-ri" scope="colgroup">Receiving item</th>
 							</tr>
-							<tr bgcolor="#FFFFCC">
+							<tr class="row-label">
 								<th id="ep-t1-sp" scope="col" width="20%">Picture</th>
 								<th id="ep-t1-sd" scope="col" width="15%">Data</th>
 								<th id="ep-t1-rp" scope="col" width="24%">Picture</th>
 								<th id="ep-t1-rr" scope="col" width="41%">Result</th>
 							</tr>
-							<tr bgcolor="#E1FFE1">
+							<tr>
 								<td headers="ep-t1-sg ep-t1-sp" width="20%">PIC 999999</td>
 								<td headers="ep-t1-sg ep-t1-sd" width="15%">
 									<div class="center-block">123456</div>
@@ -443,7 +437,7 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
+							<tr>
 								<td headers="ep-t1-sg ep-t1-sp" width="20%">PIC 9(6)</td>
 								<td headers="ep-t1-sg ep-t1-sd" width="15%">
 									<div class="center-block">000078</div>
@@ -458,7 +452,7 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
+							<tr>
 								<td headers="ep-t1-sg ep-t1-sp" width="20%">PIC 9(6)</td>
 								<td headers="ep-t1-sg ep-t1-sd" width="15%">
 									<div class="center-block">000078</div>
@@ -477,7 +471,7 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
+							<tr>
 								<td headers="ep-t1-sg ep-t1-sp" width="20%">PIC 9(6)</td>
 								<td headers="ep-t1-sg ep-t1-sd" width="15%">
 									<div class="center-block">000178</div>
@@ -495,7 +489,7 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
+							<tr>
 								<td headers="ep-t1-sg ep-t1-sp" width="20%">PIC 9(6)</td>
 								<td headers="ep-t1-sg ep-t1-sd" width="15%">
 									<div class="center-block">002178</div>
@@ -510,7 +504,7 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
+							<tr>
 								<td headers="ep-t1-sg ep-t1-sp" width="20%">PIC 9(6)</td>
 								<td headers="ep-t1-sg ep-t1-sd" width="15%">
 									<div class="center-block">120183</div>
@@ -525,7 +519,7 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
+							<tr>
 								<td headers="ep-t1-sg ep-t1-sp" width="20%">PIC 9(6)</td>
 								<td headers="ep-t1-sg ep-t1-sd" width="15%">
 									<div class="center-block">120183</div>
@@ -542,13 +536,13 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t1-sg ep-t1-sp" height="2" width="20%">PIC 9(6)</td>
-								<td headers="ep-t1-sg ep-t1-sd" height="2" width="15%">
+							<tr>
+								<td headers="ep-t1-sg ep-t1-sp" width="20%">PIC 9(6)</td>
+								<td headers="ep-t1-sg ep-t1-sd" width="15%">
 									<div class="center-block">031245</div>
 								</td>
-								<td headers="ep-t1-ri ep-t1-rp" height="2" width="24%">PIC 990099</td>
-								<td headers="ep-t1-ri ep-t1-rr" height="2" width="41%">
+								<td headers="ep-t1-ri ep-t1-rp" width="24%">PIC 990099</td>
+								<td headers="ep-t1-ri ep-t1-rr" width="41%">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -598,30 +592,26 @@
 						</p>
 						<table
 							style="margin: 0 auto"
-							bgcolor="#FFFFCC"
 							class="data-table"
-							bordercolorlight="#FFFFFF"
-							cellpadding="0"
-							cellspacing="0"
 							width="88%"
 						>
-							<tr bgcolor="#FFFFCC">
+							<tr class="row-label">
 								<th colspan="2" id="ep-t2-sg" scope="colgroup">Sending item</th>
 								<th colspan="2" id="ep-t2-ri" scope="colgroup">Receiving item</th>
 							</tr>
-							<tr bgcolor="#FFFFCC">
+							<tr class="row-label">
 								<th id="ep-t2-sp" scope="col" width="23%">Picture</th>
 								<th id="ep-t2-sd" scope="col" width="11%">Data</th>
 								<th id="ep-t2-rp" scope="col" width="22%">Picture</th>
 								<th id="ep-t2-rr" scope="col" width="44%">Result</th>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t2-sg ep-t2-sp" height="13" width="23%">PIC 999V99</td>
-								<td headers="ep-t2-sg ep-t2-sd" height="13" width="11%">
+							<tr>
+								<td headers="ep-t2-sg ep-t2-sp" width="23%">PIC 999V99</td>
+								<td headers="ep-t2-sg ep-t2-sd" width="11%">
 									<div class="center-block">12345</div>
 								</td>
-								<td headers="ep-t2-ri ep-t2-rp" height="13" width="22%">PIC 999.99</td>
-								<td headers="ep-t2-ri ep-t2-rr" height="13" width="44%">
+								<td headers="ep-t2-ri ep-t2-rp" width="22%">PIC 999.99</td>
+								<td headers="ep-t2-ri ep-t2-rr" width="44%">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -633,13 +623,13 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t2-sg ep-t2-sp" height="16" width="23%">PIC 999V99</td>
-								<td headers="ep-t2-sg ep-t2-sd" height="16" width="11%">
+							<tr>
+								<td headers="ep-t2-sg ep-t2-sp" width="23%">PIC 999V99</td>
+								<td headers="ep-t2-sg ep-t2-sd" width="11%">
 									<div class="center-block">02345</div>
 								</td>
-								<td headers="ep-t2-ri ep-t2-rp" height="16" width="22%">PIC 999.9</td>
-								<td headers="ep-t2-ri ep-t2-rr" height="16" width="44%">
+								<td headers="ep-t2-ri ep-t2-rp" width="22%">PIC 999.9</td>
+								<td headers="ep-t2-ri ep-t2-rr" width="44%">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -651,13 +641,13 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t2-sg ep-t2-sp" height="16" width="23%">PIC 999V99</td>
-								<td headers="ep-t2-sg ep-t2-sd" height="16" width="11%">
+							<tr>
+								<td headers="ep-t2-sg ep-t2-sp" width="23%">PIC 999V99</td>
+								<td headers="ep-t2-sg ep-t2-sd" width="11%">
 									<div class="center-block">71234</div>
 								</td>
-								<td headers="ep-t2-ri ep-t2-rp" height="16" width="22%">PIC 99.99</td>
-								<td headers="ep-t2-ri ep-t2-rr" height="16" width="44%">
+								<td headers="ep-t2-ri ep-t2-rp" width="22%">PIC 99.99</td>
+								<td headers="ep-t2-ri ep-t2-rr" width="44%">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -669,7 +659,7 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
+							<tr>
 								<td headers="ep-t2-sg ep-t2-sp" width="23%">PIC 9(4)</td>
 								<td headers="ep-t2-sg ep-t2-sd" width="11%">
 									<div class="center-block">2456</div>
@@ -758,29 +748,26 @@
 						</p>
 						<table
 							style="margin: 0 auto"
-							bgcolor="#FFFFCC"
 							class="data-table"
-							cellpadding="0"
-							cellspacing="0"
 							width="87%"
 						>
-							<tr bgcolor="#FFFFCC">
+							<tr class="row-label">
 								<th colspan="2" id="ep-t3-sg" scope="colgroup">Sending item</th>
 								<th colspan="2" id="ep-t3-ri" scope="colgroup">Receiving item</th>
 							</tr>
-							<tr bgcolor="#FFFFCC">
+							<tr class="row-label">
 								<th id="ep-t3-sp" scope="col" width="18%">Picture</th>
 								<th id="ep-t3-sd" scope="col" width="16%">Data</th>
 								<th id="ep-t3-rp" scope="col" width="20%">Picture</th>
 								<th id="ep-t3-rr" scope="col" width="46%">Result</th>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t3-sg ep-t3-sp" height="15" width="18%">PIC S999</td>
-								<td headers="ep-t3-sg ep-t3-sd" height="15" width="16%">
+							<tr>
+								<td headers="ep-t3-sg ep-t3-sp" width="18%">PIC S999</td>
+								<td headers="ep-t3-sg ep-t3-sd" width="16%">
 									<div class="center-block">-123</div>
 								</td>
-								<td headers="ep-t3-ri ep-t3-rp" height="15" width="20%">PIC -999</td>
-								<td headers="ep-t3-ri ep-t3-rr" height="15" width="46%">
+								<td headers="ep-t3-ri ep-t3-rp" width="20%">PIC -999</td>
+								<td headers="ep-t3-ri ep-t3-rr" width="46%">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -789,13 +776,13 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t3-sg ep-t3-sp" height="16" width="18%">PIC S999</td>
-								<td headers="ep-t3-sg ep-t3-sd" height="16" width="16%">
+							<tr>
+								<td headers="ep-t3-sg ep-t3-sp" width="18%">PIC S999</td>
+								<td headers="ep-t3-sg ep-t3-sd" width="16%">
 									<div class="center-block">-123</div>
 								</td>
-								<td headers="ep-t3-ri ep-t3-rp" height="16" width="20%">PIC 999-</td>
-								<td headers="ep-t3-ri ep-t3-rr" height="16" width="46%">
+								<td headers="ep-t3-ri ep-t3-rp" width="20%">PIC 999-</td>
+								<td headers="ep-t3-ri ep-t3-rr" width="46%">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -804,13 +791,13 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t3-sg ep-t3-sp" height="16" width="18%">PIC S999</td>
-								<td headers="ep-t3-sg ep-t3-sd" height="16" width="16%">
+							<tr>
+								<td headers="ep-t3-sg ep-t3-sp" width="18%">PIC S999</td>
+								<td headers="ep-t3-sg ep-t3-sd" width="16%">
 									<div class="center-block">+123</div>
 								</td>
-								<td headers="ep-t3-ri ep-t3-rp" height="16" width="20%">PIC -999</td>
-								<td headers="ep-t3-ri ep-t3-rr" height="16" width="46%">
+								<td headers="ep-t3-ri ep-t3-rp" width="20%">PIC -999</td>
+								<td headers="ep-t3-ri ep-t3-rr" width="46%">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -823,13 +810,13 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t3-sg ep-t3-sp" height="16" width="18%">PIC S9(5)</td>
-								<td headers="ep-t3-sg ep-t3-sd" height="16" width="16%">
+							<tr>
+								<td headers="ep-t3-sg ep-t3-sp" width="18%">PIC S9(5)</td>
+								<td headers="ep-t3-sg ep-t3-sd" width="16%">
 									<div class="center-block">+12345</div>
 								</td>
-								<td headers="ep-t3-ri ep-t3-rp" height="16" width="20%">PIC +9(5)</td>
-								<td headers="ep-t3-ri ep-t3-rr" height="16" width="46%">
+								<td headers="ep-t3-ri ep-t3-rp" width="20%">PIC +9(5)</td>
+								<td headers="ep-t3-ri ep-t3-rr" width="46%">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -838,13 +825,13 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t3-sg ep-t3-sp" height="16" width="18%">PIC S9(3)</td>
-								<td headers="ep-t3-sg ep-t3-sd" height="16" width="16%">
+							<tr>
+								<td headers="ep-t3-sg ep-t3-sp" width="18%">PIC S9(3)</td>
+								<td headers="ep-t3-sg ep-t3-sd" width="16%">
 									<div class="center-block">-123</div>
 								</td>
-								<td headers="ep-t3-ri ep-t3-rp" height="16" width="20%">PIC +9(3)</td>
-								<td headers="ep-t3-ri ep-t3-rr" height="16" width="46%">
+								<td headers="ep-t3-ri ep-t3-rp" width="20%">PIC +9(3)</td>
+								<td headers="ep-t3-ri ep-t3-rr" width="46%">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -856,13 +843,13 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t3-sg ep-t3-sp" height="16" width="18%">PIC S9(3)</td>
-								<td headers="ep-t3-sg ep-t3-sd" height="16" width="16%">
+							<tr>
+								<td headers="ep-t3-sg ep-t3-sp" width="18%">PIC S9(3)</td>
+								<td headers="ep-t3-sg ep-t3-sd" width="16%">
 									<div class="center-block">-123</div>
 								</td>
-								<td headers="ep-t3-ri ep-t3-rp" height="16" width="20%">PIC 999+</td>
-								<td headers="ep-t3-ri ep-t3-rr" height="16" width="46%">
+								<td headers="ep-t3-ri ep-t3-rp" width="20%">PIC 999+</td>
+								<td headers="ep-t3-ri ep-t3-rr" width="46%">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -874,13 +861,13 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t3-sg ep-t3-sp" height="16" width="18%">PIC S9(4)</td>
-								<td headers="ep-t3-sg ep-t3-sd" height="16" width="16%">
+							<tr>
+								<td headers="ep-t3-sg ep-t3-sp" width="18%">PIC S9(4)</td>
+								<td headers="ep-t3-sg ep-t3-sd" width="16%">
 									<div class="center-block">+1234</div>
 								</td>
-								<td headers="ep-t3-ri ep-t3-rp" height="16" width="20%">PIC 9(4)CR</td>
-								<td headers="ep-t3-ri ep-t3-rr" height="16" width="46%">
+								<td headers="ep-t3-ri ep-t3-rp" width="20%">PIC 9(4)CR</td>
+								<td headers="ep-t3-ri ep-t3-rr" width="46%">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -889,13 +876,13 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t3-sg ep-t3-sp" height="16" width="18%">PIC S9(4)</td>
-								<td headers="ep-t3-sg ep-t3-sd" height="16" width="16%">
+							<tr>
+								<td headers="ep-t3-sg ep-t3-sp" width="18%">PIC S9(4)</td>
+								<td headers="ep-t3-sg ep-t3-sd" width="16%">
 									<div class="center-block">-1234</div>
 								</td>
-								<td headers="ep-t3-ri ep-t3-rp" height="16" width="20%">PIC 9(4)CR</td>
-								<td headers="ep-t3-ri ep-t3-rr" height="16" width="46%">
+								<td headers="ep-t3-ri ep-t3-rp" width="20%">PIC 9(4)CR</td>
+								<td headers="ep-t3-ri ep-t3-rr" width="46%">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -904,13 +891,13 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t3-sg ep-t3-sp" height="16" width="18%">PIC S9(4)</td>
-								<td headers="ep-t3-sg ep-t3-sd" height="16" width="16%">
+							<tr>
+								<td headers="ep-t3-sg ep-t3-sp" width="18%">PIC S9(4)</td>
+								<td headers="ep-t3-sg ep-t3-sd" width="16%">
 									<div class="center-block">+1234</div>
 								</td>
-								<td headers="ep-t3-ri ep-t3-rp" height="16" width="20%">PIC 9(4)DB</td>
-								<td headers="ep-t3-ri ep-t3-rr" height="16" width="46%">
+								<td headers="ep-t3-ri ep-t3-rp" width="20%">PIC 9(4)DB</td>
+								<td headers="ep-t3-ri ep-t3-rr" width="46%">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -919,13 +906,13 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t3-sg ep-t3-sp" height="16" width="18%">PIC S9(4)</td>
-								<td headers="ep-t3-sg ep-t3-sd" height="16" width="16%">
+							<tr>
+								<td headers="ep-t3-sg ep-t3-sp" width="18%">PIC S9(4)</td>
+								<td headers="ep-t3-sg ep-t3-sd" width="16%">
 									<div class="center-block">-1234</div>
 								</td>
-								<td headers="ep-t3-ri ep-t3-rp" height="16" width="20%">PIC 9(4)DB</td>
-								<td headers="ep-t3-ri ep-t3-rr" height="16" width="46%">
+								<td headers="ep-t3-ri ep-t3-rp" width="20%">PIC 9(4)DB</td>
+								<td headers="ep-t3-ri ep-t3-rr" width="46%">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -934,13 +921,13 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t3-sg ep-t3-sp" height="16" width="18%">PIC 9(4)</td>
-								<td headers="ep-t3-sg ep-t3-sd" height="16" width="16%">
+							<tr>
+								<td headers="ep-t3-sg ep-t3-sp" width="18%">PIC 9(4)</td>
+								<td headers="ep-t3-sg ep-t3-sd" width="16%">
 									<div class="center-block">1234</div>
 								</td>
-								<td headers="ep-t3-ri ep-t3-rp" height="16" width="20%">PIC $99999</td>
-								<td headers="ep-t3-ri ep-t3-rr" height="16" width="46%">
+								<td headers="ep-t3-ri ep-t3-rp" width="20%">PIC $99999</td>
+								<td headers="ep-t3-ri ep-t3-rr" width="46%">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -949,13 +936,13 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t3-sg ep-t3-sp" height="16" width="18%">PIC 9(4)</td>
-								<td headers="ep-t3-sg ep-t3-sd" height="16" width="16%">
+							<tr>
+								<td headers="ep-t3-sg ep-t3-sp" width="18%">PIC 9(4)</td>
+								<td headers="ep-t3-sg ep-t3-sd" width="16%">
 									<div class="center-block">0000</div>
 								</td>
-								<td headers="ep-t3-ri ep-t3-rp" height="16" width="20%">PIC $ZZZZZ</td>
-								<td headers="ep-t3-ri ep-t3-rr" height="16" width="46%">
+								<td headers="ep-t3-ri ep-t3-rp" width="20%">PIC $ZZZZZ</td>
+								<td headers="ep-t3-ri ep-t3-rr" width="46%">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -1010,29 +997,26 @@
 						</p>
 						<table
 							style="margin: 0 auto"
-							bgcolor="#FFFFCC"
 							class="data-table"
-							cellpadding="0"
-							cellspacing="0"
 							width="83%"
 						>
-							<tr bgcolor="#FFFFCC">
+							<tr class="row-label">
 								<th colspan="2" id="ep-t4-sg" scope="colgroup">Sending item</th>
 								<th colspan="2" id="ep-t4-ri" scope="colgroup">Receiving item</th>
 							</tr>
-							<tr bgcolor="#FFFFCC">
+							<tr class="row-label">
 								<th id="ep-t4-sp" scope="col" width="18%">Picture</th>
 								<th id="ep-t4-sd" scope="col" width="16%">Data</th>
 								<th id="ep-t4-rp" scope="col" width="23%">Picture</th>
 								<th id="ep-t4-rr" scope="col" width="43%">Result</th>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t4-sg ep-t4-sp" height="15" width="18%">PIC 9(4)</td>
-								<td headers="ep-t4-sg ep-t4-sd" height="15" width="16%">
+							<tr>
+								<td headers="ep-t4-sg ep-t4-sp" width="18%">PIC 9(4)</td>
+								<td headers="ep-t4-sg ep-t4-sd" width="16%">
 									<div class="center-block">0000</div>
 								</td>
-								<td headers="ep-t4-ri ep-t4-rp" height="15" width="23%">PIC $$,$$9.99</td>
-								<td headers="ep-t4-ri ep-t4-rr" height="15" width="43%">
+								<td headers="ep-t4-ri ep-t4-rp" width="23%">PIC $$,$$9.99</td>
+								<td headers="ep-t4-ri ep-t4-rr" width="43%">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -1041,13 +1025,13 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t4-sg ep-t4-sp" height="16" width="18%">PIC 9(4)</td>
-								<td headers="ep-t4-sg ep-t4-sd" height="16" width="16%">
+							<tr>
+								<td headers="ep-t4-sg ep-t4-sp" width="18%">PIC 9(4)</td>
+								<td headers="ep-t4-sg ep-t4-sd" width="16%">
 									<div class="center-block">0080</div>
 								</td>
-								<td headers="ep-t4-ri ep-t4-rp" height="16" width="23%">PIC $$,$$9.00</td>
-								<td headers="ep-t4-ri ep-t4-rr" height="16" width="43%">
+								<td headers="ep-t4-ri ep-t4-rp" width="23%">PIC $$,$$9.00</td>
+								<td headers="ep-t4-ri ep-t4-rr" width="43%">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -1059,13 +1043,13 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t4-sg ep-t4-sp" height="16" width="18%">PIC 9(4)</td>
-								<td headers="ep-t4-sg ep-t4-sd" height="16" width="16%">
+							<tr>
+								<td headers="ep-t4-sg ep-t4-sp" width="18%">PIC 9(4)</td>
+								<td headers="ep-t4-sg ep-t4-sd" width="16%">
 									<div class="center-block">0128</div>
 								</td>
-								<td headers="ep-t4-ri ep-t4-rp" height="16" width="23%">PIC $$,$$9.99</td>
-								<td headers="ep-t4-ri ep-t4-rr" height="16" width="43%">
+								<td headers="ep-t4-ri ep-t4-rp" width="23%">PIC $$,$$9.99</td>
+								<td headers="ep-t4-ri ep-t4-rr" width="43%">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -1074,13 +1058,13 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t4-sg ep-t4-sp" height="16" width="18%">PIC 9(5)</td>
-								<td headers="ep-t4-sg ep-t4-sd" height="16" width="16%">
+							<tr>
+								<td headers="ep-t4-sg ep-t4-sp" width="18%">PIC 9(5)</td>
+								<td headers="ep-t4-sg ep-t4-sd" width="16%">
 									<div class="center-block"><b>5</b>7397</div>
 								</td>
-								<td headers="ep-t4-ri ep-t4-rp" height="16" width="23%">PIC $$,$$9</td>
-								<td headers="ep-t4-ri ep-t4-rr" height="16" width="43%">
+								<td headers="ep-t4-ri ep-t4-rp" width="23%">PIC $$,$$9</td>
+								<td headers="ep-t4-ri ep-t4-rr" width="43%">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -1093,13 +1077,13 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t4-sg ep-t4-sp" height="16" width="18%">PIC S9(4)</td>
-								<td headers="ep-t4-sg ep-t4-sd" height="16" width="16%">
+							<tr>
+								<td headers="ep-t4-sg ep-t4-sp" width="18%">PIC S9(4)</td>
+								<td headers="ep-t4-sg ep-t4-sd" width="16%">
 									<div class="center-block">-0005</div>
 								</td>
-								<td headers="ep-t4-ri ep-t4-rp" height="16" width="23%">PIC ++++9</td>
-								<td headers="ep-t4-ri ep-t4-rr" height="16" width="43%">
+								<td headers="ep-t4-ri ep-t4-rp" width="23%">PIC ++++9</td>
+								<td headers="ep-t4-ri ep-t4-rr" width="43%">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -1108,13 +1092,13 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t4-sg ep-t4-sp" height="16" width="18%">PIC S9(4)</td>
-								<td headers="ep-t4-sg ep-t4-sd" height="16" width="16%">
+							<tr>
+								<td headers="ep-t4-sg ep-t4-sp" width="18%">PIC S9(4)</td>
+								<td headers="ep-t4-sg ep-t4-sd" width="16%">
 									<div class="center-block">+0080</div>
 								</td>
-								<td headers="ep-t4-ri ep-t4-rp" height="16" width="23%">PIC ++++9</td>
-								<td headers="ep-t4-ri ep-t4-rr" height="16" width="43%">
+								<td headers="ep-t4-ri ep-t4-rp" width="23%">PIC ++++9</td>
+								<td headers="ep-t4-ri ep-t4-rr" width="43%">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -1123,15 +1107,15 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t4-sg ep-t4-sp" height="20" width="18%">
+							<tr>
+								<td headers="ep-t4-sg ep-t4-sp" width="18%">
 									<p>PIC S9(4)</p>
 								</td>
-								<td headers="ep-t4-sg ep-t4-sd" height="20" width="16%">
+								<td headers="ep-t4-sg ep-t4-sd" width="16%">
 									<div class="center-block">-0080</div>
 								</td>
-								<td headers="ep-t4-ri ep-t4-rp" height="20" width="23%">PIC - - - - 9</td>
-								<td headers="ep-t4-ri ep-t4-rr" height="20" width="43%" style="vertical-align: top">
+								<td headers="ep-t4-ri ep-t4-rp" width="23%">PIC - - - - 9</td>
+								<td headers="ep-t4-ri ep-t4-rr" width="43%" style="vertical-align: top">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -1140,13 +1124,13 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t4-sg ep-t4-sp" height="16" width="18%">PIC S9(5)</td>
-								<td headers="ep-t4-sg ep-t4-sd" height="16" width="16%">
+							<tr>
+								<td headers="ep-t4-sg ep-t4-sp" width="18%">PIC S9(5)</td>
+								<td headers="ep-t4-sg ep-t4-sd" width="16%">
 									<div class="center-block">+<b>7</b>1234</div>
 								</td>
-								<td headers="ep-t4-ri ep-t4-rp" height="16" width="23%">PIC - - - - 9</td>
-								<td headers="ep-t4-ri ep-t4-rr" height="16" width="43%">
+								<td headers="ep-t4-ri ep-t4-rp" width="23%">PIC - - - - 9</td>
+								<td headers="ep-t4-ri ep-t4-rr" width="43%">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -1208,29 +1192,26 @@
 					<div class="section-content">
 						<table
 							style="margin: 0 auto"
-							bgcolor="#FFFFCC"
 							class="data-table"
-							cellpadding="0"
-							cellspacing="0"
 							width="93%"
 						>
-							<tr bgcolor="#FFFFCC">
+							<tr class="row-label">
 								<th colspan="2" id="ep-t5-sg" scope="colgroup">Sending item</th>
 								<th colspan="2" id="ep-t5-ri" scope="colgroup">Receiving item</th>
 							</tr>
-							<tr bgcolor="#FFFFCC">
+							<tr class="row-label">
 								<th id="ep-t5-sp" scope="col" width="21%">Picture</th>
 								<th id="ep-t5-sd" scope="col" width="13%">Data</th>
 								<th id="ep-t5-rp" scope="col" width="25%">Picture</th>
 								<th id="ep-t5-rr" scope="col" width="41%">Result</th>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t5-sg ep-t5-sp" height="15" width="21%">PIC 9(5)</td>
-								<td headers="ep-t5-sg ep-t5-sd" height="15" width="13%">
+							<tr>
+								<td headers="ep-t5-sg ep-t5-sp" width="21%">PIC 9(5)</td>
+								<td headers="ep-t5-sg ep-t5-sd" width="13%">
 									<div class="center-block">12345</div>
 								</td>
-								<td headers="ep-t5-ri ep-t5-rp" height="15" width="25%">PIC ZZ,999</td>
-								<td headers="ep-t5-ri ep-t5-rr" height="15" width="41%">
+								<td headers="ep-t5-ri ep-t5-rp" width="25%">PIC ZZ,999</td>
+								<td headers="ep-t5-ri ep-t5-rr" width="41%">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -1239,13 +1220,13 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t5-sg ep-t5-sp" height="16" width="21%">PIC 9(5)</td>
-								<td headers="ep-t5-sg ep-t5-sd" height="16" width="13%">
+							<tr>
+								<td headers="ep-t5-sg ep-t5-sp" width="21%">PIC 9(5)</td>
+								<td headers="ep-t5-sg ep-t5-sd" width="13%">
 									<div class="center-block">01234</div>
 								</td>
-								<td headers="ep-t5-ri ep-t5-rp" height="16" width="25%">PIC ZZ,999</td>
-								<td headers="ep-t5-ri ep-t5-rr" height="16" width="41%">
+								<td headers="ep-t5-ri ep-t5-rp" width="25%">PIC ZZ,999</td>
+								<td headers="ep-t5-ri ep-t5-rr" width="41%">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -1254,13 +1235,13 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t5-sg ep-t5-sp" height="16" width="21%">PIC 9(5)</td>
-								<td headers="ep-t5-sg ep-t5-sd" height="16" width="13%">
+							<tr>
+								<td headers="ep-t5-sg ep-t5-sp" width="21%">PIC 9(5)</td>
+								<td headers="ep-t5-sg ep-t5-sd" width="13%">
 									<div class="center-block">00123</div>
 								</td>
-								<td headers="ep-t5-ri ep-t5-rp" height="16" width="25%">PIC ZZ,999</td>
-								<td headers="ep-t5-ri ep-t5-rr" height="16" width="41%">
+								<td headers="ep-t5-ri ep-t5-rp" width="25%">PIC ZZ,999</td>
+								<td headers="ep-t5-ri ep-t5-rr" width="41%">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -1272,13 +1253,13 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t5-sg ep-t5-sp" height="16" width="21%">PIC 9(5)</td>
-								<td headers="ep-t5-sg ep-t5-sd" height="16" width="13%">
+							<tr>
+								<td headers="ep-t5-sg ep-t5-sp" width="21%">PIC 9(5)</td>
+								<td headers="ep-t5-sg ep-t5-sd" width="13%">
 									<div class="center-block">00012</div>
 								</td>
-								<td headers="ep-t5-ri ep-t5-rp" height="16" width="25%">PIC ZZ,999</td>
-								<td headers="ep-t5-ri ep-t5-rr" height="16" width="41%">
+								<td headers="ep-t5-ri ep-t5-rp" width="25%">PIC ZZ,999</td>
+								<td headers="ep-t5-ri ep-t5-rr" width="41%">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -1287,13 +1268,13 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t5-sg ep-t5-sp" height="16" width="21%">PIC 9(5)</td>
-								<td headers="ep-t5-sg ep-t5-sd" height="16" width="13%">
+							<tr>
+								<td headers="ep-t5-sg ep-t5-sp" width="21%">PIC 9(5)</td>
+								<td headers="ep-t5-sg ep-t5-sd" width="13%">
 									<div class="center-block">05678</div>
 								</td>
-								<td headers="ep-t5-ri ep-t5-rp" height="16" width="25%">PIC **,**9</td>
-								<td headers="ep-t5-ri ep-t5-rr" height="16" width="41%">
+								<td headers="ep-t5-ri ep-t5-rp" width="25%">PIC **,**9</td>
+								<td headers="ep-t5-ri ep-t5-rr" width="41%">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -1302,13 +1283,13 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t5-sg ep-t5-sp" height="16" width="21%">PIC 9(5)</td>
-								<td headers="ep-t5-sg ep-t5-sd" height="16" width="13%">
+							<tr>
+								<td headers="ep-t5-sg ep-t5-sp" width="21%">PIC 9(5)</td>
+								<td headers="ep-t5-sg ep-t5-sd" width="13%">
 									<div class="center-block">00567</div>
 								</td>
-								<td headers="ep-t5-ri ep-t5-rp" height="16" width="25%">PIC **,**9</td>
-								<td headers="ep-t5-ri ep-t5-rr" height="16" width="41%">
+								<td headers="ep-t5-ri ep-t5-rp" width="25%">PIC **,**9</td>
+								<td headers="ep-t5-ri ep-t5-rr" width="41%">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -1317,13 +1298,13 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t5-sg ep-t5-sp" height="20" width="21%">PIC 9(5)</td>
-								<td headers="ep-t5-sg ep-t5-sd" height="20" width="13%">
+							<tr>
+								<td headers="ep-t5-sg ep-t5-sp" width="21%">PIC 9(5)</td>
+								<td headers="ep-t5-sg ep-t5-sd" width="13%">
 									<div class="center-block">00000</div>
 								</td>
-								<td headers="ep-t5-ri ep-t5-rp" height="20" width="25%">PIC **,***</td>
-								<td headers="ep-t5-ri ep-t5-rr" height="20" width="41%" style="vertical-align: top">
+								<td headers="ep-t5-ri ep-t5-rp" width="25%">PIC **,***</td>
+								<td headers="ep-t5-ri ep-t5-rr" width="41%" style="vertical-align: top">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -1332,18 +1313,16 @@
 									</div>
 								</td>
 							</tr>
-							<tr bgcolor="#E1FFE1">
-								<td headers="ep-t5-sg ep-t5-sp" height="20" width="21%">
+							<tr>
+								<td headers="ep-t5-sg ep-t5-sp" width="21%">
 									<p>PIC 9(5)V99</p>
 								</td>
-								<td headers="ep-t5-sg ep-t5-sd" height="20" width="13%">
+								<td headers="ep-t5-sg ep-t5-sd" width="13%">
 									<div class="center-block">00043.45</div>
 								</td>
-								<td headers="ep-t5-ri ep-t5-rp" height="20" width="25%">PIC $**,**9.99</td>
+								<td headers="ep-t5-ri ep-t5-rp" width="25%">PIC $**,**9.99</td>
 								<td
 									headers="ep-t5-ri ep-t5-rr"
-									bgcolor="#E1FFE1"
-									height="20"
 									width="41%"
 									style="vertical-align: top"
 								>
@@ -1369,18 +1348,15 @@
 						</p>
 						<table
 							style="margin: 0 auto"
-							bgcolor="#E1FFE1"
 							class="data-table"
-							cellpadding="5"
-							height="69"
 							width="47%"
 						>
-							<tr bgcolor="#FFFFCC">
+							<tr class="row-label">
 								<th scope="col" width="15%">Character</th>
 								<th scope="col" width="85%">May be followed by</th>
 							</tr>
 							<tr>
-								<td bgcolor="#FFFFCC" height="192" width="15%" style="vertical-align: top">
+								<td class="cell-label" width="15%" style="vertical-align: top">
 									<div class="center-block">
 										<pre class="language-cobol"><code class="language-cobol">P
 B
@@ -1396,7 +1372,7 @@ $
 V</code></pre>
 									</div>
 								</td>
-								<td height="192" width="85%" style="vertical-align: top">
+								<td width="85%" style="vertical-align: top">
 									<pre class="language-cobol"><code class="language-cobol">P B 0 / , + - CR DB 9 V
 P B 0 / , . + - CR DB 9 V
 P B 0 / , . + - CR DB 9 V

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -275,11 +275,7 @@
 					</div>
 					<div class="section-content">
 						<p>COBOL permits two basic types of editing picture:</p>
-						<table
-							style="margin: 0 auto"
-							width="338"
-							class="data-table"
-						>
+						<table style="margin: 0 auto" width="338" class="data-table">
 							<tr class="row-label">
 								<td width="32%" style="vertical-align: top">
 									<p class="center-block"><strong>Edit Symbol</strong></p>
@@ -407,11 +403,7 @@
 							description of the Sending item is shown in the Picture column and its current value is
 							shown in the Data column.
 						</p>
-						<table
-							style="margin: 0 auto"
-							class="data-table"
-							width="94%"
-						>
+						<table style="margin: 0 auto" class="data-table" width="94%">
 							<tr class="row-label">
 								<th colspan="2" id="ep-t1-sg" scope="colgroup">Sending item</th>
 								<th colspan="2" id="ep-t1-ri" scope="colgroup">Receiving item</th>
@@ -590,11 +582,7 @@
 							description of the Sending item is shown in the Picture column and its current value is
 							shown in the Data column.
 						</p>
-						<table
-							style="margin: 0 auto"
-							class="data-table"
-							width="88%"
-						>
+						<table style="margin: 0 auto" class="data-table" width="88%">
 							<tr class="row-label">
 								<th colspan="2" id="ep-t2-sg" scope="colgroup">Sending item</th>
 								<th colspan="2" id="ep-t2-ri" scope="colgroup">Receiving item</th>
@@ -746,11 +734,7 @@
 							produced when the value in the Sending item is moved to the edited picture in the Receiving
 							item.
 						</p>
-						<table
-							style="margin: 0 auto"
-							class="data-table"
-							width="87%"
-						>
+						<table style="margin: 0 auto" class="data-table" width="87%">
 							<tr class="row-label">
 								<th colspan="2" id="ep-t3-sg" scope="colgroup">Sending item</th>
 								<th colspan="2" id="ep-t3-ri" scope="colgroup">Receiving item</th>
@@ -995,11 +979,7 @@
 							produced when the value in the Sending item is moved to the edited picture in the Receiving
 							item.
 						</p>
-						<table
-							style="margin: 0 auto"
-							class="data-table"
-							width="83%"
-						>
+						<table style="margin: 0 auto" class="data-table" width="83%">
 							<tr class="row-label">
 								<th colspan="2" id="ep-t4-sg" scope="colgroup">Sending item</th>
 								<th colspan="2" id="ep-t4-ri" scope="colgroup">Receiving item</th>
@@ -1190,11 +1170,7 @@
 						<h3>Suppression and Replacement editing examples</h3>
 					</div>
 					<div class="section-content">
-						<table
-							style="margin: 0 auto"
-							class="data-table"
-							width="93%"
-						>
+						<table style="margin: 0 auto" class="data-table" width="93%">
 							<tr class="row-label">
 								<th colspan="2" id="ep-t5-sg" scope="colgroup">Sending item</th>
 								<th colspan="2" id="ep-t5-ri" scope="colgroup">Receiving item</th>
@@ -1321,11 +1297,7 @@
 									<div class="center-block">00043.45</div>
 								</td>
 								<td headers="ep-t5-ri ep-t5-rp" width="25%">PIC $**,**9.99</td>
-								<td
-									headers="ep-t5-ri ep-t5-rr"
-									width="41%"
-									style="vertical-align: top"
-								>
+								<td headers="ep-t5-ri ep-t5-rr" width="41%" style="vertical-align: top">
 									<div class="center-block">
 										<details class="saq-reveal">
 											<summary>Click arrow for the answer</summary>
@@ -1346,11 +1318,7 @@
 							Some combinations of picture symbols are not permitted. The table below shows the
 							combination of symbols that is allowed.
 						</p>
-						<table
-							style="margin: 0 auto"
-							class="data-table"
-							width="47%"
-						>
+						<table style="margin: 0 auto" class="data-table" width="47%">
 							<tr class="row-label">
 								<th scope="col" width="15%">Character</th>
 								<th scope="col" width="85%">May be followed by</th>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -169,10 +169,7 @@
 						</p>
 						<p>These operand endings have the following meaning:</p>
 						<table
-							bgcolor="#D2FFD2"
 							class="data-table"
-							cellpadding="4"
-							cellspacing="0"
 							width="67%"
 							style="margin: 0 auto"
 						>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -168,11 +168,7 @@
 							special operand endings are used in this unit's syntax diagrams.
 						</p>
 						<p>These operand endings have the following meaning:</p>
-						<table
-							class="data-table"
-							width="67%"
-							style="margin: 0 auto"
-						>
+						<table class="data-table" width="67%" style="margin: 0 auto">
 							<tr>
 								<td width="9%">$i</td>
 								<td width="91%">uses an alphanumeric data item</td>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -604,9 +604,9 @@ END-IF</code></pre>
 							</div>
 							<div class="section-content">
 								<h4 class="center-block">Disadvantages</h4>
-								<table cellpadding="4" width="100%" style="border: 3px solid">
+								<table class="data-table" width="100%">
 									<tr>
-										<td bgcolor="#E8E8E8" width="150">
+										<td class="cell-muted" width="150">
 											<div class="center-block"><strong>Slow</strong></div>
 										</td>
 										<td width="404">
@@ -625,7 +625,7 @@ END-IF</code></pre>
 										</td>
 									</tr>
 									<tr>
-										<td bgcolor="#E8E8E8" width="150">
+										<td class="cell-muted" width="150">
 											<div class="center-block"><strong>Complicated</strong></div>
 										</td>
 										<td width="404">
@@ -644,9 +644,9 @@ END-IF</code></pre>
 									</tr>
 								</table>
 								<h4 class="center-block">Advantages</h4>
-								<table class="data-table" cellpadding="4" width="101%">
+								<table class="data-table" width="101%">
 									<tr>
-										<td bgcolor="#E8E8E8" width="150">
+										<td class="cell-muted" width="150">
 											<div class="center-block"><strong>Fast</strong></div>
 										</td>
 										<td width="364" style="vertical-align: top">
@@ -658,7 +658,7 @@ END-IF</code></pre>
 										</td>
 									</tr>
 									<tr>
-										<td bgcolor="#E8E8E8" width="150">
+										<td class="cell-muted" width="150">
 											<div class="center-block"><strong>Most storage efficient</strong></div>
 										</td>
 										<td width="364" style="vertical-align: top">
@@ -670,7 +670,7 @@ END-IF</code></pre>
 										</td>
 									</tr>
 									<tr>
-										<td bgcolor="#E8E8E8" width="150">
+										<td class="cell-muted" width="150">
 											<div class="center-block"><strong>Simple organization</strong></div>
 										</td>
 										<td width="364" style="vertical-align: top">
@@ -678,7 +678,7 @@ END-IF</code></pre>
 										</td>
 									</tr>
 									<tr>
-										<td bgcolor="#E8E8E8" width="150">
+										<td class="cell-muted" width="150">
 											<div class="center-block">
 												<strong>Files may be stored on serial media</strong>
 											</div>
@@ -698,9 +698,9 @@ END-IF</code></pre>
 							</div>
 							<div class="section-content">
 								<h4 class="center-block">Disadvantages</h4>
-								<table cellpadding="4" width="100%" style="border: 3px solid">
+								<table class="data-table" width="100%">
 									<tr>
-										<td bgcolor="#E8E8E8" width="150">
+										<td class="cell-muted" width="150">
 											<div class="center-block">
 												<strong>Wastes storage if the file is only partially populated</strong>
 											</div>
@@ -724,7 +724,7 @@ END-IF</code></pre>
 										</td>
 									</tr>
 									<tr>
-										<td bgcolor="#E8E8E8" width="150">
+										<td class="cell-muted" width="150">
 											<div class="center-block">
 												<strong>Cannot recover space from deleted records</strong>
 											</div>
@@ -743,7 +743,7 @@ END-IF</code></pre>
 										</td>
 									</tr>
 									<tr>
-										<td bgcolor="#E8E8E8" width="150">
+										<td class="cell-muted" width="150">
 											<div class="center-block"><strong>Only a single key allowed</strong></div>
 										</td>
 										<td width="433">
@@ -767,7 +767,7 @@ END-IF</code></pre>
 										</td>
 									</tr>
 									<tr>
-										<td bgcolor="#E8E8E8" width="150">
+										<td class="cell-muted" width="150">
 											<div class="center-block"><strong>The key must be numeric</strong></div>
 										</td>
 										<td width="433">
@@ -781,7 +781,7 @@ END-IF</code></pre>
 										</td>
 									</tr>
 									<tr>
-										<td bgcolor="#E8E8E8" width="150">
+										<td class="cell-muted" width="150">
 											<div class="center-block"><strong>The key is inflexible</strong></div>
 										</td>
 										<td width="433">
@@ -826,7 +826,7 @@ END-IF</code></pre>
 										</td>
 									</tr>
 									<tr>
-										<td bgcolor="#E8E8E8" width="150">
+										<td class="cell-muted" width="150">
 											<strong>Must be stored on direct access media</strong>
 										</td>
 										<td width="433">
@@ -837,9 +837,9 @@ END-IF</code></pre>
 									</tr>
 								</table>
 								<h4 class="center-block">Advantages</h4>
-								<table class="data-table" cellpadding="4" width="101%">
+								<table class="data-table" width="101%">
 									<tr>
-										<td bgcolor="#E8E8E8" width="150">
+										<td class="cell-muted" width="150">
 											<div class="center-block">
 												<strong>Fastest direct access organization</strong>
 											</div>
@@ -852,7 +852,7 @@ END-IF</code></pre>
 										</td>
 									</tr>
 									<tr>
-										<td bgcolor="#E8E8E8" width="150">
+										<td class="cell-muted" width="150">
 											<div class="center-block">
 												<strong>Very little storage overhead</strong>
 											</div>
@@ -865,7 +865,7 @@ END-IF</code></pre>
 										</td>
 									</tr>
 									<tr>
-										<td bgcolor="#E8E8E8" width="150">
+										<td class="cell-muted" width="150">
 											<div class="center-block"><strong>Can be read sequentially</strong></div>
 										</td>
 										<td width="73%">
@@ -885,9 +885,9 @@ END-IF</code></pre>
 							</div>
 							<div class="section-content">
 								<h4 class="center-block">Disadvantages</h4>
-								<table cellpadding="4" width="100%" style="border: 3px solid">
+								<table class="data-table" width="100%">
 									<tr>
-										<td bgcolor="#E8E8E8" width="150">
+										<td class="cell-muted" width="150">
 											<div class="center-block">
 												<strong>Slowest direct access organization</strong>
 											</div>
@@ -916,7 +916,7 @@ END-IF</code></pre>
 										</td>
 									</tr>
 									<tr>
-										<td bgcolor="#E8E8E8" width="150">
+										<td class="cell-muted" width="150">
 											<div class="center-block"><strong>Not very storage efficient</strong></div>
 										</td>
 										<td width="73%">
@@ -936,7 +936,7 @@ END-IF</code></pre>
 										</td>
 									</tr>
 									<tr>
-										<td bgcolor="#E8E8E8" width="150">
+										<td class="cell-muted" width="150">
 											<div class="center-block">
 												<strong>Must be stored on direct access media</strong>
 											</div>
@@ -949,9 +949,9 @@ END-IF</code></pre>
 									</tr>
 								</table>
 								<h4 class="center-block">Advantages</h4>
-								<table class="data-table" cellpadding="4" width="101%">
+								<table class="data-table" width="101%">
 									<tr>
-										<td bgcolor="#E8E8E8" width="27%">
+										<td class="cell-muted" width="27%">
 											<div class="center-block"><strong>Versatile keys</strong></div>
 										</td>
 										<td width="73%">

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -147,8 +147,8 @@
 								<strong>Iteration constructs and their COBOL equivalents</strong>
 							</p>
 							<div>
-								<table bgcolor="#E1FFE1" cellpadding="7" cellspacing="1" width="411" class="data-table">
-									<tr bgcolor="#FFFFCC">
+								<table width="411" class="data-table">
+									<tr class="row-label">
 										<th scope="col" width="18%">C</th>
 										<th scope="col" width="23%">Modula-2</th>
 										<th scope="col" width="59%">COBOL</th>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -355,10 +355,7 @@ MOVE FUNCTION ORD-MAX(IntElement(ALL)) TO OrdPos             </code></pre>
 					</div>
 					<div class="section-content">
 						<div class="table-scroll">
-							<table
-								class="data-table"
-								width="502"
-							>
+							<table class="data-table" width="502">
 								<tr>
 									<th scope="col" width="34%">Function Name</th>
 									<th scope="col" width="20%">Result Type</th>
@@ -548,10 +545,7 @@ Begin.
 					</div>
 					<div class="section-content">
 						<div class="table-scroll">
-							<table
-								class="data-table"
-								width="502"
-							>
+							<table class="data-table" width="502">
 								<tr>
 									<th scope="col" width="36%">Function Name</th>
 									<th scope="col" width="20%">Result Type</th>
@@ -756,10 +750,7 @@ Begin.
 					</div>
 					<div class="section-content">
 						<div class="table-scroll">
-							<table
-								class="data-table"
-								width="502"
-							>
+							<table class="data-table" width="502">
 								<tr>
 									<th scope="col" width="36%">Function Name</th>
 									<th scope="col" width="21%">Result Type</th>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -356,11 +356,8 @@ MOVE FUNCTION ORD-MAX(IntElement(ALL)) TO OrdPos             </code></pre>
 					<div class="section-content">
 						<div class="table-scroll">
 							<table
-								bgcolor="#E1FFE1"
-								cellpadding="7"
-								cellspacing="0"
+								class="data-table"
 								width="502"
-								style="border: 2px solid"
 							>
 								<tr>
 									<th scope="col" width="34%">Function Name</th>
@@ -552,11 +549,8 @@ Begin.
 					<div class="section-content">
 						<div class="table-scroll">
 							<table
-								bgcolor="#E1FFE1"
-								cellpadding="7"
-								cellspacing="0"
+								class="data-table"
 								width="502"
-								style="border: 2px solid"
 							>
 								<tr>
 									<th scope="col" width="36%">Function Name</th>
@@ -763,11 +757,8 @@ Begin.
 					<div class="section-content">
 						<div class="table-scroll">
 							<table
-								bgcolor="#E1FFE1"
-								cellpadding="7"
-								cellspacing="0"
+								class="data-table"
 								width="502"
-								style="border: 2px solid"
 							>
 								<tr>
 									<th scope="col" width="36%">Function Name</th>

--- a/course/Resources/css/course-components.css
+++ b/course/Resources/css/course-components.css
@@ -310,37 +310,25 @@ dl.index-grid.bullet-orange {
 	border-bottom: none;
 }
 
-/* Legacy data tables colour themselves with inline bgcolor attributes —
-   green/cyan body tints (#E1FFE1, #D2FFD2, #DDFFDD, #DDFFFF, #CCFFFF),
-   #FFFFCC header markers, and grey structural cells (#E8E8E8, #CCCCCC) —
-   applied at table, row OR cell level and turned into theme tokens by the
-   global bgcolor remaps. Inside a .data-table, override all of them so every
-   data table matches the modern semantic ones:
-     1. blanket every inline tint to a plain body;
-     2. re-apply the neutral header fill for #FFFFCC headers (row- or
-        cell-level), with the 2px underline the <thead> rule uses;
-     3. keep grey structural cells, mapped to that same neutral grey.
-   Scoped to .data-table so bgcolor markup elsewhere is untouched; the extra
-   class outranks the global table/tr/td[bgcolor] remaps, and the later
-   re-apply rules outrank the blanket by source order (equal specificity). */
-.data-table[bgcolor],
-.data-table tr[bgcolor],
-.data-table td[bgcolor] {
-	background-color: transparent;
-}
-
-.data-table tr[bgcolor="#FFFFCC" i] > td,
-.data-table tr[bgcolor="#FFFFCC" i] > th,
-.data-table td[bgcolor="#FFFFCC" i],
-.data-table td[bgcolor="#E8E8E8" i],
-.data-table td[bgcolor="#CCCCCC" i] {
+/* Header-marker / label fill for data-table cells. `.row-label` marks a whole
+   label row; `.cell-label` marks an individual key cell — both get the neutral
+   fill plus the 2px underline the <thead> rule uses. These replaced the legacy
+   #FFFFCC bgcolor markup the course/exercise pages used (the green/cyan body
+   tints they also carried simply became a plain body and were dropped). */
+.data-table tr.row-label > td,
+.data-table tr.row-label > th,
+.data-table td.cell-label,
+.data-table th.cell-label {
 	background-color: var(--color-cell-label-bg);
+	border-bottom: 2px solid var(--color-border-mute);
 }
 
-.data-table tr[bgcolor="#FFFFCC" i] > td,
-.data-table tr[bgcolor="#FFFFCC" i] > th,
-.data-table td[bgcolor="#FFFFCC" i] {
-	border-bottom: 2px solid var(--color-border-mute);
+/* Grey structural/spacer cells (replacing the legacy #E8E8E8 / #CCCCCC bgcolor
+   markup): the same neutral fill but no header underline — they keep the default
+   row separator. */
+.data-table td.cell-muted,
+.data-table th.cell-muted {
+	background-color: var(--color-cell-label-bg);
 }
 
 /* Breathing room between stacked data-tables (e.g. examples/index.html lists

--- a/course/Resources/css/course.css
+++ b/course/Resources/css/course.css
@@ -324,11 +324,6 @@ body {
 		height: auto;
 	}
 
-	td[bgcolor="#993300"] > h2,
-	td[bgcolor="#993300"] > h3 {
-		margin: 0.3em 0;
-	}
-
 	blockquote {
 		margin-left: 12px;
 		margin-right: 12px;
@@ -412,56 +407,6 @@ ul.toc a {
 	display: block;
 	font-weight: bold;
 	font-size: larger;
-}
-
-/* Recolor legacy <table>/<tr>/<td> bgcolor="..." attribute markup via CSS
-   background-color, which wins over the deprecated HTML attribute. Lets the
-   theme tokens drive colors on pages that haven't been migrated to component
-   classes. */
-table[bgcolor="#FFFFCC" i],
-tr[bgcolor="#FFFFCC" i],
-td[bgcolor="#FFFFCC" i],
-th[bgcolor="#FFFFCC" i] {
-	background-color: var(--color-panel-bg);
-}
-
-table[bgcolor="#FFFFFF" i],
-tr[bgcolor="#FFFFFF" i],
-td[bgcolor="#FFFFFF" i] {
-	background-color: var(--color-bg);
-}
-
-table[bgcolor="#E1FFE1" i],
-table[bgcolor="#D2FFD2" i],
-table[bgcolor="#DDFFDD" i],
-tr[bgcolor="#E1FFE1" i],
-tr[bgcolor="#D2FFD2" i],
-tr[bgcolor="#DDFFDD" i],
-td[bgcolor="#E1FFE1" i],
-td[bgcolor="#D2FFD2" i],
-td[bgcolor="#DDFFDD" i] {
-	background-color: var(--color-code-bg);
-}
-
-table[bgcolor="#DDFFFF" i],
-table[bgcolor="#CCFFFF" i],
-tr[bgcolor="#DDFFFF" i],
-tr[bgcolor="#CCFFFF" i],
-td[bgcolor="#DDFFFF" i],
-td[bgcolor="#CCFFFF" i] {
-	background-color: var(--color-results-bg);
-}
-
-table[bgcolor="#E8E8E8" i],
-tr[bgcolor="#E8E8E8" i],
-td[bgcolor="#E8E8E8" i] {
-	background-color: var(--color-cell-label-bg);
-}
-
-td[bgcolor="#FFFFCC" i] h3,
-td[bgcolor="#FFFFCC" i] h4 {
-	color: var(--color-panel-text);
-	font-family: var(--font-sans);
 }
 
 /* Shared course-page layout */
@@ -730,15 +675,6 @@ body .token.function {
 	:root:not([data-theme="light"]) [style*="background-color: #FFFFFF" i] {
 		background-color: var(--color-bg) !important;
 	}
-
-	/* #CCCCCC has no matching light-mode token (only used as decorative
-	   spacer cells), so it's remapped only in dark mode. Uses the same
-	   --color-cell-label-bg as #E8E8E8 since both are gray. */
-	:root:not([data-theme="light"]) table[bgcolor="#CCCCCC" i],
-	:root:not([data-theme="light"]) tr[bgcolor="#CCCCCC" i],
-	:root:not([data-theme="light"]) td[bgcolor="#CCCCCC" i] {
-		background-color: var(--color-cell-label-bg);
-	}
 }
 
 /* Manual dark override — same non-token rules as the @media block above,
@@ -830,12 +766,6 @@ body .token.function {
 
 :root[data-theme="dark"] [style*="background-color: #FFFFFF" i] {
 	background-color: var(--color-bg) !important;
-}
-
-:root[data-theme="dark"] table[bgcolor="#CCCCCC" i],
-:root[data-theme="dark"] tr[bgcolor="#CCCCCC" i],
-:root[data-theme="dark"] td[bgcolor="#CCCCCC" i] {
-	background-color: var(--color-cell-label-bg);
 }
 
 /* ============================================================================

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -477,9 +477,6 @@ END-IF</code></pre>
 							by bracketing.
 						</p>
 						<table
-							bgcolor="#E1FFE1"
-							cellpadding="7"
-							cellspacing="1"
 							width="100%"
 							style="display: table; table-layout: fixed"
 							class="data-table"
@@ -489,7 +486,7 @@ END-IF</code></pre>
 								<col style="width: 35%" />
 								<col style="width: 42%" />
 							</colgroup>
-							<tr bgcolor="#FFFFCC">
+							<tr class="row-label">
 								<th style="text-align: center">
 									<span class="cobol-highlight"><strong>Precedence</strong></span>
 								</th>
@@ -558,8 +555,8 @@ END-IF
 						<p>If all the simple conditions are true; will the Complex Condition be true? Let's check.</p>
 						<table class="data-table" width="94%" style="display: table; margin-inline: auto">
 							<tr>
-								<th scope="row" bgcolor="#FFFFCC" width="16%" style="text-align: center">Condition</th>
-								<td bgcolor="#E1FFE1" width="84%">
+								<th class="cell-label" scope="row" width="16%" style="text-align: center">Condition</th>
+								<td width="84%">
 									<p style="text-align: center; margin: 0.3em 0">
 										(<code class="language-cobol">NOT</code> (Amnt1 &lt; 10))
 										<code class="language-cobol">OR</code> ((Amnt2 = 50)
@@ -568,10 +565,10 @@ END-IF
 								</td>
 							</tr>
 							<tr>
-								<th scope="row" bgcolor="#FFFFCC" width="16%" style="text-align: center">
+								<th class="cell-label" scope="row" width="16%" style="text-align: center">
 									Expressed as
 								</th>
-								<td bgcolor="#E1FFE1" width="84%">
+								<td width="84%">
 									<div class="eval-row eval-row-3col">
 										<span>(<code class="language-cobol">NOT</code> (T))</span>
 										<code class="language-cobol">OR</code>
@@ -580,10 +577,10 @@ END-IF
 								</td>
 							</tr>
 							<tr>
-								<th scope="row" bgcolor="#FFFFCC" height="17" width="16%" style="text-align: center">
+								<th class="cell-label" scope="row" width="16%" style="text-align: center">
 									Evaluates to
 								</th>
-								<td bgcolor="#E1FFE1" height="17" width="84%">
+								<td width="84%">
 									<div class="eval-row eval-row-3col">
 										<span>(F)</span>
 										<code class="language-cobol">OR</code>
@@ -592,10 +589,10 @@ END-IF
 								</td>
 							</tr>
 							<tr>
-								<th scope="row" bgcolor="#FFFFCC" width="16%" style="text-align: center">
+								<th class="cell-label" scope="row" width="16%" style="text-align: center">
 									Evaluates to
 								</th>
-								<td bgcolor="#E1FFE1" width="84%">
+								<td width="84%">
 									<p style="text-align: center; margin: 0.3em 0">
 										<code class="language-cobol">True</code>
 									</p>
@@ -608,8 +605,8 @@ END-IF
 						</p>
 						<table class="data-table" width="93%" style="display: table; margin-inline: auto">
 							<tr>
-								<th scope="row" bgcolor="#FFFFCC" width="16%" style="text-align: center">Condition</th>
-								<td bgcolor="#E1FFE1" width="84%">
+								<th class="cell-label" scope="row" width="16%" style="text-align: center">Condition</th>
+								<td width="84%">
 									<p style="text-align: center; margin: 0.3em 0">
 										<code class="language-cobol">NOT</code> ((Amnt1 &lt; 10)
 										<code class="language-cobol">OR</code> (Amnt2 = 50))
@@ -618,10 +615,10 @@ END-IF
 								</td>
 							</tr>
 							<tr>
-								<th scope="row" bgcolor="#FFFFCC" width="16%" style="text-align: center">
+								<th class="cell-label" scope="row" width="16%" style="text-align: center">
 									Expressed as
 								</th>
-								<td bgcolor="#E1FFE1" width="84%">
+								<td width="84%">
 									<div class="eval-row eval-row-4col">
 										<code class="language-cobol">NOT</code>
 										<span>((T) <code class="language-cobol">OR</code> (T))</span>
@@ -631,10 +628,10 @@ END-IF
 								</td>
 							</tr>
 							<tr>
-								<th scope="row" bgcolor="#FFFFCC" height="17" width="16%" style="text-align: center">
+								<th class="cell-label" scope="row" width="16%" style="text-align: center">
 									Evaluates to
 								</th>
-								<td bgcolor="#E1FFE1" height="17" width="84%">
+								<td width="84%">
 									<div class="eval-row eval-row-4col">
 										<code class="language-cobol">NOT</code>
 										<span>(T)</span>
@@ -644,10 +641,10 @@ END-IF
 								</td>
 							</tr>
 							<tr>
-								<th scope="row" bgcolor="#FFFFCC" width="16%" style="text-align: center">
+								<th class="cell-label" scope="row" width="16%" style="text-align: center">
 									Evaluates to
 								</th>
-								<td bgcolor="#E1FFE1" width="84%">
+								<td width="84%">
 									<div class="eval-row eval-row-4col">
 										<span style="grid-column: 1 / 3">(F)</span>
 										<code class="language-cobol">AND</code>
@@ -656,10 +653,10 @@ END-IF
 								</td>
 							</tr>
 							<tr>
-								<th scope="row" bgcolor="#FFFFCC" width="16%" style="text-align: center">
+								<th class="cell-label" scope="row" width="16%" style="text-align: center">
 									Evaluates to
 								</th>
-								<td bgcolor="#E1FFE1" width="84%">
+								<td width="84%">
 									<p style="text-align: center; margin: 0.3em 0">
 										<code class="language-cobol">False</code>
 									</p>
@@ -749,12 +746,11 @@ END-IF
 							answer, move your cursor over the text "Answer" and the correct answer should be shown.
 						</p>
 						<table
-							bgcolor="#E1FFE1"
 							class="data-table"
 							width="50%"
 							style="display: table; margin-inline: auto"
 						>
-							<tr bgcolor="#FFFFCC">
+							<tr class="row-label">
 								<th width="13%" style="text-align: center">
 									<span class="cobol-highlight"><strong>VarA</strong></span>
 								</th>
@@ -767,7 +763,7 @@ END-IF
 								<th width="12%" style="text-align: center">
 									<span class="cobol-highlight"><strong>VarG</strong></span>
 								</th>
-								<th bgcolor="#FFFFCC" width="49%" style="text-align: center">
+								<th class="cell-label" width="49%" style="text-align: center">
 									<span class="cobol-highlight"
 										><strong>
 											<code class="language-cobol">DISPLAY</code>
@@ -780,7 +776,7 @@ END-IF
 								<td width="13%" style="text-align: center">4</td>
 								<td width="13%" style="text-align: center">15</td>
 								<td width="12%" style="text-align: center">14</td>
-								<td bgcolor="#E1FFE1" width="49%" style="text-align: center">
+								<td width="49%" style="text-align: center">
 									<details class="saq-reveal">
 										<summary>Click arrow for answer</summary>
 										First is displayed
@@ -792,7 +788,7 @@ END-IF
 								<td width="13%" style="text-align: center">4</td>
 								<td width="13%" style="text-align: center">15</td>
 								<td width="12%" style="text-align: center">15</td>
-								<td bgcolor="#E1FFE1" width="49%" style="text-align: center">
+								<td width="49%" style="text-align: center">
 									<details class="saq-reveal">
 										<summary>Click arrow for answer</summary>
 										Second is displayed
@@ -804,7 +800,7 @@ END-IF
 								<td width="13%" style="text-align: center">4</td>
 								<td width="13%" style="text-align: center">3</td>
 								<td width="12%" style="text-align: center">14</td>
-								<td bgcolor="#E1FFE1" width="49%" style="text-align: center">
+								<td width="49%" style="text-align: center">
 									<details class="saq-reveal">
 										<summary>Click arrow for answer</summary>
 										Third is displayed
@@ -816,7 +812,7 @@ END-IF
 								<td width="13%" style="text-align: center">4</td>
 								<td width="13%" style="text-align: center">15</td>
 								<td width="12%" style="text-align: center">14</td>
-								<td bgcolor="#E1FFE1" width="49%" style="text-align: center">
+								<td width="49%" style="text-align: center">
 									<details class="saq-reveal">
 										<summary>Click arrow for answer</summary>
 										Third is displayed
@@ -1321,14 +1317,14 @@ END-EVALUATE
 							the
 							<code class="language-cobol">EVALUATE</code> which implements it are shown below.
 						</p>
-						<table bgcolor="#E1FFE1" class="data-table" width="83%" style="margin-inline: auto">
-							<tr bgcolor="#FFFFCC" style="vertical-align: top">
-								<th height="10" width="20%" style="text-align: center">QtyOfBooks</th>
-								<th bgcolor="#FFFFCC" height="10" width="43%" style="text-align: center">
+						<table class="data-table" width="83%" style="margin-inline: auto">
+							<tr class="row-label" style="vertical-align: top">
+								<th width="20%" style="text-align: center">QtyOfBooks</th>
+								<th class="cell-label" width="43%" style="text-align: center">
 									ValueOfPurchases (VOP)
 								</th>
-								<th height="10" width="14%" style="text-align: center">ClubMember</th>
-								<th height="10" width="23%" style="text-align: center">% Discount</th>
+								<th width="14%" style="text-align: center">ClubMember</th>
+								<th width="23%" style="text-align: center">% Discount</th>
 							</tr>
 							<tr>
 								<td width="20%" style="text-align: center">1-5</td>

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -476,11 +476,7 @@ END-IF</code></pre>
 							to right unless the order of evaluation is changed by the precedence rules (shown below) or
 							by bracketing.
 						</p>
-						<table
-							width="100%"
-							style="display: table; table-layout: fixed"
-							class="data-table"
-						>
+						<table width="100%" style="display: table; table-layout: fixed" class="data-table">
 							<colgroup>
 								<col style="width: 23%" />
 								<col style="width: 35%" />
@@ -745,11 +741,7 @@ END-IF
 							each instance, see if you can figure out which of the messages will be displayed. To see the
 							answer, move your cursor over the text "Answer" and the correct answer should be shown.
 						</p>
-						<table
-							class="data-table"
-							width="50%"
-							style="display: table; margin-inline: auto"
-						>
+						<table class="data-table" width="50%" style="display: table; margin-inline: auto">
 							<tr class="row-label">
 								<th width="13%" style="text-align: center">
 									<span class="cobol-highlight"><strong>VarA</strong></span>

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -212,8 +212,8 @@
 							In an ordered file, the records are sequenced on some field in the record (like StudentId or
 							StudentName etc). In an unordered file, the records are not in any particular order.
 						</p>
-						<table bgcolor="#E1FFE1" class="data-table" width="53%">
-							<tr bgcolor="#FFFFCC">
+						<table class="data-table" width="53%">
+							<tr class="row-label">
 								<th scope="col" width="39%">Ordered File</th>
 								<th scope="col" width="40%">Unordered File</th>
 							</tr>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -524,8 +524,8 @@ Begin.
 							significant with each successive declaration.
 						</p>
 						<p class="center-block"><strong>SortedSalesFile</strong></p>
-						<table style="margin: 0 auto" bgcolor="#E1FFE1" class="data-table" width="36%">
-							<tr bgcolor="#FFFFCC">
+						<table style="margin: 0 auto" class="data-table" width="36%">
+							<tr class="row-label">
 								<td width="58" style="vertical-align: top">
 									<p class="center-block">
 										<b
@@ -554,9 +554,9 @@ Begin.
 								</td>
 							</tr>
 							<tr>
-								<td bgcolor="#CCCCCC" width="58" style="vertical-align: top"></td>
-								<td bgcolor="#CCCCCC" width="64" style="vertical-align: top"></td>
-								<td bgcolor="#CCCCCC" width="45" style="vertical-align: top"></td>
+								<td class="cell-muted" width="58" style="vertical-align: top"></td>
+								<td class="cell-muted" width="64" style="vertical-align: top"></td>
+								<td class="cell-muted" width="45" style="vertical-align: top"></td>
 							</tr>
 							<tr>
 								<td width="58" style="vertical-align: top">

--- a/course/String.html
+++ b/course/String.html
@@ -192,7 +192,7 @@ END-STRING.</code></pre>
 								height="190"
 							/>
 						</p>
-						<table bgcolor="#DDFFDD" class="data-table" cellpadding="5" width="77%" style="margin: 0 auto">
+						<table class="data-table" width="77%" style="margin: 0 auto">
 							<tr>
 								<td width="21%">Delim$il</td>
 								<td width="79%">

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -123,11 +123,6 @@
 					width: auto !important;
 					padding: 6px 8px;
 				}
-
-				form table:has(select) > tbody > tr > td[bgcolor="#FFFFCC"] {
-					font-weight: bold;
-					padding-bottom: 2px;
-				}
 			}
 		</style>
 		<script src="../components/theme-toggle.js" defer></script>
@@ -394,9 +389,9 @@
 
 01 MonthName   PIC X(3)OCCURS 12 TIMES. </code></pre>
 						<div class="center-block">
-							<table bgcolor="#E1FFE1" class="data-table" width="96%">
+							<table class="data-table" width="96%">
 								<tr>
-									<td bgcolor="#FFFFCC" width="8%">Q1</td>
+									<td class="cell-label" width="8%">Q1</td>
 									<td width="62%">
 										What happens to the elements of the DeptTotalsTable when the statement
 										<code class="language-cobol">MOVE ZEROS TO</code> <i>DeptTotalsTable</i> is
@@ -410,7 +405,7 @@
 									</td>
 								</tr>
 								<tr>
-									<td bgcolor="#FFFFCC" width="8%">Q2</td>
+									<td class="cell-label" width="8%">Q2</td>
 									<td width="62%">
 										What happens when the statement <code class="language-cobol">MOVE</code>
 										<i>456</i> <code class="language-cobol">TO</code> <i>DeptTotal(5)</i> is
@@ -424,7 +419,7 @@
 									</td>
 								</tr>
 								<tr>
-									<td bgcolor="#FFFFCC" width="8%">Q3</td>
+									<td class="cell-label" width="8%">Q3</td>
 									<td width="62%">
 										What statement would we have to write to display the second VAT rate in the
 										VATRateTable?
@@ -437,7 +432,7 @@
 									</td>
 								</tr>
 								<tr>
-									<td bgcolor="#FFFFCC" width="8%">Q4</td>
+									<td class="cell-label" width="8%">Q4</td>
 									<td width="62%">What is the purpose of the level 88 attached to the RatesTable?</td>
 									<td width="30%" style="vertical-align: top">
 										<details class="saq-reveal">
@@ -710,8 +705,8 @@ DisplayCountyTaxes.
 							sequential file and its records have the following description-
 						</p>
 						<div class="center-block">
-							<table bgcolor="#E1FFE1" class="data-table" cellpadding="5" width="56%">
-								<tr bgcolor="#FFFFCC">
+							<table class="data-table" width="56%">
+								<tr class="row-label">
 									<th scope="col" width="32%">Name</th>
 									<th scope="col" width="26%">Description</th>
 									<th scope="col" width="42%">Value</th>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -195,7 +195,7 @@ END-UNSTRING.</code></pre>
 								height="264"
 							/>
 						</p>
-						<table bgcolor="#DDFFDD" class="data-table" cellpadding="5" width="77%" style="margin: 0 auto">
+						<table class="data-table" width="77%" style="margin: 0 auto">
 							<tr>
 								<td width="21%">Delim$il</td>
 								<td width="79%">

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -318,8 +318,8 @@ Begin.
 							<code class="language-cobol">USAGE IS COMPUTATIONAL</code>.
 						</p>
 						<p><strong>ASCII Table</strong></p>
-						<table style="margin: 0 auto" class="data-table" cellpadding="0" cellspacing="0">
-							<tr bgcolor="#FFFFCC">
+						<table style="margin: 0 auto" class="data-table">
+							<tr class="row-label">
 								<th scope="col" width="114">Char</th>
 								<th scope="col" width="66">Dec</th>
 								<th scope="col" width="60">Hex</th>
@@ -2267,8 +2267,8 @@ Begin.
 							complement numbers. The storage requirements for fields described as
 							<code class="language-cobol">COMP</code> are as follows:
 						</p>
-						<table style="margin: 0 auto" class="data-table" cellpadding="1" cellspacing="1" width="293">
-							<tr bgcolor="#FFFFCC">
+						<table style="margin: 0 auto" class="data-table" width="293">
+							<tr class="row-label">
 								<th scope="col" width="133">Number of Digits</th>
 								<th scope="col" width="166">Storage Required.</th>
 							</tr>

--- a/exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html
+++ b/exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html
@@ -166,7 +166,7 @@
 						<div class="center-block">
 							<table class="data-table">
 								<tr>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>WEIGHT TO</b><br />500&nbsp; g</p>
 									</td>
 									<td><p class="center-block">Y</p></td>
@@ -183,7 +183,7 @@
 									<td>&nbsp;</td>
 								</tr>
 								<tr>
-									<td bgcolor="#FFFFCC"><p class="center-block">1&nbsp;&nbsp;&nbsp; kg</p></td>
+									<td class="cell-label"><p class="center-block">1&nbsp;&nbsp;&nbsp; kg</p></td>
 									<td>&nbsp;</td>
 									<td>&nbsp;</td>
 									<td><p class="center-block">Y</p></td>
@@ -198,7 +198,7 @@
 									<td>&nbsp;</td>
 								</tr>
 								<tr>
-									<td bgcolor="#FFFFCC"><p class="center-block">3&nbsp;&nbsp;&nbsp; kg</p></td>
+									<td class="cell-label"><p class="center-block">3&nbsp;&nbsp;&nbsp; kg</p></td>
 									<td>&nbsp;</td>
 									<td>&nbsp;</td>
 									<td>&nbsp;</td>
@@ -213,7 +213,7 @@
 									<td>&nbsp;</td>
 								</tr>
 								<tr>
-									<td bgcolor="#FFFFCC"><p class="center-block">5&nbsp;&nbsp;&nbsp; kg</p></td>
+									<td class="cell-label"><p class="center-block">5&nbsp;&nbsp;&nbsp; kg</p></td>
 									<td>&nbsp;</td>
 									<td>&nbsp;</td>
 									<td>&nbsp;</td>
@@ -228,7 +228,7 @@
 									<td>&nbsp;</td>
 								</tr>
 								<tr>
-									<td bgcolor="#FFFFCC"><p class="center-block">10&nbsp; kg</p></td>
+									<td class="cell-label"><p class="center-block">10&nbsp; kg</p></td>
 									<td>&nbsp;</td>
 									<td>&nbsp;</td>
 									<td>&nbsp;</td>
@@ -243,7 +243,7 @@
 									<td>&nbsp;</td>
 								</tr>
 								<tr>
-									<td bgcolor="#FFFFCC"><p class="center-block">50&nbsp; kg</p></td>
+									<td class="cell-label"><p class="center-block">50&nbsp; kg</p></td>
 									<td>&nbsp;</td>
 									<td>&nbsp;</td>
 									<td>&nbsp;</td>
@@ -258,7 +258,7 @@
 									<td><p class="center-block">&nbsp;Y</p></td>
 								</tr>
 								<tr>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>COUNTRY</b></p>
 									</td>
 									<td>&nbsp;</td>
@@ -275,7 +275,7 @@
 									<td>&nbsp;</td>
 								</tr>
 								<tr>
-									<td bgcolor="#FFFFCC"><p class="center-block">Republic</p></td>
+									<td class="cell-label"><p class="center-block">Republic</p></td>
 									<td><p class="center-block">Y</p></td>
 									<td>&nbsp;</td>
 									<td><p class="center-block">Y</p></td>
@@ -290,7 +290,7 @@
 									<td>&nbsp;</td>
 								</tr>
 								<tr>
-									<td bgcolor="#FFFFCC"><p class="center-block">Other EU</p></td>
+									<td class="cell-label"><p class="center-block">Other EU</p></td>
 									<td>&nbsp;</td>
 									<td><p class="center-block">Y</p></td>
 									<td>&nbsp;</td>
@@ -305,7 +305,7 @@
 									<td><p class="center-block">Y</p></td>
 								</tr>
 								<tr>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>Post Number</b></p>
 									</td>
 									<td>
@@ -355,7 +355,7 @@
 						<h3>Orders file (Sequential)</h3>
 						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
+								<tr class="row-label">
 									<td>
 										<p class="center-block"><b>Field</b></p>
 									</td>
@@ -410,7 +410,7 @@
 						<h3>Stock File (Relative)</h3>
 						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
+								<tr class="row-label">
 									<td>
 										<p class="center-block"><b>Field</b></p>
 									</td>
@@ -487,7 +487,7 @@
 						<h3>Manufacturer File (Indexed)</h3>
 						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
+								<tr class="row-label">
 									<td>
 										<p class="center-block"><b>Field</b></p>
 									</td>

--- a/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html
+++ b/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html
@@ -138,19 +138,19 @@
 						<div class="center-block">
 							<table class="data-table">
 								<tr>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<div class="center-block"><b>Record Type</b></div>
 									</td>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>Field</b></p>
 									</td>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>Type</b></p>
 									</td>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>Length</b></p>
 									</td>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>Value</b></p>
 									</td>
 								</tr>
@@ -205,19 +205,19 @@
 						<div class="center-block">
 							<table class="data-table">
 								<tr>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>Field</b></p>
 									</td>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<div class="center-block"><b>KeyType</b></div>
 									</td>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>Type</b></p>
 									</td>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>Length</b></p>
 									</td>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>Value</b></p>
 									</td>
 								</tr>
@@ -255,19 +255,19 @@
 						<div class="center-block">
 							<table class="data-table">
 								<tr>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>Field</b></p>
 									</td>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<div class="center-block"><b>KeyType</b></div>
 									</td>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>Type</b></p>
 									</td>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>Length</b></p>
 									</td>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>Value</b></p>
 									</td>
 								</tr>

--- a/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html
+++ b/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html
@@ -123,7 +123,7 @@
 						</p>
 						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
+								<tr class="row-label">
 									<td>
 										<p class="center-block"><b>Field</b></p>
 									</td>

--- a/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html
+++ b/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html
@@ -129,7 +129,7 @@
 						</p>
 						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
+								<tr class="row-label">
 									<td>
 										<p class="center-block"><b>FIELD</b></p>
 									</td>
@@ -171,7 +171,7 @@
 						</p>
 						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
+								<tr class="row-label">
 									<td>
 										<p class="center-block"><b>FIELD</b></p>
 									</td>

--- a/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html
+++ b/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html
@@ -144,19 +144,19 @@
 						<div class="center-block">
 							<table class="data-table">
 								<tr>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>Field</b></p>
 									</td>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<div class="center-block"><b>KeyType</b></div>
 									</td>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>Type</b></p>
 									</td>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>Length</b></p>
 									</td>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>Value</b></p>
 									</td>
 								</tr>
@@ -209,19 +209,19 @@
 						<div class="center-block">
 							<table class="data-table">
 								<tr>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>Field</b></p>
 									</td>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<div class="center-block"><b>KeyType</b></div>
 									</td>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>Type</b></p>
 									</td>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>Length</b></p>
 									</td>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>Value</b></p>
 									</td>
 								</tr>
@@ -253,19 +253,19 @@
 						<div class="center-block">
 							<table class="data-table">
 								<tr>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>Field</b></p>
 									</td>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<div class="center-block"><b>KeyType</b></div>
 									</td>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>Type</b></p>
 									</td>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>Length</b></p>
 									</td>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>Value</b></p>
 									</td>
 								</tr>

--- a/exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html
+++ b/exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html
@@ -152,7 +152,7 @@
 						</p>
 						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
+								<tr class="row-label">
 									<td>
 										<p class="center-block"><b>Field</b></p>
 									</td>
@@ -212,7 +212,7 @@
 						</p>
 						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
+								<tr class="row-label">
 									<td>
 										<p class="center-block"><b>Field</b></p>
 									</td>
@@ -286,7 +286,7 @@
 						</p>
 						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
+								<tr class="row-label">
 									<td>
 										<p class="center-block"><b>Field</b></p>
 									</td>
@@ -322,7 +322,7 @@
 						</p>
 						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
+								<tr class="row-label">
 									<td>
 										<p class="center-block"><b>CourseCode</b></p>
 									</td>

--- a/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html
+++ b/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html
@@ -174,7 +174,7 @@
 						</p>
 						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
+								<tr class="row-label">
 									<td>
 										<p class="center-block"><b>Field</b></p>
 									</td>
@@ -217,7 +217,7 @@
 						</p>
 						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
+								<tr class="row-label">
 									<td>
 										<p class="center-block"><b>Field</b></p>
 									</td>

--- a/exercises/Exm-FileConversion/Exm-FileConversion.html
+++ b/exercises/Exm-FileConversion/Exm-FileConversion.html
@@ -140,16 +140,16 @@ Fred James Hoyle,17 Starry Lane Cork Co. Cork,0012</pre
 						<div class="center-block">
 							<table class="data-table">
 								<tr>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>Field</b></p>
 									</td>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>Type</b></p>
 									</td>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>Length</b></p>
 									</td>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<p class="center-block"><b>Value</b></p>
 									</td>
 								</tr>
@@ -213,7 +213,7 @@ Ryan Michael Terence          34 Winchester Drive Dubline 7 Co. Dublin    090123
 						</p>
 						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
+								<tr class="row-label">
 									<td>
 										<div class="center-block"><b>County Num</b></div>
 									</td>

--- a/exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html
+++ b/exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html
@@ -107,7 +107,7 @@
 						</p>
 						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
+								<tr class="row-label">
 									<td>
 										<p class="center-block"><b>Field</b></p>
 									</td>
@@ -180,7 +180,7 @@
 						</p>
 						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
+								<tr class="row-label">
 									<td>
 										<p class="center-block"><b>Field</b></p>
 									</td>

--- a/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html
+++ b/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html
@@ -140,7 +140,7 @@
 						</p>
 						<p>The indexed file Books.dat has the following record description;-</p>
 						<table class="data-table">
-							<tr bgcolor="#FFFFCC">
+							<tr class="row-label">
 								<td>
 									<p class="center-block"><b>Field</b></p>
 								</td>
@@ -195,7 +195,7 @@
 						</table>
 						<p>The indexed file Author.dat has the following record description;-</p>
 						<table class="data-table">
-							<tr bgcolor="#FFFFCC">
+							<tr class="row-label">
 								<td>
 									<p class="center-block"><b>Field</b></p>
 								</td>

--- a/exercises/Exm-SFbyMail/Exm-SFbyMail.html
+++ b/exercises/Exm-SFbyMail/Exm-SFbyMail.html
@@ -199,7 +199,7 @@
 						</p>
 						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
+								<tr class="row-label">
 									<td>
 										<p class="center-block"><b>&nbsp;&nbsp; Field</b></p>
 									</td>
@@ -262,7 +262,7 @@
 						</p>
 						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
+								<tr class="row-label">
 									<td>
 										<p class="center-block"><b>Field</b></p>
 									</td>
@@ -325,7 +325,7 @@
 						</p>
 						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
+								<tr class="row-label">
 									<td>
 										<p class="center-block"><b>Field</b></p>
 									</td>

--- a/exercises/Exm-StudFeesRpt/Exm-StudPay.html
+++ b/exercises/Exm-StudFeesRpt/Exm-StudPay.html
@@ -129,7 +129,7 @@
 						</p>
 						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
+								<tr class="row-label">
 									<td>
 										<p class="center-block"><b>Field</b></p>
 									</td>
@@ -165,7 +165,7 @@
 						</p>
 						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
+								<tr class="row-label">
 									<td>
 										<p class="center-block"><b>Field</b></p>
 									</td>

--- a/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html
+++ b/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html
@@ -127,7 +127,7 @@
 						</p>
 						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
+								<tr class="row-label">
 									<td>
 										<p class="center-block"><b>Field</b></p>
 									</td>
@@ -181,7 +181,7 @@
 						</p>
 						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
+								<tr class="row-label">
 									<td>
 										<p class="center-block"><b>Field</b></p>
 									</td>
@@ -228,7 +228,7 @@
 						</p>
 						<div class="center-block">
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
+								<tr class="row-label">
 									<td>
 										<p class="center-block"><b>Field</b></p>
 									</td>

--- a/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html
+++ b/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html
@@ -105,7 +105,7 @@
 							the SOVIET UNION. The following is the record description.
 						</p>
 						<table class="data-table">
-							<tr bgcolor="#FFFFCC">
+							<tr class="row-label">
 								<td>
 									<p class="center-block"><b>Field</b></p>
 								</td>
@@ -181,7 +181,7 @@
 						<div class="center-block">
 							<b>Monthly Cost Table</b>
 							<table class="data-table">
-								<tr bgcolor="#CCFFFF">
+								<tr>
 									<td rowspan="7">
 										<div class="center-block">
 											<br />
@@ -192,8 +192,8 @@
 										<div class="center-block"><b>Vessel Type</b></div>
 									</td>
 								</tr>
-								<tr bgcolor="#FFFFCC">
-									<td bgcolor="#FFFFCC"><div class="center-block"></div></td>
+								<tr class="row-label">
+									<td class="cell-label"><div class="center-block"></div></td>
 									<td>
 										<p class="center-block"><b>1</b></p>
 									</td>
@@ -232,7 +232,7 @@
 									</td>
 								</tr>
 								<tr>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<div class="center-block"><b>P</b></div>
 									</td>
 									<td><p class="center-block">2610</p></td>
@@ -249,7 +249,7 @@
 									<td><p class="center-block">0636</p></td>
 								</tr>
 								<tr>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<div class="center-block"><b>A</b></div>
 									</td>
 									<td><p class="center-block">2560</p></td>
@@ -266,7 +266,7 @@
 									<td><p class="center-block">0606</p></td>
 								</tr>
 								<tr>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<div class="center-block"><b>M</b></div>
 									</td>
 									<td><p class="center-block">2400</p></td>
@@ -283,7 +283,7 @@
 									<td><p class="center-block">0596</p></td>
 								</tr>
 								<tr>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<div class="center-block"><b>I</b></div>
 									</td>
 									<td><p class="center-block">2586</p></td>
@@ -300,7 +300,7 @@
 									<td><p class="center-block">0620</p></td>
 								</tr>
 								<tr>
-									<td bgcolor="#FFFFCC">
+									<td class="cell-label">
 										<div class="center-block"><b>O</b></div>
 									</td>
 									<td><p class="center-block">2500</p></td>
@@ -327,7 +327,7 @@
 						<div class="center-block">
 							<b>Vessel Function Table</b>
 							<table class="data-table">
-								<tr bgcolor="#FFFFCC">
+								<tr class="row-label">
 									<td>
 										<p class="center-block"><b>Vessel Type Code</b></p>
 									</td>


### PR DESCRIPTION
## Summary

The course and exercise data tables coloured themselves with deprecated `bgcolor` attributes (`#FFFFCC` header markers, `#E1FFE1`/`#D2FFD2`/`#DDFFDD`/`#DDFFFF`/`#CCFFFF` body tints, `#E8E8E8`/`#CCCCCC` grey cells), which a ~70-line remap layer in `course.css` translated into theme tokens at runtime. The MDN refresh (#665–#669) modernised how those tables *look* but left the legacy markup and its remap CSS in place.

This migrates **every hand-authored data table (25 course + exercise pages)** to semantic component classes and **deletes the remap layer entirely**:

- `.row-label` / `.cell-label` — neutral header-marker fill + 2px underline (replaces `#FFFFCC` on rows/cells)
- `.cell-muted` — neutral fill, default separator (replaces `#E8E8E8`/`#CCCCCC`)
- green/cyan body tints are dropped (they already rendered transparent inside `.data-table`)

**Phase C — consistency:** `RefMod` and `Intro2DirectAccess` had non-`.data-table` tables (green table backgrounds, 2px/3px solid box borders) that escaped the phase-4 refresh; they're now `.data-table`, matching the rest of the site. `Tables2`'s dead `bgcolor`-coupled `<style>` rule (it targeted a `form`/`select` that no longer exists on the page) is removed.

**Phase D — cleanup:** deleted the global `table/tr/td/th[bgcolor=…]` remaps, the `td[bgcolor="#FFFFCC"] h3/h4` rule, the dead `#993300` mobile rule, both dark-mode `#CCCCCC` blocks, and the scoped `.data-table[bgcolor]` rules. Net **−70 lines** from `course.css`.

After this PR there is **zero `bgcolor` in any HTML or CSS rule** across the site.

## Why

Removes a runtime attribute-remap layer that existed only to keep deprecated presentational markup theme-aware — replacing it with the semantic classes the design system already uses. Less CSS to maintain, no attribute-coupled selectors, and the tables become structurally consistent.

## Reviewer notes

- **No visual change** for the `.data-table` pages: computed styles verified identical before/after — `rgb(232,232,232)` light / `rgb(45,45,45)` dark (the `.cell-muted` token resolves dark automatically, so the deleted `#CCCCCC` dark rules were redundant).
- **Intentional** visual improvement on the Phase-C pages (heavy box borders → soft, green table bg → transparent), bringing them in line with every other table. See before/after below.
- `width` attributes are **intentionally preserved** (a separate follow-up phase). `<img>`/`<iframe>` dimensions are untouched.
- Class counts reconcile exactly with the original `bgcolor` inventory on every page.
- **Out of scope (follow-ups):** inline `style="color:#…"` spans in code samples + their `[style*="color"]` remaps; the rest of `Tables2`'s dead `form table:has(select)` style block; the `width`-attribute cleanup.

## Screenshots

Verified in the preview server, light + dark.

- **RefMod** — *before:* green table background + 2px black border; *after:* transparent body, grey header row, soft border (modern `.data-table` style).
- **Intro2DirectAccess** — *before:* Disadvantages table in a heavy 3px black box; *after:* soft border + grey `.cell-muted` label cell, matching its Advantages sibling.
- **EditedPics / Selection / exercises** — pixel-identical (no visual change).

## Checklist

- [x] `npm run validate` passes
- [ ] `npm run links` passes — N/A (no `href`/`src` changed)
- [x] `npm run format:check` passes (Prettier clean on all changed files; only the pre-existing `CLAUDE.md` warning remains, untouched on master)
- [ ] `npm run a11y` passes locally — not re-run (the preview renderer was intermittently unresponsive this session). Contrast is preserved by construction: the migrated cells use the same `--color-cell-label-bg` / `--color-border-mute` tokens that already passed `pa11y-ci` AA in the phase-4 table work; the remaps deleted here mapped to those same tokens. Happy to re-run if desired.