### PR TITLE
feat(shell): standardize the page shell — Edit on GitHub everywhere + link order

### DIFF
--- a/course/COBOLIntro.html
+++ b/course/COBOLIntro.html
@@ -124,6 +124,7 @@
 		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
@@ -1287,6 +1288,7 @@ DisplayGreeting.
 						<lesson-nav></lesson-nav>
 						<copyright-notice></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 					</div>
 				</div>
 			</div>

--- a/course/COBOLcommands.html
+++ b/course/COBOLcommands.html
@@ -100,6 +100,7 @@
 		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
@@ -1127,6 +1128,7 @@ The time is 14:41
 						<lesson-nav></lesson-nav>
 						<copyright-notice></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 					</div>
 				</div>
 			</div>

--- a/course/Copy.html
+++ b/course/Copy.html
@@ -105,6 +105,7 @@
 		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
@@ -1016,6 +1017,7 @@ COPY CopyFile7 REPLACING N1 BY Num1
 					<lesson-nav></lesson-nav>
 					<copyright-notice></copyright-notice>
 					<last-updated></last-updated>
+					<edit-on-github></edit-on-github>
 				</div>
 			</div>
 		</main>

--- a/course/DataDeclaration.html
+++ b/course/DataDeclaration.html
@@ -100,6 +100,7 @@
 		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
@@ -781,6 +782,7 @@ PIC 9(18)      is equivalent to PIC 999999999999999999 </code></pre>
 						<lesson-nav></lesson-nav>
 						<copyright-notice></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 					</div>
 				</div>
 			</div>

--- a/course/EditedPics.html
+++ b/course/EditedPics.html
@@ -100,6 +100,7 @@
 		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
@@ -1369,6 +1370,7 @@ B 0 / , + - CR DB 9</code></pre>
 					<lesson-nav></lesson-nav>
 					<copyright-notice></copyright-notice>
 					<last-updated></last-updated>
+					<edit-on-github></edit-on-github>
 				</div>
 			</div>
 		</main>

--- a/course/IndexedFiles.html
+++ b/course/IndexedFiles.html
@@ -106,6 +106,7 @@
 		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
@@ -1170,6 +1171,7 @@ ProcessOneBook.
 					<lesson-nav></lesson-nav>
 					<copyright-notice></copyright-notice>
 					<last-updated></last-updated>
+					<edit-on-github></edit-on-github>
 				</div>
 			</div>
 		</main>

--- a/course/Inspect.html
+++ b/course/Inspect.html
@@ -100,6 +100,7 @@
 		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
@@ -654,6 +655,7 @@ END-PERFORM</code></pre>
 					<lesson-nav></lesson-nav>
 					<copyright-notice></copyright-notice>
 					<last-updated></last-updated>
+					<edit-on-github></edit-on-github>
 				</div>
 			</div>
 		</main>

--- a/course/Intro2DirectAccess.html
+++ b/course/Intro2DirectAccess.html
@@ -103,6 +103,7 @@
 		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
@@ -1012,6 +1013,7 @@ END-IF</code></pre>
 					<lesson-nav></lesson-nav>
 					<copyright-notice></copyright-notice>
 					<last-updated></last-updated>
+					<edit-on-github></edit-on-github>
 				</div>
 			</div>
 		</main>

--- a/course/Iteration.html
+++ b/course/Iteration.html
@@ -100,6 +100,7 @@
 		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
@@ -1243,6 +1244,7 @@ CountMileage.
 						<lesson-nav></lesson-nav>
 						<copyright-notice></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 					</div>
 				</div>
 			</div>

--- a/course/RefMod.html
+++ b/course/RefMod.html
@@ -100,6 +100,7 @@
 		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
@@ -1224,6 +1225,7 @@ Begin.
 					<lesson-nav></lesson-nav>
 					<copyright-notice></copyright-notice>
 					<last-updated></last-updated>
+					<edit-on-github></edit-on-github>
 				</div>
 			</div>
 		</main>

--- a/course/RelativeFiles.html
+++ b/course/RelativeFiles.html
@@ -100,6 +100,7 @@
 		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
@@ -824,6 +825,7 @@ Begin.</code></pre>
 					<lesson-nav></lesson-nav>
 					<copyright-notice></copyright-notice>
 					<last-updated></last-updated>
+					<edit-on-github></edit-on-github>
 				</div>
 			</div>
 		</main>

--- a/course/ReportWriter.html
+++ b/course/ReportWriter.html
@@ -100,6 +100,7 @@
 		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
@@ -1034,6 +1035,7 @@ Programmer - Michael Coughlan               Page :  1 </code></pre>
 						<lesson-nav></lesson-nav>
 						<copyright-notice></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 					</div>
 				</div>
 			</div>

--- a/course/ReportWriterSS.html
+++ b/course/ReportWriterSS.html
@@ -99,6 +99,7 @@
 		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
@@ -1256,6 +1257,7 @@ END DECLARATIVES.</code></pre>
 				<lesson-nav></lesson-nav>
 				<copyright-notice></copyright-notice>
 				<last-updated></last-updated>
+				<edit-on-github></edit-on-github>
 			</div>
 		</main>
 	</body>

--- a/course/Search.html
+++ b/course/Search.html
@@ -100,6 +100,7 @@
 		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
@@ -1176,6 +1177,7 @@ DisplayCountyTaxes.
 				<lesson-nav></lesson-nav>
 				<copyright-notice></copyright-notice>
 				<last-updated></last-updated>
+				<edit-on-github></edit-on-github>
 			</div>
 		</main>
 	</body>

--- a/course/Selection.html
+++ b/course/Selection.html
@@ -112,6 +112,7 @@
 		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
@@ -1485,6 +1486,7 @@ END-EVALUATE
 						<lesson-nav></lesson-nav>
 						<copyright-notice></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 					</div>
 				</div>
 			</div>

--- a/course/SequentialFiles1.html
+++ b/course/SequentialFiles1.html
@@ -100,6 +100,7 @@
 		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
@@ -858,6 +859,7 @@ GetStudentRecord.
 					<lesson-nav></lesson-nav>
 					<copyright-notice></copyright-notice>
 					<last-updated></last-updated>
+					<edit-on-github></edit-on-github>
 				</div>
 			</div>
 		</main>

--- a/course/SequentialFiles2.html
+++ b/course/SequentialFiles2.html
@@ -100,6 +100,7 @@
 		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
@@ -579,6 +580,7 @@ END-PERFORM
 					<lesson-nav></lesson-nav>
 					<copyright-notice></copyright-notice>
 					<last-updated></last-updated>
+					<edit-on-github></edit-on-github>
 				</div>
 			</div>
 		</main>

--- a/course/SequentialFiles3.html
+++ b/course/SequentialFiles3.html
@@ -100,6 +100,7 @@
 		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
@@ -1029,6 +1030,7 @@ DisplayTransactions.
 						<lesson-nav></lesson-nav>
 						<copyright-notice></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 					</div>
 				</div>
 			</div>

--- a/course/SortMerge.html
+++ b/course/SortMerge.html
@@ -100,6 +100,7 @@
 		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
@@ -1613,6 +1614,7 @@ Begin.
 					<lesson-nav></lesson-nav>
 					<copyright-notice></copyright-notice>
 					<last-updated></last-updated>
+					<edit-on-github></edit-on-github>
 				</div>
 			</div>
 		</main>

--- a/course/String.html
+++ b/course/String.html
@@ -100,6 +100,7 @@
 		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
@@ -484,6 +485,7 @@ END-STRING.</code></pre>
 					<lesson-nav></lesson-nav>
 					<copyright-notice></copyright-notice>
 					<last-updated></last-updated>
+					<edit-on-github></edit-on-github>
 				</div>
 			</div>
 		</main>

--- a/course/Subprograms.html
+++ b/course/Subprograms.html
@@ -100,6 +100,7 @@
 		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
@@ -1260,6 +1261,7 @@ Value - 0</code></pre>
 					<lesson-nav></lesson-nav>
 					<copyright-notice></copyright-notice>
 					<last-updated></last-updated>
+					<edit-on-github></edit-on-github>
 				</div>
 			</div>
 		</main>

--- a/course/Tables1.html
+++ b/course/Tables1.html
@@ -100,6 +100,7 @@
 		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
@@ -632,6 +633,7 @@ Begin.
 					<lesson-nav></lesson-nav>
 					<copyright-notice></copyright-notice>
 					<last-updated></last-updated>
+					<edit-on-github></edit-on-github>
 				</div>
 			</div>
 		</main>

--- a/course/Tables2.html
+++ b/course/Tables2.html
@@ -133,6 +133,7 @@
 		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
@@ -1485,6 +1486,7 @@ DisplayCountyTaxes.
 						<lesson-nav></lesson-nav>
 						<copyright-notice></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 					</div>
 				</div>
 			</div>

--- a/course/Unstring.html
+++ b/course/Unstring.html
@@ -100,6 +100,7 @@
 		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
@@ -605,6 +606,7 @@ Begin.
 					<lesson-nav></lesson-nav>
 					<copyright-notice></copyright-notice>
 					<last-updated></last-updated>
+					<edit-on-github></edit-on-github>
 				</div>
 			</div>
 		</main>

--- a/course/Usage.html
+++ b/course/Usage.html
@@ -100,6 +100,7 @@
 		<script src="../components/lesson-checkbox.js" defer></script>
 		<script src="../components/copyright-notice.js" defer></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/page-toc.js" defer></script>
@@ -2403,6 +2404,7 @@ Begin.
 					<lesson-nav></lesson-nav>
 					<copyright-notice></copyright-notice>
 					<last-updated></last-updated>
+					<edit-on-github></edit-on-github>
 				</div>
 			</div>
 		</main>

--- a/course/glossary.html
+++ b/course/glossary.html
@@ -32,8 +32,8 @@
 			content="COBOL glossary, COBOL keywords, COBOL terminology, COBOL reference, PERFORM, EVALUATE, OCCURS, REDEFINES, PIC, LINKAGE SECTION"
 		/>
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/glossary.html" />
-		<link rel="stylesheet" href="Resources/css/course.css" />
-		<link rel="stylesheet" href="Resources/css/course-components.css" />
+		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link
 			rel="stylesheet"
 			href="Resources/vendor/prism/themes/prism.min.css"
@@ -269,6 +269,7 @@
 		<script src="../components/site-header.js" type="module"></script>
 		<script src="../components/course-sidebar.js" type="module"></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/related-content.js" defer></script>
 	</head>
 	<body>
@@ -1547,6 +1548,7 @@
 
 			<copyright-notice></copyright-notice>
 			<last-updated></last-updated>
+			<edit-on-github></edit-on-github>
 		</main>
 
 		<script>

--- a/course/index.html
+++ b/course/index.html
@@ -40,8 +40,8 @@
 			}
 		</script>
 		<title>COBOL Course</title>
-		<link rel="stylesheet" href="Resources/css/course.css" />
-		<link rel="stylesheet" href="Resources/css/course-components.css" />
+		<link href="Resources/css/course.css" rel="stylesheet" />
+		<link href="Resources/css/course-components.css" rel="stylesheet" />
 		<link
 			href="Resources/vendor/prism/themes/prism.min.css"
 			rel="stylesheet"

--- a/exercises/COBOLExams/COBOLExams.html
+++ b/exercises/COBOLExams/COBOLExams.html
@@ -59,6 +59,7 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -208,6 +209,7 @@
 
 					<copyright-notice type="exercises"></copyright-notice>
 					<last-updated></last-updated>
+					<edit-on-github></edit-on-github>
 					<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
 				</div>
 			</div>

--- a/exercises/CountDown.html
+++ b/exercises/CountDown.html
@@ -44,6 +44,7 @@
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/site-header.js" type="module"></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/exercise-progress.js" defer></script>
 		<script src="../components/exercises-sidebar.js" type="module"></script>
 		<script src="../components/exercises-nav.js" defer></script>
@@ -196,6 +197,7 @@ Your name is Mike Ryan</samp></pre>
 						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="index.html">&larr; Back to COBOL Exercises</a></p>
 					</div>
 				</div>

--- a/exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html
+++ b/exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html
@@ -62,6 +62,7 @@
 		<script src="../../components/exercises-nav.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -562,6 +563,7 @@
 						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
 					</div>
 				</div>

--- a/exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html
+++ b/exercises/Exm-AcmeStockReorder/Prg-AcmeStockReorder.html
@@ -63,6 +63,7 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -280,6 +281,7 @@ EXTRACT-ADDRESS-ITEMS.
 						<hr />
 						<copyright-notice type="examples"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="Exm-AcmeStockReorder.html">&larr; Back to specification</a></p>
 					</div>
 				</div>

--- a/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html
+++ b/exercises/Exm-AromaOilFileMainRpt/Exm-AromaOilFileMainRpt.html
@@ -62,6 +62,7 @@
 		<script src="../../components/exercises-nav.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -377,6 +378,7 @@
 						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
 					</div>
 				</div>

--- a/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html
+++ b/exercises/Exm-AromaOilFileMainRpt/Prg-AromaOilFileMainRpt.html
@@ -69,6 +69,7 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -265,6 +266,7 @@ Print-Stock-Report.
 						<hr />
 						<copyright-notice type="examples"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block">
 							<a href="Exm-AromaOilFileMainRpt.html">&larr; Back to specification</a>
 						</p>

--- a/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html
+++ b/exercises/Exm-AromaSalesRpt/Exm-AromaSalesSummaryRpt.html
@@ -62,6 +62,7 @@
 		<script src="../../components/exercises-nav.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -243,6 +244,7 @@
 						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
 					</div>
 				</div>

--- a/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html
+++ b/exercises/Exm-AromaSalesRpt/Prg-AromaSalesSummaryRpt.html
@@ -63,6 +63,7 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -278,6 +279,7 @@ Print-Customer-Lines.
 						<hr />
 						<copyright-notice type="examples"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block">
 							<a href="Exm-AromaSalesSummaryRpt.html">&larr; Back to specification</a>
 						</p>

--- a/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html
+++ b/exercises/Exm-BestSellersRpt/Exm-FolioBestSellersRpt.html
@@ -62,6 +62,7 @@
 		<script src="../../components/exercises-nav.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -246,6 +247,7 @@
 						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
 					</div>
 				</div>

--- a/exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html
+++ b/exercises/Exm-BestSellersRpt/Prg-FolioBestSellersRpt.html
@@ -69,6 +69,7 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -261,6 +262,7 @@ CheckBookRank.
 						<hr />
 						<copyright-notice type="examples"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block">
 							<a href="Exm-FolioBestSellersRpt.html">&larr; Back to specification</a>
 						</p>

--- a/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html
+++ b/exercises/Exm-BookshopLectReqRpt/Exm-BookshopLectReqRpt.html
@@ -62,6 +62,7 @@
 		<script src="../../components/exercises-nav.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -329,6 +330,7 @@
 						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
 					</div>
 				</div>

--- a/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html
+++ b/exercises/Exm-BookshopLectReqRpt/Prg-BookshopLectReqRpt.html
@@ -69,6 +69,7 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -291,6 +292,7 @@ Process-Publisher.
 						<hr />
 						<copyright-notice type="examples"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block">
 							<a href="Exm-BookshopLectReqRpt.html">&larr; Back to specification</a>
 						</p>

--- a/exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html
+++ b/exercises/Exm-CSISEmailDomain/Exm-CSISEmailDomain.html
@@ -62,6 +62,7 @@
 		<script src="../../components/exercises-nav.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -372,6 +373,7 @@
 						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
 					</div>
 				</div>

--- a/exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html
+++ b/exercises/Exm-CSISEmailDomain/Prg-CSISEmailDomain.html
@@ -63,6 +63,7 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -223,6 +224,7 @@ LoadCountryTable.
 						<hr />
 						<copyright-notice type="examples"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="Exm-CSISEmailDomain.html">&larr; Back to specification</a></p>
 					</div>
 				</div>

--- a/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html
+++ b/exercises/Exm-DueSubsRpt/Exm-DueSubsRpt.html
@@ -62,6 +62,7 @@
 		<script src="../../components/exercises-nav.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -342,6 +343,7 @@
 						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
 					</div>
 				</div>

--- a/exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html
+++ b/exercises/Exm-DueSubsRpt/Prg-DueSubsRpt.html
@@ -63,6 +63,7 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -380,6 +381,7 @@ PrintFinalTotals.
 						<hr />
 						<copyright-notice type="examples"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="Exm-DueSubsRpt.html">&larr; Back to specification</a></p>
 					</div>
 				</div>

--- a/exercises/Exm-FileConversion/Exm-FileConversion.html
+++ b/exercises/Exm-FileConversion/Exm-FileConversion.html
@@ -62,6 +62,7 @@
 		<script src="../../components/exercises-nav.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -363,6 +364,7 @@ Ryan Michael Terence          34 Winchester Drive Dubline 7 Co. Dublin    090123
 						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
 					</div>
 				</div>

--- a/exercises/Exm-FileConversion/Prg-FileConversion.html
+++ b/exercises/Exm-FileConversion/Prg-FileConversion.html
@@ -63,6 +63,7 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -256,6 +257,7 @@ RESTRUCTURE-NAME.
 						<hr />
 						<copyright-notice type="examples"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="Exm-FileConversion.html">&larr; Back to specification</a></p>
 					</div>
 				</div>

--- a/exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html
+++ b/exercises/Exm-FlyByNightTravel/Exm-FlyByNight.html
@@ -62,6 +62,7 @@
 		<script src="../../components/exercises-nav.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -274,6 +275,7 @@
 						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
 					</div>
 				</div>

--- a/exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html
+++ b/exercises/Exm-FlyByNightTravel/Prg-FlyByNight.html
@@ -63,6 +63,7 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -243,6 +244,7 @@ BEGIN.
 						<hr />
 						<copyright-notice type="examples"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="Exm-FlyByNight.html">&larr; Back to specification</a></p>
 					</div>
 				</div>

--- a/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html
+++ b/exercises/Exm-RoyaltyPaymentsRpt/Exm-LibRoyaltyRpt.html
@@ -62,6 +62,7 @@
 		<script src="../../components/exercises-nav.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -361,6 +362,7 @@
 						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
 					</div>
 				</div>

--- a/exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html
+++ b/exercises/Exm-RoyaltyPaymentsRpt/Prg-LibRoyaltyRpt.html
@@ -63,6 +63,7 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -294,6 +295,7 @@ PROCEDURE DIVISION.
 						<hr />
 						<copyright-notice type="examples"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="Exm-LibRoyaltyRpt.html">&larr; Back to specification</a></p>
 					</div>
 				</div>

--- a/exercises/Exm-SFbyMail/Exm-SFbyMail.html
+++ b/exercises/Exm-SFbyMail/Exm-SFbyMail.html
@@ -62,6 +62,7 @@
 		<script src="../../components/exercises-nav.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -428,6 +429,7 @@
 						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
 					</div>
 				</div>

--- a/exercises/Exm-SFbyMail/Prg-SFbyMail.html
+++ b/exercises/Exm-SFbyMail/Prg-SFbyMail.html
@@ -63,6 +63,7 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -208,6 +209,7 @@ GetCopyPostage.
 						<hr />
 						<copyright-notice type="examples"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="Exm-SFbyMail.html">&larr; Back to specification</a></p>
 					</div>
 				</div>

--- a/exercises/Exm-StudFeesRpt/Exm-StudPay.html
+++ b/exercises/Exm-StudFeesRpt/Exm-StudPay.html
@@ -62,6 +62,7 @@
 		<script src="../../components/exercises-nav.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -259,6 +260,7 @@
 						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
 					</div>
 				</div>

--- a/exercises/Exm-StudFeesRpt/Prg-StudPay.html
+++ b/exercises/Exm-StudFeesRpt/Prg-StudPay.html
@@ -63,6 +63,7 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -222,6 +223,7 @@ Print-Outstanding-Fees-Rpt.
 						<hr />
 						<copyright-notice type="examples"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="Exm-StudPay.html">&larr; Back to specification</a></p>
 					</div>
 				</div>

--- a/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html
+++ b/exercises/Exm-TopSupplierRpt/Exm-TopSupplierRpt.html
@@ -62,6 +62,7 @@
 		<script src="../../components/exercises-nav.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -303,6 +304,7 @@
 						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
 					</div>
 				</div>

--- a/exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html
+++ b/exercises/Exm-TopSupplierRpt/Prg-TopSupplierRpt.html
@@ -63,6 +63,7 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -347,6 +348,7 @@ SUM-TITLE-EARNINGS.
 						<hr />
 						<copyright-notice type="examples"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="Exm-TopSupplierRpt.html">&larr; Back to specification</a></p>
 					</div>
 				</div>

--- a/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html
+++ b/exercises/Exm-USSRshipRpt/Exm-USSRshipRpt.html
@@ -62,6 +62,7 @@
 		<script src="../../components/exercises-nav.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -462,6 +463,7 @@
 						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
 					</div>
 				</div>

--- a/exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html
+++ b/exercises/Exm-USSRshipRpt/Prg-USSRshipRpt.html
@@ -63,6 +63,7 @@
 		<script src="../../components/related-content.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -313,6 +314,7 @@ SELECT-MAJOR-SHIPS SECTION.
 						<hr />
 						<copyright-notice type="examples"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="Exm-USSRshipRpt.html">&larr; Back to specification</a></p>
 					</div>
 				</div>

--- a/exercises/GettingStarted.html
+++ b/exercises/GettingStarted.html
@@ -56,6 +56,7 @@
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/site-header.js" type="module"></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/copy-button.js" defer></script>
 		<script src="../components/run-in-ce.js" defer></script>
 		<script src="../components/exercise-progress.js" defer></script>
@@ -298,6 +299,7 @@ Result is = 00</samp></pre>
 						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="index.html">&larr; Back to COBOL Exercises</a></p>
 					</div>
 				</div>

--- a/exercises/MonthTable.html
+++ b/exercises/MonthTable.html
@@ -53,6 +53,7 @@
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/site-header.js" type="module"></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/exercise-progress.js" defer></script>
 		<script src="../components/exercises-sidebar.js" type="module"></script>
 		<script src="../components/exercises-nav.js" defer></script>
@@ -218,6 +219,7 @@ December          5</samp></pre>
 						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="index.html">&larr; Back to COBOL Exercises</a></p>
 					</div>
 				</div>

--- a/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html
+++ b/exercises/Prj-AromaInvoicesRpt/Prj-AromaInvoicesRpt.html
@@ -62,6 +62,7 @@
 		<script src="../../components/exercises-nav.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -278,6 +279,7 @@
 						<exercises-nav></exercises-nav>
 						<copyright-notice type="project"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
 					</div>
 				</div>

--- a/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html
+++ b/exercises/Prj-AromaSalesRpt/Prj-AromaSalesRpt.html
@@ -62,6 +62,7 @@
 		<script src="../../components/exercises-nav.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -313,6 +314,7 @@
 						<exercises-nav></exercises-nav>
 						<copyright-notice type="project"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
 					</div>
 				</div>

--- a/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html
+++ b/exercises/Prj-CAOPointsCalc/Prj-CAOcalculator.html
@@ -62,6 +62,7 @@
 		<script src="../../components/exercises-nav.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -635,6 +636,7 @@
 						<exercises-nav></exercises-nav>
 						<copyright-notice type="project"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
 					</div>
 				</div>

--- a/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html
+++ b/exercises/Prj-MunsterSurnamesFreqRpt/Prj-MunsterSurnamesFreqRpt.html
@@ -62,6 +62,7 @@
 		<script src="../../components/exercises-nav.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -186,6 +187,7 @@
 						<exercises-nav></exercises-nav>
 						<copyright-notice type="project"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
 					</div>
 				</div>

--- a/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html
+++ b/exercises/Prj-NewtronicsFileMaint/Prj-NewtronicsFileMaint.html
@@ -95,6 +95,7 @@
 		<script src="../../components/exercises-nav.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -673,6 +674,7 @@ Check Digit       =            4</pre
 						<exercises-nav></exercises-nav>
 						<copyright-notice type="project"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
 					</div>
 				</div>

--- a/exercises/Proj-CSISEvalform/CSISEvalForm.html
+++ b/exercises/Proj-CSISEvalform/CSISEvalForm.html
@@ -62,6 +62,7 @@
 		<script src="../../components/exercises-nav.js" defer></script>
 		<script src="../../components/site-header.js" type="module"></script>
 		<script src="../../components/last-updated.js" defer></script>
+		<script src="../../components/edit-on-github.js" defer></script>
 	</head>
 	<body>
 		<a class="skip-link" href="#main-content">Skip to main content</a>
@@ -303,6 +304,7 @@
 						<exercises-nav></exercises-nav>
 						<copyright-notice type="project"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="../index.html">&larr; Back to COBOL Exercises</a></p>
 					</div>
 				</div>

--- a/exercises/SeqInsert.html
+++ b/exercises/SeqInsert.html
@@ -53,6 +53,7 @@
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/site-header.js" type="module"></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/exercise-progress.js" defer></script>
 		<script src="../components/exercises-sidebar.js" type="module"></script>
 		<script src="../components/exercises-nav.js" defer></script>
@@ -271,6 +272,7 @@
 						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="index.html">&larr; Back to COBOL Exercises</a></p>
 					</div>
 				</div>

--- a/exercises/SeqRead.html
+++ b/exercises/SeqRead.html
@@ -53,6 +53,7 @@
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/site-header.js" type="module"></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/exercise-progress.js" defer></script>
 		<script src="../components/exercises-sidebar.js" type="module"></script>
 		<script src="../components/exercises-nav.js" defer></script>
@@ -228,6 +229,7 @@ etc.</samp></pre>
 						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="index.html">&larr; Back to COBOL Exercises</a></p>
 					</div>
 				</div>

--- a/exercises/SeqReadIf.html
+++ b/exercises/SeqReadIf.html
@@ -53,6 +53,7 @@
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/site-header.js" type="module"></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/exercise-progress.js" defer></script>
 		<script src="../components/exercises-sidebar.js" type="module"></script>
 		<script src="../components/exercises-nav.js" defer></script>
@@ -189,6 +190,7 @@ Number of Females = 15</samp></pre>
 						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="index.html">&larr; Back to COBOL Exercises</a></p>
 					</div>
 				</div>

--- a/exercises/SeqUpdate.html
+++ b/exercises/SeqUpdate.html
@@ -53,6 +53,7 @@
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/site-header.js" type="module"></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/exercise-progress.js" defer></script>
 		<script src="../components/exercises-sidebar.js" type="module"></script>
 		<script src="../components/exercises-nav.js" defer></script>
@@ -290,6 +291,7 @@
 						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="index.html">&larr; Back to COBOL Exercises</a></p>
 					</div>
 				</div>

--- a/exercises/SeqWrite.html
+++ b/exercises/SeqWrite.html
@@ -53,6 +53,7 @@
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/site-header.js" type="module"></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/exercise-progress.js" defer></script>
 		<script src="../components/exercises-sidebar.js" type="module"></script>
 		<script src="../components/exercises-nav.js" defer></script>
@@ -189,6 +190,7 @@ nnnnnnnSSSSSSSSiiG
 						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="index.html">&larr; Back to COBOL Exercises</a></p>
 					</div>
 				</div>

--- a/exercises/SortIP.html
+++ b/exercises/SortIP.html
@@ -53,6 +53,7 @@
 		<script src="../components/related-content.js" defer></script>
 		<script src="../components/site-header.js" type="module"></script>
 		<script src="../components/last-updated.js" defer></script>
+		<script src="../components/edit-on-github.js" defer></script>
 		<script src="../components/exercise-progress.js" defer></script>
 		<script src="../components/exercises-sidebar.js" type="module"></script>
 		<script src="../components/exercises-nav.js" defer></script>
@@ -260,6 +261,7 @@
 						<exercises-nav></exercises-nav>
 						<copyright-notice type="exercises"></copyright-notice>
 						<last-updated></last-updated>
+						<edit-on-github></edit-on-github>
 						<p class="center-block"><a href="index.html">&larr; Back to COBOL Exercises</a></p>
 					</div>
 				</div>

--- a/index.html
+++ b/index.html
@@ -42,8 +42,8 @@
 		<meta name="robots" content="All" />
 		<meta name="rating" content="General" />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/" />
-		<link rel="stylesheet" href="course/Resources/css/course.css" />
-		<link rel="stylesheet" href="course/Resources/css/course-components.css" />
+		<link href="course/Resources/css/course.css" rel="stylesheet" />
+		<link href="course/Resources/css/course-components.css" rel="stylesheet" />
 		<!-- Open Graph -->
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://bushidocodes.github.io/limerick-cobol/" />


### PR DESCRIPTION
## Summary

A head/shell consistency pass. Auditing the `<head>` and page chrome across all categories showed the site is already largely consistent — the real cross-category gap is the **"Help improve this page"** footer (`edit-on-github`, issue #402), which shipped only on the **generated example pages** even though the component derives its links entirely from `window.location.pathname` (its own docstring uses `course/COBOLIntro.html` as the example — it was designed to work everywhere).

- **Roll out `<edit-on-github>` to all 70 hand-authored content pages** (26 course + 44 exercises). The site now offers the same Edit / Report-a-problem affordance on every content page (**111 total**, incl. examples), matching the MDN-style direction of the recent refresh.
  - Index/landing pages (`course/index.html`, `exercises/index.html`) are deliberately excluded, mirroring `examples/index.html`.
  - The script tag's relative depth is derived from each page's existing `last-updated.js` tag, so course (`../`), flat exercises (`../`), and nested exercises (`../../`) all resolve correctly. `<edit-on-github>` is placed right after `<last-updated>`, matching the examples.
- **Normalize the three `<link rel="stylesheet" href>` outliers** (`index.html`, `course/index.html`, `course/glossary.html`) to the dominant `href`-then-`rel` order used by the other ~140 pages.

## Verification

- Renders with the correct edit URL on a course page (`…/edit/master/course/COBOLIntro.html`) and a nested exercise (`…/edit/master/exercises/Exm-AcmeStockReorder/Exm-AcmeStockReorder.html`); screenshot confirms the footer panel.
- `npm run validate` passes; `prettier --check` clean across the repo.

## Audit findings (for context)

Each category was already internally consistent for viewport-first, theme bootstrap, canonical, favicon, OG/Twitter. The apparent "stragglers" were the index/glossary landing pages differing for legitimate reasons (no `rel=prev/next` on non-sequential pages, etc.).

## Out of scope (separate follow-ups)

- `ld+json` on exercises/examples and `rel=prev/next` on the exercise sequence — both need per-page/sequence data, so they're better as their own change.
- The remaining head gaps (favicon, viewport-first on a few) are on the **lecture iframe-shell pages**, which belong to the lecture-chrome cleanup.

## Checklist

- [x] `npm run validate` passes
- [ ] `npm run links` — N/A (no existing `href`/`src` changed; new links are component-generated GitHub URLs)
- [x] `npm run format:check` passes
- [ ] `npm run a11y` — not re-run (flaky preview renderer this session); the `edit-on-github` block is the same component already shipped and a11y-passing on the example pages.