### PR TITLE
fix(lectures): add favicon to lecture/ppz viewer pages; tidy viewport order

### DIFF
--- a/course/Resources/ppz/TC-Call.html
+++ b/course/Resources/ppz/TC-Call.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>COBOL CALL Statement — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Call." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Call.html" />

--- a/course/Resources/ppz/TC-CobIntro1.html
+++ b/course/Resources/ppz/TC-CobIntro1.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>Introduction to COBOL, Part 1 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-CobIntro1." />
 		<link

--- a/course/Resources/ppz/TC-CobIntro2.html
+++ b/course/Resources/ppz/TC-CobIntro2.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>Introduction to COBOL, Part 2 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-CobIntro2." />
 		<link

--- a/course/Resources/ppz/TC-CobIntro3.html
+++ b/course/Resources/ppz/TC-CobIntro3.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>Introduction to COBOL, Part 3 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-CobIntro3." />
 		<link

--- a/course/Resources/ppz/TC-CobIntro4.html
+++ b/course/Resources/ppz/TC-CobIntro4.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>Introduction to COBOL, Part 4 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-CobIntro4." />
 		<link

--- a/course/Resources/ppz/TC-CobIntro5.html
+++ b/course/Resources/ppz/TC-CobIntro5.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>Introduction to COBOL, Part 5 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-CobIntro5." />
 		<link

--- a/course/Resources/ppz/TC-CobIntro6.html
+++ b/course/Resources/ppz/TC-CobIntro6.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>Introduction to COBOL, Part 6 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-CobIntro6." />
 		<link

--- a/course/Resources/ppz/TC-Commands1.html
+++ b/course/Resources/ppz/TC-Commands1.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>COBOL Commands, Part 1 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Commands1." />
 		<link

--- a/course/Resources/ppz/TC-Commands2.html
+++ b/course/Resources/ppz/TC-Commands2.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>COBOL Commands, Part 2 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Commands2." />
 		<link

--- a/course/Resources/ppz/TC-Condition1.html
+++ b/course/Resources/ppz/TC-Condition1.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>COBOL Conditions, Part 1 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Condition1." />
 		<link

--- a/course/Resources/ppz/TC-Condition2.html
+++ b/course/Resources/ppz/TC-Condition2.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>COBOL Conditions, Part 2 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Condition2." />
 		<link

--- a/course/Resources/ppz/TC-Data1.html
+++ b/course/Resources/ppz/TC-Data1.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>COBOL Data Division, Part 1 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Data1." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Data1.html" />

--- a/course/Resources/ppz/TC-Data2.html
+++ b/course/Resources/ppz/TC-Data2.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>COBOL Data Division, Part 2 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Data2." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/course/Resources/ppz/TC-Data2.html" />

--- a/course/Resources/ppz/TC-Perform1.html
+++ b/course/Resources/ppz/TC-Perform1.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>COBOL PERFORM Statement, Part 1 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Perform1." />
 		<link

--- a/course/Resources/ppz/TC-Perform2.html
+++ b/course/Resources/ppz/TC-Perform2.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>COBOL PERFORM Statement, Part 2 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Perform2." />
 		<link

--- a/course/Resources/ppz/TC-Search2.html
+++ b/course/Resources/ppz/TC-Search2.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>COBOL SEARCH Statement, Part 2 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Search2." />
 		<link

--- a/course/Resources/ppz/TC-SeqFile1.html
+++ b/course/Resources/ppz/TC-SeqFile1.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>Sequential Files in COBOL, Part 1 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-SeqFile1." />
 		<link

--- a/course/Resources/ppz/TC-SeqFile2a.html
+++ b/course/Resources/ppz/TC-SeqFile2a.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>Sequential Files in COBOL, Part 2a — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-SeqFile2a." />
 		<link

--- a/course/Resources/ppz/TC-SeqFile2b.html
+++ b/course/Resources/ppz/TC-SeqFile2b.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>Sequential Files in COBOL, Part 2b — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-SeqFile2b." />
 		<link

--- a/course/Resources/ppz/TC-SeqFile2c.html
+++ b/course/Resources/ppz/TC-SeqFile2c.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>Sequential Files in COBOL, Part 2c — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-SeqFile2c." />
 		<link

--- a/course/Resources/ppz/TC-SeqFile2d.html
+++ b/course/Resources/ppz/TC-SeqFile2d.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>Sequential Files in COBOL, Part 2d — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-SeqFile2d." />
 		<link

--- a/course/Resources/ppz/TC-SeqFile2e.html
+++ b/course/Resources/ppz/TC-SeqFile2e.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>Sequential Files in COBOL, Part 2e — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-SeqFile2e." />
 		<link

--- a/course/Resources/ppz/TC-SeqFile3a.html
+++ b/course/Resources/ppz/TC-SeqFile3a.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>Sequential Files in COBOL, Part 3a — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-SeqFile3a." />
 		<link

--- a/course/Resources/ppz/TC-Tables1.html
+++ b/course/Resources/ppz/TC-Tables1.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>COBOL Tables, Part 1 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Tables1." />
 		<link

--- a/course/Resources/ppz/TC-Tables2.html
+++ b/course/Resources/ppz/TC-Tables2.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>COBOL Tables, Part 2 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Tables2." />
 		<link

--- a/course/Resources/ppz/TC-Tables3.html
+++ b/course/Resources/ppz/TC-Tables3.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>COBOL Tables, Part 3 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Tables3." />
 		<link

--- a/course/Resources/ppz/TC-Tables4.html
+++ b/course/Resources/ppz/TC-Tables4.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>COBOL Tables, Part 4 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Tables4." />
 		<link

--- a/course/Resources/ppz/TC-Tables5.html
+++ b/course/Resources/ppz/TC-Tables5.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>COBOL Tables, Part 5 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Tables5." />
 		<link

--- a/course/Resources/ppz/TC-Tables7.html
+++ b/course/Resources/ppz/TC-Tables7.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>COBOL Tables, Part 7 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Tables7." />
 		<link

--- a/course/Resources/ppz/TC-Tables8.html
+++ b/course/Resources/ppz/TC-Tables8.html
@@ -4,6 +4,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+		<link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../../../apple-touch-icon.png" />
+		<link rel="manifest" href="../../../manifest.json" />
 		<title>COBOL Tables, Part 8 — COBOL Course Animation</title>
 		<meta name="description" content="COBOL programming lesson on TC-Tables8." />
 		<link

--- a/lectures/arithmetic.html
+++ b/lectures/arithmetic.html
@@ -20,6 +20,9 @@
 				}
 			})();
 		</script>
+		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
+		<link rel="manifest" href="../manifest.json" />
 		<title>Arithmetic and Edited Pictures — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Arithmetic." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/arithmetic.html" />

--- a/lectures/basics1.html
+++ b/lectures/basics1.html
@@ -20,6 +20,9 @@
 				}
 			})();
 		</script>
+		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
+		<link rel="manifest" href="../manifest.json" />
 		<title>COBOL Basics 1 — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Basics1." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/basics1.html" />

--- a/lectures/basics2.html
+++ b/lectures/basics2.html
@@ -20,6 +20,9 @@
 				}
 			})();
 		</script>
+		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
+		<link rel="manifest" href="../manifest.json" />
 		<title>COBOL Basics 2 — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering basics2." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/basics2.html" />

--- a/lectures/call.html
+++ b/lectures/call.html
@@ -20,6 +20,9 @@
 				}
 			})();
 		</script>
+		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
+		<link rel="manifest" href="../manifest.json" />
 		<title>Calling Subprograms — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering call." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/call.html" />

--- a/lectures/cobintro.html
+++ b/lectures/cobintro.html
@@ -20,6 +20,9 @@
 				}
 			})();
 		</script>
+		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
+		<link rel="manifest" href="../manifest.json" />
 		<title>Introduction to COBOL — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering cobintro." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/cobintro.html" />

--- a/lectures/conditions.html
+++ b/lectures/conditions.html
@@ -20,6 +20,9 @@
 				}
 			})();
 		</script>
+		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
+		<link rel="manifest" href="../manifest.json" />
 		<title>Conditions — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Conditions." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/conditions.html" />

--- a/lectures/copy.html
+++ b/lectures/copy.html
@@ -20,6 +20,9 @@
 				}
 			})();
 		</script>
+		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
+		<link rel="manifest" href="../manifest.json" />
 		<title>The COPY — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering COPY." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/copy.html" />

--- a/lectures/design.html
+++ b/lectures/design.html
@@ -20,6 +20,9 @@
 				}
 			})();
 		</script>
+		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
+		<link rel="manifest" href="../manifest.json" />
 		<title>Designing Programs — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering design." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/design.html" />

--- a/lectures/direct1.html
+++ b/lectures/direct1.html
@@ -20,6 +20,9 @@
 				}
 			})();
 		</script>
+		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
+		<link rel="manifest" href="../manifest.json" />
 		<title>Introduction to Direct Access Files — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering direct1." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/direct1.html" />

--- a/lectures/dsr1.html
+++ b/lectures/dsr1.html
@@ -20,6 +20,9 @@
 				}
 			})();
 		</script>
+		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
+		<link rel="manifest" href="../manifest.json" />
 		<title>Introduction to Diagrammatic Stepwise Refinement — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering dsr1." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/dsr1.html" />

--- a/lectures/genintro.html
+++ b/lectures/genintro.html
@@ -20,6 +20,9 @@
 				}
 			})();
 		</script>
+		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
+		<link rel="manifest" href="../manifest.json" />
 		<title>General Introduction — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering GenIntro." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/genintro.html" />

--- a/lectures/indexed.html
+++ b/lectures/indexed.html
@@ -20,6 +20,9 @@
 				}
 			})();
 		</script>
+		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
+		<link rel="manifest" href="../manifest.json" />
 		<title>Indexed Files — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Indexed." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/indexed.html" />

--- a/lectures/inspect.html
+++ b/lectures/inspect.html
@@ -20,6 +20,9 @@
 				}
 			})();
 		</script>
+		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
+		<link rel="manifest" href="../manifest.json" />
 		<title>The INSPECT — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Inspect." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/inspect.html" />

--- a/lectures/perform.html
+++ b/lectures/perform.html
@@ -20,6 +20,9 @@
 				}
 			})();
 		</script>
+		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
+		<link rel="manifest" href="../manifest.json" />
 		<title>Simple Iteration with the PERFORM Verb — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering perform." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/perform.html" />

--- a/lectures/relative.html
+++ b/lectures/relative.html
@@ -20,6 +20,9 @@
 				}
 			})();
 		</script>
+		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
+		<link rel="manifest" href="../manifest.json" />
 		<title>Relative Files — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Relative." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/relative.html" />

--- a/lectures/reportwriterssweb.html
+++ b/lectures/reportwriterssweb.html
@@ -1,7 +1,7 @@
 ﻿<!doctype html>
 <html lang="en">
 	<head>
-		<meta content="width=device-width, initial-scale=1" name="viewport" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
@@ -21,6 +21,9 @@
 			})();
 		</script>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
+		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
+		<link rel="manifest" href="../manifest.json" />
 		<title>COBOL Report Writer - Syntax and Semantics</title>
 		<meta name="description" content="COBOL lecture slides covering COBOL Report Writer - Syntax and Semantics." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/reportwriterssweb.html" />

--- a/lectures/reportwriterweb.html
+++ b/lectures/reportwriterweb.html
@@ -1,7 +1,7 @@
 ﻿<!doctype html>
 <html lang="en">
 	<head>
-		<meta content="width=device-width, initial-scale=1" name="viewport" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
 		<script>
@@ -21,6 +21,9 @@
 			})();
 		</script>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
+		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
+		<link rel="manifest" href="../manifest.json" />
 		<title>COBOL Report Writer</title>
 		<meta name="description" content="COBOL lecture slides covering COBOL Report Writer." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/reportwriterweb.html" />

--- a/lectures/search.html
+++ b/lectures/search.html
@@ -20,6 +20,9 @@
 				}
 			})();
 		</script>
+		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
+		<link rel="manifest" href="../manifest.json" />
 		<title>Searching Tables — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Search." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/search.html" />

--- a/lectures/seqfile1.html
+++ b/lectures/seqfile1.html
@@ -20,6 +20,9 @@
 				}
 			})();
 		</script>
+		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
+		<link rel="manifest" href="../manifest.json" />
 		<title>Introduction to Sequential Files — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering SeqFile1." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/seqfile1.html" />

--- a/lectures/seqfile2.html
+++ b/lectures/seqfile2.html
@@ -20,6 +20,9 @@
 				}
 			})();
 		</script>
+		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
+		<link rel="manifest" href="../manifest.json" />
 		<title>Processing Sequential Files — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering SeqFile2." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/seqfile2.html" />

--- a/lectures/seqfile3.html
+++ b/lectures/seqfile3.html
@@ -20,6 +20,9 @@
 				}
 			})();
 		</script>
+		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
+		<link rel="manifest" href="../manifest.json" />
 		<title>Advanced Sequential Files — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering SeqFile3." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/seqfile3.html" />

--- a/lectures/sort.html
+++ b/lectures/sort.html
@@ -20,6 +20,9 @@
 				}
 			})();
 		</script>
+		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
+		<link rel="manifest" href="../manifest.json" />
 		<title>SORT and MERGE — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering SORT." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/sort.html" />

--- a/lectures/string.html
+++ b/lectures/string.html
@@ -20,6 +20,9 @@
 				}
 			})();
 		</script>
+		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
+		<link rel="manifest" href="../manifest.json" />
 		<title>The STRING — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering String." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/string.html" />

--- a/lectures/tables1.html
+++ b/lectures/tables1.html
@@ -20,6 +20,9 @@
 				}
 			})();
 		</script>
+		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
+		<link rel="manifest" href="../manifest.json" />
 		<title>Tables and the PERFORM ... VARYING — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Tables1." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/tables1.html" />

--- a/lectures/tables2.html
+++ b/lectures/tables2.html
@@ -20,6 +20,9 @@
 				}
 			})();
 		</script>
+		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
+		<link rel="manifest" href="../manifest.json" />
 		<title>Advanced Tables — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Tables2." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/tables2.html" />

--- a/lectures/unstring.html
+++ b/lectures/unstring.html
@@ -20,6 +20,9 @@
 				}
 			})();
 		</script>
+		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
+		<link rel="manifest" href="../manifest.json" />
 		<title>The UNSTRING — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Unstring." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/unstring.html" />

--- a/lectures/usage.html
+++ b/lectures/usage.html
@@ -20,6 +20,9 @@
 				}
 			})();
 		</script>
+		<link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png" />
+		<link rel="manifest" href="../manifest.json" />
 		<title>The USAGE Clause — COBOL Lecture</title>
 		<meta name="description" content="COBOL lecture slides covering Usage." />
 		<link rel="canonical" href="https://bushidocodes.github.io/limerick-cobol/lectures/usage.html" />


### PR DESCRIPTION
## Summary

Minimal head-consistency polish for the slide-viewer pages. Per the decision to **keep the lecture pages as minimal full-screen viewers** (so an instructor can present slides directly off the page), this deliberately does **not** add site chrome or touch the viewer layout — it only fills the genuine, non-conflicting `<head>` gaps the audit found.

- **Add the standard favicon block** (`icon` / `apple-touch-icon` / `manifest`) to the **57** `lectures/*.html` and `course/Resources/ppz/TC-*.html` viewer pages that lacked it, so they show the site icon in the browser tab like every other page. Relative depth differs by location (`../` for lectures, `../../../` for ppz); inserted right before `<title>` to match the site convention.
- **Normalize the viewport meta attribute order** (`content,name` → `name,content`) on the two report-writer lecture pages, matching the ~140 other pages.

`lectures/cs4312topics.html` is skipped — it's a `noindex` meta-refresh redirect stub, so favicon/OG/etc. don't apply.

## Not changed (intentionally)

The full-screen iframe viewer and the present-directly behavior are untouched. The earlier idea of wrapping lectures in full site chrome was dropped because it shrank the slides and broke that workflow.

## Verification

- favicon assets return **200** from both depths (`/favicon.svg`, and `course/Resources/ppz/../../../favicon.svg`); `apple-touch-icon.png` and `manifest.json` likewise.
- `npm run validate` passes; `prettier --check` clean across the repo.
- The audit's other apparent gaps were false alarms: the "viewport-first" flags were just the attribute-order nit above (viewport *is* first), and the missing theme-bootstrap/OG/Twitter were all the `cs4312topics` redirect stub.

## Checklist

- [x] `npm run validate` passes
- [x] `npm run links` — favicon hrefs verified resolving via the live server (200 from both depths); no other `href`/`src` changed
- [x] `npm run format:check` passes
- [ ] `npm run a11y` — N/A (head-only metadata; no rendered/contrast change)