### PR TITLE
refactor(css): retire legacy inline color spans for token classes

### DIFF
--- a/course/Copy.html
+++ b/course/Copy.html
@@ -354,9 +354,9 @@
 								</p>
 								<p>
 									<strong>MOVE Total TO Print-Total</strong><br />
-									4 Text Words - <span style="color: #0000ff"><strong>MOVE</strong></span>
+									4 Text Words - <span class="text-emphasis"><strong>MOVE</strong></span>
 									<strong>
-										<span style="color: #0000ff">
+										<span class="text-emphasis">
 											<span class="cobol-highlight">Total</span> TO
 											<span class="cobol-highlight">Print-Total</span>
 										</span>
@@ -364,20 +364,20 @@
 								</p>
 								<p>
 									<strong>MOVE Total TO Print-Total.</strong><br />
-									5 Text Words - <span style="color: #0000ff"><strong>MOVE</strong></span>
+									5 Text Words - <span class="text-emphasis"><strong>MOVE</strong></span>
 									<strong>
 										<span class="cobol-highlight">Total</span>
-										<span style="color: #0000ff">TO</span>
+										<span class="text-emphasis">TO</span>
 										<span class="cobol-highlight">Print-Total</span>
-										<span style="color: #0000ff">.</span>
+										<span class="text-emphasis">.</span>
 									</strong>
 								</p>
 								<p>
 									<strong>PIC S9(4)V9(6)</strong><br />
 									9 Text words -
 									<strong>
-										<span style="color: #0000ff">PIC</span>
-										<span style="color: #0000ff">
+										<span class="text-emphasis">PIC</span>
+										<span class="text-emphasis">
 											<span class="cobol-highlight">S9</span> (
 											<span class="cobol-highlight">4</span> )
 											<span class="cobol-highlight">V9</span> (
@@ -387,7 +387,7 @@
 								</p>
 								<p>
 									<strong>"PIC S9(4)V9(6)"</strong><br />
-									1 Text word - <span style="color: #0000ff"><strong>"PIC S9(4)V9(6)"</strong></span>
+									1 Text word - <span class="text-emphasis"><strong>"PIC S9(4)V9(6)"</strong></span>
 								</p>
 							</blockquote>
 						</div>
@@ -496,7 +496,7 @@ COPY CopyFile4 IN EGLIB.</code></pre>
 						</p>
 						<p>
 							Text in
-							<span style="color: #006600"><strong>green</strong></span>
+							<span class="text-success"><strong>green</strong></span>
 							is the copy statement in the source text before processing.
 						</p>
 						<p>
@@ -510,7 +510,7 @@ COPY CopyFile4 IN EGLIB.</code></pre>
 						<p>
 							Text in
 							<strong>
-								<span style="color: #cccccc">grey</span>
+								<span class="text-subtle">grey</span>
 							</strong>
 							is the COPY statement which has been applied.
 						</p>

--- a/course/Resources/css/course.css
+++ b/course/Resources/css/course.css
@@ -499,32 +499,24 @@ ul.toc a {
 	}
 }
 
-/* Inline style colour corrections — light mode.
-   Legacy <span style="color: #cccccc"> fails 4.5:1 against any light
-   background. Remap to a dark grey that passes without the rule being
-   visible in dark mode (the dark-mode block below uses higher-specificity
-   :root:not([data-theme="light"]) selectors and overrides this).
-   `!important` is required: attribute selectors only see the raw inline
-   value, but the actual `color` declaration sits in the element's `style`
-   attribute, whose specificity (1,0,0,0) outranks any author selector
-   without `!important`. */
-[style*="color: #CCCCCC" i] {
-	color: var(--color-text-muted) !important;
-}
-
 .cobol-highlight {
 	color: var(--color-syntax-highlight);
 }
 
-/* Legacy <span style="color: #ff0000"> fails 4.5:1 against light backgrounds
-   (#E1FFE1 gives 3.73:1, #FFFFCC gives 3.89:1, white gives 4:1). Remap to a
-   darker red. Dark-mode override below uses higher-specificity selectors and
-   maps to #ff8a8a for legibility on dark panel backgrounds. `!important` is
-   required for the same reason as the #cccccc rule above — we're overriding
-   an inline `style="color:..."` declaration. */
-[style*="color: #FF0000" i],
-[style*="color: #E32D00" i] {
-	color: var(--color-danger) !important;
+/* Inline-text highlight colours, routed through theme tokens (these replaced
+   legacy <span style="color: #..."> markup). `.cobol-highlight` above covers the
+   red emphasis; the rest map to the matching token so they stay legible in both
+   themes. */
+.text-emphasis {
+	color: var(--color-emphasis);
+}
+
+.text-success {
+	color: var(--color-inline-green);
+}
+
+.text-subtle {
+	color: var(--color-text-muted);
 }
 
 /* ============================================================================
@@ -648,41 +640,11 @@ body .token.function {
 	:root:not([data-theme="light"]) {
 		--img-filter: invert(0.92) hue-rotate(180deg);
 	}
-
-	/* Override inline `style="color: #..."` spans baked into legacy code
-	   samples. These attribute selectors target the raw inline value, so
-	   `!important` is required to beat the inline declaration. */
-	:root:not([data-theme="light"]) [style*="color: #0000FF" i] {
-		color: var(--color-link) !important;
-	}
-
-	:root:not([data-theme="light"]) [style*="color: #FF0000" i],
-	:root:not([data-theme="light"]) [style*="color: #E32D00" i] {
-		color: var(--color-danger) !important;
-	}
-
-	:root:not([data-theme="light"]) [style*="color: #006600" i] {
-		color: var(--color-inline-green) !important;
-	}
-
-	:root:not([data-theme="light"]) [style*="color: #CCCCCC" i] {
-		color: var(--color-text-muted) !important;
-	}
-
-	/* Inline background-color: #ffffff stays white in dark mode, leaving light
-	   inherited text on a white canvas — very low contrast. Map to the dark
-	   page background so normal dark-mode text colours apply. */
-	:root:not([data-theme="light"]) [style*="background-color: #FFFFFF" i] {
-		background-color: var(--color-bg) !important;
-	}
 }
 
-/* Manual dark override — same non-token rules as the @media block above,
-   applied regardless of OS preference. The `[style*="..."]` overrides below
-   need `!important` for the same reason as their @media-dark twins: they
-   target the raw inline-style attribute, but the actual `color` /
-   `background-color` declaration sits in `style=""` at specificity (1,0,0,0)
-   and can't be beaten without it. */
+/* Manual dark override — same non-token rules as the @media block above
+   (Prism token colours and image inversion), applied regardless of OS
+   preference. */
 :root[data-theme="dark"] body pre[class*="language-"],
 :root[data-theme="dark"] body code[class*="language-"] {
 	background: var(--prism-bg);
@@ -745,27 +707,6 @@ body .token.function {
 
 :root[data-theme="dark"] {
 	--img-filter: invert(0.92) hue-rotate(180deg);
-}
-
-:root[data-theme="dark"] [style*="color: #0000FF" i] {
-	color: var(--color-link) !important;
-}
-
-:root[data-theme="dark"] [style*="color: #FF0000" i],
-:root[data-theme="dark"] [style*="color: #E32D00" i] {
-	color: var(--color-danger) !important;
-}
-
-:root[data-theme="dark"] [style*="color: #006600" i] {
-	color: var(--color-inline-green) !important;
-}
-
-:root[data-theme="dark"] [style*="color: #CCCCCC" i] {
-	color: var(--color-text-muted) !important;
-}
-
-:root[data-theme="dark"] [style*="background-color: #FFFFFF" i] {
-	background-color: var(--color-bg) !important;
 }
 
 /* ============================================================================

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -553,13 +553,13 @@ Begin.
 							<div class="run-part">
 								<div class="center-block">
 									<strong>Example Runs<br /></strong>
-									The parameter value is shown in <span style="color: #0000ff">blue</span> and the
+									The parameter value is shown in <span class="text-emphasis">blue</span> and the
 									result displayed is shown in <span class="cobol-highlight">red</span>.<br />
 								</div>
 								<hr />
 								<div class="center-block">First Run<br /></div>
 								<div class="center-block">
-									<span style="color: #0000ff"><b>12</b></span>
+									<span class="text-emphasis"><b>12</b></span>
 									<b
 										><br />
 										<span class="cobol-highlight">Total = 62</span>
@@ -568,7 +568,7 @@ Begin.
 								<hr />
 								<div class="center-block">Second Run<br /></div>
 								<div class="center-block">
-									<span style="color: #0000ff"><b>5</b></span>
+									<span class="text-emphasis"><b>5</b></span>
 									<b
 										><br />
 										<span class="cobol-highlight">Total = 55</span>
@@ -577,7 +577,7 @@ Begin.
 								<hr />
 								<div class="center-block">Third Run<br /></div>
 								<div class="center-block">
-									<span style="color: #0000ff"><b>12</b></span>
+									<span class="text-emphasis"><b>12</b></span>
 									<b
 										><br />
 										<span class="cobol-highlight">Total = 62</span>
@@ -615,13 +615,13 @@ Begin.
 							<div class="run-part">
 								<div class="center-block">
 									<strong>Example Runs<br /></strong>
-									The parameter value is shown in <span style="color: #0000ff">blue</span> and the
+									The parameter value is shown in <span class="text-emphasis">blue</span> and the
 									result displayed is shown in <span class="cobol-highlight">red</span>.<br />
 								</div>
 								<hr />
 								<div class="center-block">First Run<br /></div>
 								<div class="center-block">
-									<span style="color: #0000ff"><b>12</b></span>
+									<span class="text-emphasis"><b>12</b></span>
 									<b
 										><br />
 										<span class="cobol-highlight">Total = 62</span>
@@ -631,7 +631,7 @@ Begin.
 								<div class="center-block">Second Run<br /></div>
 								<div class="center-block">
 									<div>
-										<span style="color: #0000ff"><b>5</b></span>
+										<span class="text-emphasis"><b>5</b></span>
 										<b
 											><br />
 											<span class="cobol-highlight">Total = 67</span>
@@ -640,7 +640,7 @@ Begin.
 									<hr />
 									Third Run<br />
 									<div class="center-block">
-										<span style="color: #0000ff"><b>12</b></span>
+										<span class="text-emphasis"><b>12</b></span>
 										<b
 											><br />
 											<span class="cobol-highlight">Total = 79</span>
@@ -1106,12 +1106,12 @@ Begin.
   EXIT PROGRAM.
 END PROGRAM DisplayTotal.
 END PROGRAM Counter.</code></pre>
-						<div style="background-color: #ffffff; padding: 5px; border-top: 1px solid">
+						<div style="background-color: var(--color-bg); padding: 5px; border-top: 1px solid">
 							<div class="center-block">
 								<h3><strong>Example Run</strong></h3>
 								<p>
 									Numeric values entered by the user are shown in
-									<span style="color: #0000ff">blue</span> and values output by the computer are shown
+									<span class="text-emphasis">blue</span> and values output by the computer are shown
 									in <span class="cobol-highlight">red</span>.
 								</p>
 							</div>

--- a/exercises/MonthTable.html
+++ b/exercises/MonthTable.html
@@ -199,7 +199,7 @@ December          5</samp></pre>
 						</p>
 						<p class="center-block">
 							<b
-								><u><span style="color: #ff0000">WARNING</span></u></b
+								><u><span class="cobol-highlight">WARNING</span></u></b
 							>
 						</p>
 						<p>

--- a/exercises/SeqInsert.html
+++ b/exercises/SeqInsert.html
@@ -226,7 +226,7 @@
 						</p>
 						<p class="center-block">
 							<b
-								><u><span style="color: #ff0000">WARNING</span></u></b
+								><u><span class="cobol-highlight">WARNING</span></u></b
 							>
 						</p>
 						<p>

--- a/exercises/SeqUpdate.html
+++ b/exercises/SeqUpdate.html
@@ -270,7 +270,7 @@
 						</p>
 						<p class="center-block">
 							<b
-								><u><span style="color: #ff0000">WARNING</span></u></b
+								><u><span class="cobol-highlight">WARNING</span></u></b
 							>
 						</p>
 						<p>

--- a/exercises/SeqWrite.html
+++ b/exercises/SeqWrite.html
@@ -171,7 +171,7 @@ nnnnnnnSSSSSSSSiiG
 							<a href="../examples/SeqWrite/SEQWRITE.cbl">sample solution</a>.
 						</p>
 						<p class="center-block">
-							<b><span style="color: #ff0000">WARNING</span></b>
+							<b><span class="cobol-highlight">WARNING</span></b>
 						</p>
 						<p>
 							Do not look at the solution until you have finished your own or at least have made a

--- a/exercises/SortIP.html
+++ b/exercises/SortIP.html
@@ -241,7 +241,7 @@
 						</p>
 						<p class="center-block">
 							<b
-								><u><span style="color: #ff0000">WARNING</span></u></b
+								><u><span class="cobol-highlight">WARNING</span></u></b
 							>
 						</p>
 						<p>

--- a/lectures/reportwriterssweb.html
+++ b/lectures/reportwriterssweb.html
@@ -291,7 +291,7 @@ INPUT-OUTPUT SECTION.
 FILE-CONTROL.
     SELECT SalesFile ASSIGN TO "GBPAY.dat"
            ORGANIZATION IS LINE SEQUENTIAL.
-    <span style="color: #FF0000"><b>SELECT PrintFile ASSIGN TO "SALESREPORT.lpt".</b></span>
+    <span class="cobol-highlight"><b>SELECT PrintFile ASSIGN TO "SALESREPORT.lpt".</b></span>
 
 
 DATA DIVISION.
@@ -303,14 +303,14 @@ FD  SalesFile.
     02 SalesPersonNum   PIC 9.
     02 ValueOfSale      PIC 9(4)V99.
 
-<b><span style="color: #FF0000">FD  PrintFile
+<b><span class="cobol-highlight">FD  PrintFile
     REPORT IS SalesReport.
 
 </span></b>    : intervening entries :
     : intervening entries :
 
 REPORT SECTION.
-<b><span style="color: #e32d00">RD  SalesReport</span></b>
+<b><span class="cobol-highlight">RD  SalesReport</span></b>
     CONTROLS ARE FINAL
                  CityCode
                  SalesPersonNum
@@ -771,9 +771,9 @@ REPORT SECTION.
 						<pre>01  DetailLine TYPE IS DETAIL.
     02 LINE IS PLUS 1.
        03 COLUMN 1      PIC X(9)
-                        SOURCE CityName(CityCode) <span style="color: #FF0000"><b>GROUP INDICATE</b></span>.
+                        SOURCE CityName(CityCode) <span class="cobol-highlight"><b>GROUP INDICATE</b></span>.
        03 COLUMN 15     PIC 9
-                        SOURCE SalesPersonNum  <b><span style="color: #FF0000">GROUP INDICATE</span></b>.
+                        SOURCE SalesPersonNum  <b><span class="cobol-highlight">GROUP INDICATE</span></b>.
        03 COLUMN 25     PIC $$,$$$.99 SOURCE ValueOfSale.</pre>
 						<p>
 							The <code class="language-cobol">GROUP INDICATE</code> clause can only appear in a
@@ -844,21 +844,21 @@ REPORT SECTION.
     TYPE IS CONTROL FOOTING SalesPersonNum  NEXT GROUP PLUS 2.
                       :<i> other entries</i> :
                       :<i> other entries</i> :
-       03 <span style="color: #FF0000"><b>SMS</b></span> COLUMN 45 PIC $$$$$,$$$.99 <span style="color: #FF0000"><b>SUM ValueOfSale</b></span>.
+       03 <span class="cobol-highlight"><b>SMS</b></span> COLUMN 45 PIC $$$$$,$$$.99 <span class="cobol-highlight"><b>SUM ValueOfSale</b></span>.
 
 
 
 01  CityGrp TYPE IS CONTROL FOOTING CityCode NEXT GROUP PLUS 2.
                       :<i> other entries</i> :
                       :<i> other entries</i> :
-       03 <b><span style="color: #FF0000">CS</span></b> COLUMN 45  PIC $$$$$,$$$.99 <span style="color: #FF0000"><b>SUM SMS</b></span>.
+       03 <b><span class="cobol-highlight">CS</span></b> COLUMN 45  PIC $$$$$,$$$.99 <span class="cobol-highlight"><b>SUM SMS</b></span>.
 
 
 
 01  TotalSalesGrp TYPE IS CONTROL FOOTING FINAL.
                       :<i> other entries</i> :
                       :<i> other entries</i> :
-       03 COLUMN 45     PIC $$$$$,$$$.99 <b><span style="color: #FF0000">SUM CS</span></b>.</pre>
+       03 COLUMN 45     PIC $$$$$,$$$.99 <b><span class="cobol-highlight">SUM CS</span></b>.</pre>
 						<hr />
 						<h3><b>Cross Footing</b></h3>
 						<p>
@@ -872,9 +872,9 @@ REPORT SECTION.
     TYPE IS CONTROL FOOTING ShopNum  NEXT GROUP PLUS 2.
                       :<i> other entries</i> :
                       :<i> other entries</i> :
-       03 <span style="color: #FF0000"><b>SPS</b></span> COLUMN 20 PIC $$$,$$$.99  <span style="color: #FF0000"><b>SUM SalesPersonSale</b></span>.
-       03 <span style="color: #FF0000"><b>SCS</b></span> COLUMN 40 PIC $$$,$$$.99  <span style="color: #FF0000"><b>SUM CounterSale</b></span>.
-       03     COLUMN 60 PIC $$$$,$$$.99 <span style="color: #FF0000"><b>SUM SPS, SCS</b></span>.
+       03 <span class="cobol-highlight"><b>SPS</b></span> COLUMN 20 PIC $$$,$$$.99  <span class="cobol-highlight"><b>SUM SalesPersonSale</b></span>.
+       03 <span class="cobol-highlight"><b>SCS</b></span> COLUMN 40 PIC $$$,$$$.99  <span class="cobol-highlight"><b>SUM CounterSale</b></span>.
+       03     COLUMN 60 PIC $$$$,$$$.99 <span class="cobol-highlight"><b>SUM SPS, SCS</b></span>.
 </pre>
 						<h3>Rules</h3>
 						<ol>
@@ -984,7 +984,7 @@ REPORT SECTION.
        03 COLUMN 1      PIC X(29)
                         VALUE "Programmer - Michael Coughlan".
        03 COLUMN 45     PIC X(6) VALUE "Page :".
-       03 COLUMN 52     PIC Z9 SOURCE<b><span style="color: #FF0000"> PAGE-COUNTER.</span></b></pre>
+       03 COLUMN 52     PIC Z9 SOURCE<b><span class="cobol-highlight"> PAGE-COUNTER.</span></b></pre>
 						<hr />
 					</div>
 				</div>
@@ -1274,7 +1274,7 @@ Programmer - Michael Coughlan               Page :  1
 					</div>
 					<div class="section-content">
 						<pre>PROCEDURE DIVISION.
-<b><span style="color: #FF0000">DECLARATIVES.
+<b><span class="cobol-highlight">DECLARATIVES.
 Calc SECTION.
     USE BEFORE REPORTING SalesPersonGrp.
 Calculate-Salary.
@@ -1321,7 +1321,7 @@ CheckShopSales SECTION.
     USE BEFORE REPORTING ShopTotalGrp.
 PrintMajorShopsOnly.
     IF SalesTotal &lt; 10000<b>
-       <span style="color: #e32d00">SUPPRESS PRINTING</span>
+       <span class="cobol-highlight">SUPPRESS PRINTING</span>
 </b>    END-IF.
 END DECLARATIVES.</pre>
 						<hr />

--- a/lectures/reportwriterweb.html
+++ b/lectures/reportwriterweb.html
@@ -663,7 +663,7 @@ Programmer - Michael Coughlan               Page :  1
 						<hr />
 						<pre>REPORT SECTION.
 RD  SalesReport
-    CONTROLS ARE <b><span style="color: #FF0000">FINAL
+    CONTROLS ARE <b><span class="cobol-highlight">FINAL
                  CityCode</span></b>
                  SalesPersonNum
     PAGE LIMIT IS 66
@@ -709,9 +709,9 @@ RD  SalesReport
        03 COLUMN 15     PIC X(21) VALUE "Sales for salesperson".
        03 COLUMN 37     PIC 9 SOURCE SalesPersonNum.
        03 COLUMN 43     PIC X VALUE "=".
-       03 <b><span style="color: #FF0000">SMS</span></b> COLUMN 45 PIC $$$$$,$$$.99 SUM ValueOfSale.
+       03 <b><span class="cobol-highlight">SMS</span></b> COLUMN 45 PIC $$$$$,$$$.99 SUM ValueOfSale.
 
-<b><span style="color: #FF0000">
+<b><span class="cobol-highlight">
 01  CityGrp TYPE IS CONTROL FOOTING CityCode NEXT GROUP PLUS 2.
     02 LINE IS PLUS 2.
        03 COLUMN 15     PIC X(9) VALUE "Sales for".
@@ -960,7 +960,7 @@ RD  SalesReport
        03 COLUMN 43     PIC X VALUE "=".
        03 SMS COLUMN 45 PIC $$$$$,$$$.99 SUM ValueOfSale.
 
-<b><span style="color: #FF0000">    02 LINE IS PLUS 1.
+<b><span class="cobol-highlight">    02 LINE IS PLUS 1.
        03 COLUMN 15     PIC X(19) VALUE "Sales commission is".
        03 COLUMN 43     PIC X VALUE "=".
        03 COLUMN 45     PIC $$$$$,$$$.99 SOURCE Commission.
@@ -989,7 +989,7 @@ RD  SalesReport
        03 COLUMN 43     PIC X VALUE "=".
        03 CS COLUMN 45  PIC $$$$$,$$$.99 SUM SMS.
 
-<b><span style="color: #FF0000">    02 LINE IS PLUS 1.
+<b><span class="cobol-highlight">    02 LINE IS PLUS 1.
        03 COLUMN 15     PIC X(12)
                         VALUE "Current city".
        03 COLUMN 43     PIC X VALUE "=".
@@ -1019,7 +1019,7 @@ RD  SalesReport
 
 
 PROCEDURE DIVISION.
-<b><span style="color: #FF0000">DECLARATIVES.
+<b><span class="cobol-highlight">DECLARATIVES.
 Calc SECTION.
     USE BEFORE REPORTING SalesPersonGrp.
 Calculate-Salary.
@@ -1045,7 +1045,7 @@ Begin.
 
 
 PrintSalaryReport.
-<b><span style="color: #FF0000">    MOVE CityCode TO CityNow.
+<b><span class="cobol-highlight">    MOVE CityCode TO CityNow.
     MOVE SalesPersonNum  TO SalesPersonNow.</span></b>
     GENERATE DetailLine.
     READ SalesFile


### PR DESCRIPTION
## Summary

Follow-up to #670 (legacy `bgcolor` table migration). The remaining legacy presentational markup was inline `style="color: #…"` spans — pedagogical highlights in code samples and report layouts — kept theme-aware by a layer of `[style*="color: #…"] { …!important }` remaps in `course.css` (a light block plus both dark blocks).

This replaces the **46 inline color declarations across 9 pages** with theme-token classes and deletes the remap layer entirely:

| Inline value | → class | Token |
| --- | --- | --- |
| `#FF0000` / `#E32D00` (red emphasis) | `.cobol-highlight` (existing) | `--color-syntax-highlight` |
| `#0000FF` (blue references) | `.text-emphasis` (new) | `--color-emphasis` |
| `#006600` (green) | `.text-success` (new) | `--color-inline-green` |
| `#CCCCCC` (grey) | `.text-subtle` (new) | `--color-text-muted` |
| `background-color: #FFFFFF` (1×, multi-prop) | retokened inline to `var(--color-bg)` | — |

**Deleted:** the light `[style*="color: #CCCCCC"]` and `[style*="color: #FF0000"/"#E32D00"]` rules, plus both dark-mode blocks (`#0000FF`, `#FF0000`/`#E32D00`, `#006600`, `#CCCCCC`, `background-color #FFFFFF`). After this PR **no page has inline color markup and no `[style*=…]` remap rule remains** — `course.css` drops ~93 lines.

## Why

Same rationale as #670: replace deprecated inline presentational markup + its runtime `!important` remap layer with the semantic, token-backed classes the design system already uses. Less CSS, no `!important` attribute-overrides, theme-correctness comes from tokens.

## Reviewer notes

- **Parity (computed styles, both themes):** red / green / grey / bg are **identical** before/after — the classes resolve to the exact tokens the remaps used (`#c00000`→`#ff8a8a`, `#006600`→`#7ec47e`, `#6a6a6a`→`#a0a0a0`, white→`#1a1a1a`).
- **One intentional minor shift:** blue moves from pure `#0000ff` to `--color-emphasis` (`#000099` light / `#8aa8ff` dark) — a slightly stronger-contrast blue that is now theme-aware (previously pure `#0000ff` had no light-mode token and only got a dark remap). Affects the "shown in blue" references in Copy/Subprograms and a few report-layout marks.
- Files: `course/Copy.html`, `course/Subprograms.html`, the two content lecture pages (`reportwriterssweb`, `reportwriterweb`), and 5 exercise pages.
- `.cobol-highlight` was already the established red class (used on 5 course pages); this just routes the inline reds through it too.

## Checklist

- [x] `npm run validate` passes
- [ ] `npm run links` passes — N/A (no `href`/`src` changed)
- [x] `npm run format:check` passes (Prettier clean on all changed files; only the pre-existing `CLAUDE.md` warning remains)
- [ ] `npm run a11y` — not re-run (flaky preview renderer this session). Contrast is preserved or improved: red/green/grey map to the same AA-audited tokens the deleted remaps used; the blue shift increases contrast on both backgrounds.